### PR TITLE
 Fix column width preset cycle wrapping

### DIFF
--- a/.changeset/20260608215720-fix-column-width-preset-cycling-wrapping-at-both.md
+++ b/.changeset/20260608215720-fix-column-width-preset-cycling-wrapping-at-both.md
@@ -1,0 +1,6 @@
+---
+"nehir": patch
+contributors: [stefanpinterBE]
+---
+
+Fix column width preset cycling wrapping at both ends

--- a/.changeset/20260608222609-respect-app-enforced-resize-minimums-during-colu.md
+++ b/.changeset/20260608222609-respect-app-enforced-resize-minimums-during-colu.md
@@ -1,0 +1,6 @@
+---
+"nehir": patch
+
+---
+
+Respect app-enforced resize minimums during column resize animations

--- a/Sources/Nehir/Core/Controller/LayoutRefreshController.swift
+++ b/Sources/Nehir/Core/Controller/LayoutRefreshController.swift
@@ -2970,6 +2970,12 @@ import QuartzCore
             mergedMinimumSize.width > $0.width || mergedMinimumSize.height > $0.height
         } ?? true
         controller.workspaceManager.setInferredResizeMinimumSize(mergedMinimumSize, for: entry.token)
+        if let engine = controller.niriEngine {
+            var constraints = controller.workspaceManager.cachedConstraints(for: entry.token) ?? .unconstrained
+            constraints.minSize.width = max(constraints.minSize.width, mergedMinimumSize.width)
+            constraints.minSize.height = max(constraints.minSize.height, mergedMinimumSize.height)
+            engine.updateWindowConstraints(for: entry.token, constraints: constraints)
+        }
         controller.axManager.recordFrameApplyTrace(
             "resizeMin.learn id=\(entry.windowId) source=refusal target=\(LayoutTrace.rect(result.targetFrame)) observed=\(LayoutTrace.rect(result.writeResult.observedFrame)) minimum=\(String(format: "%.1fx%.1f", mergedMinimumSize.width, mergedMinimumSize.height))"
         )
@@ -2982,7 +2988,12 @@ import QuartzCore
             )
         }
         if inferredMinimumIncreased {
-            requestRelayout(reason: .axWindowChanged, affectedWorkspaceIds: [entry.workspaceId])
+            for tiledEntry in controller.workspaceManager.tiledEntries(in: entry.workspaceId)
+                where controller.workspaceManager.hiddenState(for: tiledEntry.token) == nil
+            {
+                controller.axManager.forceApplyNextFrame(for: tiledEntry.windowId)
+            }
+            requestImmediateRelayout(reason: .layoutCommand, affectedWorkspaceIds: [entry.workspaceId])
         }
     }
 

--- a/Sources/Nehir/Core/Layout/Niri/NiriLayoutEngine+Sizing.swift
+++ b/Sources/Nehir/Core/Layout/Niri/NiriLayoutEngine+Sizing.swift
@@ -417,13 +417,13 @@ extension NiriLayoutEngine {
         let targetWindow = targetWindow ?? column.activeWindow ?? column.windowNodes.first
 
         let nextIdx: Int
+        let wrappedPresetBoundary: Bool
         if !column.isFullWidth, let currentIdx = column.presetWidthIdx {
-            nextIdx = if forwards {
-                (currentIdx + 1) % presetCount
-            } else {
-                (currentIdx - 1 + presetCount) % presetCount
-            }
+            let rawNextIdx = forwards ? currentIdx + 1 : currentIdx - 1
+            wrappedPresetBoundary = rawNextIdx < 0 || rawNextIdx >= presetCount
+            nextIdx = (rawNextIdx + presetCount) % presetCount
         } else {
+            wrappedPresetBoundary = false
             let currentTile: CGFloat
             if let singleWindowContext = singleWindowLayoutContext(in: workspaceId),
                singleWindowContext.container === column,
@@ -478,7 +478,7 @@ extension NiriLayoutEngine {
         traceResize(
             "cmd=\(commandId) compute kind=\(commandKind) source=\(ResizeWidthSource.presetCycle.rawValue) "
                 + "previous=\(fmt(previousWidth)) currentSpec=\(widthSpecDescription(currentSpec)) "
-                + "nextPreset=\(nextIdx) newSpec=\(widthSpecDescription(newWidth)) "
+                + "wrappedBoundary=\(wrappedPresetBoundary) nextPreset=\(nextIdx) newSpec=\(widthSpecDescription(newWidth)) "
                 + "state{\(columnWidthSnapshot(column, in: workspaceId, workingFrame: workingFrame, gaps: gaps, window: targetWindow))}"
         )
 

--- a/Sources/Nehir/Core/Layout/Niri/NiriLayoutEngine+Sizing.swift
+++ b/Sources/Nehir/Core/Layout/Niri/NiriLayoutEngine+Sizing.swift
@@ -418,22 +418,10 @@ extension NiriLayoutEngine {
 
         let nextIdx: Int
         if !column.isFullWidth, let currentIdx = column.presetWidthIdx {
-            if forwards {
-                guard currentIdx + 1 < presetCount else {
-                    traceResize(
-                        "cmd=\(commandId) compute kind=\(commandKind) source=\(ResizeWidthSource.presetCycle.rawValue) previous=\(fmt(previousWidth)) currentPreset=\(currentIdx) atBoundary=true state{\(columnWidthSnapshot(column, in: workspaceId, workingFrame: workingFrame, gaps: gaps, window: targetWindow))}"
-                    )
-                    return
-                }
-                nextIdx = currentIdx + 1
+            nextIdx = if forwards {
+                (currentIdx + 1) % presetCount
             } else {
-                guard currentIdx > 0 else {
-                    traceResize(
-                        "cmd=\(commandId) compute kind=\(commandKind) source=\(ResizeWidthSource.presetCycle.rawValue) previous=\(fmt(previousWidth)) currentPreset=\(currentIdx) atBoundary=true state{\(columnWidthSnapshot(column, in: workspaceId, workingFrame: workingFrame, gaps: gaps, window: targetWindow))}"
-                    )
-                    return
-                }
-                nextIdx = currentIdx - 1
+                (currentIdx - 1 + presetCount) % presetCount
             }
         } else {
             let currentTile: CGFloat

--- a/Sources/Nehir/Core/Layout/Niri/NiriLayoutEngine+Windows.swift
+++ b/Sources/Nehir/Core/Layout/Niri/NiriLayoutEngine+Windows.swift
@@ -85,11 +85,30 @@ extension NiriLayoutEngine {
         let normalized = constraints.normalized()
         guard node.constraints != normalized else { return }
         node.constraints = normalized
-        if let column = node.parent as? NiriContainer, column.cachedWidth > 0 {
-            let bounds = column.widthBounds()
-            column.cachedWidth = max(column.cachedWidth, bounds.min)
-            if let maxWidth = bounds.max {
-                column.cachedWidth = min(column.cachedWidth, maxWidth)
+        clampColumnWidthToBounds(for: node)
+    }
+
+    func clampColumnWidthToBounds(for token: WindowToken) {
+        guard let node = tokenToNode[token] else { return }
+        clampColumnWidthToBounds(for: node)
+    }
+
+    private func clampColumnWidthToBounds(for node: NiriNode) {
+        guard let column = node.parent as? NiriContainer, column.cachedWidth > 0 else { return }
+
+        let bounds = column.widthBounds()
+        column.cachedWidth = max(column.cachedWidth, bounds.min)
+        if let maxWidth = bounds.max {
+            column.cachedWidth = min(column.cachedWidth, maxWidth)
+        }
+
+        if let targetWidth = column.targetWidth {
+            let clampedTargetWidth = bounds.max.map { min(max(targetWidth, bounds.min), $0) }
+                ?? max(targetWidth, bounds.min)
+            if abs(clampedTargetWidth - targetWidth) > 0.001 {
+                column.cachedWidth = clampedTargetWidth
+                column.widthAnimation = nil
+                column.targetWidth = nil
             }
         }
     }

--- a/Tests/NehirTests/NiriLayoutEngineTests.swift
+++ b/Tests/NehirTests/NiriLayoutEngineTests.swift
@@ -6171,6 +6171,53 @@ private func makeCenteredCrossMonitorFixture(
         #expect(column.presetWidthIdx == 3)
     }
 
+    @Test func toggleColumnWidthWrapsAtPresetBoundaries() {
+        let engine = NiriLayoutEngine(maxVisibleColumns: 3)
+        engine.presetColumnWidths = [
+            .proportion(1.0 / 3.0),
+            .proportion(0.5),
+            .proportion(0.666)
+        ]
+        let wsId = UUID()
+
+        let window = engine.addWindow(handle: makeTestHandle(), to: wsId, afterSelection: nil)
+        guard let column = engine.column(of: window) else {
+            Issue.record("Expected column for preset boundary wrap test")
+            return
+        }
+
+        var state = ViewportState()
+        let workingFrame = CGRect(x: 0, y: 0, width: 1600, height: 900)
+
+        column.width = .proportion(1.0 / 3.0)
+        column.presetWidthIdx = 0
+        engine.toggleColumnWidth(
+            column,
+            forwards: false,
+            in: wsId,
+            state: &state,
+            workingFrame: workingFrame,
+            gaps: 8
+        )
+        #expect(column.width == .proportion(0.666))
+        #expect(column.presetWidthIdx == 2)
+
+        engine.toggleColumnWidth(
+            column,
+            forwards: true,
+            in: wsId,
+            state: &state,
+            workingFrame: workingFrame,
+            gaps: 8
+        )
+        if case let .proportion(proportion) = column.width {
+            #expect(abs(proportion - 1.0 / 3.0) < 0.001)
+        } else {
+            Issue.record("Expected wrapped column width to use first proportional preset")
+        }
+        #expect(column.presetWidthIdx == 0)
+    }
+
     @Test func balanceSizesUsesExplicitDefaultWidthAndResetsManualState() {
         let engine = NiriLayoutEngine(maxVisibleColumns: 3)
         engine.presetColumnWidths = [

--- a/Tests/NehirTests/NiriLayoutEngineTests.swift
+++ b/Tests/NehirTests/NiriLayoutEngineTests.swift
@@ -1968,6 +1968,40 @@ private func makeCenteredCrossMonitorFixture(
         #expect(window.constraints.maxSize.width == 800)
     }
 
+    @Test func constraintApplicationCancelsWidthAnimationWhenRuntimeMinimumExceedsTarget() {
+        let engine = NiriLayoutEngine()
+        let wsId = UUID()
+        let window = engine.addWindow(handle: makeTestHandle(), to: wsId, afterSelection: nil)
+        guard let column = engine.column(of: window) else {
+            Issue.record("Expected column for runtime minimum animation clamp test")
+            return
+        }
+
+        column.cachedWidth = 401.6
+        column.widthAnimation = SpringAnimation(
+            from: 606.4,
+            to: 401.6,
+            initialVelocity: 0,
+            startTime: 0,
+            config: engine.windowMovementAnimationConfig,
+            displayRefreshRate: 60
+        )
+        column.targetWidth = 401.6
+
+        engine.updateWindowConstraints(
+            for: window.token,
+            constraints: WindowSizeConstraints(
+                minSize: CGSize(width: 668, height: 100),
+                maxSize: .zero,
+                isFixed: false
+            )
+        )
+
+        #expect(column.cachedWidth == 668)
+        #expect(column.targetWidth == nil)
+        #expect(column.widthAnimation == nil)
+    }
+
     @Test func solverRedistributesSpaceAfterMaxCapsWithoutReviolatingThem() {
         let outputs = NiriAxisSolver.solve(
             windows: [
@@ -6199,7 +6233,11 @@ private func makeCenteredCrossMonitorFixture(
             workingFrame: workingFrame,
             gaps: 8
         )
-        #expect(column.width == .proportion(0.666))
+        if case let .proportion(proportion) = column.width {
+            #expect(abs(proportion - 0.666) < 0.001)
+        } else {
+            Issue.record("Expected wrapped column width to use last proportional preset")
+        }
         #expect(column.presetWidthIdx == 2)
 
         engine.toggleColumnWidth(

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -371,7 +371,7 @@ The Niri layout engine follows this contract:
 
 This separation means layout logic can be unit-tested without any macOS UI or accessibility infrastructure. The `LayoutRefreshController` feeds workspace snapshots to the active engine and collects frame outputs, then `AXManager.applyFramesParallel()` writes the frames to actual windows.
 
-When AX readback shows that a real app refused or clamped a requested resize, the refresh controller records an inferred runtime minimum (`inferredResizeMinimumSize`) on the window model and requests another relayout. The corrected minimum is fed into future layout snapshots, so the real accepted size—not substitute geometry—is used by the layout engine.
+When AX readback shows that a real app refused or clamped a requested resize, the refresh controller records an inferred runtime minimum (`inferredResizeMinimumSize`) on the window model, immediately clamps the affected Niri column away from the refused optimistic target, and requests an immediate relayout. The corrected minimum is fed into future layout snapshots, so the real accepted size—not substitute geometry—is used by the layout engine.
 
 ### 3.6 Thread Safety Model
 


### PR DESCRIPTION
## Summary

fixes #15 

## Release notes

Choose one:

- [x] Added a `.changeset/*.md` for user-visible changes (`mise run changeset -- patch "..."`).

## Validation

<!-- Commands run, screenshots, or manual checks. -->

- [ ] Ran relevant tests/checks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed column width preset cycling to wrap around at boundaries instead of stopping at ends
  * Improved handling of app-enforced resize minimums during column resizing operations
  * Column width constraints are now properly clamped and applied when window constraints change

* **Tests**
  * Added test coverage for constraint application and width animation cancellation
  * Added test coverage for column width preset cycling wrapping behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->