### PR TITLE
Implement resize trace functionality in NiriLayoutEngine and WMController

### DIFF
--- a/.changeset/20260604141301-improve-runtime-resize-tracing-for-niri-width-co.md
+++ b/.changeset/20260604141301-improve-runtime-resize-tracing-for-niri-width-co.md
@@ -1,0 +1,5 @@
+---
+"nehir": patch
+---
+
+Improve runtime resize tracing for Niri width commands

--- a/Sources/Nehir/Core/Controller/NiriLayoutHandler.swift
+++ b/Sources/Nehir/Core/Controller/NiriLayoutHandler.swift
@@ -1424,6 +1424,7 @@ enum NiriWindowMoveResult {
         engine.renderStyle.tabIndicatorWidth = TabbedColumnOverlayManager.tabIndicatorWidth
         engine.animationClock = controller.animationClock
         controller.niriEngine = engine
+        controller.syncNiriResizeTraceSink()
 
         syncMonitorsToNiriEngine()
 

--- a/Sources/Nehir/Core/Controller/WMController.swift
+++ b/Sources/Nehir/Core/Controller/WMController.swift
@@ -180,6 +180,8 @@ final class WMController {
     private var runtimeTraceCaptureSession: RuntimeTraceCaptureSession?
     @ObservationIgnored
     private var runtimeViewportTraceRecords: [String] = []
+    @ObservationIgnored
+    private var runtimeResizeTraceRecords: [String] = []
 
     var runtimeTraceCaptureStatus: RuntimeTraceCaptureStatus {
         RuntimeTraceCaptureStatus(
@@ -1904,6 +1906,25 @@ final class WMController {
         copyDebugTextToPasteboard(snapshot.formattedDump())
     }
 
+    func syncNiriResizeTraceSink() {
+        guard let engine = niriEngine else { return }
+        if runtimeTraceCaptureSession != nil {
+            engine.resizeTraceSink = { [weak self] message in
+                self?.recordRuntimeResizeTrace(message)
+            }
+        } else {
+            engine.resizeTraceSink = nil
+        }
+    }
+
+    func recordRuntimeResizeTrace(_ message: String) {
+        guard runtimeTraceCaptureSession != nil else { return }
+        runtimeResizeTraceRecords.append(Date().ISO8601Format() + " " + message)
+        if runtimeResizeTraceRecords.count > 400 {
+            runtimeResizeTraceRecords.removeFirst(runtimeResizeTraceRecords.count - 400)
+        }
+    }
+
     func recordRuntimeViewportTrace(
         workspaceId: WorkspaceDescriptor.ID,
         reason: String
@@ -1946,6 +1967,7 @@ final class WMController {
             "selectedNode=\(selectedNode)",
             "preferredFocus=\(preferredFocus)",
             "confirmedFocus=\(confirmedFocus)",
+            "resizeCommandSeq=\(engine.resizeCommandGeneration)",
             "layout=\(layoutDecisions)"
         ]
         .joined(separator: " ")
@@ -1987,7 +2009,7 @@ final class WMController {
                 let selected = state.selectedNodeId == window.id ? ":selected" : ""
                 return "w\(token.windowId)\(selected){cur=\(current),target=\(target),last=\(last),live=\(live),replacement=\(replacement),observed=\(observed),\(hidden)}"
             }.joined(separator: ",")
-            return "c\(colIdx)[x=\(String(format: "%.1f", columnXForDebug(colIdx, columns: columns, gap: gap))),w=\(String(format: "%.1f", column.cachedWidth))]{\(windows)}"
+            return "c\(colIdx)[\(niriColumnSizingDebug(column, index: colIdx, columns: columns, gap: gap))]{\(windows)}"
         }.joined(separator: "|")
     }
 
@@ -2026,6 +2048,45 @@ final class WMController {
     private func columnXForDebug(_ index: Int, columns: [NiriContainer], gap: CGFloat) -> CGFloat {
         guard index > 0 else { return 0 }
         return columns.prefix(index).reduce(CGFloat(0)) { $0 + $1.cachedWidth + gap }
+    }
+
+    private func niriWidthSpecDebug(_ spec: ProportionalSize) -> String {
+        switch spec {
+        case let .proportion(proportion):
+            String(format: "prop:%.4f", proportion)
+        case let .fixed(width):
+            String(format: "fix:%.1f", width)
+        }
+    }
+
+    private func niriColumnSizingDebug(
+        _ column: NiriContainer,
+        index: Int,
+        columns: [NiriContainer],
+        gap: CGFloat
+    ) -> String {
+        let now = animationClock.now()
+        let animationText: String
+        if let animation = column.widthAnimation {
+            animationText = String(
+                format: "anim=%.1f->%.1f vel=%.1f",
+                animation.value(at: now),
+                animation.target,
+                animation.velocity(at: now)
+            )
+        } else {
+            animationText = "anim=nil"
+        }
+        return [
+            String(format: "x=%.1f", columnXForDebug(index, columns: columns, gap: gap)),
+            String(format: "cached=%.1f", column.cachedWidth),
+            "spec=\(niriWidthSpecDebug(column.width))",
+            "target=\(column.targetWidth.map { String(format: "%.1f", $0) } ?? "nil")",
+            "preset=\(column.presetWidthIdx.map(String.init) ?? "nil")",
+            "full=\(column.isFullWidth)",
+            "manual=\(column.hasManualSingleWindowWidthOverride)",
+            animationText
+        ].joined(separator: ",")
     }
 
     private func compactRect(_ rect: CGRect) -> String {
@@ -2140,7 +2201,7 @@ final class WMController {
             "accessibilityGranted=\(accessibilityPermissionGranted) lockScreenActive=\(isLockScreenActive) overviewOpen=\(isOverviewOpen()) startedServices=\(hasStartedServices)",
             "focusFollowsMouse=\(focusFollowsMouseEnabled) moveMouseToFocusedWindow=\(moveMouseToFocusedWindowEnabled) mouseWarpPolicyEnabled=\(isMouseWarpPolicyEnabled)",
             "isTransferringWindow=\(isTransferringWindow) hiddenAppPIDs=\(hiddenAppPIDs.count) workspaceBarHiddenMonitors=\(hiddenWorkspaceBarMonitorIds.count)",
-            "runtimeTraceCaptureActive=\(traceCaptureStatus.isActive) runtimeTraceStartedAt=\(traceCaptureStatus.startedAt?.ISO8601Format() ?? "nil") viewportTraceRecords=\(runtimeViewportTraceRecords.count)",
+            "runtimeTraceCaptureActive=\(traceCaptureStatus.isActive) runtimeTraceStartedAt=\(traceCaptureStatus.startedAt?.ISO8601Format() ?? "nil") viewportTraceRecords=\(runtimeViewportTraceRecords.count) resizeTraceRecords=\(runtimeResizeTraceRecords.count)",
             "workspaceBarRefreshDebugState requestCount=\(workspaceBarRefreshDebugState.requestCount) scheduledCount=\(workspaceBarRefreshDebugState.scheduledCount) executionCount=\(workspaceBarRefreshDebugState.executionCount) isQueued=\(workspaceBarRefreshDebugState.isQueued)",
             "-- Focus Targets --",
             focusTargetDebugDump(),
@@ -2188,6 +2249,8 @@ final class WMController {
         if runtimeTraceCaptureSession != nil {
             runtimeTraceCaptureSession = nil
             runtimeViewportTraceRecords.removeAll(keepingCapacity: true)
+            runtimeResizeTraceRecords.removeAll(keepingCapacity: true)
+            syncNiriResizeTraceSink()
             workspaceBarManager.update()
         }
         mouseEventHandler.handleInputSuppressionBegan()
@@ -2259,6 +2322,7 @@ final class WMController {
         }
 
         runtimeViewportTraceRecords.removeAll(keepingCapacity: true)
+        runtimeResizeTraceRecords.removeAll(keepingCapacity: true)
         let startedAt = Date()
         let startRuntimeStateDump = runtimeStateDebugDump(
             traceLimit: 0,
@@ -2268,6 +2332,7 @@ final class WMController {
             startedAt: startedAt,
             startRuntimeStateDump: startRuntimeStateDump
         )
+        syncNiriResizeTraceSink()
         workspaceManager.resetReconcileTraceForDebug()
         workspaceBarManager.update()
         return .executed
@@ -2291,6 +2356,9 @@ final class WMController {
         let viewportTraceDump = runtimeViewportTraceRecords.isEmpty
             ? "viewport trace empty"
             : runtimeViewportTraceRecords.joined(separator: "\n")
+        let resizeTraceDump = runtimeResizeTraceRecords.isEmpty
+            ? "resize trace empty"
+            : runtimeResizeTraceRecords.joined(separator: "\n")
         let body = [
             "Nehir runtime trace capture",
             "startedAt=\(session.startedAt.ISO8601Format())",
@@ -2305,6 +2373,9 @@ final class WMController {
             "",
             "## Niri viewport trace",
             viewportTraceDump,
+            "",
+            "## Niri resize trace",
+            resizeTraceDump,
             "",
             "## Runtime state at end",
             endRuntimeStateDump,
@@ -2326,6 +2397,8 @@ final class WMController {
 
         runtimeTraceCaptureSession = nil
         runtimeViewportTraceRecords.removeAll(keepingCapacity: true)
+        runtimeResizeTraceRecords.removeAll(keepingCapacity: true)
+        syncNiriResizeTraceSink()
         workspaceBarManager.update()
         return .executed
     }

--- a/Sources/Nehir/Core/Layout/Niri/NiriLayoutEngine+Sizing.swift
+++ b/Sources/Nehir/Core/Layout/Niri/NiriLayoutEngine+Sizing.swift
@@ -7,6 +7,92 @@ extension NiriLayoutEngine {
         case window(CGFloat)
     }
 
+    private enum ResizeWidthSource: String {
+        case cachedWidth
+        case resolvedSpec
+        case presetCycle
+        case fullWidthToggle
+        case availableWidthExpansion
+    }
+
+    private func fmt(_ value: CGFloat?) -> String {
+        guard let value else { return "nil" }
+        return String(format: "%.1f", value)
+    }
+
+    private func widthSpecDescription(_ width: ProportionalSize) -> String {
+        switch width {
+        case let .proportion(proportion):
+            return String(format: "proportion(%.4f)", proportion)
+        case let .fixed(width):
+            return String(format: "fixed(%.1f)", width)
+        }
+    }
+
+    private func windowWidthSnapshot(_ window: NiriWindow?) -> String {
+        guard let window else { return "window=nil" }
+        let maxWidth = window.constraints.maxSize.width > 0 ? fmt(window.constraints.maxSize.width) : "none"
+        return [
+            "window=\(window.token.windowId)",
+            "resolved=\(fmt(window.resolvedWidth))",
+            "frame=\(fmt(window.frame?.width))",
+            "min=\(fmt(window.constraints.minSize.width))",
+            "max=\(maxWidth)",
+            "mode=\(window.sizingMode)"
+        ].joined(separator: ",")
+    }
+
+    private func widthAnimationSnapshot(_ column: NiriContainer) -> String {
+        let now = animationClock?.now() ?? CACurrentMediaTime()
+        guard let animation = column.widthAnimation else {
+            return "anim=none"
+        }
+        return [
+            "animCurrent=\(fmt(CGFloat(animation.value(at: now))))",
+            "animFrom=\(fmt(CGFloat(animation.from)))",
+            "animTarget=\(fmt(CGFloat(animation.target)))",
+            "animVelocity=\(fmt(CGFloat(animation.velocity(at: now))))",
+            "targetWidth=\(fmt(column.targetWidth))"
+        ].joined(separator: ",")
+    }
+
+    private func columnWidthSnapshot(
+        _ column: NiriContainer,
+        in workspaceId: WorkspaceDescriptor.ID,
+        workingFrame: CGRect,
+        gaps: CGFloat,
+        window: NiriWindow? = nil
+    ) -> String {
+        let currentSpec = column.isFullWidth ? ProportionalSize.proportion(1) : column.width
+        let resolvedSpec = resolvedColumnPixels(
+            currentSpec,
+            for: column,
+            workingFrame: workingFrame,
+            gaps: gaps
+        )
+        let columnIndex = columnIndex(of: column, in: workspaceId).map(String.init) ?? "nil"
+        return [
+            "columnIndex=\(columnIndex)",
+            "widthSpec=\(widthSpecDescription(column.width))",
+            "effectiveSpec=\(widthSpecDescription(currentSpec))",
+            "cached=\(fmt(column.cachedWidth))",
+            "resolvedSpec=\(fmt(resolvedSpec))",
+            "targetWidth=\(fmt(column.targetWidth))",
+            "presetIdx=\(column.presetWidthIdx.map(String.init) ?? "nil")",
+            "full=\(column.isFullWidth)",
+            "manual=\(column.hasManualSingleWindowWidthOverride)",
+            widthAnimationSnapshot(column),
+            windowWidthSnapshot(window ?? column.activeWindow ?? column.windowNodes.first)
+        ].joined(separator: " ")
+    }
+
+    private func traceResize(_ message: @autoclosure () -> String) {
+        guard resizeTraceSink != nil || LayoutTrace.isEnabled else { return }
+        let text = message()
+        resizeTraceSink?(text)
+        LayoutTrace.log("resizeTrace \(text)")
+    }
+
     private func cachedWidthForResizeStart(
         _ column: NiriContainer,
         in workspaceId: WorkspaceDescriptor.ID,
@@ -141,7 +227,11 @@ extension NiriLayoutEngine {
         motion: MotionSnapshot,
         state: inout ViewportState,
         workingFrame: CGRect,
-        gaps: CGFloat
+        gaps: CGFloat,
+        commandId: UInt64? = nil,
+        commandKind: String? = nil,
+        source: ResizeWidthSource? = nil,
+        targetWindow: NiriWindow? = nil
     ) {
         cancelInteractiveResize(for: column, in: workspaceId)
 
@@ -158,6 +248,7 @@ extension NiriLayoutEngine {
             gaps: gaps
         )
 
+        let beforeAnimation = widthAnimationSnapshot(column)
         let didStartWidthAnimation = column.animateWidthTo(
             newWidth: targetPixels,
             clock: animationClock,
@@ -165,6 +256,15 @@ extension NiriLayoutEngine {
             displayRefreshRate: displayRefreshRate,
             animated: motion.animationsEnabled
         )
+        if let commandId, let commandKind, let source {
+            traceResize(
+                "cmd=\(commandId) apply kind=\(commandKind) source=\(source.rawValue) "
+                    + "previous=\(fmt(previousWidth)) targetPixels=\(fmt(targetPixels)) "
+                    + "newSpec=\(widthSpecDescription(newWidth)) presetIdx=\(presetIndex.map(String.init) ?? "nil") "
+                    + "animations=\(motion.animationsEnabled) didStartAnimation=\(didStartWidthAnimation) "
+                    + "beforeAnim{\(beforeAnimation)} after{\(columnWidthSnapshot(column, in: workspaceId, workingFrame: workingFrame, gaps: gaps, window: targetWindow))}"
+            )
+        }
 
         ensureSelectionVisibleForPendingWidth(
             column,
@@ -303,6 +403,8 @@ extension NiriLayoutEngine {
         gaps: CGFloat
     ) {
         guard !presetColumnWidths.isEmpty else { return }
+        let commandId = nextResizeCommandId()
+        let commandKind = "toggleColumnWidth(\(forwards ? "forward" : "backward"))"
 
         let previousWidth = cachedWidthForResizeStart(
             column,
@@ -373,6 +475,12 @@ extension NiriLayoutEngine {
             workingFrame: workingFrame,
             gaps: gaps
         )
+        traceResize(
+            "cmd=\(commandId) compute kind=\(commandKind) source=\(ResizeWidthSource.presetCycle.rawValue) "
+                + "previous=\(fmt(previousWidth)) currentSpec=\(widthSpecDescription(currentSpec)) "
+                + "nextPreset=\(nextIdx) newSpec=\(widthSpecDescription(newWidth)) "
+                + "state{\(columnWidthSnapshot(column, in: workspaceId, workingFrame: workingFrame, gaps: gaps, window: targetWindow))}"
+        )
 
         applyColumnWidth(
             column,
@@ -383,7 +491,11 @@ extension NiriLayoutEngine {
             motion: motion,
             state: &state,
             workingFrame: workingFrame,
-            gaps: gaps
+            gaps: gaps,
+            commandId: commandId,
+            commandKind: commandKind,
+            source: .presetCycle,
+            targetWindow: targetWindow
         )
     }
 
@@ -416,8 +528,11 @@ extension NiriLayoutEngine {
         motion: MotionSnapshot = .enabled,
         state: inout ViewportState,
         workingFrame: CGRect,
-        gaps: CGFloat
+        gaps: CGFloat,
+        commandKind: String = "setColumnWidth",
+        targetWindow: NiriWindow? = nil
     ) {
+        let commandId = nextResizeCommandId()
         let previousWidth = cachedWidthForResizeStart(
             column,
             in: workspaceId,
@@ -439,6 +554,12 @@ extension NiriLayoutEngine {
             workingFrame: workingFrame,
             gaps: gaps
         )
+        traceResize(
+            "cmd=\(commandId) compute kind=\(commandKind) change=\(change) source=\(ResizeWidthSource.resolvedSpec.rawValue) "
+                + "previous=\(fmt(previousWidth)) currentPixels=\(fmt(currentPixels)) "
+                + "currentSpec=\(widthSpecDescription(currentSpec)) newSpec=\(widthSpecDescription(newWidth)) "
+                + "state{\(columnWidthSnapshot(column, in: workspaceId, workingFrame: workingFrame, gaps: gaps, window: targetWindow))}"
+        )
 
         applyColumnWidth(
             column,
@@ -449,7 +570,11 @@ extension NiriLayoutEngine {
             motion: motion,
             state: &state,
             workingFrame: workingFrame,
-            gaps: gaps
+            gaps: gaps,
+            commandId: commandId,
+            commandKind: commandKind,
+            source: .resolvedSpec,
+            targetWindow: targetWindow
         )
     }
 
@@ -470,7 +595,9 @@ extension NiriLayoutEngine {
             motion: motion,
             state: &state,
             workingFrame: workingFrame,
-            gaps: gaps
+            gaps: gaps,
+            commandKind: "setWindowWidth",
+            targetWindow: window
         )
     }
 
@@ -482,6 +609,8 @@ extension NiriLayoutEngine {
         workingFrame: CGRect,
         gaps: CGFloat
     ) {
+        let commandId = nextResizeCommandId()
+        let commandKind = "toggleFullWidth"
         let workingAreaWidth = workingFrame.width
         let previousWidth = cachedWidthForResizeStart(
             column,
@@ -513,12 +642,24 @@ extension NiriLayoutEngine {
             targetPixels = resolvedColumnPixels(.proportion(1), for: column, workingFrame: workingFrame, gaps: gaps)
         }
 
+        traceResize(
+            "cmd=\(commandId) compute kind=\(commandKind) source=\(ResizeWidthSource.fullWidthToggle.rawValue) "
+                + "previous=\(fmt(previousWidth)) targetPixels=\(fmt(targetPixels)) "
+                + "state{\(columnWidthSnapshot(column, in: workspaceId, workingFrame: workingFrame, gaps: gaps))}"
+        )
+        let beforeAnimation = widthAnimationSnapshot(column)
         let didStartWidthAnimation = column.animateWidthTo(
             newWidth: targetPixels,
             clock: animationClock,
             config: windowMovementAnimationConfig,
             displayRefreshRate: displayRefreshRate,
             animated: motion.animationsEnabled
+        )
+        traceResize(
+            "cmd=\(commandId) apply kind=\(commandKind) source=\(ResizeWidthSource.fullWidthToggle.rawValue) "
+                + "previous=\(fmt(previousWidth)) targetPixels=\(fmt(targetPixels)) "
+                + "animations=\(motion.animationsEnabled) didStartAnimation=\(didStartWidthAnimation) "
+                + "beforeAnim{\(beforeAnimation)} after{\(columnWidthSnapshot(column, in: workspaceId, workingFrame: workingFrame, gaps: gaps))}"
         )
 
         ensureSelectionVisibleForPendingWidth(
@@ -620,6 +761,8 @@ extension NiriLayoutEngine {
 
         guard let leftmostColX, let activeColX else { return }
 
+        let commandId = nextResizeCommandId()
+        let commandKind = "expandColumnToAvailableWidth"
         let previousWidth = cachedWidthForResizeStart(
             column,
             in: workspaceId,
@@ -627,6 +770,12 @@ extension NiriLayoutEngine {
             gaps: gaps
         )
         let targetWidth = (column.cachedWidth + availableWidth).clamped(to: 1 ... NiriSizeChange.maxPixels)
+        traceResize(
+            "cmd=\(commandId) compute kind=\(commandKind) source=\(ResizeWidthSource.availableWidthExpansion.rawValue) "
+                + "previous=\(fmt(previousWidth)) available=\(fmt(availableWidth)) target=\(fmt(targetWidth)) "
+                + "viewX=\(fmt(viewX)) activeColX=\(fmt(activeColX)) leftmostColX=\(fmt(leftmostColX)) "
+                + "state{\(columnWidthSnapshot(column, in: workspaceId, workingFrame: workingFrame, gaps: gaps))}"
+        )
         applyColumnWidth(
             column,
             width: .fixed(targetWidth),
@@ -636,7 +785,10 @@ extension NiriLayoutEngine {
             motion: motion,
             state: &state,
             workingFrame: workingFrame,
-            gaps: gaps
+            gaps: gaps,
+            commandId: commandId,
+            commandKind: commandKind,
+            source: .availableWidthExpansion
         )
 
         let targetOffset = leftmostColX - gaps - activeColX

--- a/Sources/Nehir/Core/Layout/Niri/NiriLayoutEngine.swift
+++ b/Sources/Nehir/Core/Layout/Niri/NiriLayoutEngine.swift
@@ -144,6 +144,14 @@ final class NiriLayoutEngine {
     var presetWindowHeights: [PresetSize] = NiriLayoutEngine.defaultPresetWindowHeights
     var defaultColumnWidth: CGFloat? = 0.5
 
+    var resizeTraceSink: ((String) -> Void)?
+    private(set) var resizeCommandGeneration: UInt64 = 0
+
+    func nextResizeCommandId() -> UInt64 {
+        resizeCommandGeneration += 1
+        return resizeCommandGeneration
+    }
+
     init(maxVisibleColumns: Int = 2, infiniteLoop: Bool = false) {
         self.maxVisibleColumns = max(1, min(5, maxVisibleColumns))
         self.infiniteLoop = infiniteLoop


### PR DESCRIPTION
## Summary
## Release notes

Choose one:

- [x] Added a `.changeset/*.md` for user-visible changes (`mise run changeset -- patch "..."`).

## Validation

<!-- Commands run, screenshots, or manual checks. -->

- [ ] Ran relevant tests/checks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced runtime resize tracing for window layout operations with more detailed debug information.
  * Improved trace capture to include resize command sequences and detailed sizing/animation state diagnostics.
  * Better visibility into layout decision-making through expanded debug output formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->