### PR TITLE
Fix window parking issue when moving to inactive workspaces

### DIFF
--- a/.changeset/20260604022935-avoid-wrong-display-hidden-window-parking-when-m.md
+++ b/.changeset/20260604022935-avoid-wrong-display-hidden-window-parking-when-m.md
@@ -1,0 +1,5 @@
+---
+"nehir": patch
+---
+
+Avoid wrong-display hidden window parking when moving windows to inactive workspaces.

--- a/Sources/Nehir/Core/Controller/LayoutRefreshController.swift
+++ b/Sources/Nehir/Core/Controller/LayoutRefreshController.swift
@@ -2173,7 +2173,7 @@ import QuartzCore
 
         let verifyEpsilon: CGFloat = 1.0
         for plan in plans {
-            if let observedOrigin = observedWindowOrigin(plan.entry) {
+            if let observedOrigin = liveWindowOrigin(plan.entry) {
                 let dx = abs(observedOrigin.x - plan.origin.x)
                 let dy = abs(observedOrigin.y - plan.origin.y)
                 // Diagnostic: log SkyLight result vs requested
@@ -2182,7 +2182,7 @@ import QuartzCore
                     let fallbackFrame = CGRect(origin: plan.origin, size: plan.frameSize)
                     let axResult = AXWindowService.setFrame(plan.entry.axRef, frame: fallbackFrame)
                     // Diagnostic: log AX fallback result
-                    if let afterFallback = observedWindowOrigin(plan.entry) {
+                    if let afterFallback = liveWindowOrigin(plan.entry) {
                         controller.axManager.recordFrameApplyTrace("hidePlan.axFallback id=\(plan.entry.windowId) axResult=\(axResult) requested=\(LayoutTrace.point(plan.origin)) afterFallback=\(LayoutTrace.point(afterFallback))")
                     } else {
                         controller.axManager.recordFrameApplyTrace("hidePlan.axFallback id=\(plan.entry.windowId) axResult=\(axResult) afterFallback=nil")
@@ -2940,6 +2940,10 @@ import QuartzCore
 
     private func observedWindowOrigin(_ entry: WindowModel.Entry) -> CGPoint? {
         observedWindowFrame(entry)?.origin
+    }
+
+    private func liveWindowOrigin(_ entry: WindowModel.Entry) -> CGPoint? {
+        AXWindowService.framePreferFast(entry.axRef)?.origin
     }
 
     func parkResizePlaceholderWindow(

--- a/Sources/Nehir/Core/Layout/SideHiding.swift
+++ b/Sources/Nehir/Core/Layout/SideHiding.swift
@@ -80,39 +80,71 @@ enum HiddenWindowPlacementResolver {
     ) -> CGPoint {
         let reveal = baseReveal / max(1.0, scale)
 
-        func origin(for side: HideSide) -> CGPoint {
+        func origin(for side: HideSide, y: CGFloat) -> CGPoint {
             switch side {
             case .left:
                 CGPoint(
                     x: monitor.frame.minX - size.width + reveal,
-                    y: targetY
+                    y: y
                 )
             case .right:
                 CGPoint(
                     x: monitor.frame.maxX - reveal,
-                    y: targetY
+                    y: y
                 )
             }
         }
 
-        let primaryOrigin = origin(for: requestedSide)
-        let primaryOverlap = overlapArea(
-            for: CGRect(origin: primaryOrigin, size: size),
+        let alternateSide: HideSide = requestedSide == .left ? .right : .left
+        let sides = [requestedSide, alternateSide]
+        // The live frame can still be on the source display when a window is assigned
+        // directly to an inactive workspace on another display. Try nearby vertical
+        // parking lanes too, otherwise preserving that source-display Y can leave a
+        // large strip visible on an adjacent monitor.
+        let yCandidates = verticalParkingCandidates(
+            for: size,
+            targetY: targetY,
             monitor: monitor,
             monitors: monitors
         )
-        if primaryOverlap == 0 {
-            return primaryOrigin
+
+        var bestOrigin = origin(for: requestedSide, y: targetY)
+        var bestOverlap = CGFloat.greatestFiniteMagnitude
+        var bestLanePenalty = Int.max
+        var bestSidePenalty = Int.max
+        var bestDistance = CGFloat.greatestFiniteMagnitude
+
+        for (sideIndex, side) in sides.enumerated() {
+            for y in yCandidates {
+                let candidateOrigin = origin(for: side, y: y)
+                let candidateFrame = CGRect(origin: candidateOrigin, size: size)
+                let overlap = overlapArea(
+                    for: candidateFrame,
+                    monitor: monitor,
+                    monitors: monitors
+                )
+                let lanePenalty = verticalOverlap(candidateFrame, monitor.frame) > 0 ? 0 : 1
+                let distance = abs(y - targetY)
+                if lanePenalty < bestLanePenalty
+                    || (lanePenalty == bestLanePenalty && overlap < bestOverlap)
+                    || (lanePenalty == bestLanePenalty
+                        && overlap == bestOverlap
+                        && distance < bestDistance)
+                    || (lanePenalty == bestLanePenalty
+                        && overlap == bestOverlap
+                        && distance == bestDistance
+                        && sideIndex < bestSidePenalty)
+                {
+                    bestOrigin = candidateOrigin
+                    bestOverlap = overlap
+                    bestLanePenalty = lanePenalty
+                    bestSidePenalty = sideIndex
+                    bestDistance = distance
+                }
+            }
         }
 
-        let alternateSide: HideSide = requestedSide == .left ? .right : .left
-        let alternateOrigin = origin(for: alternateSide)
-        let alternateOverlap = overlapArea(
-            for: CGRect(origin: alternateOrigin, size: size),
-            monitor: monitor,
-            monitors: monitors
-        )
-        return alternateOverlap < primaryOverlap ? alternateOrigin : primaryOrigin
+        return bestOrigin
     }
 
     static func placement(
@@ -192,6 +224,37 @@ enum HiddenWindowPlacementResolver {
             resolvedEdge: requestedEdge,
             origin: primaryOrigin
         )
+    }
+
+    private static func verticalOverlap(_ lhs: CGRect, _ rhs: CGRect) -> CGFloat {
+        max(0, min(lhs.maxY, rhs.maxY) - max(lhs.minY, rhs.minY))
+    }
+
+    private static func verticalParkingCandidates(
+        for size: CGSize,
+        targetY: CGFloat,
+        monitor: HiddenPlacementMonitorContext,
+        monitors: [HiddenPlacementMonitorContext]
+    ) -> [CGFloat] {
+        var candidates: [CGFloat] = []
+
+        func append(_ y: CGFloat) {
+            guard y.isFinite else { return }
+            if !candidates.contains(where: { abs($0 - y) < 0.5 }) {
+                candidates.append(y)
+            }
+        }
+
+        append(targetY)
+        append(monitor.frame.minY)
+        append(monitor.frame.maxY - size.height)
+
+        for other in monitors where other.id != monitor.id {
+            append(other.frame.minY - size.height)
+            append(other.frame.maxY)
+        }
+
+        return candidates
     }
 
     private static func overlapArea(

--- a/Tests/NehirTests/LayoutRefreshControllerTests.swift
+++ b/Tests/NehirTests/LayoutRefreshControllerTests.swift
@@ -51,6 +51,89 @@ private func makeUnavailableLayoutPlanTestWindow(windowId: Int) -> AXWindowRef {
         #expect(origin == CGPoint(x: 2055, y: 8))
     }
 
+    @Test @MainActor func workspaceHiddenPlacementAvoidsAdjacentMonitorWhenSourceYBelongsToOtherDisplay() {
+        let builtIn = HiddenPlacementMonitorContext(
+            id: Monitor.ID(displayId: 1),
+            frame: CGRect(x: 0, y: 0, width: 2056, height: 1329),
+            visibleFrame: CGRect(x: 0, y: 0, width: 2056, height: 1329)
+        )
+        let external = HiddenPlacementMonitorContext(
+            id: Monitor.ID(displayId: 2),
+            frame: CGRect(x: -263, y: 1329, width: 2560, height: 1440),
+            visibleFrame: CGRect(x: -263, y: 1329, width: 2560, height: 1440)
+        )
+
+        let origin = HiddenWindowPlacementResolver.physicalScreenEdgeOrigin(
+            for: CGSize(width: 1268, height: 1424),
+            requestedSide: .right,
+            targetY: 1337,
+            baseReveal: LayoutRefreshController.hiddenWindowEdgeRevealEpsilon,
+            scale: 1,
+            monitor: builtIn,
+            monitors: [builtIn, external]
+        )
+
+        #expect(origin == CGPoint(x: 2055, y: -95))
+        let parkedFrame = CGRect(origin: origin, size: CGSize(width: 1268, height: 1424))
+        let overlap = parkedFrame.intersection(external.frame)
+        #expect(overlap.width * overlap.height == 0)
+    }
+
+    @Test @MainActor func workspaceHiddenPlacementUsesTargetMonitorLaneWhenTargetYIsOutsideTargetDisplay() {
+        let builtIn = HiddenPlacementMonitorContext(
+            id: Monitor.ID(displayId: 1),
+            frame: CGRect(x: 0, y: 0, width: 2056, height: 1329),
+            visibleFrame: CGRect(x: 0, y: 0, width: 2056, height: 1329)
+        )
+        let external = HiddenPlacementMonitorContext(
+            id: Monitor.ID(displayId: 2),
+            frame: CGRect(x: -263, y: 1329, width: 2560, height: 1440),
+            visibleFrame: CGRect(x: -263, y: 1329, width: 2560, height: 1440)
+        )
+
+        let origin = HiddenWindowPlacementResolver.physicalScreenEdgeOrigin(
+            for: CGSize(width: 1016, height: 1274),
+            requestedSide: .right,
+            targetY: 8,
+            baseReveal: LayoutRefreshController.hiddenWindowEdgeRevealEpsilon,
+            scale: 1,
+            monitor: external,
+            monitors: [builtIn, external]
+        )
+
+        #expect(origin == CGPoint(x: 2296, y: 1329))
+    }
+
+    @Test @MainActor func workspaceHiddenPlacementPrefersTargetLaneOverOffBandZeroOverlap() {
+        let left = HiddenPlacementMonitorContext(
+            id: Monitor.ID(displayId: 1),
+            frame: CGRect(x: -1920, y: 0, width: 1920, height: 1080),
+            visibleFrame: CGRect(x: -1920, y: 0, width: 1920, height: 1080)
+        )
+        let target = HiddenPlacementMonitorContext(
+            id: Monitor.ID(displayId: 2),
+            frame: CGRect(x: 0, y: 0, width: 1920, height: 1080),
+            visibleFrame: CGRect(x: 0, y: 0, width: 1920, height: 1080)
+        )
+        let right = HiddenPlacementMonitorContext(
+            id: Monitor.ID(displayId: 3),
+            frame: CGRect(x: 1920, y: 0, width: 1920, height: 1080),
+            visibleFrame: CGRect(x: 1920, y: 0, width: 1920, height: 1080)
+        )
+
+        let origin = HiddenWindowPlacementResolver.physicalScreenEdgeOrigin(
+            for: CGSize(width: 800, height: 600),
+            requestedSide: .right,
+            targetY: 100,
+            baseReveal: LayoutRefreshController.hiddenWindowEdgeRevealEpsilon,
+            scale: 1,
+            monitor: target,
+            monitors: [left, target, right]
+        )
+
+        #expect(origin == CGPoint(x: 1919, y: 100))
+    }
+
     @Test @MainActor func buildMonitorSnapshotUsesConfiguredWorkspaceBarInsetInOverlappingMode() {
         let monitor = Monitor(
             id: Monitor.ID(displayId: 91),

--- a/docs/offscreen-clamp-fix.md
+++ b/docs/offscreen-clamp-fix.md
@@ -41,18 +41,18 @@ Combined: a hidden window at target `(-1712, -10000)` is clamped to approximatel
 
 **Neither axis can be used to push a full-size window completely offscreen on macOS.**
 
-### 2. Layout-Pass Cache Returning Stale Pre-Move Positions
+### 2. Layout-Pass Cache Returning Stale Pre-Move Positions — Fixed for Hide Verification
 
 `applyPositionPlans` used `observedWindowOrigin()` which reads through the
 `RefreshFrameContext` cache. This cache is populated once per layout pass — the first time
 `fastFrame` is called for a token (in `resolveHideOperation`). It caches the window's
 **current on-screen position** (e.g., `(1126, 8)`).
 
-After SkyLight moves the window, the verify step reads `observedWindowOrigin` which returns
-the **stale cached** value instead of the real post-move position. This makes every hide
-plan appear to fail, triggering the AX fallback unnecessarily.
+After SkyLight moves the window, the verify step read `observedWindowOrigin()` which could
+return the **stale cached** value instead of the real post-move position. This made hide
+plans appear to fail or obscured the actual WindowServer clamp result.
 
-Diagnostic lesson: hide verification should bypass the layout-pass cache and read directly from AX.
+Fixed: hide-plan verification now bypasses the layout-pass cache and reads live WindowServer bounds (via `AXWindowService.framePreferFast`) when checking post-move positions.
 
 ### 3. Stale Gesture Viewport Regression — Fixed
 
@@ -71,6 +71,19 @@ positions causing visible overlaps and missing columns.
 
 Fixed in `879a330`: tiled windows in tiling mode now skip the proportional restore
 position and move directly to their layout target (`LayoutRefreshController` line ~3416).
+
+### 5. Cross-Monitor Workspace-Inactive Parking Lane — Mitigated
+
+When a window is moved directly to an inactive workspace on another monitor, its live frame
+can still be on the source monitor when Nehir computes the workspace-inactive parking
+origin. Preserving that source-monitor Y can make WindowServer clamp the window against the
+wrong display and leave a large visible strip on the source or adjacent monitor.
+
+Mitigation: workspace-inactive and scratchpad parking now evaluate nearby vertical parking
+lanes and prefer candidates that avoid overlap with other monitors while still intersecting
+the target monitor's vertical band. This does not remove macOS offscreen clamping, but it
+avoids the wrong-display parking coordinates seen in direct built-in ↔ external workspace
+assignment traces.
 
 ## Status
 
@@ -97,8 +110,12 @@ behavior must be confirmed manually in a real trace/run first.
 Useful confirmed findings:
 
 - macOS clamps both horizontal and vertical offscreen positions for external app windows.
-- The stale `RefreshFrameContext` cache can make hide verification misleading; live AX
-  reads are necessary when diagnosing post-move positions.
+- The stale `RefreshFrameContext` cache can make hide verification misleading; hide-plan
+  verification now bypasses that cache and reads live WindowServer bounds when checking
+  post-move positions.
+- Direct moves to inactive workspaces on another monitor can preserve a source-display Y;
+  workspace-inactive parking should choose a target-monitor vertical lane to avoid
+  wrong-display clamp strips.
 - Workspace-inactive hiding appears acceptable because it parks windows at the physical
   screen edge with ~1px visible; this is not a true hide. Some apps (confirmed with a
   Zoom call window) clamp to a larger visible strip if requested exactly at the edge,
@@ -184,7 +201,7 @@ while earlier traces showed ~34px. The threshold may vary with window size or ti
 | 9 | `SLSWindowSetShape` with 1×1 offscreen region | No visible effect. Regular app windows override the shape on each draw cycle. Only works on windows created via `SLSNewWindow`. | |
 | 10 | `SLSTransactionOrderWindow` with mode 1 (kCGSOrderOut) | Transaction ordered the window but `isWindowOrderedIn` still returns `true`. Window remains rendered. | Trace: `hidePlan.orderOut id=985 orderedIn=true` |
 | 11 | `SLSOrderWindow` (direct, non-transaction) with mode 1 | Same result — `isWindowOrderedIn` still `true`. Neither transaction nor direct call orders out regular app windows. | Trace: `hidePlan.orderOut id=985 orderedIn=true` |
-| 12 | Stale cache in `applyPositionPlans` | `observedWindowOrigin` returned pre-move position from cache, making SkyLight moves appear to fail. Useful diagnostic finding, not a hiding approach. | |
+| 12 | Stale cache in `applyPositionPlans` | `observedWindowOrigin` returned pre-move position from cache, making SkyLight moves appear to fail or hiding the real clamp result. Fixed for hide verification by reading live WindowServer bounds; useful diagnostic finding, not a hiding approach. | |
 | 13 | Push all hidden windows to x=monitor.maxX (right edge) | With AX fallback this parks windows at the same 1px right-edge position as workspace-inactive hide, but left-hidden windows visibly fly across the screen to get there. Without AX fallback, SkyLight-only moves can leave left-edge clamps. | |
 | 14 | `SLSSetWindowTransform` / `CGSSetWindowTransform` raw near-zero scale | API returns success but does not hide external app pixels reliably. Raw scale pulls windows toward global origin, causing random-width left-edge clamp artifacts. | Trace: `hideTransform.apply ... result=CGError(rawValue: 0)` followed by visible artifacts |
 | 15 | Anchored `SLSSetWindowTransform` near-zero scale, skip move | API still returns success, but the window remains visually parked at natural left-clamped position — effectively as if nothing happened/worse. Transform is not a usable external-window hide primitive. | |


### PR DESCRIPTION
## Summary

## Release notes

Choose one:

- [x] Added a `.changeset/*.md` for user-visible changes (`mise run changeset -- patch "..."`).

## Validation

<!-- Commands run, screenshots, or manual checks. -->

- [ ] Ran relevant tests/checks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed hidden-window parking from displaying incorrectly when moving windows to inactive workspaces across multiple monitors, ensuring proper placement accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->