### PR TITLE
Enhance hotkey functionality by making all commands assignable in settings

### DIFF
--- a/.changeset/20260608212251-made-every-hotkey-assignable-command-available-c.md
+++ b/.changeset/20260608212251-made-every-hotkey-assignable-command-available-c.md
@@ -1,0 +1,6 @@
+---
+"nehir": patch
+contributors: [VyLowry7337]
+---
+
+Made every hotkey-assignable command available consistently in hotkey settings, the command palette, IPC/CLI, and TOML config. Fixed #14.

--- a/Sources/Nehir/Core/Config/HotkeyConfigMapping.swift
+++ b/Sources/Nehir/Core/Config/HotkeyConfigMapping.swift
@@ -20,6 +20,7 @@ enum HotkeyConfigMapping {
         NumberedGroup(section: "workspace", key: "switch", internalIdPattern: "switchWorkspace.%d", indexOffset: -1),
         NumberedGroup(section: "workspace", key: "moveTo", internalIdPattern: "moveToWorkspace.%d", indexOffset: -1),
         NumberedGroup(section: "workspace", key: "moveColumnTo", internalIdPattern: "moveColumnToWorkspace.%d", indexOffset: -1),
+        NumberedGroup(section: "workspace", key: "focusAnywhere", internalIdPattern: "focusWorkspaceAnywhere.%d", indexOffset: -1),
         NumberedGroup(section: "focus", key: "column", internalIdPattern: "focusColumn.%d", indexOffset: -1),
         NumberedGroup(section: "focus", key: "windowInColumn", internalIdPattern: "focusWindowInColumn.%d", indexOffset: 0),
         NumberedGroup(section: "move", key: "columnToIndex", internalIdPattern: "moveColumnToIndex.%d", indexOffset: 0),
@@ -31,6 +32,10 @@ enum HotkeyConfigMapping {
         ("workspace", "backAndForth", "workspaceBackAndForth"),
         ("workspace", "next", "switchWorkspace.next"),
         ("workspace", "previous", "switchWorkspace.previous"),
+        ("workspace", "swapWithMonitorLeft", "swapWorkspaceWithMonitor.left"),
+        ("workspace", "swapWithMonitorRight", "swapWorkspaceWithMonitor.right"),
+        ("workspace", "swapWithMonitorUp", "swapWorkspaceWithMonitor.up"),
+        ("workspace", "swapWithMonitorDown", "swapWorkspaceWithMonitor.down"),
         // focus
         ("focus", "left", "focus.left"),
         ("focus", "down", "focus.down"),
@@ -123,6 +128,12 @@ enum HotkeyConfigMapping {
                 let internalIdx = n + g.indexOffset
                 let internalId = String(format: g.internalIdPattern, internalIdx)
                 map[configKey] = internalId
+            }
+        }
+        for n in 1...9 {
+            for direction in ["left", "right", "up", "down"] {
+                map["move.windowToWorkspaceOnMonitor.\(n).\(direction)"] =
+                    "moveWindowToWorkspaceOnMonitor.\(n - 1).\(direction)"
             }
         }
         return map

--- a/Sources/Nehir/Core/Config/HotkeysTOMLCodec.swift
+++ b/Sources/Nehir/Core/Config/HotkeysTOMLCodec.swift
@@ -45,6 +45,13 @@ enum HotkeysTOMLCodec {
                     lines.append("\(singleton.key) = \(quoted(value))")
                 }
             }
+
+            // Handle generated config keys that are not represented by a compact group.
+            for configKey in bindingMap.keys.sorted() where configKey.hasPrefix("\(section).") {
+                guard let value = bindingMap.removeValue(forKey: configKey) else { continue }
+                let key = String(configKey.dropFirst(section.count + 1))
+                lines.append("\(quoted(key)) = \(quoted(value))")
+            }
         }
 
         let output = lines.joined(separator: "\n") + "\n"

--- a/Sources/Nehir/Core/Input/ActionCatalog.swift
+++ b/Sources/Nehir/Core/Input/ActionCatalog.swift
@@ -1,19 +1,12 @@
 import Carbon
 import NehirIPC
 
-enum HotkeyVisibility: String {
-    case normal
-    case advanced
-    case hidden
-}
-
 struct ActionSpec: Equatable {
     let id: String
     let command: HotkeyCommand
     let title: String
     let keywords: [String]
     let category: HotkeyCategory
-    let visibility: HotkeyVisibility
     let defaultBinding: KeyBinding
     let ipcCommandName: IPCCommandName?
 
@@ -65,10 +58,6 @@ enum ActionCatalog {
 
     static func category(for id: String) -> HotkeyCategory? {
         spec(for: id)?.category
-    }
-
-    static func visibility(for id: String) -> HotkeyVisibility? {
-        spec(for: id)?.visibility
     }
 
     static func defaultHotkeyBindings() -> [HotkeyBinding] {
@@ -206,56 +195,48 @@ enum ActionCatalog {
                 command: .focusDownOrLeft,
                 category: .focus,
                 binding: .unassigned,
-                visibility: .advanced
             ),
             action(
                 id: "focusUpOrRight",
                 command: .focusUpOrRight,
                 category: .focus,
                 binding: .unassigned,
-                visibility: .advanced
             ),
             action(
                 id: "focusWindowTop",
                 command: .focusWindowTop,
                 category: .focus,
                 binding: .unassigned,
-                visibility: .advanced
             ),
             action(
                 id: "focusWindowBottom",
                 command: .focusWindowBottom,
                 category: .focus,
                 binding: .unassigned,
-                visibility: .advanced
             ),
             action(
                 id: "focusWindowDownOrTop",
                 command: .focusWindowDownOrTop,
                 category: .focus,
                 binding: .unassigned,
-                visibility: .advanced
             ),
             action(
                 id: "focusWindowUpOrBottom",
                 command: .focusWindowUpOrBottom,
                 category: .focus,
                 binding: .unassigned,
-                visibility: .advanced
             ),
             action(
                 id: "focusWindowOrWorkspaceDown",
                 command: .focusWindowOrWorkspaceDown,
                 category: .focus,
                 binding: .unassigned,
-                visibility: .advanced
             ),
             action(
                 id: "focusWindowOrWorkspaceUp",
                 command: .focusWindowOrWorkspaceUp,
                 category: .focus,
                 binding: .unassigned,
-                visibility: .advanced
             )
         ])
 
@@ -265,14 +246,12 @@ enum ActionCatalog {
                 command: .centerColumn,
                 category: .layout,
                 binding: .unassigned,
-                visibility: .advanced
             ),
             action(
                 id: "centerVisibleColumns",
                 command: .centerVisibleColumns,
                 category: .layout,
                 binding: .unassigned,
-                visibility: .advanced
             )
         ])
 
@@ -313,9 +292,43 @@ enum ActionCatalog {
                     command: .moveColumnToWorkspace(idx),
                     category: .workspace,
                     binding: .unassigned,
-                    visibility: .advanced
-                )
+                    )
             )
+        }
+
+        for direction in [Direction.left, .right, .up, .down] {
+            specs.append(
+                action(
+                    id: "swapWorkspaceWithMonitor.\(direction.rawValue)",
+                    command: .swapWorkspaceWithMonitor(direction),
+                    category: .workspace,
+                    binding: .unassigned,
+                    )
+            )
+        }
+
+        for idx in 0 ..< 9 {
+            specs.append(
+                action(
+                    id: "focusWorkspaceAnywhere.\(idx)",
+                    command: .focusWorkspaceAnywhere(idx),
+                    category: .workspace,
+                    binding: .unassigned,
+                    )
+            )
+        }
+
+        for idx in 0 ..< 9 {
+            for direction in [Direction.left, .right, .up, .down] {
+                specs.append(
+                    action(
+                        id: "moveWindowToWorkspaceOnMonitor.\(idx).\(direction.rawValue)",
+                        command: .moveWindowToWorkspaceOnMonitor(workspaceIndex: idx, monitorDirection: direction),
+                        category: .workspace,
+                        binding: .unassigned,
+                            )
+                )
+            }
         }
 
         specs.append(contentsOf: [
@@ -351,56 +364,48 @@ enum ActionCatalog {
                 command: .moveWindowDown,
                 category: .move,
                 binding: .unassigned,
-                visibility: .hidden
             ),
             action(
                 id: "moveWindowUp",
                 command: .moveWindowUp,
                 category: .move,
                 binding: .unassigned,
-                visibility: .hidden
             ),
             action(
                 id: "moveWindowDownOrToWorkspaceDown",
                 command: .moveWindowDownOrToWorkspaceDown,
                 category: .move,
                 binding: .unassigned,
-                visibility: .advanced
             ),
             action(
                 id: "moveWindowUpOrToWorkspaceUp",
                 command: .moveWindowUpOrToWorkspaceUp,
                 category: .move,
                 binding: .unassigned,
-                visibility: .advanced
             ),
             action(
                 id: "consumeOrExpelWindowLeft",
                 command: .consumeOrExpelWindowLeft,
                 category: .move,
                 binding: .unassigned,
-                visibility: .hidden
             ),
             action(
                 id: "consumeOrExpelWindowRight",
                 command: .consumeOrExpelWindowRight,
                 category: .move,
                 binding: .unassigned,
-                visibility: .hidden
             ),
             action(
                 id: "consumeWindowIntoColumn",
                 command: .consumeWindowIntoColumn,
                 category: .move,
                 binding: .unassigned,
-                visibility: .advanced
             ),
             action(
                 id: "expelWindowFromColumn",
                 command: .expelWindowFromColumn,
                 category: .move,
                 binding: .unassigned,
-                visibility: .advanced
             )
         ])
 
@@ -495,8 +500,7 @@ enum ActionCatalog {
                     command: .focusColumn(idx),
                     category: .focus,
                     binding: KeyBinding(keyCode: code, modifiers: UInt32(optionKey | controlKey)),
-                    visibility: .advanced
-                )
+                    )
             )
         }
 
@@ -507,8 +511,7 @@ enum ActionCatalog {
                     command: .focusWindowInColumn(idx),
                     category: .focus,
                     binding: .unassigned,
-                    visibility: .advanced
-                )
+                    )
             )
         }
 
@@ -519,8 +522,7 @@ enum ActionCatalog {
                     command: .moveColumnToIndex(idx),
                     category: .column,
                     binding: .unassigned,
-                    visibility: .advanced
-                )
+                    )
             )
         }
 
@@ -530,42 +532,36 @@ enum ActionCatalog {
                 command: .cycleColumnWidthForward,
                 category: .column,
                 binding: KeyBinding(keyCode: UInt32(kVK_ANSI_Period), modifiers: UInt32(optionKey)),
-                visibility: .advanced
             ),
             action(
                 id: "cycleColumnWidthBackward",
                 command: .cycleColumnWidthBackward,
                 category: .column,
                 binding: KeyBinding(keyCode: UInt32(kVK_ANSI_Comma), modifiers: UInt32(optionKey)),
-                visibility: .advanced
             ),
             action(
                 id: "cycleWindowWidthForward",
                 command: .cycleWindowWidthForward,
                 category: .column,
                 binding: .unassigned,
-                visibility: .advanced
             ),
             action(
                 id: "cycleWindowWidthBackward",
                 command: .cycleWindowWidthBackward,
                 category: .column,
                 binding: .unassigned,
-                visibility: .advanced
             ),
             action(
                 id: "cycleWindowHeightForward",
                 command: .cycleWindowHeightForward,
                 category: .column,
                 binding: .unassigned,
-                visibility: .advanced
             ),
             action(
                 id: "cycleWindowHeightBackward",
                 command: .cycleWindowHeightBackward,
                 category: .column,
                 binding: .unassigned,
-                visibility: .advanced
             ),
             action(
                 id: "toggleColumnFullWidth",
@@ -578,21 +574,18 @@ enum ActionCatalog {
                 command: .expandColumnToAvailableWidth,
                 category: .column,
                 binding: KeyBinding(keyCode: UInt32(kVK_ANSI_F), modifiers: UInt32(optionKey | controlKey)),
-                visibility: .advanced
             ),
             action(
                 id: "resetWindowHeight",
                 command: .resetWindowHeight,
                 category: .column,
                 binding: KeyBinding(keyCode: UInt32(kVK_ANSI_R), modifiers: UInt32(optionKey | controlKey)),
-                visibility: .advanced
             ),
             action(
                 id: "setColumnWidth.decrease10Percent",
                 command: .setColumnWidth(.adjustProportion(-10)),
                 category: .column,
                 binding: KeyBinding(keyCode: UInt32(kVK_ANSI_Minus), modifiers: UInt32(optionKey)),
-                visibility: .advanced,
                 keywords: ["shrink column", "resize column"]
             ),
             action(
@@ -600,7 +593,6 @@ enum ActionCatalog {
                 command: .setColumnWidth(.adjustProportion(10)),
                 category: .column,
                 binding: KeyBinding(keyCode: UInt32(kVK_ANSI_Equal), modifiers: UInt32(optionKey)),
-                visibility: .advanced,
                 keywords: ["grow column", "resize column"]
             ),
             action(
@@ -608,7 +600,6 @@ enum ActionCatalog {
                 command: .setWindowWidth(.adjustProportion(-10)),
                 category: .column,
                 binding: .unassigned,
-                visibility: .advanced,
                 keywords: ["shrink window", "resize window"]
             ),
             action(
@@ -616,7 +607,6 @@ enum ActionCatalog {
                 command: .setWindowWidth(.adjustProportion(10)),
                 category: .column,
                 binding: .unassigned,
-                visibility: .advanced,
                 keywords: ["grow window", "resize window"]
             ),
             action(
@@ -624,7 +614,6 @@ enum ActionCatalog {
                 command: .setWindowHeight(.adjustProportion(-10)),
                 category: .column,
                 binding: KeyBinding(keyCode: UInt32(kVK_ANSI_Minus), modifiers: UInt32(optionKey | shiftKey)),
-                visibility: .advanced,
                 keywords: ["shorter window", "resize window"]
             ),
             action(
@@ -632,7 +621,6 @@ enum ActionCatalog {
                 command: .setWindowHeight(.adjustProportion(10)),
                 category: .column,
                 binding: KeyBinding(keyCode: UInt32(kVK_ANSI_Equal), modifiers: UInt32(optionKey | shiftKey)),
-                visibility: .advanced,
                 keywords: ["taller window", "resize window"]
             ),
             action(
@@ -745,7 +733,6 @@ enum ActionCatalog {
         command: HotkeyCommand,
         category: HotkeyCategory,
         binding: KeyBinding,
-        visibility: HotkeyVisibility = .normal,
         keywords: [String] = []
     ) -> ActionSpec {
         let title = displayName(for: command)
@@ -755,7 +742,6 @@ enum ActionCatalog {
             title: title,
             keywords: uniqueTerms(keywords + [title, id]),
             category: category,
-            visibility: visibility,
             defaultBinding: defaultBinding(for: binding),
             ipcCommandName: ipcCommandName(for: command)
         )

--- a/Sources/Nehir/UI/CommandPalette/CommandPaletteController.swift
+++ b/Sources/Nehir/UI/CommandPalette/CommandPaletteController.swift
@@ -492,7 +492,6 @@ final class CommandPaletteController: NSObject, ObservableObject, NSWindowDelega
             uniqueKeysWithValues: wmController.settings.hotkeyBindings.map { ($0.id, $0.binding) }
         )
         return ActionCatalog.allSpecs()
-            .filter { $0.visibility != .hidden }
             .map { spec in
                 let trigger = bindingsByID[spec.id]
                 let bindingDisplay = trigger.flatMap { $0.isUnassigned ? nil : $0.displayString }

--- a/Sources/Nehir/UI/HotkeySettingsView.swift
+++ b/Sources/Nehir/UI/HotkeySettingsView.swift
@@ -101,12 +101,7 @@ private struct HotkeySettingsSection: Identifiable {
 
 enum HotkeySettingsDisplayModel {
     static func isVisible(bindingId: String) -> Bool {
-        switch ActionCatalog.visibility(for: bindingId) ?? .normal {
-        case .normal:
-            true
-        case .advanced, .hidden:
-            false
-        }
+        ActionCatalog.spec(for: bindingId) != nil
     }
 
     static func matchesSearch(_ query: String, binding: HotkeyBinding) -> Bool {

--- a/Tests/NehirTests/ActionCatalogTests.swift
+++ b/Tests/NehirTests/ActionCatalogTests.swift
@@ -97,6 +97,8 @@ import Testing
     @Test func niriWindowMoveActionsUsePublicCommandDescriptors() throws {
         let down = try #require(ActionCatalog.spec(for: "moveWindowDown"))
         let fallback = try #require(ActionCatalog.spec(for: "moveWindowDownOrToWorkspaceDown"))
+        let consumeOrExpelLeft = try #require(ActionCatalog.spec(for: "consumeOrExpelWindowLeft"))
+        let consumeOrExpelRight = try #require(ActionCatalog.spec(for: "consumeOrExpelWindowRight"))
         let consume = try #require(ActionCatalog.spec(for: "consumeWindowIntoColumn"))
         let expel = try #require(ActionCatalog.spec(for: "expelWindowFromColumn"))
 
@@ -104,9 +106,34 @@ import Testing
         #expect(down.ipcDescriptor?.path == "command move-window-down")
         #expect(fallback.ipcCommandName == .moveWindowDownOrToWorkspaceDown)
         #expect(fallback.ipcDescriptor?.path == "command move-window-down-or-to-workspace-down")
+        #expect(consumeOrExpelLeft.ipcCommandName == .consumeOrExpelWindowLeft)
+        #expect(consumeOrExpelLeft.ipcDescriptor?.path == "command consume-or-expel-window-left")
+        #expect(consumeOrExpelRight.ipcCommandName == .consumeOrExpelWindowRight)
+        #expect(consumeOrExpelRight.ipcDescriptor?.path == "command consume-or-expel-window-right")
         #expect(consume.ipcCommandName == .consumeWindowIntoColumn)
         #expect(consume.ipcDescriptor?.path == "command consume-window-into-column")
         #expect(expel.ipcCommandName == .expelWindowFromColumn)
         #expect(expel.ipcDescriptor?.path == "command expel-window-from-column")
+    }
+
+    @Test func allCatalogActionsAreAssignableSearchableConfigurableAndPubliclyInvokable() {
+        for spec in ActionCatalog.allSpecs() {
+            #expect(HotkeySettingsDisplayModel.isVisible(bindingId: spec.id), "\(spec.id) should be visible in hotkey assignment UI")
+            #expect(HotkeyConfigMapping.configKey(forInternalId: spec.id) != nil, "\(spec.id) should have a TOML config key")
+            #expect(spec.ipcCommandName != nil, "\(spec.id) should have an IPC/CLI command")
+        }
+    }
+
+    @Test func generatedWorkspaceActionsAreCataloguedForAllAccessPaths() throws {
+        let swap = try #require(ActionCatalog.spec(for: "swapWorkspaceWithMonitor.left"))
+        let focusAnywhere = try #require(ActionCatalog.spec(for: "focusWorkspaceAnywhere.0"))
+        let moveOnMonitor = try #require(ActionCatalog.spec(for: "moveWindowToWorkspaceOnMonitor.0.left"))
+
+        #expect(swap.ipcDescriptor?.path == "command swap-workspace-with-monitor <left|right|up|down>")
+        #expect(focusAnywhere.ipcDescriptor?.path == "command switch-workspace anywhere <number>")
+        #expect(moveOnMonitor.ipcDescriptor?.path == "command move-to-workspace on-monitor <number> <left|right|up|down>")
+        #expect(HotkeyConfigMapping.configKey(forInternalId: swap.id) == "workspace.swapWithMonitorLeft")
+        #expect(HotkeyConfigMapping.configKey(forInternalId: focusAnywhere.id) == "workspace.focusAnywhere.1")
+        #expect(HotkeyConfigMapping.configKey(forInternalId: moveOnMonitor.id) == "move.windowToWorkspaceOnMonitor.1.left")
     }
 }


### PR DESCRIPTION
## Summary

Enhance hotkey functionality by making all commands assignable in settings, command palette, IPC/CLI, and TOML config; add new workspace actions and improve visibility checks.

fixes #14 

## Release notes

- [x] Added a `.changeset/*.md` for user-visible changes (`mise run changeset -- patch "..."`).

## Validation

<!-- Commands run, screenshots, or manual checks. -->

- [ ] Ran relevant tests/checks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new workspace and monitor movement commands available for hotkey assignment.
  * All assignable commands now consistently available across hotkey settings, command palette, configuration files, and CLI—previously restricted commands are now accessible and configurable everywhere.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->