### PR TITLE
Fix focused-window commands to prioritize floating windows over tiled windows

### DIFF
--- a/.changeset/20260608185612-fix-focused-window-commands-targeting-tiled-wind.md
+++ b/.changeset/20260608185612-fix-focused-window-commands-targeting-tiled-wind.md
@@ -1,0 +1,6 @@
+---
+"nehir": patch
+contributors: [sebb3]
+---
+
+Fix focused-window commands targeting tiled windows behind focused floating windows. Fixes #12.

--- a/Sources/Nehir/Core/Controller/WMController.swift
+++ b/Sources/Nehir/Core/Controller/WMController.swift
@@ -1348,7 +1348,7 @@ final class WMController {
         return NSScreen.screens.first(where: { $0.displayId == monitor.displayId })
     }
 
-    func managedCommandTarget() -> WMCommandTarget? {
+    private func layoutSelectionCommandTarget() -> WMCommandTarget? {
         if let workspaceId = interactionWorkspace()?.id,
            let engine = niriEngine,
            let selectedNodeId = workspaceManager.niriViewportState(for: workspaceId).selectedNodeId,
@@ -1362,9 +1362,14 @@ final class WMController {
             )
         }
 
+        return nil
+    }
+
+    func managedCommandTarget() -> WMCommandTarget? {
         if let token = workspaceManager.confirmedManagedFocusToken,
            let workspaceId = workspaceManager.workspace(for: token),
-           workspaceManager.entry(for: token) != nil
+           let entry = workspaceManager.entry(for: token),
+           entry.mode == .floating
         {
             return WMCommandTarget(
                 token: token,
@@ -1377,6 +1382,33 @@ final class WMController {
             ?? NSWorkspace.shared.frontmostApplication?.processIdentifier
         let frontmostToken = commandHandler.frontmostFocusedWindowTokenProvider?()
             ?? frontmostPid.flatMap { axEventHandler.focusedWindowToken(for: $0) }
+        if let frontmostToken,
+           let workspaceId = workspaceManager.workspace(for: frontmostToken),
+           let entry = workspaceManager.entry(for: frontmostToken),
+           entry.mode == .floating
+        {
+            return WMCommandTarget(
+                token: frontmostToken,
+                workspaceId: workspaceId,
+                source: .frontmostManagedFallback
+            )
+        }
+
+        if let target = layoutSelectionCommandTarget() {
+            return target
+        }
+
+        if let token = workspaceManager.confirmedManagedFocusToken,
+           let workspaceId = workspaceManager.workspace(for: token),
+           workspaceManager.entry(for: token) != nil
+        {
+            return WMCommandTarget(
+                token: token,
+                workspaceId: workspaceId,
+                source: .confirmedManagedFocus
+            )
+        }
+
         guard let frontmostToken,
               let workspaceId = workspaceManager.workspace(for: frontmostToken),
               workspaceManager.entry(for: frontmostToken) != nil
@@ -1392,6 +1424,10 @@ final class WMController {
 
     func managedCommandTargetToken() -> WindowToken? {
         managedCommandTarget()?.token
+    }
+
+    func managedLayoutCommandTargetToken() -> WindowToken? {
+        layoutSelectionCommandTarget()?.token ?? managedCommandTargetToken()
     }
 
     private func focusedManagedTokenForCommand() -> WindowToken? {

--- a/Sources/Nehir/Core/Controller/WorkspaceNavigationHandler.swift
+++ b/Sources/Nehir/Core/Controller/WorkspaceNavigationHandler.swift
@@ -556,7 +556,7 @@ final class WorkspaceNavigationHandler {
     func moveColumnToAdjacentWorkspace(direction: Direction) {
         guard let controller else { return }
         guard let engine = controller.niriEngine else { return }
-        guard let token = controller.managedCommandTargetToken() else { return }
+        guard let token = controller.managedLayoutCommandTargetToken() else { return }
         guard let currentMonitorId = interactionMonitorId(for: controller)
         else { return }
         guard let wsId = controller.interactionWorkspace()?.id else { return }
@@ -625,7 +625,7 @@ final class WorkspaceNavigationHandler {
     func moveColumnToWorkspace(rawWorkspaceID: String) {
         guard let controller else { return }
         guard let engine = controller.niriEngine else { return }
-        guard let token = controller.managedCommandTargetToken() else { return }
+        guard let token = controller.managedLayoutCommandTargetToken() else { return }
         guard let wsId = controller.interactionWorkspace()?.id else { return }
 
         guard let targetWsId = controller.workspaceManager.workspaceId(for: rawWorkspaceID, createIfMissing: false)

--- a/Tests/NehirTests/IPCCommandRouterTests.swift
+++ b/Tests/NehirTests/IPCCommandRouterTests.swift
@@ -624,6 +624,27 @@ private func prepareIPCNiriState(
         #expect(idleRouter.handle(.toggleFocusedWindowFloating) == .notFound)
     }
 
+    @Test @MainActor func toggleFocusedWindowFloatingTargetsFocusedFloatingWindowOverNiriSelection() async throws {
+        let controller = makeLayoutPlanTestController()
+        controller.enableNiriLayout()
+        let router = makeIPCCommandRouter(for: controller)
+        let workspaceId = try #require(controller.workspaceManager.workspaceId(for: "1", createIfMissing: false))
+        let monitor = try #require(controller.workspaceManager.monitor(for: workspaceId))
+        let tiledToken = addLayoutPlanTestWindow(on: controller, workspaceId: workspaceId, windowId: 2_451)
+        let floatingToken = addLayoutPlanTestWindow(on: controller, workspaceId: workspaceId, windowId: 2_452)
+
+        _ = controller.workspaceManager.setManagedFocus(tiledToken, in: workspaceId, onMonitor: monitor.id)
+        controller.layoutRefreshController.requestImmediateRelayout(reason: .workspaceTransition)
+        await controller.layoutRefreshController.waitForRefreshWorkForTests()
+        _ = controller.transitionWindowMode(for: floatingToken, to: .floating, preferredMonitor: monitor)
+        _ = controller.workspaceManager.setManagedFocus(floatingToken, in: workspaceId, onMonitor: monitor.id)
+
+        #expect(controller.managedCommandTarget()?.token == floatingToken)
+        #expect(router.handle(.toggleFocusedWindowFloating) == .executed)
+        #expect(controller.workspaceManager.entry(for: floatingToken)?.mode == .tiling)
+        #expect(controller.workspaceManager.entry(for: tiledToken)?.mode == .tiling)
+    }
+
     @Test func scratchpadToggleReturnsExecutedForPendingAsyncReveal() throws {
         let controller = makeLayoutPlanTestController()
         let router = makeIPCCommandRouter(for: controller)

--- a/docs/IPC-CLI.md
+++ b/docs/IPC-CLI.md
@@ -340,6 +340,8 @@ Workspace IDs are positive numeric strings. Direct hotkeys stay limited to `1-9`
 | `command scratchpad assign` | — | command | Assign the focused window to the scratchpad |
 | `command scratchpad toggle` | — | command | Show or hide the scratchpad window |
 
+When a managed floating window has keyboard focus, focused-window commands target that floating window even if the Niri viewport selection still points at a tiled window underneath it.
+
 ### UI Toggles
 
 | Command | Arguments | Surface | Description |


### PR DESCRIPTION
## Summary

fixes #12 
The regression was introduced by c17827de in the focus-target refactor.

## What changed

Before c17827de, toggleFocusedWindowFloating() used focusedManagedTokenForCommand(), which resolved through focusedOrFrontmostWindowTokenForAutomation():

- confirmed focused managed token first
- then AX/frontmost focused window fallback

In c17827de, focusedManagedTokenForCommand() was changed to use the new managedCommandTargetToken().

managedCommandTarget() prioritized Niri viewport selection before confirmed/frontmost focus:

swift if let workspaceId = interactionWorkspace()?.id,    let engine = niriEngine,    let selectedNodeId = workspaceManager.niriViewportState(for: workspaceId).selectedNodeId,    let selectedWindow = engine.findNode(by: selectedNodeId) as? NiriWindow,    workspaceManager.entry(for: selectedWindow.token) != nil {     return WMCommandTarget(... source: .layoutSelection) } 

## Why this regressed floating windows

Floating windows are not represented as selected NiriWindow nodes in the tiled Niri viewport.

After toggling a tiled window to floating, the floating window can have real keyboard focus and border, but the Niri viewport selection may still point to a tiled window underneath or behind it.

Because .layoutSelection was checked first, focused-window commands targeted the stale tiled selection before they ever considered confirmed managed focus or frontmost AX focus.

As a result, toggleFocusedWindowFloating() kept floating the tiled window behind the focused floating window instead of untoggling the focused floating window.

## Original change intent

c17827de was trying to separate:

- command/border target
- confirmed managed focus
- active focus request
- interaction workspace/monitor

That was directionally correct for Niri gestures and viewport browsing. Commands often need to follow the Niri selection even while macOS focus confirmation lags or stays stable during gesture animation.

## Bug in that change

The refactor treated Niri layout selection as universally higher-priority than real focused/frontmost managed windows.

That is only safe for tiled/Niri-managed selection context.

It failed to account for focused floating windows, which live outside the Niri selection model.

## Fix

The fix preserves the original intent by making focused/frontmost floating windows override Niri selection, then falling back to Niri selection for tiled commands.

## Release notes

Choose one:

- [x] Added a `.changeset/*.md` for user-visible changes (`mise run changeset -- patch "..."`).

## Validation

<!-- Commands run, screenshots, or manual checks. -->

- [ ] Ran relevant tests/checks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed focused-window commands incorrectly targeting tiled windows when a floating window has focus; now correctly prioritizes the floating window.

* **Documentation**
  * Clarified that focused-window commands properly target floating windows with focus, even when the viewport selection points to tiled windows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->