### PR TITLE
Streamline runtime trace capture functionality and related UI elements

### DIFF
--- a/.changeset/20260603022108-overhauled-debug-tracing-tools-renamed-and-regro.md
+++ b/.changeset/20260603022108-overhauled-debug-tracing-tools-renamed-and-regro.md
@@ -1,0 +1,5 @@
+---
+"nehir": patch
+---
+
+Overhauled debug tracing tools: moved debug commands into a dedicated Debugging & Tracing category, renamed IPC/CLI paths under the `debug` namespace, made Toggle Trace Capture the primary hotkey action, folded trace start/stop scripting into `debug trace toggle <active|inactive>`, added an optional workspace bar trace button, and documented the `invalid_state` IPC error code.

--- a/README.md
+++ b/README.md
@@ -70,15 +70,15 @@ nehirctl command switch-workspace 2
 nehirctl --help
 ```
 
-## Runtime Debugging
+## Debugging & Tracing
 
-Nehir includes a few runtime-debug commands in the command palette and IPC/CLI surface:
+Nehir includes runtime debugging and trace-capture commands. They are exposed consistently through IPC/CLI, the command palette, and hotkey handling, and appear in the **Debugging & Tracing** category:
 
-- **Dump Runtime State** — copies the current runtime dump to the clipboard and writes it to the unified log
-- **Reset Runtime State** — clears runtime state and reboots tracking from a startup-style rescan
-- **Restart App Clearing Runtime State** — clears runtime state and relaunches the app
-- **Start Runtime Trace Capture** — default hotkey: `Ctrl+Option+Cmd+T`
-- **Stop Runtime Trace Capture** — default hotkey: `Ctrl+Option+Shift+Cmd+T`
+- **Debug: Dump Runtime State** — copies the current runtime debug dump to the clipboard and writes it to the unified log
+- **Debug: Reset Runtime State** — clears runtime debugging state and reboots tracking from a startup-style rescan
+- **Debug: Restart Clearing Runtime State** — clears runtime debugging state and relaunches the app
+- **Debug: Toggle Trace Capture** — default hotkey: `Ctrl+Option+Cmd+T`
+  - IPC/CLI accepts an optional `desiredState` argument (`active` or `inactive`) for idempotent scripting: `nehirctl command debug trace toggle active`
 
 Stopping a trace capture writes a log bundle to:
 
@@ -87,6 +87,8 @@ ${XDG_STATE_HOME:-$HOME/.local/state}/nehir/traces/
 ```
 
 and copies the dumped file path to the clipboard.
+
+For feedback/debug reports: toggle tracing on, reproduce the issue, toggle tracing off, then share the copied trace-bundle path or file. An optional **Show Trace Capture Button** workspace-bar setting provides the same toggle in the bar for advanced users and developers.
 
 For IPC/CLI usage, see [docs/IPC-CLI.md](docs/IPC-CLI.md).
 

--- a/Sources/Nehir/Core/Config/CanonicalTOMLConfig.swift
+++ b/Sources/Nehir/Core/Config/CanonicalTOMLConfig.swift
@@ -83,6 +83,7 @@ struct CanonicalTOMLConfig: Codable, Equatable {
         var enabled: Bool
         var showLabels: Bool
         var showFloatingWindows: Bool
+        var showTraceButton: Bool
         var windowLevel: String
         var position: String
         var notchAware: Bool
@@ -194,6 +195,7 @@ extension CanonicalTOMLConfig {
             enabled: export.workspaceBarEnabled,
             showLabels: export.workspaceBarShowLabels,
             showFloatingWindows: export.workspaceBarShowFloatingWindows,
+            showTraceButton: export.workspaceBarShowTraceButton,
             windowLevel: export.workspaceBarWindowLevel,
             position: export.workspaceBarPosition,
             notchAware: export.workspaceBarNotchAware,
@@ -257,6 +259,7 @@ extension CanonicalTOMLConfig {
             workspaceBarEnabled: workspaceBar.enabled,
             workspaceBarShowLabels: workspaceBar.showLabels,
             workspaceBarShowFloatingWindows: workspaceBar.showFloatingWindows,
+            workspaceBarShowTraceButton: workspaceBar.showTraceButton,
             workspaceBarWindowLevel: workspaceBar.windowLevel,
             workspaceBarPosition: workspaceBar.position,
             workspaceBarNotchAware: workspaceBar.notchAware,
@@ -404,6 +407,7 @@ extension CanonicalTOMLConfig.WorkspaceBar {
         enabled = try container.decodeWithDefault(Bool.self, forKey: .enabled, default: d.enabled)
         showLabels = try container.decodeWithDefault(Bool.self, forKey: .showLabels, default: d.showLabels)
         showFloatingWindows = try container.decodeWithDefault(Bool.self, forKey: .showFloatingWindows, default: d.showFloatingWindows)
+        showTraceButton = try container.decodeWithDefault(Bool.self, forKey: .showTraceButton, default: d.showTraceButton)
         windowLevel = try container.decodeWithDefault(String.self, forKey: .windowLevel, default: d.windowLevel)
         position = try container.decodeWithDefault(String.self, forKey: .position, default: d.position)
         notchAware = try container.decodeWithDefault(Bool.self, forKey: .notchAware, default: d.notchAware)

--- a/Sources/Nehir/Core/Config/HotkeyConfigMapping.swift
+++ b/Sources/Nehir/Core/Config/HotkeyConfigMapping.swift
@@ -5,7 +5,7 @@ import Foundation
 /// the new human-readable TOML config keys (e.g., workspace.switch.1).
 enum HotkeyConfigMapping {
     /// TOML section names in output order.
-    static let sectionOrder: [String] = ["workspace", "focus", "move", "layout", "ui"]
+    static let sectionOrder: [String] = ["workspace", "focus", "move", "layout", "debugging", "ui"]
 
     /// Numbered group definitions: each group expands to 9 bindings (1–9).
     /// The internalIdPattern uses `%d` for the index, with the specified offset.
@@ -98,6 +98,11 @@ enum HotkeyConfigMapping {
         ("layout", "toggleScratchpad", "toggleScratchpadWindow"),
         ("layout", "raiseAllFloating", "raiseAllFloatingWindows"),
         ("layout", "rescueOffscreen", "rescueOffscreenWindows"),
+        // debugging
+        ("debugging", "dumpRuntimeState", "debug.dumpRuntimeState"),
+        ("debugging", "resetRuntimeState", "debug.resetRuntimeState"),
+        ("debugging", "restartClearingRuntimeState", "debug.restartClearingRuntimeState"),
+        ("debugging", "toggleTraceCapture", "debug.toggleTraceCapture"),
         // ui
         ("ui", "commandPalette", "openCommandPalette"),
         ("ui", "menuAnywhere", "openMenuAnywhere"),

--- a/Sources/Nehir/Core/Config/MonitorBarSettings.swift
+++ b/Sources/Nehir/Core/Config/MonitorBarSettings.swift
@@ -13,6 +13,7 @@ struct MonitorBarSettings: MonitorSettingsType {
     var hideEmptyWorkspaces: Bool?
     var reserveLayoutSpace: Bool?
     var notchAware: Bool?
+    var showTraceButton: Bool?
     var position: WorkspaceBarPosition?
     var windowLevel: WorkspaceBarWindowLevel?
     var height: Double?
@@ -31,6 +32,7 @@ struct MonitorBarSettings: MonitorSettingsType {
         hideEmptyWorkspaces: Bool? = nil,
         reserveLayoutSpace: Bool? = nil,
         notchAware: Bool? = nil,
+        showTraceButton: Bool? = nil,
         position: WorkspaceBarPosition? = nil,
         windowLevel: WorkspaceBarWindowLevel? = nil,
         height: Double? = nil,
@@ -48,6 +50,7 @@ struct MonitorBarSettings: MonitorSettingsType {
         self.hideEmptyWorkspaces = hideEmptyWorkspaces
         self.reserveLayoutSpace = reserveLayoutSpace
         self.notchAware = notchAware
+        self.showTraceButton = showTraceButton
         self.position = position
         self.windowLevel = windowLevel
         self.height = height
@@ -58,7 +61,7 @@ struct MonitorBarSettings: MonitorSettingsType {
 
     private enum CodingKeys: String, CodingKey {
         case id, monitorName, monitorDisplayId, enabled, showLabels, showFloatingWindows, deduplicateAppIcons
-        case hideEmptyWorkspaces, reserveLayoutSpace, notchAware, position, windowLevel
+        case hideEmptyWorkspaces, reserveLayoutSpace, notchAware, showTraceButton, position, windowLevel
         case height, backgroundOpacity, xOffset, yOffset
     }
 
@@ -74,6 +77,7 @@ struct MonitorBarSettings: MonitorSettingsType {
         hideEmptyWorkspaces = try container.decodeIfPresent(Bool.self, forKey: .hideEmptyWorkspaces)
         reserveLayoutSpace = try container.decodeIfPresent(Bool.self, forKey: .reserveLayoutSpace)
         notchAware = try container.decodeIfPresent(Bool.self, forKey: .notchAware)
+        showTraceButton = try container.decodeIfPresent(Bool.self, forKey: .showTraceButton)
         position = try container.decodeIfPresent(String.self, forKey: .position)
             .flatMap { WorkspaceBarPosition(rawValue: $0) }
         windowLevel = try container.decodeIfPresent(String.self, forKey: .windowLevel)
@@ -96,6 +100,7 @@ struct MonitorBarSettings: MonitorSettingsType {
         try container.encodeIfPresent(hideEmptyWorkspaces, forKey: .hideEmptyWorkspaces)
         try container.encodeIfPresent(reserveLayoutSpace, forKey: .reserveLayoutSpace)
         try container.encodeIfPresent(notchAware, forKey: .notchAware)
+        try container.encodeIfPresent(showTraceButton, forKey: .showTraceButton)
         try container.encodeIfPresent(position?.rawValue, forKey: .position)
         try container.encodeIfPresent(windowLevel?.rawValue, forKey: .windowLevel)
         try container.encodeIfPresent(height, forKey: .height)
@@ -109,6 +114,7 @@ struct ResolvedBarSettings {
     let enabled: Bool
     let showLabels: Bool
     let showFloatingWindows: Bool
+    let showTraceButton: Bool
     let deduplicateAppIcons: Bool
     let hideEmptyWorkspaces: Bool
     let reserveLayoutSpace: Bool

--- a/Sources/Nehir/Core/Config/SettingsExport.swift
+++ b/Sources/Nehir/Core/Config/SettingsExport.swift
@@ -46,6 +46,7 @@ struct SettingsExport: Equatable {
     var workspaceBarEnabled: Bool
     var workspaceBarShowLabels: Bool
     var workspaceBarShowFloatingWindows: Bool
+    var workspaceBarShowTraceButton: Bool
     var workspaceBarWindowLevel: String
     var workspaceBarPosition: String
     var workspaceBarNotchAware: Bool
@@ -119,6 +120,7 @@ extension SettingsExport {
             workspaceBarEnabled: true,
             workspaceBarShowLabels: true,
             workspaceBarShowFloatingWindows: false,
+            workspaceBarShowTraceButton: false,
             workspaceBarWindowLevel: WorkspaceBarWindowLevel.popup.rawValue,
             workspaceBarPosition: WorkspaceBarPosition.overlappingMenuBar.rawValue,
             workspaceBarNotchAware: true,

--- a/Sources/Nehir/Core/Config/SettingsStore.swift
+++ b/Sources/Nehir/Core/Config/SettingsStore.swift
@@ -151,6 +151,10 @@ final class SettingsStore {
         didSet { scheduleSave() }
     }
 
+    var workspaceBarShowTraceButton = SettingsStore.defaultExport.workspaceBarShowTraceButton {
+        didSet { scheduleSave() }
+    }
+
     var workspaceBarWindowLevel = WorkspaceBarWindowLevel(
         rawValue: SettingsStore.defaultExport.workspaceBarWindowLevel
     ) ?? .popup {
@@ -396,6 +400,7 @@ final class SettingsStore {
             workspaceBarEnabled: workspaceBarEnabled,
             workspaceBarShowLabels: workspaceBarShowLabels,
             workspaceBarShowFloatingWindows: workspaceBarShowFloatingWindows,
+            workspaceBarShowTraceButton: workspaceBarShowTraceButton,
             workspaceBarWindowLevel: workspaceBarWindowLevel.rawValue,
             workspaceBarPosition: workspaceBarPosition.rawValue,
             workspaceBarNotchAware: workspaceBarNotchAware,
@@ -476,6 +481,7 @@ final class SettingsStore {
         workspaceBarEnabled = export.workspaceBarEnabled
         workspaceBarShowLabels = export.workspaceBarShowLabels
         workspaceBarShowFloatingWindows = export.workspaceBarShowFloatingWindows
+        workspaceBarShowTraceButton = export.workspaceBarShowTraceButton
         workspaceBarWindowLevel = WorkspaceBarWindowLevel(rawValue: export.workspaceBarWindowLevel) ?? .popup
         workspaceBarPosition = WorkspaceBarPosition(rawValue: export.workspaceBarPosition) ?? .overlappingMenuBar
         workspaceBarNotchAware = export.workspaceBarNotchAware
@@ -689,6 +695,7 @@ final class SettingsStore {
             enabled: override?.enabled ?? workspaceBarEnabled,
             showLabels: override?.showLabels ?? workspaceBarShowLabels,
             showFloatingWindows: override?.showFloatingWindows ?? workspaceBarShowFloatingWindows,
+            showTraceButton: override?.showTraceButton ?? workspaceBarShowTraceButton,
             deduplicateAppIcons: override?.deduplicateAppIcons ?? workspaceBarDeduplicateAppIcons,
             hideEmptyWorkspaces: override?.hideEmptyWorkspaces ?? workspaceBarHideEmptyWorkspaces,
             reserveLayoutSpace: override?.reserveLayoutSpace ?? workspaceBarReserveLayoutSpace,

--- a/Sources/Nehir/Core/Controller/CommandHandler.swift
+++ b/Sources/Nehir/Core/Controller/CommandHandler.swift
@@ -178,16 +178,14 @@ final class CommandHandler {
             return controller.toggleScratchpadWindow()
         case .openMenuAnywhere:
             controller.openMenuAnywhere()
-        case .dumpRuntimeState:
+        case .debugDumpRuntimeState:
             controller.dumpRuntimeState()
-        case .resetRuntimeState:
+        case .debugResetRuntimeState:
             controller.resetRuntimeState()
-        case .restartAppClearingRuntimeState:
+        case .debugRestartClearingRuntimeState:
             controller.restartAppClearingRuntimeState()
-        case .startRuntimeTraceCapture:
-            controller.startRuntimeTraceCapture()
-        case .stopRuntimeTraceCapture:
-            controller.stopRuntimeTraceCapture()
+        case .debugToggleTraceCapture:
+            return controller.toggleRuntimeTraceCapture()
         case .toggleWorkspaceBarVisibility:
             controller.toggleWorkspaceBarVisibility()
         case .toggleOverview:
@@ -200,11 +198,10 @@ final class CommandHandler {
     static func shouldIgnoreCommand(_ command: HotkeyCommand, isOverviewOpen: Bool) -> Bool {
         isOverviewOpen
             && command != .toggleOverview
-            && command != .dumpRuntimeState
-            && command != .resetRuntimeState
-            && command != .restartAppClearingRuntimeState
-            && command != .startRuntimeTraceCapture
-            && command != .stopRuntimeTraceCapture
+            && command != .debugDumpRuntimeState
+            && command != .debugResetRuntimeState
+            && command != .debugRestartClearingRuntimeState
+            && command != .debugToggleTraceCapture
     }
 
 

--- a/Sources/Nehir/Core/Controller/WMController.swift
+++ b/Sources/Nehir/Core/Controller/WMController.swift
@@ -49,6 +49,11 @@ final class WMController {
         let startRuntimeStateDump: String
     }
 
+    struct RuntimeTraceCaptureStatus: Equatable {
+        let isActive: Bool
+        let startedAt: Date?
+    }
+
     struct WorkspaceBarRefreshDebugState {
         var requestCount: Int = 0
         var scheduledCount: Int = 0
@@ -175,6 +180,17 @@ final class WMController {
     private var runtimeTraceCaptureSession: RuntimeTraceCaptureSession?
     @ObservationIgnored
     private var runtimeViewportTraceRecords: [String] = []
+
+    var runtimeTraceCaptureStatus: RuntimeTraceCaptureStatus {
+        RuntimeTraceCaptureStatus(
+            isActive: runtimeTraceCaptureSession != nil,
+            startedAt: runtimeTraceCaptureSession?.startedAt
+        )
+    }
+
+    var isRuntimeTraceCaptureActive: Bool {
+        runtimeTraceCaptureSession != nil
+    }
 
     let animationClock = AnimationClock()
     let motionPolicy: MotionPolicy
@@ -2106,13 +2122,17 @@ final class WMController {
         ].joined(separator: " ")
     }
 
-    func runtimeStateDebugDump(traceLimit: Int = 50) -> String {
+    func runtimeStateDebugDump(
+        traceLimit: Int = 50,
+        traceCaptureStatusOverride: RuntimeTraceCaptureStatus? = nil
+    ) -> String {
         let axSnapshot = axManager.windowStateDebugSnapshot()
         let refreshSnapshot = layoutRefreshController.refreshDebugSnapshot()
         let mouseTapSnapshot = mouseEventHandler.mouseTapDebugSnapshot()
         let mouseWarpSnapshot = mouseWarpHandler.mouseWarpDebugSnapshot()
         let axEventSnapshot = axEventHandler.debugCounters
         let cgsSnapshot = CGSEventObserver.shared.cgsDebugSnapshot()
+        let traceCaptureStatus = traceCaptureStatusOverride ?? runtimeTraceCaptureStatus
 
         let lines: [String] = [
             "WMController runtime state",
@@ -2120,6 +2140,7 @@ final class WMController {
             "accessibilityGranted=\(accessibilityPermissionGranted) lockScreenActive=\(isLockScreenActive) overviewOpen=\(isOverviewOpen()) startedServices=\(hasStartedServices)",
             "focusFollowsMouse=\(focusFollowsMouseEnabled) moveMouseToFocusedWindow=\(moveMouseToFocusedWindowEnabled) mouseWarpPolicyEnabled=\(isMouseWarpPolicyEnabled)",
             "isTransferringWindow=\(isTransferringWindow) hiddenAppPIDs=\(hiddenAppPIDs.count) workspaceBarHiddenMonitors=\(hiddenWorkspaceBarMonitorIds.count)",
+            "runtimeTraceCaptureActive=\(traceCaptureStatus.isActive) runtimeTraceStartedAt=\(traceCaptureStatus.startedAt?.ISO8601Format() ?? "nil") viewportTraceRecords=\(runtimeViewportTraceRecords.count)",
             "workspaceBarRefreshDebugState requestCount=\(workspaceBarRefreshDebugState.requestCount) scheduledCount=\(workspaceBarRefreshDebugState.scheduledCount) executionCount=\(workspaceBarRefreshDebugState.executionCount) isQueued=\(workspaceBarRefreshDebugState.isQueued)",
             "-- Focus Targets --",
             focusTargetDebugDump(),
@@ -2164,6 +2185,11 @@ final class WMController {
     }
 
     func resetRuntimeState() {
+        if runtimeTraceCaptureSession != nil {
+            runtimeTraceCaptureSession = nil
+            runtimeViewportTraceRecords.removeAll(keepingCapacity: true)
+            workspaceBarManager.update()
+        }
         mouseEventHandler.handleInputSuppressionBegan()
         mouseEventHandler.resetDebugStateForTests()
         mouseWarpHandler.resetDebugStateForTests()
@@ -2213,23 +2239,52 @@ final class WMController {
         NSApp.terminate(nil)
     }
 
-    func startRuntimeTraceCapture() {
-        runtimeViewportTraceRecords.removeAll(keepingCapacity: true)
-        runtimeTraceCaptureSession = RuntimeTraceCaptureSession(
-            startedAt: Date(),
-            startRuntimeStateDump: runtimeStateDebugDump(traceLimit: 0)
-        )
-        workspaceManager.resetReconcileTraceForDebug()
+    @discardableResult
+    func toggleRuntimeTraceCapture(desiredState: IPCTraceDesiredState? = nil) -> ExternalCommandResult {
+        switch desiredState {
+        case .active:
+            return isRuntimeTraceCaptureActive ? .executed : startRuntimeTraceCapture()
+        case .inactive:
+            return isRuntimeTraceCaptureActive ? stopRuntimeTraceCapture() : .executed
+        case nil:
+            return isRuntimeTraceCaptureActive ? stopRuntimeTraceCapture() : startRuntimeTraceCapture()
+        }
     }
 
-    func stopRuntimeTraceCapture() {
+    @discardableResult
+    private func startRuntimeTraceCapture() -> ExternalCommandResult {
+        guard runtimeTraceCaptureSession == nil else {
+            Self.runtimeDebugLogger.error("Start runtime trace capture requested while a capture is already active")
+            return .invalidState
+        }
+
+        runtimeViewportTraceRecords.removeAll(keepingCapacity: true)
+        let startedAt = Date()
+        let startRuntimeStateDump = runtimeStateDebugDump(
+            traceLimit: 0,
+            traceCaptureStatusOverride: RuntimeTraceCaptureStatus(isActive: true, startedAt: startedAt)
+        )
+        runtimeTraceCaptureSession = RuntimeTraceCaptureSession(
+            startedAt: startedAt,
+            startRuntimeStateDump: startRuntimeStateDump
+        )
+        workspaceManager.resetReconcileTraceForDebug()
+        workspaceBarManager.update()
+        return .executed
+    }
+
+    @discardableResult
+    private func stopRuntimeTraceCapture() -> ExternalCommandResult {
         guard let session = runtimeTraceCaptureSession else {
             Self.runtimeDebugLogger.error("Stop runtime trace capture requested without an active session")
-            return
+            return .invalidState
         }
 
         let endedAt = Date()
-        let endRuntimeStateDump = runtimeStateDebugDump(traceLimit: 0)
+        let endRuntimeStateDump = runtimeStateDebugDump(
+            traceLimit: 0,
+            traceCaptureStatusOverride: RuntimeTraceCaptureStatus(isActive: false, startedAt: nil)
+        )
         let traceDump = workspaceManager.reconcileTraceDump(limit: nil)
         let duration = endedAt.timeIntervalSince(session.startedAt)
         let fileURL = runtimeTraceCaptureFileURL(startedAt: session.startedAt, endedAt: endedAt)
@@ -2266,10 +2321,13 @@ final class WMController {
             Self.runtimeDebugLogger.info("Wrote runtime trace capture to \(fileURL.path, privacy: .public)")
         } catch {
             Self.runtimeDebugLogger.error("Failed to write runtime trace capture: \(error.localizedDescription, privacy: .public)")
+            return .internalError
         }
 
         runtimeTraceCaptureSession = nil
         runtimeViewportTraceRecords.removeAll(keepingCapacity: true)
+        workspaceBarManager.update()
+        return .executed
     }
 
     func clearManualWindowOverride(for token: WindowToken) {
@@ -2291,7 +2349,7 @@ final class WMController {
     private func runtimeTraceCaptureFileURL(startedAt: Date, endedAt: Date) -> URL {
         let baseDirectory = NehirStoragePaths.live.stateDirectory
             .appendingPathComponent("traces", isDirectory: true)
-        let filename = "runtime-trace-\(Int(startedAt.timeIntervalSince1970))-\(Int(endedAt.timeIntervalSince1970)).log"
+        let filename = "runtime-trace-\(Int(startedAt.timeIntervalSince1970 * 1000))-\(Int(endedAt.timeIntervalSince1970 * 1000)).log"
         return baseDirectory.appendingPathComponent(filename, isDirectory: false)
     }
 

--- a/Sources/Nehir/Core/Input/ActionCatalog.swift
+++ b/Sources/Nehir/Core/Input/ActionCatalog.swift
@@ -21,11 +21,15 @@ struct ActionSpec: Equatable {
         ipcCommandName.flatMap(IPCAutomationManifest.commandDescriptor(for:))
     }
 
+    var ipcDescriptors: [IPCCommandDescriptor] {
+        ipcCommandName.map(IPCAutomationManifest.commandDescriptors(for:)) ?? []
+    }
+
     var searchTerms: [String] {
         ActionCatalog.uniqueTerms(
             [title, id]
                 + keywords
-                + (ipcDescriptor.map { [$0.path] + $0.commandWords } ?? [])
+                + ipcDescriptors.flatMap { [$0.path] + $0.commandWords }
         )
     }
 }
@@ -690,39 +694,32 @@ enum ActionCatalog {
                 keywords: ["menu", "anywhere"]
             ),
             action(
-                id: "dumpRuntimeState",
-                command: .dumpRuntimeState,
-                category: .layout,
+                id: "debug.dumpRuntimeState",
+                command: .debugDumpRuntimeState,
+                category: .debugging,
                 binding: .unassigned,
                 keywords: ["debug", "runtime", "state", "dump", "clipboard", "trace"]
             ),
             action(
-                id: "resetRuntimeState",
-                command: .resetRuntimeState,
-                category: .layout,
+                id: "debug.resetRuntimeState",
+                command: .debugResetRuntimeState,
+                category: .debugging,
                 binding: .unassigned,
                 keywords: ["debug", "runtime", "state", "reset", "clear", "rebuild"]
             ),
             action(
-                id: "restartAppClearingRuntimeState",
-                command: .restartAppClearingRuntimeState,
-                category: .layout,
+                id: "debug.restartClearingRuntimeState",
+                command: .debugRestartClearingRuntimeState,
+                category: .debugging,
                 binding: .unassigned,
-                keywords: ["restart", "relaunch", "runtime", "state", "clear", "reset"]
+                keywords: ["debug", "restart", "relaunch", "runtime", "state", "clear", "reset"]
             ),
             action(
-                id: "startRuntimeTraceCapture",
-                command: .startRuntimeTraceCapture,
-                category: .layout,
+                id: "debug.toggleTraceCapture",
+                command: .debugToggleTraceCapture,
+                category: .debugging,
                 binding: KeyBinding(keyCode: UInt32(kVK_ANSI_T), modifiers: UInt32(controlKey | optionKey | cmdKey)),
-                keywords: ["trace", "tracing", "capture", "debug", "events", "start"]
-            ),
-            action(
-                id: "stopRuntimeTraceCapture",
-                command: .stopRuntimeTraceCapture,
-                category: .layout,
-                binding: KeyBinding(keyCode: UInt32(kVK_ANSI_T), modifiers: UInt32(controlKey | optionKey | shiftKey | cmdKey)),
-                keywords: ["trace", "tracing", "capture", "debug", "events", "stop", "dump", "file"]
+                keywords: ["debug", "trace", "tracing", "capture", "runtime", "events", "toggle", "start", "stop"]
             ),
             action(
                 id: "toggleWorkspaceBarVisibility",
@@ -851,11 +848,10 @@ enum ActionCatalog {
         case .assignFocusedWindowToScratchpad: "Assign Focused Window to Scratchpad"
         case .toggleScratchpadWindow: "Toggle Scratchpad Window"
         case .openMenuAnywhere: "Open Menu Anywhere"
-        case .dumpRuntimeState: "Dump Runtime State"
-        case .resetRuntimeState: "Reset Runtime State"
-        case .restartAppClearingRuntimeState: "Restart App Clearing Runtime State"
-        case .startRuntimeTraceCapture: "Start Runtime Trace Capture"
-        case .stopRuntimeTraceCapture: "Stop Runtime Trace Capture"
+        case .debugDumpRuntimeState: "Debug: Dump Runtime State"
+        case .debugResetRuntimeState: "Debug: Reset Runtime State"
+        case .debugRestartClearingRuntimeState: "Debug: Restart Clearing Runtime State"
+        case .debugToggleTraceCapture: "Debug: Toggle Trace Capture"
         case .toggleWorkspaceBarVisibility: "Toggle Workspace Bar"
         case .toggleOverview: "Toggle Overview"
         }
@@ -1003,16 +999,14 @@ enum ActionCatalog {
             .scratchpadToggle
         case .openMenuAnywhere:
             .openMenuAnywhere
-        case .dumpRuntimeState:
-            .dumpRuntimeState
-        case .resetRuntimeState:
-            .resetRuntimeState
-        case .restartAppClearingRuntimeState:
-            .restartAppClearingRuntimeState
-        case .startRuntimeTraceCapture:
-            .startRuntimeTraceCapture
-        case .stopRuntimeTraceCapture:
-            .stopRuntimeTraceCapture
+        case .debugDumpRuntimeState:
+            .debugDumpRuntimeState
+        case .debugResetRuntimeState:
+            .debugResetRuntimeState
+        case .debugRestartClearingRuntimeState:
+            .debugRestartClearingRuntimeState
+        case .debugToggleTraceCapture:
+            .debugToggleTraceCapture
         }
     }
 

--- a/Sources/Nehir/Core/Input/HotkeyBinding.swift
+++ b/Sources/Nehir/Core/Input/HotkeyBinding.swift
@@ -335,4 +335,5 @@ enum HotkeyCategory: String, CaseIterable {
     case monitor = "Monitor"
     case layout = "Layout"
     case column = "Column"
+    case debugging = "Debugging & Tracing"
 }

--- a/Sources/Nehir/Core/Input/HotkeyCommand.swift
+++ b/Sources/Nehir/Core/Input/HotkeyCommand.swift
@@ -77,11 +77,10 @@ enum HotkeyCommand: Codable, Equatable, Hashable {
 
     case openMenuAnywhere
 
-    case dumpRuntimeState
-    case resetRuntimeState
-    case restartAppClearingRuntimeState
-    case startRuntimeTraceCapture
-    case stopRuntimeTraceCapture
+    case debugDumpRuntimeState
+    case debugResetRuntimeState
+    case debugRestartClearingRuntimeState
+    case debugToggleTraceCapture
 
     case toggleWorkspaceBarVisibility
     case toggleOverview

--- a/Sources/Nehir/IPC/ExternalCommandResult.swift
+++ b/Sources/Nehir/IPC/ExternalCommandResult.swift
@@ -7,4 +7,6 @@ enum ExternalCommandResult: Equatable, Sendable, Error {
     case staleWindowId
     case notFound
     case invalidArguments
+    case invalidState
+    case internalError
 }

--- a/Sources/Nehir/IPC/IPCApplicationBridge.swift
+++ b/Sources/Nehir/IPC/IPCApplicationBridge.swift
@@ -323,6 +323,10 @@ actor IPCApplicationBridge {
             return .failure(id: id, kind: kind, code: .notFound)
         case .invalidArguments:
             return .failure(id: id, kind: kind, code: .invalidArguments)
+        case .invalidState:
+            return .failure(id: id, kind: kind, code: .invalidState)
+        case .internalError:
+            return .failure(id: id, kind: kind, code: .internalError)
         }
     }
 

--- a/Sources/Nehir/IPC/IPCCommandRouter.swift
+++ b/Sources/Nehir/IPC/IPCCommandRouter.swift
@@ -180,16 +180,14 @@ final class IPCCommandRouter {
             return toggleScratchpad()
         case .openMenuAnywhere:
             return controller.commandHandler.performCommand(.openMenuAnywhere)
-        case .dumpRuntimeState:
-            return controller.commandHandler.performCommand(.dumpRuntimeState)
-        case .resetRuntimeState:
-            return controller.commandHandler.performCommand(.resetRuntimeState)
-        case .restartAppClearingRuntimeState:
-            return controller.commandHandler.performCommand(.restartAppClearingRuntimeState)
-        case .startRuntimeTraceCapture:
-            return controller.commandHandler.performCommand(.startRuntimeTraceCapture)
-        case .stopRuntimeTraceCapture:
-            return controller.commandHandler.performCommand(.stopRuntimeTraceCapture)
+        case .debugDumpRuntimeState:
+            return controller.commandHandler.performCommand(.debugDumpRuntimeState)
+        case .debugResetRuntimeState:
+            return controller.commandHandler.performCommand(.debugResetRuntimeState)
+        case .debugRestartClearingRuntimeState:
+            return controller.commandHandler.performCommand(.debugRestartClearingRuntimeState)
+        case .debugToggleTraceCapture(let desiredState):
+            return controller.toggleRuntimeTraceCapture(desiredState: desiredState)
         }
     }
 

--- a/Sources/Nehir/UI/HotkeySettingsView.swift
+++ b/Sources/Nehir/UI/HotkeySettingsView.swift
@@ -526,6 +526,8 @@ struct HotkeySettingsView: View {
             return "Move"
         case "layout":
             return "Layout"
+        case "debugging":
+            return "Debugging & Tracing"
         case "ui":
             return "UI"
         default:

--- a/Sources/Nehir/UI/WorkspaceBar/WorkspaceBarManager.swift
+++ b/Sources/Nehir/UI/WorkspaceBar/WorkspaceBarManager.swift
@@ -224,6 +224,9 @@ final class WorkspaceBarManager {
                 },
                 onOpenCommandPalette: { [weak controller] in
                     controller?.openCommandPalette()
+                },
+                onToggleTraceCapture: { [weak controller] in
+                    controller?.toggleRuntimeTraceCapture()
                 }
             )
         )
@@ -337,6 +340,8 @@ final class WorkspaceBarManager {
             showLabels: current.showLabels,
             backgroundOpacity: current.backgroundOpacity,
             barHeight: current.barHeight,
+            showTraceCaptureButton: current.showTraceCaptureButton,
+            traceCaptureStatus: current.traceCaptureStatus,
             accentColor: resolved.accentColor,
             textColor: resolved.textColor
         )
@@ -408,6 +413,8 @@ final class WorkspaceBarManager {
             showLabels: resolved.showLabels,
             backgroundOpacity: resolved.backgroundOpacity,
             barHeight: geometry.barHeight,
+            showTraceCaptureButton: resolved.showTraceButton,
+            traceCaptureStatus: controller?.runtimeTraceCaptureStatus ?? .init(isActive: false, startedAt: nil),
             accentColor: resolved.accentColor,
             textColor: resolved.textColor
         )

--- a/Sources/Nehir/UI/WorkspaceBar/WorkspaceBarView.swift
+++ b/Sources/Nehir/UI/WorkspaceBar/WorkspaceBarView.swift
@@ -64,6 +64,8 @@ struct WorkspaceBarSnapshot: Equatable {
     let showLabels: Bool
     let backgroundOpacity: Double
     let barHeight: CGFloat
+    let showTraceCaptureButton: Bool
+    let traceCaptureStatus: WMController.RuntimeTraceCaptureStatus
     let accentColor: SettingsColor?
     let textColor: SettingsColor?
 
@@ -93,6 +95,7 @@ struct WorkspaceBarView: View {
     let onFocusWindow: (WindowToken) -> Void
     let onActivateScratchpad: () -> Void
     let onOpenCommandPalette: () -> Void
+    let onToggleTraceCapture: () -> Void
 
     var body: some View {
         WorkspaceBarContentView(
@@ -101,7 +104,8 @@ struct WorkspaceBarView: View {
             onFocusWorkspace: onFocusWorkspace,
             onFocusWindow: onFocusWindow,
             onActivateScratchpad: onActivateScratchpad,
-            onOpenCommandPalette: onOpenCommandPalette
+            onOpenCommandPalette: onOpenCommandPalette,
+            onToggleTraceCapture: onToggleTraceCapture
         )
     }
 }
@@ -117,7 +121,8 @@ struct WorkspaceBarMeasurementView: View {
             onFocusWorkspace: { _ in },
             onFocusWindow: { _ in },
             onActivateScratchpad: {},
-            onOpenCommandPalette: {}
+            onOpenCommandPalette: {},
+            onToggleTraceCapture: {}
         )
         .fixedSize(horizontal: true, vertical: false)
     }
@@ -131,6 +136,7 @@ private struct WorkspaceBarContentView: View {
     let onFocusWindow: (WindowToken) -> Void
     let onActivateScratchpad: () -> Void
     let onOpenCommandPalette: () -> Void
+    let onToggleTraceCapture: () -> Void
 
     @Environment(\.accessibilityReduceMotion) private var accessibilityReduceMotion
     @Environment(\.accessibilityReduceTransparency) private var accessibilityReduceTransparency
@@ -198,6 +204,18 @@ private struct WorkspaceBarContentView: View {
                     accentColor: accentColor,
                     textColor: textColor,
                     onActivateScratchpad: onActivateScratchpad
+                )
+            }
+
+            if snapshot.showTraceCaptureButton {
+                TraceCaptureBarButton(
+                    isActive: snapshot.traceCaptureStatus.isActive,
+                    startedAt: snapshot.traceCaptureStatus.startedAt,
+                    iconSize: iconSize,
+                    itemHeight: itemHeight,
+                    accentColor: accentColor,
+                    textColor: textColor,
+                    onToggleTraceCapture: onToggleTraceCapture
                 )
             }
 
@@ -655,6 +673,67 @@ private struct WindowCountBadge: View {
             )
             .frame(minWidth: max(12, iconSize * 0.55), minHeight: max(12, iconSize * 0.55))
             .accessibilityHidden(true)
+    }
+}
+
+@MainActor
+private struct TraceCaptureBarButton: View {
+    let isActive: Bool
+    let startedAt: Date?
+    let iconSize: CGFloat
+    let itemHeight: CGFloat
+    let accentColor: Color?
+    let textColor: Color?
+    let onToggleTraceCapture: () -> Void
+
+    @State private var isHovered = false
+
+    private var resolvedIconColor: Color {
+        isActive ? .red : (textColor ?? .secondary)
+    }
+
+    private var symbolName: String {
+        isActive ? "record.circle.fill" : "record.circle"
+    }
+
+    private var accessibilityText: String {
+        isActive ? "Debug: Stop Trace Capture" : "Debug: Start Trace Capture"
+    }
+
+    private var helpText: String {
+        guard isActive else { return "Debug: Start Trace Capture" }
+        guard let startedAt else { return "Debug: Stop Trace Capture" }
+        let time = DateFormatter.localizedString(from: startedAt, dateStyle: .none, timeStyle: .medium)
+        return "Debug: Stop Trace Capture (started at \(time))"
+    }
+
+    var body: some View {
+        Button(action: onToggleTraceCapture) {
+            Image(systemName: symbolName)
+                .font(.system(size: max(10, iconSize * 0.7), weight: isActive ? .semibold : .medium))
+                .foregroundStyle(resolvedIconColor)
+                .frame(width: itemHeight, height: itemHeight)
+                .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .scaleEffect(isHovered ? 1.03 : 1.0)
+        .background {
+            if isHovered || isActive {
+                RoundedRectangle(cornerRadius: 6, style: .continuous)
+                    .fill(isActive ? Color.red.opacity(0.16) : Color.clear)
+                    .background {
+                        if isHovered {
+                            RoundedRectangle(cornerRadius: 6, style: .continuous)
+                                .fill(.regularMaterial)
+                        }
+                    }
+            }
+        }
+        .onHover { hovering in
+            isHovered = hovering
+        }
+        .accessibilityLabel(accessibilityText)
+        .help(helpText)
     }
 }
 

--- a/Sources/Nehir/UI/WorkspaceBarSettingsTab.swift
+++ b/Sources/Nehir/UI/WorkspaceBarSettingsTab.swift
@@ -65,6 +65,12 @@ private struct GlobalBarSettingsSection: View {
                         controller.updateWorkspaceBarSettings()
                     }
 
+                Toggle("Show Trace Capture Button", isOn: $settings.workspaceBarShowTraceButton)
+                    .onChange(of: settings.workspaceBarShowTraceButton) { _, _ in
+                        controller.updateWorkspaceBarSettings()
+                    }
+                    .help("Adds a workspace bar button that starts or stops runtime trace capture for debugging reports.")
+
                 Toggle("Deduplicate App Icons", isOn: $settings.workspaceBarDeduplicateAppIcons)
                     .onChange(of: settings.workspaceBarDeduplicateAppIcons) { _, _ in
                         controller.updateWorkspaceBarSettings()
@@ -326,6 +332,15 @@ private struct MonitorBarSettingsSection: View {
                 onReset: { updateSetting { $0.notchAware = nil } }
             )
             .help("Shift bar to the right of the notch on MacBook Pro")
+
+            OverridableToggle(
+                label: "Show Trace Capture Button",
+                value: ms.showTraceButton,
+                globalValue: settings.workspaceBarShowTraceButton,
+                onChange: { newValue in updateSetting { $0.showTraceButton = newValue } },
+                onReset: { updateSetting { $0.showTraceButton = nil } }
+            )
+            .help("Show a trace capture toggle button in the workspace bar")
         }
 
         Section("Position & Level") {

--- a/Sources/NehirCtl/CLICompletionGenerator.swift
+++ b/Sources/NehirCtl/CLICompletionGenerator.swift
@@ -50,28 +50,14 @@ enum CLICompletionGenerator {
               fi
               ;;
             command)
-              local first="${words[3]}"
-              local second="${words[4]}"
-              if (( CURRENT == 3 )); then
-                suggestions="\(shellWords(commandFirstWords))"
-              elif (( CURRENT == 4 )); then
-                case "$first" in
-                  \(renderZshCase(map: commandSlotThreeSuggestionsByFirst))
-                esac
-              elif (( CURRENT == 5 )); then
-                case "$first $second" in
-                  \(renderZshCase(map: commandSlotFourSuggestionsByPath))
-                  *)
-                    case "$first" in
-                      \(renderZshCase(map: commandSlotFourFallbackByFirst))
-                    esac
-                    ;;
-                esac
-              elif (( CURRENT == 6 )); then
-                case "$first $second" in
-                  \(renderZshCase(map: commandSlotFiveSuggestionsByPath))
-                esac
-              fi
+              local command_prefix=""
+              local i
+              for (( i = 3; i < CURRENT; i++ )); do
+                command_prefix="${command_prefix:+$command_prefix }${words[i]}"
+              done
+              case "$command_prefix" in
+                \(renderZshCase(map: commandSuggestionsByPrefix))
+              esac
               ;;
             rule)
               if (( CURRENT == 3 )); then
@@ -157,38 +143,16 @@ enum CLICompletionGenerator {
               return 0
               ;;
             command)
-              first="${COMP_WORDS[2]}"
-              second="${COMP_WORDS[3]}"
-              if [[ ${COMP_CWORD} -eq 2 ]]; then
-                __nehirctl_compgen "\(shellWords(commandFirstWords))"
-                return 0
-              elif [[ ${COMP_CWORD} -eq 3 ]]; then
-                suggestions=""
-                case "$first" in
-                  \(renderBashCase(map: commandSlotThreeSuggestionsByFirst))
-                esac
-                __nehirctl_compgen "$suggestions"
-                return 0
-              elif [[ ${COMP_CWORD} -eq 4 ]]; then
-                suggestions=""
-                case "$first $second" in
-                  \(renderBashCase(map: commandSlotFourSuggestionsByPath))
-                  *)
-                    case "$first" in
-                      \(renderBashCase(map: commandSlotFourFallbackByFirst))
-                    esac
-                    ;;
-                esac
-                __nehirctl_compgen "$suggestions"
-                return 0
-              elif [[ ${COMP_CWORD} -eq 5 ]]; then
-                suggestions=""
-                case "$first $second" in
-                  \(renderBashCase(map: commandSlotFiveSuggestionsByPath))
-                esac
-                __nehirctl_compgen "$suggestions"
-                return 0
-              fi
+              local command_prefix="" i
+              for (( i = 2; i < COMP_CWORD; i++ )); do
+                command_prefix="${command_prefix:+$command_prefix }${COMP_WORDS[i]}"
+              done
+              suggestions=""
+              case "$command_prefix" in
+                \(renderBashCase(map: commandSuggestionsByPrefix))
+              esac
+              __nehirctl_compgen "$suggestions"
+              return 0
               ;;
             rule)
               if [[ ${COMP_CWORD} -eq 2 ]]; then
@@ -263,31 +227,9 @@ enum CLICompletionGenerator {
                 "complete -c nehirctl -f -n '__fish_seen_subcommand_from query; and __fish_seen_subcommand_from \(queryName); and __nehirctl_prev_arg_is --fields' -a '\(field)'"
             }
         }
-        let commandRootLines = commandFirstWords.map { word in
-            "complete -c nehirctl -f -n '__fish_seen_subcommand_from command' -a '\(word)'"
-        }
-        let commandNestedLines = commandSlotThreeSuggestionsByFirst.flatMap { first, suggestions in
+        let commandCompletionLines = commandSuggestionsByPrefix.flatMap { prefix, suggestions in
             suggestions.map { suggestion in
-                "complete -c nehirctl -f -n '__fish_seen_subcommand_from command; and __fish_seen_subcommand_from \(first)' -a '\(suggestion)'"
-            }
-        }
-        let commandPathArgumentLines = commandSlotFourSuggestionsByPath.flatMap { path, suggestions in
-            let pathWords = path.split(separator: " ").map(String.init)
-            guard pathWords.count == 2 else { return [String]() }
-            return suggestions.map { suggestion in
-                "complete -c nehirctl -f -n '__fish_seen_subcommand_from command; and __fish_seen_subcommand_from \(pathWords[0]); and __fish_seen_subcommand_from \(pathWords[1])' -a '\(suggestion)'"
-            }
-        }
-        let commandFallbackLines = commandSlotFourFallbackByFirst.flatMap { first, suggestions in
-            suggestions.map { suggestion in
-                "complete -c nehirctl -f -n '__fish_seen_subcommand_from command; and __fish_seen_subcommand_from \(first)' -a '\(suggestion)'"
-            }
-        }
-        let commandSecondArgumentLines = commandSlotFiveSuggestionsByPath.flatMap { path, suggestions in
-            let pathWords = path.split(separator: " ").map(String.init)
-            guard pathWords.count == 2 else { return [String]() }
-            return suggestions.map { suggestion in
-                "complete -c nehirctl -f -n '__fish_seen_subcommand_from command; and __fish_seen_subcommand_from \(pathWords[0]); and __fish_seen_subcommand_from \(pathWords[1])' -a '\(suggestion)'"
+                "complete -c nehirctl -f -n '\(fishCommandCondition(for: prefix))' -a '\(suggestion)'"
             }
         }
         let ruleLines = ruleActionNames.map { action in
@@ -324,11 +266,7 @@ enum CLICompletionGenerator {
                 + queryLines
                 + queryFlagLines.sorted()
                 + queryFieldLines.sorted()
-                + commandRootLines
-                + commandNestedLines.sorted()
-                + commandPathArgumentLines.sorted()
-                + commandFallbackLines.sorted()
-                + commandSecondArgumentLines.sorted()
+                + commandCompletionLines.sorted()
                 + ruleLines
                 + ruleDefinitionLines
                 + ruleApplyLines
@@ -385,64 +323,27 @@ enum CLICompletionGenerator {
         IPCAutomationManifest.windowActionDescriptors.map(\.name.rawValue)
     }
 
-    private static var commandFirstWords: [String] {
-        sortedUnique(IPCAutomationManifest.commandDescriptors.compactMap { $0.commandWords.first })
-    }
-
-    private static var commandSlotThreeSuggestionsByFirst: [String: [String]] {
+    private static var commandSuggestionsByPrefix: [String: [String]] {
         var map: [String: Set<String>] = [:]
 
         for descriptor in IPCAutomationManifest.commandDescriptors {
-            guard let first = descriptor.commandWords.first else { continue }
-            if descriptor.commandWords.count > 1 {
-                map[first, default: []].insert(descriptor.commandWords[1])
+            for index in descriptor.commandWords.indices {
+                let prefix = pathKey(Array(descriptor.commandWords.prefix(index)))
+                map[prefix, default: []].insert(descriptor.commandWords[index])
             }
+
             if let literals = literalValues(for: descriptor.arguments.first?.kind) {
-                map[first, default: []].formUnion(literals)
+                map[pathKey(descriptor.commandWords), default: []].formUnion(literals)
             }
         }
 
         return map.mapValues { Array($0).sorted() }
     }
 
-    private static var commandSlotFourSuggestionsByPath: [String: [String]] {
-        commandArgumentSuggestionsByPath(argumentIndex: 0, commandWordCount: 2)
-    }
-
-    private static var commandSlotFourFallbackByFirst: [String: [String]] {
-        var map: [String: Set<String>] = [:]
-        for descriptor in IPCAutomationManifest.commandDescriptors where descriptor.commandWords.count == 1 {
-            guard descriptor.arguments.count > 1,
-                  let literals = literalValues(for: descriptor.arguments[1].kind),
-                  let first = descriptor.commandWords.first
-            else {
-                continue
-            }
-            map[first, default: []].formUnion(literals)
-        }
-        return map.mapValues { Array($0).sorted() }
-    }
-
-    private static var commandSlotFiveSuggestionsByPath: [String: [String]] {
-        commandArgumentSuggestionsByPath(argumentIndex: 1, commandWordCount: 2)
-    }
-
-    private static func commandArgumentSuggestionsByPath(
-        argumentIndex: Int,
-        commandWordCount: Int
-    ) -> [String: [String]] {
-        var map: [String: Set<String>] = [:]
-        for descriptor in IPCAutomationManifest.commandDescriptors
-            where descriptor.commandWords.count == commandWordCount
-        {
-            guard descriptor.arguments.count > argumentIndex,
-                  let literals = literalValues(for: descriptor.arguments[argumentIndex].kind)
-            else {
-                continue
-            }
-            map[pathKey(descriptor.commandWords), default: []].formUnion(literals)
-        }
-        return map.mapValues { Array($0).sorted() }
+    private static func fishCommandCondition(for prefix: String) -> String {
+        let prefixWords = prefix.split(separator: " ").map(String.init)
+        return (["__fish_seen_subcommand_from command"] + prefixWords.map { "__fish_seen_subcommand_from \($0)" })
+            .joined(separator: "; and ")
     }
 
     private static var queryFlagsByName: [String: [String]] {
@@ -478,6 +379,8 @@ enum CLICompletionGenerator {
              .windowIndex,
              .sizeChange:
             return nil
+        case .traceDesiredState:
+            return ["active", "inactive"]
         }
     }
 

--- a/Sources/NehirCtl/CLIParser.swift
+++ b/Sources/NehirCtl/CLIParser.swift
@@ -690,7 +690,16 @@ enum CLIParser {
             return .resizeOperation(try parseResizeOperation(token))
         case .sizeChange:
             return .sizeChange(try parseSizeChange(token))
+        case .traceDesiredState:
+            return .traceDesiredState(try parseTraceDesiredState(token))
         }
+    }
+
+    private static func parseTraceDesiredState(_ rawValue: String) throws -> IPCTraceDesiredState {
+        guard let state = IPCTraceDesiredState(rawValue: rawValue) else {
+            throw CLIParseError.usage(usageText)
+        }
+        return state
     }
 
     static let usageText: String = {

--- a/Sources/NehirCtl/CLIRenderer.swift
+++ b/Sources/NehirCtl/CLIRenderer.swift
@@ -78,6 +78,7 @@ enum CLIRenderer {
              .staleWindowId,
              .notFound,
              .invalidArguments,
+             .invalidState,
              .invalidRequest,
              .none:
             return .rejected

--- a/Sources/NehirIPC/IPCAutomationManifest.swift
+++ b/Sources/NehirIPC/IPCAutomationManifest.swift
@@ -43,6 +43,7 @@ public enum IPCCommandArgumentKind: String, Codable, CaseIterable, Equatable, Se
     case windowIndex = "window-index"
     case resizeOperation = "resize-operation"
     case sizeChange = "size-change"
+    case traceDesiredState = "trace-desired-state"
 
     public var usagePlaceholder: String {
         switch self {
@@ -56,6 +57,8 @@ public enum IPCCommandArgumentKind: String, Codable, CaseIterable, Equatable, Se
             "<grow|shrink>"
         case .sizeChange:
             "<size-change>"
+        case .traceDesiredState:
+            "<active|inactive>"
         }
     }
 }
@@ -250,6 +253,10 @@ public enum IPCAutomationManifest {
     private static let sizeChangeArgument = IPCCommandArgumentDescriptor(
         kind: .sizeChange,
         summary: "Size change such as 100, 50%, +10, or -10%."
+    )
+    private static let traceDesiredStateArgument = IPCCommandArgumentDescriptor(
+        kind: .traceDesiredState,
+        summary: "Desired trace capture state: \"active\" or \"inactive\"."
     )
 
     private static func command(
@@ -726,11 +733,11 @@ public enum IPCAutomationManifest {
         ),
         command(["scratchpad", "toggle"], name: .scratchpadToggle, summary: "Show or hide the scratchpad window."),
         command(["open-menu-anywhere"], name: .openMenuAnywhere, summary: "Open the menu surface anywhere."),
-        command(["dump-runtime-state"], name: .dumpRuntimeState, summary: "Dump runtime state to the clipboard and unified log."),
-        command(["reset-runtime-state"], name: .resetRuntimeState, summary: "Clear runtime state and rebootstrap from a startup-style rescan."),
-        command(["restart-app-clearing-runtime-state"], name: .restartAppClearingRuntimeState, summary: "Clear runtime state, relaunch the app, and exit the current process."),
-        command(["start-runtime-trace-capture"], name: .startRuntimeTraceCapture, summary: "Begin capturing internal runtime trace events for later export."),
-        command(["stop-runtime-trace-capture"], name: .stopRuntimeTraceCapture, summary: "Write the captured runtime trace bundle to disk and copy the file path to the clipboard."),
+        command(["debug", "dump-runtime-state"], name: .debugDumpRuntimeState, summary: "Dump runtime debugging state to the clipboard and unified log."),
+        command(["debug", "reset-runtime-state"], name: .debugResetRuntimeState, summary: "Clear runtime debugging state and rebootstrap from a startup-style rescan."),
+        command(["debug", "restart-clearing-runtime-state"], name: .debugRestartClearingRuntimeState, summary: "Clear runtime debugging state, relaunch the app, and exit the current process."),
+        command(["debug", "trace", "toggle"], name: .debugToggleTraceCapture, summary: "Start runtime debugging trace capture, or stop and export the active capture."),
+        command(["debug", "trace", "toggle"], name: .debugToggleTraceCapture, summary: "Ensure trace capture is in the desired state (idempotent).", arguments: [traceDesiredStateArgument]),
         command(
             ["toggle-workspace-bar"],
             name: .toggleWorkspaceBar,
@@ -919,8 +926,12 @@ public enum IPCAutomationManifest {
         queryDescriptors.first { $0.name == name }
     }
 
+    public static func commandDescriptors(for name: IPCCommandName) -> [IPCCommandDescriptor] {
+        commandDescriptors.filter { $0.name == name }
+    }
+
     public static func commandDescriptor(for name: IPCCommandName) -> IPCCommandDescriptor? {
-        commandDescriptors.first { $0.name == name }
+        commandDescriptors(for: name).first
     }
 
     public static func ruleActionDescriptor(for name: IPCRuleActionName) -> IPCRuleActionDescriptor? {

--- a/Sources/NehirIPC/IPCModels.swift
+++ b/Sources/NehirIPC/IPCModels.swift
@@ -63,6 +63,7 @@ public enum IPCResponseStatus: String, Codable, Equatable, Sendable {
 public enum IPCErrorCode: String, Codable, Equatable, Sendable, Error {
     case invalidRequest = "invalid_request"
     case invalidArguments = "invalid_arguments"
+    case invalidState = "invalid_state"
     case protocolMismatch = "protocol_mismatch"
     case disabled = "ignored_disabled"
     case overviewOpen = "ignored_overview"
@@ -276,11 +277,10 @@ public enum IPCCommandName: String, Codable, CaseIterable, Equatable, Sendable {
     case scratchpadAssign = "scratchpad-assign"
     case scratchpadToggle = "scratchpad-toggle"
     case openMenuAnywhere = "open-menu-anywhere"
-    case dumpRuntimeState = "dump-runtime-state"
-    case resetRuntimeState = "reset-runtime-state"
-    case restartAppClearingRuntimeState = "restart-app-clearing-runtime-state"
-    case startRuntimeTraceCapture = "start-runtime-trace-capture"
-    case stopRuntimeTraceCapture = "stop-runtime-trace-capture"
+    case debugDumpRuntimeState = "debug-dump-runtime-state"
+    case debugResetRuntimeState = "debug-reset-runtime-state"
+    case debugRestartClearingRuntimeState = "debug-restart-clearing-runtime-state"
+    case debugToggleTraceCapture = "debug-toggle-trace-capture"
 }
 
 public enum IPCSizeChangeKind: String, Codable, Equatable, Sendable {
@@ -316,11 +316,17 @@ public struct IPCSizeChange: Codable, Equatable, Sendable {
     }
 }
 
+public enum IPCTraceDesiredState: String, Codable, Equatable, Sendable {
+    case active
+    case inactive
+}
+
 public enum IPCCommandArgumentValue: Equatable, Sendable {
     case direction(IPCDirection)
     case integer(Int)
     case resizeOperation(IPCResizeOperation)
     case sizeChange(IPCSizeChange)
+    case traceDesiredState(IPCTraceDesiredState)
 }
 
 public enum IPCCommandRequestConstructionError: Error, Equatable, Sendable {
@@ -399,11 +405,10 @@ public enum IPCCommandRequest: Equatable, Sendable {
     case scratchpadAssign
     case scratchpadToggle
     case openMenuAnywhere
-    case dumpRuntimeState
-    case resetRuntimeState
-    case restartAppClearingRuntimeState
-    case startRuntimeTraceCapture
-    case stopRuntimeTraceCapture
+    case debugDumpRuntimeState
+    case debugResetRuntimeState
+    case debugRestartClearingRuntimeState
+    case debugToggleTraceCapture(desiredState: IPCTraceDesiredState?)
 
     public var name: IPCCommandName {
         switch self {
@@ -547,16 +552,14 @@ public enum IPCCommandRequest: Equatable, Sendable {
             .scratchpadToggle
         case .openMenuAnywhere:
             .openMenuAnywhere
-        case .dumpRuntimeState:
-            .dumpRuntimeState
-        case .resetRuntimeState:
-            .resetRuntimeState
-        case .restartAppClearingRuntimeState:
-            .restartAppClearingRuntimeState
-        case .startRuntimeTraceCapture:
-            .startRuntimeTraceCapture
-        case .stopRuntimeTraceCapture:
-            .stopRuntimeTraceCapture
+        case .debugDumpRuntimeState:
+            .debugDumpRuntimeState
+        case .debugResetRuntimeState:
+            .debugResetRuntimeState
+        case .debugRestartClearingRuntimeState:
+            .debugRestartClearingRuntimeState
+        case .debugToggleTraceCapture:
+            .debugToggleTraceCapture
         }
     }
 
@@ -809,21 +812,23 @@ public enum IPCCommandRequest: Equatable, Sendable {
         case .openMenuAnywhere:
             try requireNoArguments()
             self = .openMenuAnywhere
-        case .dumpRuntimeState:
+        case .debugDumpRuntimeState:
             try requireNoArguments()
-            self = .dumpRuntimeState
-        case .resetRuntimeState:
+            self = .debugDumpRuntimeState
+        case .debugResetRuntimeState:
             try requireNoArguments()
-            self = .resetRuntimeState
-        case .restartAppClearingRuntimeState:
+            self = .debugResetRuntimeState
+        case .debugRestartClearingRuntimeState:
             try requireNoArguments()
-            self = .restartAppClearingRuntimeState
-        case .startRuntimeTraceCapture:
-            try requireNoArguments()
-            self = .startRuntimeTraceCapture
-        case .stopRuntimeTraceCapture:
-            try requireNoArguments()
-            self = .stopRuntimeTraceCapture
+            self = .debugRestartClearingRuntimeState
+        case .debugToggleTraceCapture:
+            if argumentValues.isEmpty {
+                self = .debugToggleTraceCapture(desiredState: nil)
+            } else if argumentValues.count == 1, case let .traceDesiredState(state) = argumentValues[0] {
+                self = .debugToggleTraceCapture(desiredState: state)
+            } else {
+                throw IPCCommandRequestConstructionError.invalidArgumentType
+            }
         }
     }
 }
@@ -863,6 +868,10 @@ extension IPCCommandRequest: Codable {
 
     private struct IPCSizeChangeArguments: Codable, Equatable, Sendable {
         let change: IPCSizeChange
+    }
+
+    private struct IPCTraceDesiredStateArguments: Codable, Equatable, Sendable {
+        let desiredState: IPCTraceDesiredState
     }
 
     public init(from decoder: Decoder) throws {
@@ -1025,16 +1034,19 @@ extension IPCCommandRequest: Codable {
             self = .scratchpadToggle
         case .openMenuAnywhere:
             self = .openMenuAnywhere
-        case .dumpRuntimeState:
-            self = .dumpRuntimeState
-        case .resetRuntimeState:
-            self = .resetRuntimeState
-        case .restartAppClearingRuntimeState:
-            self = .restartAppClearingRuntimeState
-        case .startRuntimeTraceCapture:
-            self = .startRuntimeTraceCapture
-        case .stopRuntimeTraceCapture:
-            self = .stopRuntimeTraceCapture
+        case .debugDumpRuntimeState:
+            self = .debugDumpRuntimeState
+        case .debugResetRuntimeState:
+            self = .debugResetRuntimeState
+        case .debugRestartClearingRuntimeState:
+            self = .debugRestartClearingRuntimeState
+        case .debugToggleTraceCapture:
+            if container.contains(.arguments) {
+                let arguments = try container.decode(IPCTraceDesiredStateArguments.self, forKey: .arguments)
+                self = .debugToggleTraceCapture(desiredState: arguments.desiredState)
+            } else {
+                self = .debugToggleTraceCapture(desiredState: nil)
+            }
         }
     }
 
@@ -1186,16 +1198,16 @@ extension IPCCommandRequest: Codable {
             break
         case .openMenuAnywhere:
             break
-        case .dumpRuntimeState:
+        case .debugDumpRuntimeState:
             break
-        case .resetRuntimeState:
+        case .debugResetRuntimeState:
             break
-        case .restartAppClearingRuntimeState:
+        case .debugRestartClearingRuntimeState:
             break
-        case .startRuntimeTraceCapture:
-            break
-        case .stopRuntimeTraceCapture:
-            break
+        case let .debugToggleTraceCapture(desiredState):
+            if let desiredState {
+                try container.encode(IPCTraceDesiredStateArguments(desiredState: desiredState), forKey: .arguments)
+            }
         }
     }
 }

--- a/Tests/NehirTests/CLIParserTests.swift
+++ b/Tests/NehirTests/CLIParserTests.swift
@@ -17,6 +17,8 @@ private func representativeCommandToken(for kind: IPCCommandArgumentKind) -> Str
         "grow"
     case .sizeChange:
         "+10%"
+    case .traceDesiredState:
+        "active"
     }
 }
 
@@ -34,6 +36,8 @@ private func representativeCommandValue(for kind: IPCCommandArgumentKind) -> IPC
         .resizeOperation(.grow)
     case .sizeChange:
         .sizeChange(.adjustProportion(10))
+    case .traceDesiredState:
+        .traceDesiredState(.active)
     }
 }
 

--- a/Tests/NehirTests/CommandHandlerTests.swift
+++ b/Tests/NehirTests/CommandHandlerTests.swift
@@ -7,6 +7,35 @@ import Testing
         #expect(HotkeyCommand.openCommandPalette.displayName == "Toggle Command Palette")
     }
 
+    @Test func debugTraceToggleIsStateful() {
+        let controller = makeLayoutPlanTestController()
+        defer {
+            if controller.isRuntimeTraceCaptureActive {
+                _ = controller.toggleRuntimeTraceCapture(desiredState: .inactive)
+            }
+            resetSharedControllerStateForTests()
+        }
+
+        // toggle with no desiredState flips state
+        #expect(!controller.isRuntimeTraceCaptureActive)
+        #expect(controller.toggleRuntimeTraceCapture() == .executed)
+        #expect(controller.isRuntimeTraceCaptureActive)
+        #expect(controller.toggleRuntimeTraceCapture() == .executed)
+        #expect(!controller.isRuntimeTraceCaptureActive)
+
+        // desiredState .active is idempotent
+        #expect(controller.toggleRuntimeTraceCapture(desiredState: .active) == .executed)
+        #expect(controller.isRuntimeTraceCaptureActive)
+        #expect(controller.toggleRuntimeTraceCapture(desiredState: .active) == .executed)
+        #expect(controller.isRuntimeTraceCaptureActive)
+
+        // desiredState .inactive is idempotent
+        #expect(controller.toggleRuntimeTraceCapture(desiredState: .inactive) == .executed)
+        #expect(!controller.isRuntimeTraceCaptureActive)
+        #expect(controller.toggleRuntimeTraceCapture(desiredState: .inactive) == .executed)
+        #expect(!controller.isRuntimeTraceCaptureActive)
+    }
+
     @Test func overviewIgnoresNonOverviewHotkeys() {
         #expect(CommandHandler.shouldIgnoreCommand(.switchWorkspace(1), isOverviewOpen: true) == true)
         #expect(CommandHandler.shouldIgnoreCommand(.move(.left), isOverviewOpen: true) == true)
@@ -76,8 +105,17 @@ import Testing
         }
     }
 
-    @Test func overviewStillAllowsOverviewToggleHotkey() {
+    @Test func overviewStillAllowsOverviewAndDebuggingHotkeys() {
         #expect(CommandHandler.shouldIgnoreCommand(.toggleOverview, isOverviewOpen: true) == false)
         #expect(CommandHandler.shouldIgnoreCommand(.toggleOverview, isOverviewOpen: false) == false)
+
+        for command in [
+            HotkeyCommand.debugDumpRuntimeState,
+            .debugResetRuntimeState,
+            .debugRestartClearingRuntimeState,
+            .debugToggleTraceCapture,
+        ] {
+            #expect(CommandHandler.shouldIgnoreCommand(command, isOverviewOpen: true) == false)
+        }
     }
 }

--- a/Tests/NehirTests/Fixtures/canonical-settings.toml
+++ b/Tests/NehirTests/Fixtures/canonical-settings.toml
@@ -72,6 +72,7 @@ position = "overlappingMenuBar"
 reserveLayoutSpace = false
 showFloatingWindows = false
 showLabels = true
+showTraceButton = false
 windowLevel = "popup"
 xOffset = 0.0
 yOffset = 0.0

--- a/Tests/NehirTests/IPCModelsTests.swift
+++ b/Tests/NehirTests/IPCModelsTests.swift
@@ -385,6 +385,15 @@ private func assertRoundTrip<T: Codable & Equatable>(_ value: T) throws {
             IPCCommandRequest.setColumnWidth(change: .adjustProportion(-10))
         )
         try assertRoundTrip(
+            IPCCommandRequest.debugToggleTraceCapture(desiredState: nil)
+        )
+        try assertRoundTrip(
+            IPCCommandRequest.debugToggleTraceCapture(desiredState: .active)
+        )
+        try assertRoundTrip(
+            IPCCommandRequest.debugToggleTraceCapture(desiredState: .inactive)
+        )
+        try assertRoundTrip(
             IPCSizeChange.setFixed(600)
         )
         try assertRoundTrip(
@@ -395,6 +404,15 @@ private func assertRoundTrip<T: Codable & Equatable>(_ value: T) throws {
                 result: IPCResult(version: IPCVersionResult(protocolVersion: 3, appVersion: "1.2.3"))
             )
         )
+    }
+
+    @Test func debugTraceToggleRejectsInvalidDesiredState() {
+        let json = #"{"name":"debug-toggle-trace-capture","arguments":{"desiredState":"invalid"}}"#
+        let data = Data(json.utf8)
+
+        #expect(throws: (any Error).self) {
+            try IPCWire.makeDecoder().decode(IPCCommandRequest.self, from: data)
+        }
     }
 
     @Test func manifestIncludesFocusedMonitorSurface() {
@@ -436,7 +454,15 @@ private func assertRoundTrip<T: Codable & Equatable>(_ value: T) throws {
         let descriptorNames = Set(IPCAutomationManifest.commandDescriptors.map(\.name))
 
         #expect(descriptorNames == Set(IPCCommandName.allCases))
-        #expect(IPCAutomationManifest.commandDescriptors.count == IPCCommandName.allCases.count)
+    }
+
+    @Test func commandDescriptorLookupCanExposeMultipleFormsForSameCommandName() {
+        let descriptors = IPCAutomationManifest.commandDescriptors(for: .debugToggleTraceCapture)
+
+        #expect(descriptors.map(\.path) == [
+            "command debug trace toggle",
+            "command debug trace toggle <active|inactive>",
+        ])
     }
 
     @Test func queryDescriptorsCoverEveryPublicQueryName() {

--- a/docs/IPC-CLI.md
+++ b/docs/IPC-CLI.md
@@ -28,7 +28,7 @@ This document covers the Nehir automation surface. For the docs hub, see [Docume
   - [Layout & Sizing](#layout--sizing)
   - [Window Management](#window-management)
   - [UI Toggles](#ui-toggles)
-  - [Runtime Debugging](#runtime-debugging)
+  - [Debugging & Tracing](#debugging--tracing)
 - [Queries](#queries)
   - [Query Selectors](#query-selectors)
   - [Query Fields](#query-fields)
@@ -349,22 +349,25 @@ Workspace IDs are positive numeric strings. Direct hotkeys stay limited to `1-9`
 | `command toggle-workspace-bar` | — | command | Toggle workspace bar visibility |
 | `command toggle-overview` | — | command | Toggle the overview surface |
 
-### Runtime Debugging
+### Debugging & Tracing
+
+These commands are exposed consistently through IPC/CLI, the command palette, and hotkey handling. In the command palette and shortcut settings they appear in the **Debugging & Tracing** category.
 
 | Command | Arguments | Surface | Description |
 |---------|-----------|---------|-------------|
-| `command dump-runtime-state` | — | command | Dump runtime state to the clipboard and unified log |
-| `command reset-runtime-state` | — | command | Clear runtime state and rebootstrap from a startup-style full rescan |
-| `command restart-app-clearing-runtime-state` | — | command | Clear runtime state, relaunch the app, and exit the current process |
-| `command start-runtime-trace-capture` | — | command | Start capturing internal runtime trace events |
-| `command stop-runtime-trace-capture` | — | command | Write the captured trace bundle to `${XDG_STATE_HOME:-$HOME/.local/state}/nehir/traces/…` and copy the file path to the clipboard |
+| `command debug dump-runtime-state` | — | command | Dump runtime debugging state to the clipboard and unified log |
+| `command debug reset-runtime-state` | — | command | Clear runtime debugging state and rebootstrap from a startup-style full rescan |
+| `command debug restart-clearing-runtime-state` | — | command | Clear runtime debugging state, relaunch the app, and exit the current process |
+| `command debug trace toggle` | — | command | Start runtime debugging trace capture, or stop and export the active capture |
+| `command debug trace toggle` | `<active\|inactive>` | command | Ensure trace capture is in the desired state (idempotent; returns `executed` even if already in that state) |
 
-The default hotkeys are:
+The default hotkey is:
 
-- `Ctrl+Option+Cmd+T` — Start Runtime Trace Capture
-- `Ctrl+Option+Shift+Cmd+T` — Stop Runtime Trace Capture
+- `Ctrl+Option+Cmd+T` — Debug: Toggle Trace Capture
 
-Runtime dumps include separate focus-target fields so gesture and hotkey bugs can be diagnosed without conflating concepts: `wmCommandTarget`, `wmCommandTargetSource`, `layoutSelection`, `observedManagedFocus`, `focusRequest`, `borderTarget`, `interactionWorkspace`, `interactionMonitor`, and `nonManaged`.
+The optional workspace-bar **Show Trace Capture Button** setting adds the same toggle button to the bar, which is useful when collecting a reproduction trace for feedback.
+
+Runtime dumps include separate focus-target fields so gesture and hotkey bugs can be diagnosed without conflating concepts: `wmCommandTarget`, `wmCommandTargetSource`, `layoutSelection`, `observedManagedFocus`, `focusRequest`, `borderTarget`, `interactionWorkspace`, `interactionMonitor`, `nonManaged`, `runtimeTraceCaptureActive`, `runtimeTraceStartedAt`, and `viewportTraceRecords`.
 
 ---
 
@@ -867,6 +870,7 @@ This envelope is produced locally by the CLI, so it does not include IPC fields 
 |------|---------|
 | `invalid_request` | Malformed, oversized, or unparseable request |
 | `invalid_arguments` | Bad arguments for the command/rule |
+| `invalid_state` | Command is well-formed but not valid in the current runtime state |
 | `protocol_mismatch` | Client/server protocol version mismatch |
 | `ignored_disabled` | Window manager is disabled |
 | `ignored_overview` | Overview surface is open |


### PR DESCRIPTION
- Introduced `showTraceButton` in `CanonicalTOMLConfig` and `MonitorBarSettings` to control the visibility of the trace capture button.
- Updated `HotkeyConfigMapping` to include debugging commands for trace capture.
- Implemented `toggleRuntimeTraceCapture`, `startRuntimeTraceCapture`, and `stopRuntimeTraceCapture` methods in `WMController`.
- Added new commands for debugging in `IPCCommandRouter` and `IPCCommandRequest`.
- Enhanced `CommandPalette` and `WorkspaceBar` to support trace capture actions.
- Updated CLI documentation to reflect new debugging commands and their usage.
- Added tests to ensure stateful behavior of trace capture commands.

## Summary

<!-- What changed and why? -->

## Release notes

Choose one:

- [x] Added a `.changeset/*.md` for user-visible changes (`mise run changeset -- patch "..."`).

## Validation

<!-- Commands run, screenshots, or manual checks. -->

- [ ] Ran relevant tests/checks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Single "Debug: Toggle Trace Capture" command (default hotkey Ctrl+Option+Cmd+T) replaces separate start/stop actions
  * Optional workspace-bar Trace Capture button for quick toggling
  * CLI/IPC accepts optional state argument (active/inactive) for idempotent scripting
  * Debug commands reorganized under "Debugging & Tracing"

* **Documentation**
  * Guidance for creating/sharing trace bundles for feedback
  * Documented new invalid_state error for state-related command failures
<!-- end of auto-generated comment: release notes by coderabbit.ai -->