### PR TITLE
Fix native fullscreen restore column drift

### DIFF
--- a/.changeset/20260608234000-preserve-column-placement-when-restoring-native-.md
+++ b/.changeset/20260608234000-preserve-column-placement-when-restoring-native-.md
@@ -1,0 +1,6 @@
+---
+"nehir": patch
+
+---
+
+Preserve column placement when restoring native fullscreen windows

--- a/Sources/Nehir/Core/Controller/AXEventHandler.swift
+++ b/Sources/Nehir/Core/Controller/AXEventHandler.swift
@@ -1860,7 +1860,14 @@ final class AXEventHandler: CGSEventDelegate {
             }
             return .restored(scheduledRelayout: scheduledRelayout)
         }
-        guard let entry = rekeyManagedWindowIdentity(from: record.currentToken, to: token, windowId: windowId, axRef: axRef)
+        let hasDuplicateRestoredToken = controller.workspaceManager.entry(for: token) != nil
+        guard let entry = rekeyManagedWindowIdentity(
+            from: record.currentToken,
+            to: token,
+            windowId: windowId,
+            axRef: axRef,
+            replacingExistingDuplicate: hasDuplicateRestoredToken
+        )
         else {
             return .notRestored
         }
@@ -1999,7 +2006,8 @@ final class AXEventHandler: CGSEventDelegate {
         to newToken: WindowToken,
         windowId: UInt32,
         axRef: AXWindowRef,
-        managedReplacementMetadata: ManagedReplacementMetadata? = nil
+        managedReplacementMetadata: ManagedReplacementMetadata? = nil,
+        replacingExistingDuplicate: Bool = false
     ) -> WindowModel.Entry? {
         guard let controller else { return nil }
 
@@ -2007,13 +2015,18 @@ final class AXEventHandler: CGSEventDelegate {
             from: oldToken,
             to: newToken,
             newAXRef: axRef,
-            managedReplacementMetadata: managedReplacementMetadata
+            managedReplacementMetadata: managedReplacementMetadata,
+            replacingExistingDuplicate: replacingExistingDuplicate
         )
         else {
             return nil
         }
 
-        _ = controller.niriEngine?.rekeyWindow(from: oldToken, to: newToken)
+        _ = controller.niriEngine?.rekeyWindow(
+            from: oldToken,
+            to: newToken,
+            replacingExistingDuplicate: replacingExistingDuplicate
+        )
         controller.nativeFullscreenPlaceholderManager.rekey(from: oldToken, to: newToken)
 
         controller.focusBridge.rekeyPendingFocus(from: oldToken, to: newToken)
@@ -2944,6 +2957,7 @@ final class AXEventHandler: CGSEventDelegate {
                 return
             }
             controller.layoutRefreshController.requestFullRescan(reason: .activeSpaceChanged)
+            self.cleanupClosedNativeFullscreenPlaceholderIfNeeded(record)
         }
         pendingNativeFullscreenStaleCleanupTasks[originalToken] = Task { @MainActor [weak self] in
             try? await Task.sleep(for: Self.nativeFullscreenStaleCleanupDelay)
@@ -2962,6 +2976,26 @@ final class AXEventHandler: CGSEventDelegate {
             }
             controller.layoutRefreshController.requestFullRescan(reason: .activeSpaceChanged)
         }
+    }
+
+    private func cleanupClosedNativeFullscreenPlaceholderIfNeeded(
+        _ record: WorkspaceManager.NativeFullscreenRecord
+    ) {
+        guard let controller,
+              !controller.workspaceManager.isAppFullscreenActive,
+              resolveAXWindowRef(windowId: UInt32(record.currentToken.windowId), pid: record.currentToken.pid) == nil
+        else {
+            return
+        }
+
+        let removedEntries = controller.workspaceManager.expireStaleTemporarilyUnavailableNativeFullscreenRecords(
+            staleInterval: 0
+        )
+        guard !removedEntries.isEmpty else { return }
+        for entry in removedEntries {
+            controller.nativeFullscreenPlaceholderManager.remove(entry.token)
+        }
+        controller.layoutRefreshController.requestFullRescan(reason: .activeSpaceChanged)
     }
 
     func cancelNativeFullscreenLifecycleTasks(for originalToken: WindowToken) {

--- a/Sources/Nehir/Core/Layout/Niri/NiriLayoutEngine+Windows.swift
+++ b/Sources/Nehir/Core/Layout/Niri/NiriLayoutEngine+Windows.swift
@@ -554,13 +554,25 @@ extension NiriLayoutEngine {
     }
 
     @discardableResult
-    func rekeyWindow(from oldToken: WindowToken, to newToken: WindowToken) -> Bool {
-        guard oldToken != newToken,
-              tokenToNode[newToken] == nil,
-              let node = tokenToNode.removeValue(forKey: oldToken)
-        else {
+    func rekeyWindow(
+        from oldToken: WindowToken,
+        to newToken: WindowToken,
+        replacingExistingDuplicate: Bool = false
+    ) -> Bool {
+        guard oldToken != newToken else { return false }
+
+        guard let node = tokenToNode[oldToken] else {
             return false
         }
+
+        if tokenToNode[newToken] != nil {
+            guard replacingExistingDuplicate else { return false }
+            removeWindow(token: newToken)
+            framePool.removeValue(forKey: newToken)
+            hiddenPool.removeValue(forKey: newToken)
+        }
+
+        tokenToNode.removeValue(forKey: oldToken)
 
         node.token = newToken
         tokenToNode[newToken] = node

--- a/Sources/Nehir/Core/Workspace/WindowModel.swift
+++ b/Sources/Nehir/Core/Workspace/WindowModel.swift
@@ -406,7 +406,8 @@ final class WindowModel {
         from oldToken: WindowToken,
         to newToken: WindowToken,
         newAXRef: AXWindowRef,
-        managedReplacementMetadata: ManagedReplacementMetadata? = nil
+        managedReplacementMetadata: ManagedReplacementMetadata? = nil,
+        replacingExistingDuplicate: Bool = false
     ) -> Entry? {
         if oldToken == newToken {
             guard let entry = entries[oldToken] else { return nil }
@@ -420,11 +421,18 @@ final class WindowModel {
             return entry
         }
 
-        guard entries[newToken] == nil,
-              let entry = entries.removeValue(forKey: oldToken)
-        else {
+        guard let entry = entries[oldToken] else {
             return nil
         }
+
+        if let duplicateEntry = entries[newToken] {
+            guard replacingExistingDuplicate else { return nil }
+            missingDetectionCountByToken.removeValue(forKey: newToken)
+            removeIndexes(for: duplicateEntry, token: newToken, windowId: newToken.windowId)
+            entries.removeValue(forKey: newToken)
+        }
+
+        entries.removeValue(forKey: oldToken)
 
         entry.handle.id = newToken
         entry.axRef = newAXRef

--- a/Sources/Nehir/Core/Workspace/WorkspaceManager.swift
+++ b/Sources/Nehir/Core/Workspace/WorkspaceManager.swift
@@ -2429,13 +2429,15 @@ final class WorkspaceManager {
         from oldToken: WindowToken,
         to newToken: WindowToken,
         newAXRef: AXWindowRef,
-        managedReplacementMetadata: ManagedReplacementMetadata? = nil
+        managedReplacementMetadata: ManagedReplacementMetadata? = nil,
+        replacingExistingDuplicate: Bool = false
     ) -> WindowModel.Entry? {
         guard let entry = windows.rekeyWindow(
             from: oldToken,
             to: newToken,
             newAXRef: newAXRef,
-            managedReplacementMetadata: managedReplacementMetadata
+            managedReplacementMetadata: managedReplacementMetadata,
+            replacingExistingDuplicate: replacingExistingDuplicate
         ) else {
             return nil
         }

--- a/Tests/NehirTests/AXEventHandlerTests.swift
+++ b/Tests/NehirTests/AXEventHandlerTests.swift
@@ -2503,6 +2503,66 @@ private func waitUntilAXEventTest(
         #expect(controller.workspaceManager.layoutReason(for: replacementToken) == .standard)
     }
 
+    @Test @MainActor func nativeFullscreenDuplicateRestoredTokenRekeyPreservesManagedIdentityAndNiriNode() {
+        let controller = makeAXEventTestController()
+        defer { controller.axEventHandler.resetDebugStateForTests() }
+        guard let workspaceId = controller.interactionWorkspace()?.id else {
+            Issue.record("Missing active workspace")
+            return
+        }
+
+        controller.enableNiriLayout()
+        guard let engine = controller.niriEngine else {
+            Issue.record("Missing Niri engine")
+            return
+        }
+
+        let replacementToken = controller.workspaceManager.addWindow(
+            AXWindowRef(element: AXUIElementCreateSystemWide(), windowId: 8046),
+            pid: getpid(),
+            windowId: 8046,
+            to: workspaceId
+        )
+        let restoredToken = controller.workspaceManager.addWindow(
+            AXWindowRef(element: AXUIElementCreateSystemWide(), windowId: 8047),
+            pid: getpid(),
+            windowId: 8047,
+            to: workspaceId
+        )
+        guard let replacementEntry = controller.workspaceManager.entry(for: replacementToken) else {
+            Issue.record("Missing replacement entry")
+            return
+        }
+
+        let replacementNode = engine.addWindow(
+            token: replacementToken,
+            to: workspaceId,
+            afterSelection: nil,
+            focusedToken: replacementToken
+        )
+        let duplicateNode = engine.addWindow(
+            token: restoredToken,
+            to: workspaceId,
+            afterSelection: replacementNode.id,
+            focusedToken: replacementToken
+        )
+
+        let restoredEntry = controller.axEventHandler.rekeyManagedWindowIdentity(
+            from: replacementToken,
+            to: restoredToken,
+            windowId: UInt32(restoredToken.windowId),
+            axRef: AXWindowRef(element: AXUIElementCreateSystemWide(), windowId: restoredToken.windowId),
+            replacingExistingDuplicate: true
+        )
+
+        #expect(restoredEntry?.handle === replacementEntry.handle)
+        #expect(controller.workspaceManager.entry(for: replacementToken) == nil)
+        #expect(controller.workspaceManager.entry(for: restoredToken)?.handle === replacementEntry.handle)
+        #expect(engine.findNode(for: replacementToken) == nil)
+        #expect(engine.findNode(for: restoredToken)?.id == replacementNode.id)
+        #expect(engine.findNode(by: duplicateNode.id) == nil)
+    }
+
     @Test @MainActor func nativeFullscreenSameTokenReplacementSuspensionClearsFocusedBorderAndRelayouts() async {
         let controller = makeAXEventTestController()
         defer { controller.axEventHandler.resetDebugStateForTests() }


### PR DESCRIPTION
## Summary

<!-- What changed and why? -->

## Release notes

Choose one:

- [x] Added a `.changeset/*.md` for user-visible changes (`mise run changeset -- patch "..."`).
- [ ] No user-visible change; apply the `no release note` label to make CI skip intentional.

## Validation

<!-- Commands run, screenshots, or manual checks. -->

- [x] Ran relevant tests/checks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Restored windows now preserve their original column placement when exiting native fullscreen, so workspace layouts remain consistent.
  * Cleans up stale fullscreen placeholders so closed fullscreen windows no longer leave behind phantom or mispositioned entries in the workspace.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->