### PR TITLE
Add display diagnostics for Dock and monitor arrangement recommendations

### DIFF
--- a/.changeset/20260604033130-add-display-diagnostics-for-dock-and-monitor-arr.md
+++ b/.changeset/20260604033130-add-display-diagnostics-for-dock-and-monitor-arr.md
@@ -1,0 +1,5 @@
+---
+"nehir": patch
+---
+
+Add display diagnostics for Dock and monitor arrangement recommendations.

--- a/Sources/Nehir/Core/Monitor/DisplayEnvironmentDiagnostics.swift
+++ b/Sources/Nehir/Core/Monitor/DisplayEnvironmentDiagnostics.swift
@@ -1,0 +1,145 @@
+import CoreGraphics
+import Foundation
+
+struct DisplayEnvironmentDiagnostics: Equatable {
+    struct Issue: Identifiable, Equatable {
+        enum Kind: Equatable {
+            case fixedDock(
+                monitorId: Monitor.ID,
+                monitorName: String,
+                edge: DockEdge,
+                inset: CGFloat
+            )
+            case horizontalDisplayArrangement(
+                firstMonitorId: Monitor.ID,
+                firstMonitorName: String,
+                secondMonitorId: Monitor.ID,
+                secondMonitorName: String
+            )
+        }
+
+        let kind: Kind
+
+        var id: String {
+            switch kind {
+            case let .fixedDock(monitorId, _, edge, _):
+                "fixedDock:\(monitorId.displayId):\(edge.rawValue)"
+            case let .horizontalDisplayArrangement(firstMonitorId, _, secondMonitorId, _):
+                "horizontalDisplayArrangement:\(firstMonitorId.displayId):\(secondMonitorId.displayId)"
+            }
+        }
+
+        var title: String {
+            switch kind {
+            case let .fixedDock(_, monitorName, _, _):
+                "Fixed Dock detected on \(monitorName)"
+            case .horizontalDisplayArrangement:
+                "Side-by-side display arrangement detected"
+            }
+        }
+
+        var message: String {
+            switch kind {
+            case let .fixedDock(_, _, edge, inset):
+                "The Dock appears to reserve \(Int(inset.rounded())) px on the \(edge.displayName.lowercased()) edge. Parked transient windows can be clamped to the Dock boundary and leave a visible strip."
+            case let .horizontalDisplayArrangement(_, firstMonitorName, _, secondMonitorName):
+                "\(firstMonitorName) and \(secondMonitorName) overlap vertically in macOS display arrangement. Horizontally parked windows can bleed onto the neighboring display."
+            }
+        }
+
+        var recommendation: String {
+            switch kind {
+            case .fixedDock:
+                "Enable Dock auto-hide in System Settings > Desktop & Dock, or move the fixed Dock away from the edge used for hidden-window parking."
+            case .horizontalDisplayArrangement:
+                "Arrange displays vertically in System Settings > Displays > Arrange so horizontal parking edges do not touch another display."
+            }
+        }
+    }
+
+    enum DockEdge: String, Equatable {
+        case left
+        case right
+        case bottom
+
+        var displayName: String {
+            switch self {
+            case .left: "Left"
+            case .right: "Right"
+            case .bottom: "Bottom"
+            }
+        }
+    }
+
+    let issues: [Issue]
+
+    var hasWarnings: Bool {
+        !issues.isEmpty
+    }
+
+    static func current() -> DisplayEnvironmentDiagnostics {
+        evaluate(monitors: Monitor.current())
+    }
+
+    static func evaluate(monitors: [Monitor]) -> DisplayEnvironmentDiagnostics {
+        var issues: [Issue] = []
+        issues.append(contentsOf: fixedDockIssues(monitors: monitors))
+        issues.append(contentsOf: horizontalArrangementIssues(monitors: monitors))
+        return DisplayEnvironmentDiagnostics(issues: issues)
+    }
+
+    private static func fixedDockIssues(monitors: [Monitor]) -> [Issue] {
+        monitors.flatMap { monitor -> [Issue] in
+            let frame = monitor.frame
+            let visibleFrame = monitor.visibleFrame
+            let threshold: CGFloat = 24
+            let insets: [(DockEdge, CGFloat)] = [
+                (.left, visibleFrame.minX - frame.minX),
+                (.right, frame.maxX - visibleFrame.maxX),
+                (.bottom, visibleFrame.minY - frame.minY),
+            ]
+
+            return insets.compactMap { edge, inset in
+                guard inset >= threshold else { return nil }
+                return Issue(kind: .fixedDock(monitorId: monitor.id, monitorName: monitor.name, edge: edge, inset: inset))
+            }
+        }
+    }
+
+    private static func horizontalArrangementIssues(monitors: [Monitor]) -> [Issue] {
+        guard monitors.count > 1 else { return [] }
+
+        var issues: [Issue] = []
+        for firstIndex in monitors.indices {
+            for secondIndex in monitors.indices where secondIndex > firstIndex {
+                let first = monitors[firstIndex]
+                let second = monitors[secondIndex]
+                let verticalOverlap = overlap(
+                    first.frame.minY ... first.frame.maxY,
+                    second.frame.minY ... second.frame.maxY
+                )
+                guard verticalOverlap > 1 else { continue }
+                let horizontalOverlap = overlap(
+                    first.frame.minX ... first.frame.maxX,
+                    second.frame.minX ... second.frame.maxX
+                )
+                guard horizontalOverlap < 1 else { continue }
+                issues.append(
+                    Issue(
+                        kind: .horizontalDisplayArrangement(
+                            firstMonitorId: first.id,
+                            firstMonitorName: first.name,
+                            secondMonitorId: second.id,
+                            secondMonitorName: second.name
+                        )
+                    )
+                )
+            }
+        }
+        return issues
+    }
+
+    private static func overlap(_ lhs: ClosedRange<CGFloat>, _ rhs: ClosedRange<CGFloat>) -> CGFloat {
+        max(0, min(lhs.upperBound, rhs.upperBound) - max(lhs.lowerBound, rhs.lowerBound))
+    }
+}

--- a/Sources/Nehir/UI/DisplayDiagnosticsSettingsTab.swift
+++ b/Sources/Nehir/UI/DisplayDiagnosticsSettingsTab.swift
@@ -1,0 +1,110 @@
+import AppKit
+import SwiftUI
+
+struct DisplayDiagnosticsSettingsTab: View {
+    @State private var diagnostics = DisplayEnvironmentDiagnostics.current()
+    @State private var monitors = Monitor.current()
+
+    var body: some View {
+        Form {
+            Section("Status") {
+                HStack(alignment: .top, spacing: 10) {
+                    Image(systemName: diagnostics.hasWarnings ? "exclamationmark.triangle.fill" : "checkmark.circle.fill")
+                        .foregroundStyle(diagnostics.hasWarnings ? .yellow : .green)
+                        .font(.title3)
+                        .accessibilityHidden(true)
+
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text(diagnostics.hasWarnings ? "Recommendations need attention" : "Display environment looks good")
+                            .font(.headline)
+                        Text(statusMessage)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+
+                Button("Refresh Diagnostics") {
+                    refresh()
+                }
+            }
+
+            Section("Display and Dock Recommendations") {
+                SettingsCaption("For the best Niri scrolling experience, use an auto-hide Dock and arrange displays vertically in macOS System Settings.")
+
+                if diagnostics.issues.isEmpty {
+                    Label("No fixed Dock or side-by-side display arrangement detected.", systemImage: "checkmark.circle")
+                        .foregroundStyle(.green)
+                } else {
+                    ForEach(diagnostics.issues) { issue in
+                        DiagnosticIssueView(issue: issue)
+                    }
+                }
+            }
+
+            Section("Detected Displays") {
+                if monitors.isEmpty {
+                    Text("No displays detected.")
+                        .foregroundStyle(.secondary)
+                } else {
+                    ForEach(monitors, id: \.id) { monitor in
+                        DisplayDiagnosticMonitorRow(monitor: monitor)
+                    }
+                }
+            }
+        }
+        .formStyle(.grouped)
+        .onAppear(perform: refresh)
+        .onReceive(NotificationCenter.default.publisher(for: NSApplication.didChangeScreenParametersNotification)) { _ in
+            refresh()
+        }
+    }
+
+    private var statusMessage: String {
+        guard diagnostics.hasWarnings else {
+            return "Auto-hide Dock and vertical display arrangement are the expected low-artifact configuration."
+        }
+        return "Nehir can still run, but parked offscreen windows may leave visible strips or bleed onto neighboring displays."
+    }
+
+    private func refresh() {
+        monitors = Monitor.current()
+        diagnostics = DisplayEnvironmentDiagnostics.evaluate(monitors: monitors)
+    }
+}
+
+private struct DiagnosticIssueView: View {
+    let issue: DisplayEnvironmentDiagnostics.Issue
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Label(issue.title, systemImage: "exclamationmark.triangle.fill")
+                .font(.headline)
+                .foregroundStyle(.yellow)
+            Text(issue.message)
+                .foregroundStyle(.secondary)
+            Text(issue.recommendation)
+        }
+        .padding(.vertical, 4)
+    }
+}
+
+private struct DisplayDiagnosticMonitorRow: View {
+    let monitor: Monitor
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(monitor.name)
+                .font(.headline)
+            Text("Frame: \(format(monitor.frame))")
+                .foregroundStyle(.secondary)
+                .font(.caption.monospacedDigit())
+            Text("Visible: \(format(monitor.visibleFrame))")
+                .foregroundStyle(.secondary)
+                .font(.caption.monospacedDigit())
+        }
+        .padding(.vertical, 2)
+    }
+
+    private func format(_ rect: CGRect) -> String {
+        "x=\(Int(rect.minX.rounded())) y=\(Int(rect.minY.rounded())) w=\(Int(rect.width.rounded())) h=\(Int(rect.height.rounded()))"
+    }
+}

--- a/Sources/Nehir/UI/SettingsDetailView.swift
+++ b/Sources/Nehir/UI/SettingsDetailView.swift
@@ -21,6 +21,8 @@ struct SettingsDetailView: View {
                 settings: settings,
                 controller: controller,
             )
+        case .diagnostics:
+            DisplayDiagnosticsSettingsTab()
         case .niri:
             NiriSettingsTab(settings: settings, controller: controller)
         case .monitors:

--- a/Sources/Nehir/UI/SettingsSection.swift
+++ b/Sources/Nehir/UI/SettingsSection.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 enum SettingsSection: String, CaseIterable, Identifiable {
     case general
+    case diagnostics
     case niri
     case monitors
     case workspaces
@@ -16,6 +17,7 @@ enum SettingsSection: String, CaseIterable, Identifiable {
     var displayName: String {
         switch self {
         case .general: "General"
+        case .diagnostics: "Diagnostics"
         case .niri: "Niri Layout"
         case .monitors: "Monitors"
         case .workspaces: "Workspaces"
@@ -28,6 +30,7 @@ enum SettingsSection: String, CaseIterable, Identifiable {
     var icon: String {
         switch self {
         case .general: "gearshape"
+        case .diagnostics: "exclamationmark.triangle"
         case .niri: "scroll"
         case .monitors: "display"
         case .workspaces: "rectangle.3.group"
@@ -51,7 +54,7 @@ enum SettingsSectionGroup: String, CaseIterable, Identifiable {
     var sections: [SettingsSection] {
         switch self {
         case .basics:
-            [.general]
+            [.general, .diagnostics]
         case .layouts:
             [.niri, .monitors]
         case .workspace:

--- a/Sources/Nehir/UI/SettingsView.swift
+++ b/Sources/Nehir/UI/SettingsView.swift
@@ -1,16 +1,26 @@
+import Observation
 import SwiftUI
+
+@MainActor @Observable
+final class SettingsNavigationModel {
+    var selectedSection: SettingsSection
+
+    init(selectedSection: SettingsSection = .general) {
+        self.selectedSection = selectedSection
+    }
+}
 
 struct SettingsView: View {
     @Bindable var settings: SettingsStore
     @Bindable var controller: WMController
-    @State private var selectedSection: SettingsSection = .general
+    @Bindable var navigation: SettingsNavigationModel
 
     var body: some View {
         NavigationSplitView {
-            SettingsSidebar(selection: $selectedSection)
+            SettingsSidebar(selection: $navigation.selectedSection)
         } detail: {
             SettingsDetailView(
-                section: selectedSection,
+                section: navigation.selectedSection,
                 settings: settings,
                 controller: controller
             )

--- a/Sources/Nehir/UI/SettingsWindowController.swift
+++ b/Sources/Nehir/UI/SettingsWindowController.swift
@@ -6,21 +6,36 @@ final class SettingsWindowController {
     static let shared = SettingsWindowController()
 
     private var window: NSWindow?
+    private nonisolated(unsafe) var willCloseObserverToken: NSObjectProtocol?
+    private let navigation = SettingsNavigationModel()
     private let ownedWindowRegistry = OwnedWindowRegistry.shared
+
+    deinit {
+        if let willCloseObserverToken {
+            NotificationCenter.default.removeObserver(willCloseObserverToken)
+        }
+    }
 
     func show(
         settings: SettingsStore,
         controller: WMController,
+        section: SettingsSection? = nil
     ) {
+        if let section {
+            navigation.selectedSection = section
+        }
+
         if let window {
             window.makeKeyAndOrderFront(nil)
             NSApp.activate(ignoringOtherApps: true)
             return
         }
 
+        navigation.selectedSection = section ?? .general
         let settingsView = SettingsView(
             settings: settings,
             controller: controller,
+            navigation: navigation
         )
 
         let hosting = NSHostingController(rootView: settingsView)
@@ -36,9 +51,16 @@ final class SettingsWindowController {
         window.makeKeyAndOrderFront(nil)
         NSApp.activate(ignoringOtherApps: true)
 
-        NotificationCenter.default
+        if let willCloseObserverToken {
+            NotificationCenter.default.removeObserver(willCloseObserverToken)
+        }
+        willCloseObserverToken = NotificationCenter.default
             .addObserver(forName: NSWindow.willCloseNotification, object: window, queue: .main) { [weak self] _ in
                 MainActor.assumeIsolated {
+                    if let willCloseObserverToken = self?.willCloseObserverToken {
+                        NotificationCenter.default.removeObserver(willCloseObserverToken)
+                        self?.willCloseObserverToken = nil
+                    }
                     self?.ownedWindowRegistry.unregister(window)
                     self?.window = nil
                 }

--- a/Sources/Nehir/UI/WorkspaceBar/WorkspaceBarManager.swift
+++ b/Sources/Nehir/UI/WorkspaceBar/WorkspaceBarManager.swift
@@ -227,6 +227,14 @@ final class WorkspaceBarManager {
                 },
                 onToggleTraceCapture: { [weak controller] in
                     controller?.toggleRuntimeTraceCapture()
+                },
+                onOpenDiagnostics: { [weak controller, weak settings] in
+                    guard let controller, let settings else { return }
+                    SettingsWindowController.shared.show(
+                        settings: settings,
+                        controller: controller,
+                        section: .diagnostics
+                    )
                 }
             )
         )
@@ -342,6 +350,7 @@ final class WorkspaceBarManager {
             barHeight: current.barHeight,
             showTraceCaptureButton: current.showTraceCaptureButton,
             traceCaptureStatus: current.traceCaptureStatus,
+            hasDisplayDiagnosticsWarning: current.hasDisplayDiagnosticsWarning,
             accentColor: resolved.accentColor,
             textColor: resolved.textColor
         )
@@ -415,6 +424,7 @@ final class WorkspaceBarManager {
             barHeight: geometry.barHeight,
             showTraceCaptureButton: resolved.showTraceButton,
             traceCaptureStatus: controller?.runtimeTraceCaptureStatus ?? .init(isActive: false, startedAt: nil),
+            hasDisplayDiagnosticsWarning: DisplayEnvironmentDiagnostics.evaluate(monitors: monitorProvider()).hasWarnings,
             accentColor: resolved.accentColor,
             textColor: resolved.textColor
         )

--- a/Sources/Nehir/UI/WorkspaceBar/WorkspaceBarView.swift
+++ b/Sources/Nehir/UI/WorkspaceBar/WorkspaceBarView.swift
@@ -66,6 +66,7 @@ struct WorkspaceBarSnapshot: Equatable {
     let barHeight: CGFloat
     let showTraceCaptureButton: Bool
     let traceCaptureStatus: WMController.RuntimeTraceCaptureStatus
+    let hasDisplayDiagnosticsWarning: Bool
     let accentColor: SettingsColor?
     let textColor: SettingsColor?
 
@@ -96,6 +97,7 @@ struct WorkspaceBarView: View {
     let onActivateScratchpad: () -> Void
     let onOpenCommandPalette: () -> Void
     let onToggleTraceCapture: () -> Void
+    let onOpenDiagnostics: () -> Void
 
     var body: some View {
         WorkspaceBarContentView(
@@ -105,7 +107,8 @@ struct WorkspaceBarView: View {
             onFocusWindow: onFocusWindow,
             onActivateScratchpad: onActivateScratchpad,
             onOpenCommandPalette: onOpenCommandPalette,
-            onToggleTraceCapture: onToggleTraceCapture
+            onToggleTraceCapture: onToggleTraceCapture,
+            onOpenDiagnostics: onOpenDiagnostics
         )
     }
 }
@@ -122,7 +125,8 @@ struct WorkspaceBarMeasurementView: View {
             onFocusWindow: { _ in },
             onActivateScratchpad: {},
             onOpenCommandPalette: {},
-            onToggleTraceCapture: {}
+            onToggleTraceCapture: {},
+            onOpenDiagnostics: {}
         )
         .fixedSize(horizontal: true, vertical: false)
     }
@@ -137,6 +141,7 @@ private struct WorkspaceBarContentView: View {
     let onActivateScratchpad: () -> Void
     let onOpenCommandPalette: () -> Void
     let onToggleTraceCapture: () -> Void
+    let onOpenDiagnostics: () -> Void
 
     @Environment(\.accessibilityReduceMotion) private var accessibilityReduceMotion
     @Environment(\.accessibilityReduceTransparency) private var accessibilityReduceTransparency
@@ -216,6 +221,14 @@ private struct WorkspaceBarContentView: View {
                     accentColor: accentColor,
                     textColor: textColor,
                     onToggleTraceCapture: onToggleTraceCapture
+                )
+            }
+
+            if snapshot.hasDisplayDiagnosticsWarning {
+                DisplayDiagnosticsBarButton(
+                    iconSize: iconSize,
+                    itemHeight: itemHeight,
+                    onOpenDiagnostics: onOpenDiagnostics
                 )
             }
 
@@ -734,6 +747,38 @@ private struct TraceCaptureBarButton: View {
         }
         .accessibilityLabel(accessibilityText)
         .help(helpText)
+    }
+}
+
+@MainActor
+private struct DisplayDiagnosticsBarButton: View {
+    let iconSize: CGFloat
+    let itemHeight: CGFloat
+    let onOpenDiagnostics: () -> Void
+
+    @State private var isHovered = false
+
+    var body: some View {
+        Button(action: onOpenDiagnostics) {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .font(.system(size: max(10, iconSize * 0.7), weight: .semibold))
+                .foregroundStyle(.yellow)
+                .frame(width: itemHeight, height: itemHeight)
+                .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .scaleEffect(isHovered ? 1.03 : 1.0)
+        .background {
+            if isHovered {
+                RoundedRectangle(cornerRadius: 6, style: .continuous)
+                    .fill(.regularMaterial)
+            }
+        }
+        .onHover { hovering in
+            isHovered = hovering
+        }
+        .accessibilityLabel("Display Diagnostics Warning")
+        .help("Open Display and Dock Diagnostics")
     }
 }
 

--- a/Tests/NehirTests/DisplayEnvironmentDiagnosticsTests.swift
+++ b/Tests/NehirTests/DisplayEnvironmentDiagnosticsTests.swift
@@ -1,0 +1,114 @@
+import CoreGraphics
+import Foundation
+@testable import Nehir
+import Testing
+
+@Suite struct DisplayEnvironmentDiagnosticsTests {
+    @Test func detectsFixedDockInsetsExceptMenuBarTopInset() {
+        let monitor = makeMonitor(
+            name: "Built-in Display",
+            frame: CGRect(x: 0, y: 0, width: 1728, height: 1117),
+            visibleFrame: CGRect(x: 0, y: 0, width: 1640, height: 1080)
+        )
+
+        let diagnostics = DisplayEnvironmentDiagnostics.evaluate(monitors: [monitor])
+
+        #expect(diagnostics.issues.contains { issue in
+            if case let .fixedDock(_, monitorName, edge, inset) = issue.kind {
+                return monitorName == "Built-in Display" && edge == .right && abs(inset - 88) < 0.001
+            }
+            return false
+        })
+        #expect(diagnostics.issues.count == 1)
+    }
+
+    @Test func detectsSideBySideDisplayArrangement() {
+        let primary = makeMonitor(
+            name: "Primary",
+            frame: CGRect(x: 0, y: 0, width: 1440, height: 900)
+        )
+        let secondary = makeMonitor(
+            name: "Secondary",
+            frame: CGRect(x: 1440, y: 100, width: 1440, height: 900)
+        )
+
+        let diagnostics = DisplayEnvironmentDiagnostics.evaluate(monitors: [primary, secondary])
+
+        #expect(diagnostics.issues.contains { issue in
+            if case let .horizontalDisplayArrangement(_, firstMonitorName, _, secondMonitorName) = issue.kind {
+                return firstMonitorName == "Primary" && secondMonitorName == "Secondary"
+            }
+            return false
+        })
+    }
+
+    @Test func acceptsVerticalDisplayArrangementWithoutDockInsets() {
+        let primary = makeMonitor(
+            name: "Primary",
+            frame: CGRect(x: 0, y: 0, width: 1440, height: 900),
+            visibleFrame: CGRect(x: 0, y: 0, width: 1440, height: 860)
+        )
+        let secondary = makeMonitor(
+            name: "Secondary",
+            frame: CGRect(x: 0, y: 900, width: 1440, height: 900),
+            visibleFrame: CGRect(x: 0, y: 900, width: 1440, height: 900)
+        )
+
+        let diagnostics = DisplayEnvironmentDiagnostics.evaluate(monitors: [primary, secondary])
+
+        #expect(!diagnostics.hasWarnings)
+    }
+
+    @Test func mirroredDisplaysAreNotReportedAsSideBySide() {
+        let primary = makeMonitor(
+            name: "Primary",
+            frame: CGRect(x: 0, y: 0, width: 1440, height: 900)
+        )
+        let mirror = makeMonitor(
+            name: "Mirror",
+            frame: CGRect(x: 0, y: 0, width: 1440, height: 900)
+        )
+
+        let diagnostics = DisplayEnvironmentDiagnostics.evaluate(monitors: [primary, mirror])
+
+        #expect(!diagnostics.hasWarnings)
+    }
+
+    @Test func issueIdsUseDisplayIdsWhenMonitorNamesCollide() {
+        let first = makeMonitor(
+            name: "Display",
+            displayId: 101,
+            frame: CGRect(x: 0, y: 0, width: 1000, height: 800),
+            visibleFrame: CGRect(x: 0, y: 0, width: 940, height: 800)
+        )
+        let second = makeMonitor(
+            name: "Display",
+            displayId: 202,
+            frame: CGRect(x: 0, y: 1000, width: 1000, height: 800),
+            visibleFrame: CGRect(x: 0, y: 1000, width: 940, height: 800)
+        )
+
+        let diagnostics = DisplayEnvironmentDiagnostics.evaluate(monitors: [first, second])
+        let ids = diagnostics.issues.map(\.id)
+
+        #expect(ids.count == 2)
+        #expect(Set(ids).count == 2)
+    }
+
+    private func makeMonitor(
+        name: String,
+        displayId: CGDirectDisplayID? = nil,
+        frame: CGRect,
+        visibleFrame: CGRect? = nil
+    ) -> Monitor {
+        let resolvedDisplayId = displayId ?? CGDirectDisplayID(abs(name.hashValue % 10_000) + 1)
+        return Monitor(
+            id: Monitor.ID(displayId: resolvedDisplayId),
+            displayId: resolvedDisplayId,
+            frame: frame,
+            visibleFrame: visibleFrame ?? frame,
+            hasNotch: false,
+            name: name
+        )
+    }
+}


### PR DESCRIPTION
## Summary

## Release notes

Choose one:

- [x] Added a `.changeset/*.md` for user-visible changes (`mise run changeset -- patch "..."`).

## Validation

<img width="918" height="722" alt="Screenshot 2026-06-04 at 03 33 17" src="https://github.com/user-attachments/assets/e39087eb-a3a5-4418-b5f3-3b25681fd34f" />

- [ ] Ran relevant tests/checks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Diagnostics settings tab that analyzes your display and Dock configuration and shows detected displays.
  * Added a Refresh Diagnostics action and an "Open Diagnostics" entry from the workspace bar.
  * Workspace bar now shows a warning button when display issues are detected.

* **User Guidance**
  * Provides clear titles, messages and recommendations for resolving display-related problems.

* **Tests**
  * Added comprehensive test coverage for diagnostics detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->