### PR TITLE
Fix mouse cursor behavior with moveMouseToFocusedWindow enabled

### DIFF
--- a/.changeset/20260609143706-fix-multiple-mouse-focus-regressions-when-movemo.md
+++ b/.changeset/20260609143706-fix-multiple-mouse-focus-regressions-when-movemo.md
@@ -1,0 +1,14 @@
+---
+"nehir": patch
+contributors: [charmbyte]
+---
+
+Fix multiple mouse focus regressions when `moveMouseToFocusedWindow` is enabled:
+
+- Suppress cursor warp on pointer-initiated focus, workspace bar clicks, tab clicks, and trackpad gestures.
+- Prevent `focusFollowsMouse` from activating tiled columns while a floating window is active above the Niri layout, or behind unmanaged windows during hover, click, or drag interactions.
+- Restore `focusFollowsMouse` after scroll animation and owned window close.
+- When `focusFollowsMouse` is enabled, keep swipe gesture end from committing focus to the snapped column; final focus follows the pointer instead.
+- Warp the cursor to the target monitor center when switching to an empty workspace.
+
+Fixes #21.

--- a/README.md
+++ b/README.md
@@ -116,6 +116,18 @@ All files are watched for changes — edits are applied live without restarting.
 
 See [Configuration Principles](docs/CONFIGURATION.md) for the design rationale.
 
+### Mouse focus behavior
+
+Two settings interact here:
+
+- `moveMouseToFocusedWindow` moves the pointer after focus changes, but Nehir treats it primarily as a keyboard/command-navigation affordance. Pointer-originated focus changes do not warp the cursor: mouse hover/click, workspace bar clicks, tab overlay clicks, trackpad gestures, scroll animations, and floating-window clicks/drags all preserve pointer position.
+- Empty workspace command switching is the main intentional exception: when there is no focused window target, Nehir warps to the target monitor center so the pointer lands on the display you navigated to.
+- `focusFollowsMouse` is debounced and refreshes after scroll/swipe animations settle and after owned Nehir UI windows (Settings, App Rules, Command Palette) close, because those interactions may not generate a fresh mouse-move event.
+- With `focusFollowsMouse` enabled, swipe gesture end updates the viewport selection but does not commit focus to the snapped column; final focus follows the pointer after the gesture/animation settles.
+- Tiled hover focus is disabled while a floating window is the active surface above the Niri layout, so moving toward that floating window does not accidentally focus and raise a tiled column behind it.
+- A floating window that is merely visible but behind the active tiled window does not disable tiled hover focus.
+- Hover focus is also blocked over visible unmanaged WindowServer windows and briefly suppressed after floating/unmanaged pointer interaction so clicking or dragging those windows does not immediately activate a tiled column behind them.
+
 ### Default Shortcut Model
 
 Nehir defaults are stored and shown as physical key chords.
@@ -168,6 +180,7 @@ The original project tried to accommodate a wide range of user requests; Nehir d
 - **Split TOML configuration.** Runtime config is organized under `~/.config/nehir/` with separate files for settings, hotkeys, workspaces, app rules, and monitor overrides.
 - **Close/collapse focus stays local.** When macOS reports another same-app window as focused after closing or collapsing the current one, Nehir treats that as native fallback focus rather than user navigation. Same-app fallback to inactive workspaces is ignored, and unmanaged quick-terminal fallback is also ignored on the current workspace so the viewport does not scroll to that app's managed column. Explicit Nehir focus commands still take precedence.
 - **Configurable gesture scroll snap.** Trackpad swipe gestures can snap to column boundaries or stop freely mid-scroll. Controlled by `gestures.scrollSnap` in `settings.toml` (default `true`).
+- **Smarter mouse focus and cursor warp.** Pointer-initiated focus no longer makes `moveMouseToFocusedWindow` jump the cursor, and hover focus is constrained around floating/unmanaged windows to fit the Niri layout model.
 - **Built-in runtime debugging tools.** Nehir now ships command-palette and IPC/CLI actions to dump runtime state, reset/rebootstrap runtime state, restart while clearing runtime state, and capture runtime trace bundles under `${XDG_STATE_HOME:-$HOME/.local/state}/nehir/traces/`.
 
 ## License

--- a/Sources/Nehir/Core/Controller/AXEventHandler.swift
+++ b/Sources/Nehir/Core/Controller/AXEventHandler.swift
@@ -1757,7 +1757,8 @@ final class AXEventHandler: CGSEventDelegate {
         if shouldConfirmRequest,
            controller.moveMouseToFocusedWindowEnabled,
            controller.workspaceManager.confirmedManagedFocusToken == entry.token,
-           !controller.workspaceManager.isNonManagedFocusActive
+           !controller.workspaceManager.isNonManagedFocusActive,
+           !controller.shouldSuppressMouseMoveToFocusedWindow(for: entry.token)
         {
             controller.moveMouseToWindow(entry.token, preferredFrame: preferredMouseFrame)
         }

--- a/Sources/Nehir/Core/Controller/MouseEventHandler.swift
+++ b/Sources/Nehir/Core/Controller/MouseEventHandler.swift
@@ -182,6 +182,7 @@ final class MouseEventHandler {
 
         var lastFocusFollowsMouseTime: Date = .distantPast
         var lastFocusFollowsMouseToken: WindowToken?
+        var suppressFocusFollowsMouseUntil: Date = .distantPast
         let focusFollowsMouseDebounce: TimeInterval = 0.1
         var dragGhostController: DragGhostController?
         var moveIsInsertMode: Bool = false
@@ -204,6 +205,7 @@ final class MouseEventHandler {
     weak var controller: WMController?
     var state = State()
     var pressedMouseButtonsProvider: @MainActor () -> Int = { Int(NSEvent.pressedMouseButtons) }
+    var mouseLocationProvider: @MainActor () -> CGPoint = { NSEvent.mouseLocation }
 
     init(controller: WMController) {
         self.controller = controller
@@ -317,6 +319,15 @@ final class MouseEventHandler {
             return
         }
         handleMouseMovedFromTap(at: location)
+    }
+
+    func refreshFocusFollowsMouseAtCurrentPointer() {
+        guard !isInputSuppressed else { return }
+        handleMouseMovedFromTap(at: mouseLocationProvider())
+    }
+
+    func resetFocusFollowsMouseTimeForTesting() {
+        state.lastFocusFollowsMouseTime = .distantPast
     }
 
     @discardableResult
@@ -737,6 +748,7 @@ final class MouseEventHandler {
 
     private func shouldHandleFocusFollowsMouse(at location: CGPoint) -> Bool {
         guard !state.isResizing, !isViewportGestureActive else { return false }
+        guard Date() >= state.suppressFocusFollowsMouseUntil else { return false }
         guard let controller else { return false }
         guard let monitor = location.monitorApproximation(in: controller.workspaceManager.monitors),
               let workspace = controller.workspaceManager.activeWorkspaceOrFirst(on: monitor.id)
@@ -758,6 +770,9 @@ final class MouseEventHandler {
         if shouldBlockOwnWindowInput(at: location) {
             return false
         }
+
+        markRecentFloatingPointerInteractionIfNeeded(at: location)
+        suppressMouseMoveToFocusedWindowForPointerTarget(at: location)
 
         guard let engine = controller.niriEngine,
               let wsId = workspaceIdForPointer(at: location) ?? controller.interactionWorkspace()?.id
@@ -869,6 +884,9 @@ final class MouseEventHandler {
         guard let controller else { return }
         guard controller.isEnabled else { return }
         if controller.isOverviewOpen() { return }
+        if button == .left {
+            markRecentFloatingPointerInteractionIfNeeded(at: location)
+        }
         if requirePressedButtonCheck {
             guard pressedMouseButtonsProvider() & button.pressedMask != 0 else { return }
         }
@@ -943,6 +961,9 @@ final class MouseEventHandler {
     private func handleMouseUpFromTap(at location: CGPoint, button: MouseButton) {
         guard let controller else { return }
         if controller.isOverviewOpen() { return }
+        if button == .left {
+            markRecentFloatingPointerInteractionIfNeeded(at: location)
+        }
 
         if state.isMoving {
             guard shouldAcceptInteractionButton(button) else { return }
@@ -1077,18 +1098,28 @@ final class MouseEventHandler {
         guard let target = resolveFocusFollowsMouseTarget(at: location) else { return }
         let token = focusFollowsMouseToken(for: target)
 
-        if token != state.lastFocusFollowsMouseToken,
-           token != controller.workspaceManager.confirmedManagedFocusToken
+        guard token != controller.workspaceManager.confirmedManagedFocusToken else { return }
+        if token == state.lastFocusFollowsMouseToken,
+           token == controller.workspaceManager.activeFocusRequestToken
         {
-            state.lastFocusFollowsMouseTime = now
-            state.lastFocusFollowsMouseToken = token
-            activateFocusFollowsMouseTarget(target)
+            return
         }
+
+        state.lastFocusFollowsMouseTime = now
+        state.lastFocusFollowsMouseToken = token
+        activateFocusFollowsMouseTarget(target)
     }
 
     private func resolveFocusFollowsMouseTarget(at location: CGPoint) -> FocusFollowsMouseTarget? {
         guard let controller else { return nil }
         guard let wsId = workspaceIdForPointer(at: location) ?? controller.interactionWorkspace()?.id else {
+            return nil
+        }
+
+        if isFloatingWindowCoveringPointer(at: location, in: wsId)
+            || hasVisibleFloatingWindowOverNiriLayout(in: wsId)
+            || controller.unmanagedWindowServerWindowCovers(point: location)
+        {
             return nil
         }
 
@@ -1100,6 +1131,65 @@ final class MouseEventHandler {
         return .niri(workspaceId: wsId, window: window)
     }
 
+    private func isFloatingWindowCoveringPointer(
+        at location: CGPoint,
+        in workspaceId: WorkspaceDescriptor.ID
+    ) -> Bool {
+        floatingEntryCoveringPointer(at: location, in: workspaceId) != nil
+    }
+
+    private func hasVisibleFloatingWindowOverNiriLayout(in workspaceId: WorkspaceDescriptor.ID) -> Bool {
+        guard let controller else { return false }
+
+        if let focusedToken = controller.workspaceManager.confirmedManagedFocusToken,
+           let focusedEntry = controller.workspaceManager.entry(for: focusedToken),
+           focusedEntry.workspaceId == workspaceId,
+           focusedEntry.mode == .tiling
+        {
+            return false
+        }
+
+        let layoutFrame = controller.workspaceManager.monitor(for: workspaceId)?.visibleFrame
+        return controller.workspaceManager.floatingEntries(in: workspaceId).contains { entry in
+            guard entry.observedState.isVisible, entry.hiddenReason == nil else { return false }
+            let frame = floatingFrame(for: entry)
+            guard let frame else { return true }
+            return layoutFrame.map { frame.intersects($0) } ?? true
+        }
+    }
+
+    private func floatingEntryCoveringPointer(
+        at location: CGPoint,
+        in workspaceId: WorkspaceDescriptor.ID
+    ) -> WindowModel.Entry? {
+        guard let controller else { return nil }
+        return controller.workspaceManager.floatingEntries(in: workspaceId).first { entry in
+            guard entry.observedState.isVisible, entry.hiddenReason == nil else { return false }
+            return floatingFrame(for: entry)?.contains(location) ?? false
+        }
+    }
+
+    private func floatingFrame(for entry: WindowModel.Entry) -> CGRect? {
+        entry.observedState.frame
+            ?? entry.desiredState.floatingFrame
+            ?? entry.floatingState?.lastFrame
+            ?? AXWindowService.framePreferFast(entry.axRef)
+    }
+
+    private func markRecentFloatingPointerInteractionIfNeeded(at location: CGPoint) {
+        guard let controller else { return }
+        let workspaceId = workspaceIdForPointer(at: location) ?? controller.interactionWorkspace()?.id
+        let floatingEntry = workspaceId.flatMap {
+            floatingEntryCoveringPointer(at: location, in: $0)
+        }
+        if let floatingEntry {
+            controller.suppressMouseMoveToFocusedWindow(for: floatingEntry.token)
+        }
+        let isOverUnmanaged = controller.unmanagedWindowServerWindowCovers(point: location)
+        guard floatingEntry != nil || isOverUnmanaged else { return }
+        state.suppressFocusFollowsMouseUntil = Date().addingTimeInterval(2.0)
+    }
+
     private func focusFollowsMouseToken(for target: FocusFollowsMouseTarget) -> WindowToken {
         switch target {
         case let .niri(_, window):
@@ -1107,11 +1197,17 @@ final class MouseEventHandler {
         }
     }
 
+    private func suppressMouseMoveToFocusedWindowForPointerTarget(at location: CGPoint) {
+        guard let target = resolveFocusFollowsMouseTarget(at: location) else { return }
+        controller?.suppressMouseMoveToFocusedWindow(for: focusFollowsMouseToken(for: target))
+    }
+
     private func activateFocusFollowsMouseTarget(_ target: FocusFollowsMouseTarget) {
         guard let controller else { return }
 
         switch target {
         case let .niri(workspaceId, window):
+            controller.suppressMouseMoveToFocusedWindow(for: window.token)
             controller.workspaceManager.withNiriViewportState(for: workspaceId) { vstate in
                 controller.niriLayoutHandler.activateNode(
                     window,
@@ -1432,7 +1528,8 @@ final class MouseEventHandler {
         }
         if let selectedWindow {
             rememberViewportFocusAnchor(selectedWindow, engine: engine, wsId: wsId)
-            if !controller.workspaceManager.isNonManagedFocusActive,
+            if !controller.focusFollowsMouseEnabled,
+               !controller.workspaceManager.isNonManagedFocusActive,
                let target = controller.managedKeyboardFocusTarget(for: selectedWindow.token)
             {
                 _ = controller.renderKeyboardFocusBorder(
@@ -1440,6 +1537,7 @@ final class MouseEventHandler {
                     preferredFrame: selectedWindow.renderedFrame ?? selectedWindow.frame,
                     forceOrdering: false
                 )
+                controller.suppressMouseMoveToFocusedWindow(for: selectedWindow.token)
                 controller.focusWindow(selectedWindow.token)
             }
         }
@@ -1451,6 +1549,9 @@ final class MouseEventHandler {
             controller.layoutRefreshController.startScrollAnimation(for: wsId)
         } else {
             controller.layoutRefreshController.requestImmediateRelayout(reason: .interactiveGesture)
+            if controller.focusFollowsMouseEnabled {
+                refreshFocusFollowsMouseAtCurrentPointer()
+            }
         }
     }
 

--- a/Sources/Nehir/Core/Controller/NiriLayoutHandler.swift
+++ b/Sources/Nehir/Core/Controller/NiriLayoutHandler.swift
@@ -86,6 +86,7 @@ enum NiriWindowMoveResult {
         let windowAnimationsRunning = engine.tickAllWindowAnimations(in: wsId, at: targetTime)
         let columnAnimationsRunning = engine.tickAllColumnAnimations(in: wsId, at: targetTime)
 
+        var didFinishAnimations = false
         controller.workspaceManager.withNiriViewportState(for: wsId) { state in
             let viewportAnimationRunning = state.advanceAnimations(at: targetTime)
 
@@ -109,17 +110,20 @@ enum NiriWindowMoveResult {
                 || windowAnimationsRunning
                 || columnAnimationsRunning
 
-            if !animationsOngoing {
-                self.finalizeAnimation()
-                var activeIds = Set<WorkspaceDescriptor.ID>()
-                for mon in controller.workspaceManager.monitors {
-                    if let ws = controller.workspaceManager.activeWorkspaceOrFirst(on: mon.id) {
-                        activeIds.insert(ws.id)
-                    }
+            didFinishAnimations = !animationsOngoing
+        }
+
+        if didFinishAnimations {
+            finalizeAnimation()
+            var activeIds = Set<WorkspaceDescriptor.ID>()
+            for mon in controller.workspaceManager.monitors {
+                if let ws = controller.workspaceManager.activeWorkspaceOrFirst(on: mon.id) {
+                    activeIds.insert(ws.id)
                 }
-                controller.layoutRefreshController.hideInactiveWorkspaces(activeWorkspaceIds: activeIds)
-                controller.layoutRefreshController.stopScrollAnimation(for: displayId)
             }
+            controller.layoutRefreshController.hideInactiveWorkspaces(activeWorkspaceIds: activeIds)
+            controller.layoutRefreshController.stopScrollAnimation(for: displayId)
+            controller.mouseEventHandler.refreshFocusFollowsMouseAtCurrentPointer()
         }
     }
 
@@ -178,7 +182,8 @@ enum NiriWindowMoveResult {
 
         if controller.moveMouseToFocusedWindowEnabled,
            controller.workspaceManager.activeFocusRequestToken == nil,
-           let token = controller.workspaceManager.confirmedManagedFocusToken
+           let token = controller.workspaceManager.confirmedManagedFocusToken,
+           !controller.shouldSuppressMouseMoveToFocusedWindow(for: token)
         {
             controller.moveMouseToWindow(token, preferredFrame: controller.preferredKeyboardFocusFrame(for: token))
         }
@@ -1052,6 +1057,7 @@ enum NiriWindowMoveResult {
         engine.updateTabbedColumnVisibility(column: column)
 
         let target = windows[storageIndex]
+        controller.suppressMouseMoveToFocusedWindow(for: target.token)
         var state = controller.workspaceManager.niriViewportState(for: workspaceId)
         if let monitor = controller.workspaceManager.monitor(for: workspaceId) {
             let gap = CGFloat(controller.workspaceManager.gaps)

--- a/Sources/Nehir/Core/Controller/WMController.swift
+++ b/Sources/Nehir/Core/Controller/WMController.swift
@@ -9,17 +9,22 @@ struct WindowFocusOperations {
     let focusSpecificWindow: (pid_t, UInt32, AXUIElement) -> Void
     let raiseWindow: (AXUIElement) -> Void
     let orderWindow: (UInt32) -> Void
+    let visibleWindowInfoProvider: () -> [WindowServerInfo]
 
     init(
         activateApp: @escaping (pid_t) -> Void,
         focusSpecificWindow: @escaping (pid_t, UInt32, AXUIElement) -> Void,
         raiseWindow: @escaping (AXUIElement) -> Void,
-        orderWindow: @escaping (UInt32) -> Void = { _ in }
+        orderWindow: @escaping (UInt32) -> Void = { _ in },
+        visibleWindowInfoProvider: @escaping () -> [WindowServerInfo] = {
+            SkyLight.shared.queryAllVisibleWindows()
+        }
     ) {
         self.activateApp = activateApp
         self.focusSpecificWindow = focusSpecificWindow
         self.raiseWindow = raiseWindow
         self.orderWindow = orderWindow
+        self.visibleWindowInfoProvider = visibleWindowInfoProvider
     }
 
     static let live = WindowFocusOperations(
@@ -83,6 +88,8 @@ final class WMController {
     private(set) var accessibilityPermissionGranted = AccessibilityPermissionMonitor.shared.isGranted
     private(set) var focusFollowsMouseEnabled: Bool = false
     private(set) var moveMouseToFocusedWindowEnabled: Bool = false
+    private var pointerFocusWarpSuppression: (token: WindowToken, timestamp: Date)?
+    private let pointerFocusWarpSuppressionInterval: TimeInterval = 1.0
 
     let settings: SettingsStore
     let workspaceManager: WorkspaceManager
@@ -150,7 +157,8 @@ final class WMController {
     @ObservationIgnored
     private(set) lazy var windowActionHandler = WindowActionHandler(
         controller: self,
-        orderWindow: windowFocusOperations.orderWindow
+        orderWindow: windowFocusOperations.orderWindow,
+        visibleWindowInfoProvider: windowFocusOperations.visibleWindowInfoProvider
     )
     @ObservationIgnored
     private(set) lazy var focusNotificationDispatcher = FocusNotificationDispatcher(controller: self)
@@ -166,6 +174,8 @@ final class WMController {
     var workspaceBarRefreshExecutionHookForTests: (() -> Void)?
     @ObservationIgnored
     var warpMouseCursorPosition: (CGPoint) -> Void = { CGWarpMouseCursorPosition($0) }
+    @ObservationIgnored
+    var unmanagedWindowServerWindowFramesProvider: @MainActor (Set<Int>) -> [CGRect] = WMController.visibleUnmanagedWindowServerFrames
     @ObservationIgnored
     weak var ipcApplicationBridge: IPCApplicationBridge?
     @ObservationIgnored
@@ -508,11 +518,11 @@ final class WMController {
     }
 
     func focusWorkspaceFromBar(named name: String) {
-        windowActionHandler.focusWorkspaceFromBar(named: name)
+        windowActionHandler.focusWorkspaceFromBar(named: name, suppressMouseWarp: true)
     }
 
     func focusWindowFromBar(token: WindowToken) {
-        windowActionHandler.focusWindowFromBar(token: token)
+        windowActionHandler.focusWindowFromBar(token: token, suppressMouseWarp: true)
     }
 
     @discardableResult
@@ -544,7 +554,7 @@ final class WMController {
                 : .notFound
         }
 
-        if windowActionHandler.focusWindowFromBar(token: scratchpadToken) {
+        if windowActionHandler.focusWindowFromBar(token: scratchpadToken, suppressMouseWarp: true) {
             return .executed
         }
 
@@ -558,6 +568,19 @@ final class WMController {
 
     func setMoveMouseToFocusedWindow(_ enabled: Bool) {
         moveMouseToFocusedWindowEnabled = enabled
+    }
+
+    func suppressMouseMoveToFocusedWindow(for token: WindowToken) {
+        pointerFocusWarpSuppression = (token, Date())
+    }
+
+    func shouldSuppressMouseMoveToFocusedWindow(for token: WindowToken) -> Bool {
+        guard let suppression = pointerFocusWarpSuppression else { return false }
+        guard Date().timeIntervalSince(suppression.timestamp) <= pointerFocusWarpSuppressionInterval else {
+            pointerFocusWarpSuppression = nil
+            return false
+        }
+        return suppression.token == token
     }
 
     func shouldUseMouseWarp(for monitors: [Monitor]? = nil) -> Bool {
@@ -2181,6 +2204,43 @@ final class WMController {
         ].joined(separator: " ")
     }
 
+    static func visibleUnmanagedWindowServerFrames(
+        trackedWindowIds: Set<Int> = []
+    ) -> [CGRect] {
+        guard let windows = CGWindowListCopyWindowInfo(.optionOnScreenOnly, kCGNullWindowID) as? [[String: Any]] else {
+            return []
+        }
+
+        return windows.compactMap { info -> CGRect? in
+            let windowId = (info[kCGWindowNumber as String] as? NSNumber)?.uint32Value
+            guard let windowId, !trackedWindowIds.contains(Int(windowId)) else { return nil }
+
+            let layer = (info[kCGWindowLayer as String] as? NSNumber)?.intValue ?? 0
+            guard layer == 0 else { return nil }
+
+            let isOnscreen = (info[kCGWindowIsOnscreen as String] as? NSNumber)?.boolValue ?? false
+            guard isOnscreen else { return nil }
+
+            guard let bounds = info[kCGWindowBounds as String] as? [String: Any],
+                  let x = (bounds["X"] as? NSNumber)?.doubleValue,
+                  let y = (bounds["Y"] as? NSNumber)?.doubleValue,
+                  let width = (bounds["Width"] as? NSNumber)?.doubleValue,
+                  let height = (bounds["Height"] as? NSNumber)?.doubleValue,
+                  width >= 80,
+                  height >= 80
+            else { return nil }
+
+            return ScreenCoordinateSpace.toAppKit(
+                rect: CGRect(x: x, y: y, width: width, height: height)
+            )
+        }
+    }
+
+    func unmanagedWindowServerWindowCovers(point: CGPoint) -> Bool {
+        let trackedWindowIds = Set(workspaceManager.trackedWindowIdsForDebug())
+        return unmanagedWindowServerWindowFramesProvider(trackedWindowIds).contains { $0.contains(point) }
+    }
+
     private func visibleUnmanagedWindowServerDebugDump() -> String {
         guard let windows = CGWindowListCopyWindowInfo(.optionAll, kCGNullWindowID) as? [[String: Any]] else {
             return "unavailable"
@@ -3155,6 +3215,13 @@ final class WMController {
         warpMouseCursorPosition(ScreenCoordinateSpace.toWindowServer(point: center))
     }
 
+    func moveMouseToMonitor(_ monitor: Monitor) {
+        let center = monitor.visibleFrame.center
+        warpMouseCursorPosition(
+            ScreenCoordinateSpace.toWindowServer(point: center, displayId: monitor.displayId)
+        )
+    }
+
     func runningAppsWithWindows() -> [RunningAppInfo] {
         windowActionHandler.runningAppsWithWindows()
     }
@@ -3175,6 +3242,13 @@ extension WMController {
 
     var hasVisibleOwnedWindow: Bool {
         ownedWindowRegistry.hasVisibleWindow
+    }
+
+    func handleOwnedFocusSuppressingWindowClosed() {
+        guard workspaceManager.isNonManagedFocusActive, !hasVisibleOwnedWindow else { return }
+        guard workspaceManager.leaveNonManagedFocus(preserveFocusedToken: true) else { return }
+        _ = focusBorderController.refresh(forceOrdering: true)
+        mouseEventHandler.refreshFocusFollowsMouseAtCurrentPointer()
     }
 
     func isOwnedWindow(windowNumber: Int) -> Bool {

--- a/Sources/Nehir/Core/Controller/WindowActionHandler.swift
+++ b/Sources/Nehir/Core/Controller/WindowActionHandler.swift
@@ -524,7 +524,7 @@ final class WindowActionHandler {
 
 
     @discardableResult
-    func focusWorkspaceFromBar(named name: String) -> Bool {
+    func focusWorkspaceFromBar(named name: String, suppressMouseWarp: Bool = false) -> Bool {
         guard let controller else { return false }
         if let currentWorkspace = controller.interactionWorkspace() {
             controller.workspaceNavigationHandler.saveNiriViewportState(for: currentWorkspace.id)
@@ -533,6 +533,9 @@ final class WindowActionHandler {
         guard let result = controller.workspaceManager.focusWorkspace(named: name) else { return false }
 
         let focusedToken = controller.resolveAndSetWorkspaceFocusToken(for: result.workspace.id)
+        if suppressMouseWarp, let focusedToken {
+            controller.suppressMouseMoveToFocusedWindow(for: focusedToken)
+        }
         controller.layoutRefreshController
             .commitWorkspaceTransition(reason: .workspaceTransition) { [weak controller] in
                 if let focusedToken {
@@ -543,9 +546,12 @@ final class WindowActionHandler {
     }
 
     @discardableResult
-    func focusWindowFromBar(token: WindowToken) -> Bool {
+    func focusWindowFromBar(token: WindowToken, suppressMouseWarp: Bool = false) -> Bool {
         guard let controller else { return false }
         guard let entry = controller.workspaceManager.entry(for: token) else { return false }
+        if suppressMouseWarp {
+            controller.suppressMouseMoveToFocusedWindow(for: token)
+        }
         return navigateToWindowInternal(token: token, workspaceId: entry.workspaceId)
     }
 

--- a/Sources/Nehir/Core/Controller/WorkspaceNavigationHandler.swift
+++ b/Sources/Nehir/Core/Controller/WorkspaceNavigationHandler.swift
@@ -111,7 +111,7 @@ final class WorkspaceNavigationHandler {
         )
     }
 
-    private func clearManagedFocusAfterEmptyWorkspaceSwitch() {
+    private func clearManagedFocusAfterEmptyWorkspaceSwitch(to monitor: Monitor?) {
         guard let controller else { return }
         let canceledRequest = controller.focusBridge.cancelManagedRequest()
         if let canceledRequest {
@@ -120,6 +120,9 @@ final class WorkspaceNavigationHandler {
         controller.clearKeyboardFocusTarget()
         _ = controller.workspaceManager.enterNonManagedFocus(appFullscreen: false)
         controller.focusBorderController.clear()
+        if controller.moveMouseToFocusedWindowEnabled, let monitor {
+            controller.moveMouseToMonitor(monitor)
+        }
     }
 
     private func commitWorkspaceTransitionFocusHandoff(
@@ -139,7 +142,7 @@ final class WorkspaceNavigationHandler {
             if let focusToken = handoff.focusToken {
                 controller.focusWindow(focusToken)
             } else if handoff.shouldClearManagedFocus {
-                self?.clearManagedFocusAfterEmptyWorkspaceSwitch()
+                self?.clearManagedFocusAfterEmptyWorkspaceSwitch(to: monitor)
             }
             if startScrollAnimation {
                 controller.layoutRefreshController.startScrollAnimation(for: targetWorkspaceId)
@@ -176,20 +179,24 @@ final class WorkspaceNavigationHandler {
     private func switchToMonitor(_ targetMonitorId: Monitor.ID, fromMonitor currentMonitorId: Monitor.ID) {
         guard let controller else { return }
 
-        guard let targetWorkspace = controller.workspaceManager.activeWorkspaceOrFirst(on: targetMonitorId)
+        guard let target = controller.workspaceManager.monitor(byId: targetMonitorId),
+              let targetWorkspace = controller.workspaceManager.activeWorkspaceOrFirst(on: targetMonitorId)
         else {
             return
         }
 
         _ = controller.workspaceManager.setInteractionMonitor(targetMonitorId)
-        let focusToken = controller.resolveAndSetWorkspaceFocusToken(for: targetWorkspace.id)
+        let handoff = resolveWorkspaceTransitionFocusHandoff(for: targetWorkspace.id)
 
         controller.layoutRefreshController.commitWorkspaceTransition(
             affectedWorkspaces: [targetWorkspace.id],
             reason: .workspaceTransition
-        ) { [weak controller] in
-            if let focusToken {
-                controller?.focusWindow(focusToken)
+        ) { [weak self, weak controller] in
+            guard let controller else { return }
+            if let focusToken = handoff.focusToken {
+                controller.focusWindow(focusToken)
+            } else if handoff.shouldClearManagedFocus {
+                self?.clearManagedFocusAfterEmptyWorkspaceSwitch(to: target)
             }
         }
     }

--- a/Sources/Nehir/Core/Workspace/WorkspaceManager.swift
+++ b/Sources/Nehir/Core/Workspace/WorkspaceManager.swift
@@ -1790,6 +1790,26 @@ final class WorkspaceManager {
         return changed
     }
 
+    @discardableResult
+    func leaveNonManagedFocus(
+        preserveFocusedToken: Bool = true,
+        preservePendingManagedFocus: Bool = false
+    ) -> Bool {
+        let changed = applyFocusReconcileEvent(
+            .nonManagedFocusChanged(
+                active: false,
+                appFullscreen: sessionState.focus.isAppFullscreenActive,
+                preserveFocusedToken: preserveFocusedToken,
+                preservePendingManagedFocus: preservePendingManagedFocus,
+                source: .workspaceManager
+            )
+        )
+        if changed {
+            notifySessionStateChanged()
+        }
+        return changed
+    }
+
     func handleWindowRemoved(_ token: WindowToken, in workspaceId: WorkspaceDescriptor.ID?) {
         let focusChanged = updateFocusSession(notify: false) { focus in
             self.clearRememberedFocus(

--- a/Sources/Nehir/UI/AppRulesWindowController.swift
+++ b/Sources/Nehir/UI/AppRulesWindowController.swift
@@ -6,6 +6,7 @@ final class AppRulesWindowController {
     static let shared = AppRulesWindowController()
 
     private var window: NSWindow?
+    private var willCloseObserver: NSObjectProtocol?
     private let ownedWindowRegistry = OwnedWindowRegistry.shared
 
     func show(settings: SettingsStore, controller: WMController) {
@@ -14,6 +15,8 @@ final class AppRulesWindowController {
             NSApp.activate(ignoringOtherApps: true)
             return
         }
+
+        removeWillCloseObserver()
 
         let appRulesView = AppRulesView(settings: settings, controller: controller)
             .toolbarBackgroundVisibility(.hidden, for: .windowToolbar)
@@ -31,14 +34,26 @@ final class AppRulesWindowController {
         window.makeKeyAndOrderFront(nil)
         NSApp.activate(ignoringOtherApps: true)
 
-        NotificationCenter.default
-            .addObserver(forName: NSWindow.willCloseNotification, object: window, queue: .main) { [weak self] _ in
+        willCloseObserver = NotificationCenter.default
+            .addObserver(forName: NSWindow.willCloseNotification, object: window, queue: .main) { [weak self, weak controller, weak window] _ in
                 MainActor.assumeIsolated {
-                    self?.ownedWindowRegistry.unregister(window)
-                    self?.window = nil
+                    guard let self else { return }
+                    if let window {
+                        self.ownedWindowRegistry.unregister(window)
+                    }
+                    self.removeWillCloseObserver()
+                    self.window = nil
+                    controller?.handleOwnedFocusSuppressingWindowClosed()
                 }
             }
         self.window = window
+    }
+
+    private func removeWillCloseObserver() {
+        if let willCloseObserver {
+            NotificationCenter.default.removeObserver(willCloseObserver)
+            self.willCloseObserver = nil
+        }
     }
 
     var windowForTests: NSWindow? {

--- a/Sources/Nehir/UI/CommandPalette/CommandPaletteController.swift
+++ b/Sources/Nehir/UI/CommandPalette/CommandPaletteController.swift
@@ -766,6 +766,7 @@ final class CommandPaletteController: NSObject, ObservableObject, NSWindowDelega
         isProgrammaticDismiss = true
         panel?.orderOut(nil)
         isProgrammaticDismiss = false
+        wmController?.handleOwnedFocusSuppressingWindowClosed()
 
         let restoreTarget = reason == .cancel ? restoreFocusTarget : nil
 

--- a/Sources/Nehir/UI/SettingsWindowController.swift
+++ b/Sources/Nehir/UI/SettingsWindowController.swift
@@ -55,7 +55,7 @@ final class SettingsWindowController {
             NotificationCenter.default.removeObserver(willCloseObserverToken)
         }
         willCloseObserverToken = NotificationCenter.default
-            .addObserver(forName: NSWindow.willCloseNotification, object: window, queue: .main) { [weak self] _ in
+            .addObserver(forName: NSWindow.willCloseNotification, object: window, queue: .main) { [weak self, weak controller] _ in
                 MainActor.assumeIsolated {
                     if let willCloseObserverToken = self?.willCloseObserverToken {
                         NotificationCenter.default.removeObserver(willCloseObserverToken)
@@ -63,6 +63,7 @@ final class SettingsWindowController {
                     }
                     self?.ownedWindowRegistry.unregister(window)
                     self?.window = nil
+                    controller?.handleOwnedFocusSuppressingWindowClosed()
                 }
             }
         self.window = window

--- a/Tests/NehirTests/IPCCommandRouterTests.swift
+++ b/Tests/NehirTests/IPCCommandRouterTests.swift
@@ -32,7 +32,8 @@ private func makeIPCFloatingRaiseOperations(
         },
         orderWindow: { windowId in
             recorder.events.append(.order(Int(windowId)))
-        }
+        },
+        visibleWindowInfoProvider: { [] }
     )
 }
 

--- a/Tests/NehirTests/MouseEventHandlerTests.swift
+++ b/Tests/NehirTests/MouseEventHandlerTests.swift
@@ -99,6 +99,7 @@ private func makeMouseEventTestController(
         ownedWindowRegistry: ownedWindowRegistry
     )
     controller.lockScreenObserver.frontmostApplicationProvider = { nil }
+    controller.unmanagedWindowServerWindowFramesProvider = { _ in [] }
     let frame = CGRect(x: 0, y: 0, width: 1920, height: 1080)
     let monitor = Monitor(
         id: Monitor.ID(displayId: 1),
@@ -568,6 +569,65 @@ private func prepareMouseWheelScrollFixtureWithDefaultSensitivity() async -> (
         let after = fixture.controller.workspaceManager.niriViewportState(for: fixture.workspaceId)
         #expect(abs(after.viewOffsetPixels.current() - before) < 0.005)
         #expect(after.viewOffsetPixels.isGesture == false)
+    }
+
+    @Test @MainActor func focusFollowsMouseRefreshesAfterScrollAnimationSettles() async {
+        let controller = makeMouseEventTestController()
+        controller.enableNiriLayout()
+        await controller.layoutRefreshController.waitForRefreshWorkForTests()
+        controller.syncMonitorsToNiriEngine()
+        controller.setFocusFollowsMouse(true)
+
+        guard let workspaceId = controller.interactionWorkspace()?.id,
+              let engine = controller.niriEngine,
+              let monitor = controller.workspaceManager.monitor(for: workspaceId)
+        else {
+            Issue.record("Missing Niri context for post-animation focus-follow regression test")
+            return
+        }
+
+        populateNiriWorkspaceForMouseTests(
+            controller: controller,
+            engine: engine,
+            workspaceId: workspaceId,
+            monitor: monitor,
+            startingWindowId: 960,
+            count: 3
+        )
+        controller.layoutRefreshController.requestImmediateRelayout(reason: .workspaceTransition)
+        await controller.layoutRefreshController.waitForRefreshWorkForTests()
+
+        let focusedToken = controller.workspaceManager.confirmedManagedFocusToken
+        let entries = controller.workspaceManager.entries(in: workspaceId)
+        let hoverTarget = entries.compactMap { entry -> (WindowModel.Entry, CGPoint)? in
+            guard entry.token != focusedToken,
+                  let node = engine.findNode(for: entry.handle),
+                  let frame = node.renderedFrame ?? node.frame
+            else { return nil }
+            let point = frame.center
+            guard monitor.visibleFrame.contains(point),
+                  engine.hitTestFocusableWindow(point: point, in: workspaceId)?.token == entry.token
+            else { return nil }
+            return (entry, point)
+        }.first
+        guard let hoverTarget else {
+            Issue.record("Expected a visible non-focused Niri window for post-animation focus-follow regression test")
+            return
+        }
+
+        controller.mouseEventHandler.mouseLocationProvider = { hoverTarget.1 }
+        #expect(controller.niriLayoutHandler.registerScrollAnimation(
+            workspaceId,
+            on: monitor.displayId
+        ))
+
+        controller.niriLayoutHandler.tickScrollAnimation(
+            targetTime: CACurrentMediaTime() + 5,
+            displayId: monitor.displayId
+        )
+
+        #expect(controller.niriLayoutHandler.scrollAnimationByDisplay[monitor.displayId] == nil)
+        #expect(controller.workspaceManager.pendingFocusedHandle == hoverTarget.0.handle)
     }
 
     @Test @MainActor func trackpadGestureStartsFromCurrentAnimationOffset() async {
@@ -1206,6 +1266,107 @@ private func prepareMouseWheelScrollFixtureWithDefaultSensitivity() async -> (
         #expect(handler.state.lockedGestureContext == nil)
         #expect(finalizedState.viewOffsetPixels.isGesture == false)
         #expect(finalizedState.viewOffsetPixels.isAnimating)
+    }
+
+    @Test @MainActor func trackpadGestureFocusSuppressesMouseMoveToFocusedWindow() async {
+        let fixture = await prepareMouseWheelScrollFixture()
+        let controller = fixture.controller
+        controller.settings.gestureInvertDirection = false
+        controller.settings.gestureScrollSnap = true
+        controller.setMoveMouseToFocusedWindow(true)
+
+        guard let engine = controller.niriEngine else {
+            Issue.record("Missing Niri engine for trackpad focus warp suppression test")
+            return
+        }
+
+        let baseTime = CACurrentMediaTime()
+        fixture.handler.receiveTapGestureEvent(
+            .init(
+                location: fixture.location,
+                phaseRawValue: NSEvent.Phase.began.rawValue,
+                timestamp: baseTime,
+                touches: makeGestureTouchSamples(xPositions: [0.20, 0.25, 0.30])
+            )
+        )
+        fixture.handler.receiveTapGestureEvent(
+            .init(
+                location: fixture.location,
+                phaseRawValue: NSEvent.Phase.changed.rawValue,
+                timestamp: baseTime + 0.016,
+                touches: makeGestureTouchSamples(xPositions: [0.60, 0.65, 0.70])
+            )
+        )
+        fixture.handler.receiveTapGestureEvent(
+            .init(
+                location: fixture.location,
+                phaseRawValue: NSEvent.Phase.ended.rawValue,
+                timestamp: baseTime + 0.032,
+                touches: []
+            )
+        )
+
+        let finalizedState = controller.workspaceManager.niriViewportState(for: fixture.workspaceId)
+        guard let selectedNodeId = finalizedState.selectedNodeId,
+              let selectedWindow = engine.findNode(by: selectedNodeId) as? NiriWindow
+        else {
+            Issue.record("Missing selected niri window after trackpad gesture")
+            return
+        }
+
+        #expect(controller.shouldSuppressMouseMoveToFocusedWindow(for: selectedWindow.token))
+    }
+
+    @Test @MainActor func trackpadGestureDoesNotCommitSelectedFocusWhenFocusFollowsMouseIsEnabled() async {
+        let fixture = await prepareMouseWheelScrollFixture()
+        let controller = fixture.controller
+        controller.settings.gestureInvertDirection = false
+        controller.settings.gestureScrollSnap = true
+        controller.setFocusFollowsMouse(true)
+
+        guard let engine = controller.niriEngine,
+              let focusedBefore = controller.workspaceManager.confirmedManagedFocusToken
+        else {
+            Issue.record("Missing Niri engine or focused token for FFM gesture focus test")
+            return
+        }
+
+        let baseTime = CACurrentMediaTime()
+        fixture.handler.receiveTapGestureEvent(
+            .init(
+                location: fixture.location,
+                phaseRawValue: NSEvent.Phase.began.rawValue,
+                timestamp: baseTime,
+                touches: makeGestureTouchSamples(xPositions: [0.20, 0.25, 0.30])
+            )
+        )
+        fixture.handler.receiveTapGestureEvent(
+            .init(
+                location: fixture.location,
+                phaseRawValue: NSEvent.Phase.changed.rawValue,
+                timestamp: baseTime + 0.016,
+                touches: makeGestureTouchSamples(xPositions: [0.60, 0.65, 0.70])
+            )
+        )
+        fixture.handler.receiveTapGestureEvent(
+            .init(
+                location: fixture.location,
+                phaseRawValue: NSEvent.Phase.ended.rawValue,
+                timestamp: baseTime + 0.032,
+                touches: []
+            )
+        )
+
+        let finalizedState = controller.workspaceManager.niriViewportState(for: fixture.workspaceId)
+        guard let selectedNodeId = finalizedState.selectedNodeId,
+              let selectedWindow = engine.findNode(by: selectedNodeId) as? NiriWindow
+        else {
+            Issue.record("Missing selected niri window after trackpad gesture")
+            return
+        }
+
+        #expect(selectedWindow.token != focusedBefore)
+        #expect(controller.workspaceManager.confirmedManagedFocusToken == focusedBefore)
     }
 
     @Test @MainActor func trackpadGestureWaitsForNiriRecognitionThreshold() async {
@@ -1879,6 +2040,596 @@ private func prepareMouseWheelScrollFixtureWithDefaultSensitivity() async -> (
 
         #expect(controller.workspaceManager.focusedHandle == fullscreenHandle)
         #expect(controller.workspaceManager.pendingFocusedHandle == nil)
+    }
+
+    @Test @MainActor func focusFollowsMouseDoesNotActivateTiledWindowBehindFloatingWindow() async {
+        let controller = makeMouseEventTestController()
+        controller.enableNiriLayout()
+        await controller.layoutRefreshController.waitForRefreshWorkForTests()
+        controller.syncMonitorsToNiriEngine()
+        controller.setFocusFollowsMouse(true)
+
+        guard let workspaceId = controller.interactionWorkspace()?.id,
+              let engine = controller.niriEngine,
+              let monitor = controller.workspaceManager.monitor(for: workspaceId)
+        else {
+            Issue.record("Missing Niri context for floating hover occlusion regression test")
+            return
+        }
+
+        let firstToken = controller.workspaceManager.addWindow(
+            makeMouseEventTestWindow(windowId: 931),
+            pid: getpid(),
+            windowId: 931,
+            to: workspaceId
+        )
+        let secondToken = controller.workspaceManager.addWindow(
+            makeMouseEventTestWindow(windowId: 932),
+            pid: getpid(),
+            windowId: 932,
+            to: workspaceId
+        )
+        let floatingToken = controller.workspaceManager.addWindow(
+            makeMouseEventTestWindow(windowId: 933),
+            pid: getpid(),
+            windowId: 933,
+            to: workspaceId,
+            mode: .floating
+        )
+        guard let firstHandle = controller.workspaceManager.handle(for: firstToken),
+              let secondHandle = controller.workspaceManager.handle(for: secondToken)
+        else {
+            Issue.record("Missing handles for floating hover occlusion regression test")
+            return
+        }
+
+        let tiledHandles = [firstHandle, secondHandle]
+        _ = engine.syncWindows(
+            tiledHandles,
+            in: workspaceId,
+            selectedNodeId: nil,
+            focusedHandle: firstHandle
+        )
+        _ = controller.workspaceManager.setManagedFocus(firstHandle, in: workspaceId, onMonitor: monitor.id)
+        controller.layoutRefreshController.requestImmediateRelayout(reason: .workspaceTransition)
+        await controller.layoutRefreshController.waitForRefreshWorkForTests()
+
+        guard let secondNode = engine.findNode(for: secondHandle),
+              let secondFrame = secondNode.frame
+        else {
+            Issue.record("Missing tiled target frame for floating hover occlusion regression test")
+            return
+        }
+
+        let floatingFrame = CGRect(
+            x: secondFrame.midX - 80,
+            y: secondFrame.midY - 60,
+            width: 160,
+            height: 120
+        )
+        controller.workspaceManager.updateFloatingGeometry(
+            frame: floatingFrame,
+            for: floatingToken,
+            restoreToFloating: true
+        )
+
+        controller.mouseEventHandler.dispatchMouseMoved(at: floatingFrame.center)
+        await controller.layoutRefreshController.waitForRefreshWorkForTests()
+
+        #expect(controller.workspaceManager.confirmedManagedFocusToken == firstToken)
+        #expect(controller.workspaceManager.activeFocusRequestToken == nil)
+    }
+
+    @Test @MainActor func focusFollowsMouseDoesNotActivateTiledWindowBehindUnmanagedWindow() async {
+        let controller = makeMouseEventTestController()
+        controller.enableNiriLayout()
+        await controller.layoutRefreshController.waitForRefreshWorkForTests()
+        controller.syncMonitorsToNiriEngine()
+        controller.setFocusFollowsMouse(true)
+
+        guard let workspaceId = controller.interactionWorkspace()?.id,
+              let engine = controller.niriEngine,
+              let monitor = controller.workspaceManager.monitor(for: workspaceId)
+        else {
+            Issue.record("Missing Niri context for unmanaged hover occlusion regression test")
+            return
+        }
+
+        let firstToken = controller.workspaceManager.addWindow(
+            makeMouseEventTestWindow(windowId: 934),
+            pid: getpid(),
+            windowId: 934,
+            to: workspaceId
+        )
+        let secondToken = controller.workspaceManager.addWindow(
+            makeMouseEventTestWindow(windowId: 935),
+            pid: getpid(),
+            windowId: 935,
+            to: workspaceId
+        )
+        guard let firstHandle = controller.workspaceManager.handle(for: firstToken),
+              let secondHandle = controller.workspaceManager.handle(for: secondToken)
+        else {
+            Issue.record("Missing handles for unmanaged hover occlusion regression test")
+            return
+        }
+
+        _ = engine.syncWindows(
+            [firstHandle, secondHandle],
+            in: workspaceId,
+            selectedNodeId: nil,
+            focusedHandle: firstHandle
+        )
+        _ = controller.workspaceManager.setManagedFocus(firstHandle, in: workspaceId, onMonitor: monitor.id)
+        controller.layoutRefreshController.requestImmediateRelayout(reason: .workspaceTransition)
+        await controller.layoutRefreshController.waitForRefreshWorkForTests()
+
+        guard let secondNode = engine.findNode(for: secondHandle),
+              let secondFrame = secondNode.frame
+        else {
+            Issue.record("Missing tiled target frame for unmanaged hover occlusion regression test")
+            return
+        }
+
+        let unmanagedFrame = CGRect(
+            x: secondFrame.midX - 80,
+            y: secondFrame.midY - 60,
+            width: 160,
+            height: 120
+        )
+        controller.unmanagedWindowServerWindowFramesProvider = { _ in [unmanagedFrame] }
+
+        controller.mouseEventHandler.dispatchMouseMoved(at: unmanagedFrame.center)
+        await controller.layoutRefreshController.waitForRefreshWorkForTests()
+
+        #expect(controller.workspaceManager.confirmedManagedFocusToken == firstToken)
+        #expect(controller.workspaceManager.activeFocusRequestToken == nil)
+    }
+
+    @Test @MainActor func focusFollowsMouseDoesNotActivateTiledWindowWhileFloatingWindowIsVisible() async {
+        let controller = makeMouseEventTestController()
+        controller.enableNiriLayout()
+        await controller.layoutRefreshController.waitForRefreshWorkForTests()
+        controller.syncMonitorsToNiriEngine()
+        controller.setFocusFollowsMouse(true)
+
+        guard let workspaceId = controller.interactionWorkspace()?.id,
+              let engine = controller.niriEngine,
+              let monitor = controller.workspaceManager.monitor(for: workspaceId)
+        else {
+            Issue.record("Missing Niri context for visible floating focus-follow regression test")
+            return
+        }
+
+        let firstToken = controller.workspaceManager.addWindow(
+            makeMouseEventTestWindow(windowId: 929),
+            pid: getpid(),
+            windowId: 929,
+            to: workspaceId
+        )
+        let secondToken = controller.workspaceManager.addWindow(
+            makeMouseEventTestWindow(windowId: 930),
+            pid: getpid(),
+            windowId: 930,
+            to: workspaceId
+        )
+        let floatingToken = controller.workspaceManager.addWindow(
+            makeMouseEventTestWindow(windowId: 928),
+            pid: getpid(),
+            windowId: 928,
+            to: workspaceId,
+            mode: .floating
+        )
+        guard let firstHandle = controller.workspaceManager.handle(for: firstToken),
+              let secondHandle = controller.workspaceManager.handle(for: secondToken),
+              let floatingHandle = controller.workspaceManager.handle(for: floatingToken)
+        else {
+            Issue.record("Missing handles for visible floating focus-follow regression test")
+            return
+        }
+
+        _ = engine.syncWindows(
+            [firstHandle, secondHandle],
+            in: workspaceId,
+            selectedNodeId: nil,
+            focusedHandle: firstHandle
+        )
+        _ = controller.workspaceManager.setManagedFocus(floatingHandle, in: workspaceId, onMonitor: monitor.id)
+        let floatingFrame = CGRect(x: monitor.visibleFrame.midX - 100, y: monitor.visibleFrame.midY - 80, width: 200, height: 160)
+        controller.workspaceManager.updateFloatingGeometry(
+            frame: floatingFrame,
+            for: floatingToken,
+            restoreToFloating: true
+        )
+        controller.layoutRefreshController.requestImmediateRelayout(reason: .workspaceTransition)
+        await controller.layoutRefreshController.waitForRefreshWorkForTests()
+
+        guard let secondNode = engine.findNode(for: secondHandle),
+              let secondFrame = secondNode.frame
+        else {
+            Issue.record("Missing tiled target frame for visible floating focus-follow regression test")
+            return
+        }
+        let tiledPointOutsideFloating = CGPoint(x: secondFrame.midX, y: secondFrame.minY + 24)
+        #expect(secondFrame.contains(tiledPointOutsideFloating))
+        #expect(!floatingFrame.contains(tiledPointOutsideFloating))
+
+        controller.mouseEventHandler.dispatchMouseMoved(at: tiledPointOutsideFloating)
+        await controller.layoutRefreshController.waitForRefreshWorkForTests()
+
+        #expect(controller.workspaceManager.confirmedManagedFocusToken == floatingToken)
+        #expect(controller.workspaceManager.activeFocusRequestToken == nil)
+    }
+
+    @Test @MainActor func focusFollowsMouseActivatesTiledWindowWhenFloatingWindowIsBehindActiveTile() async {
+        let controller = makeMouseEventTestController()
+        controller.enableNiriLayout()
+        await controller.layoutRefreshController.waitForRefreshWorkForTests()
+        controller.syncMonitorsToNiriEngine()
+        controller.setFocusFollowsMouse(true)
+
+        guard let workspaceId = controller.interactionWorkspace()?.id,
+              let engine = controller.niriEngine,
+              let monitor = controller.workspaceManager.monitor(for: workspaceId)
+        else {
+            Issue.record("Missing Niri context for behind-floating focus-follow regression test")
+            return
+        }
+
+        let firstToken = controller.workspaceManager.addWindow(
+            makeMouseEventTestWindow(windowId: 931),
+            pid: getpid(),
+            windowId: 931,
+            to: workspaceId
+        )
+        let secondToken = controller.workspaceManager.addWindow(
+            makeMouseEventTestWindow(windowId: 932),
+            pid: getpid(),
+            windowId: 932,
+            to: workspaceId
+        )
+        let floatingToken = controller.workspaceManager.addWindow(
+            makeMouseEventTestWindow(windowId: 933),
+            pid: getpid(),
+            windowId: 933,
+            to: workspaceId,
+            mode: .floating
+        )
+        guard let firstHandle = controller.workspaceManager.handle(for: firstToken),
+              let secondHandle = controller.workspaceManager.handle(for: secondToken)
+        else {
+            Issue.record("Missing handles for behind-floating focus-follow regression test")
+            return
+        }
+
+        _ = engine.syncWindows(
+            [firstHandle, secondHandle],
+            in: workspaceId,
+            selectedNodeId: nil,
+            focusedHandle: firstHandle
+        )
+        _ = controller.workspaceManager.setManagedFocus(firstHandle, in: workspaceId, onMonitor: monitor.id)
+        controller.workspaceManager.updateFloatingGeometry(
+            frame: CGRect(x: monitor.visibleFrame.midX - 100, y: monitor.visibleFrame.midY - 80, width: 200, height: 160),
+            for: floatingToken,
+            restoreToFloating: true
+        )
+        controller.layoutRefreshController.requestImmediateRelayout(reason: .workspaceTransition)
+        await controller.layoutRefreshController.waitForRefreshWorkForTests()
+
+        guard let secondNode = engine.findNode(for: secondHandle),
+              let secondFrame = secondNode.frame
+        else {
+            Issue.record("Missing tiled target frame for behind-floating focus-follow regression test")
+            return
+        }
+
+        controller.mouseEventHandler.dispatchMouseMoved(at: CGPoint(x: secondFrame.midX, y: secondFrame.minY + 24))
+        await controller.layoutRefreshController.waitForRefreshWorkForTests()
+
+        #expect(controller.workspaceManager.pendingFocusedHandle == secondHandle)
+        #expect(controller.workspaceManager.confirmedManagedFocusToken == firstToken)
+    }
+
+    @Test @MainActor func floatingMouseInitiatedFocusDoesNotMoveMouseToFocusedWindow() async {
+        let controller = makeMouseEventTestController()
+        controller.enableNiriLayout()
+        await controller.layoutRefreshController.waitForRefreshWorkForTests()
+        controller.syncMonitorsToNiriEngine()
+        controller.setMoveMouseToFocusedWindow(true)
+
+        guard let workspaceId = controller.interactionWorkspace()?.id,
+              let engine = controller.niriEngine,
+              let monitor = controller.workspaceManager.monitor(for: workspaceId)
+        else {
+            Issue.record("Missing Niri context for floating mouse warp regression test")
+            return
+        }
+
+        let tiledToken = controller.workspaceManager.addWindow(
+            makeMouseEventTestWindow(windowId: 939),
+            pid: getpid(),
+            windowId: 939,
+            to: workspaceId
+        )
+        let floatingToken = controller.workspaceManager.addWindow(
+            makeMouseEventTestWindow(windowId: 940),
+            pid: getpid(),
+            windowId: 940,
+            to: workspaceId,
+            mode: .floating
+        )
+        guard let tiledHandle = controller.workspaceManager.handle(for: tiledToken),
+              let floatingEntry = controller.workspaceManager.entry(for: floatingToken)
+        else {
+            Issue.record("Missing handles for floating mouse warp regression test")
+            return
+        }
+
+        _ = engine.syncWindows(
+            [tiledHandle],
+            in: workspaceId,
+            selectedNodeId: nil,
+            focusedHandle: tiledHandle
+        )
+        _ = controller.workspaceManager.setManagedFocus(tiledHandle, in: workspaceId, onMonitor: monitor.id)
+        let floatingFrame = CGRect(x: 200, y: 120, width: 300, height: 220)
+        controller.workspaceManager.updateFloatingGeometry(
+            frame: floatingFrame,
+            for: floatingToken,
+            restoreToFloating: true
+        )
+        controller.layoutRefreshController.requestImmediateRelayout(reason: .workspaceTransition)
+        await controller.layoutRefreshController.waitForRefreshWorkForTests()
+
+        var warpedPoints: [CGPoint] = []
+        controller.warpMouseCursorPosition = { point in
+            warpedPoints.append(point)
+        }
+
+        controller.mouseEventHandler.dispatchMouseDown(at: floatingFrame.center, modifiers: [])
+        controller.axEventHandler.handleManagedAppActivation(
+            entry: floatingEntry,
+            isWorkspaceActive: true,
+            appFullscreen: false,
+            source: .focusedWindowChanged,
+            confirmRequest: true
+        )
+        await controller.layoutRefreshController.waitForRefreshWorkForTests()
+
+        #expect(controller.workspaceManager.confirmedManagedFocusToken == floatingToken)
+        #expect(warpedPoints.isEmpty)
+    }
+
+    @Test @MainActor func focusFollowsMouseDoesNotStealFocusDuringRecentFloatingPointerInteraction() async {
+        let controller = makeMouseEventTestController()
+        controller.enableNiriLayout()
+        await controller.layoutRefreshController.waitForRefreshWorkForTests()
+        controller.syncMonitorsToNiriEngine()
+        controller.setFocusFollowsMouse(true)
+
+        guard let workspaceId = controller.interactionWorkspace()?.id,
+              let engine = controller.niriEngine,
+              let monitor = controller.workspaceManager.monitor(for: workspaceId)
+        else {
+            Issue.record("Missing Niri context for floating pointer interaction regression test")
+            return
+        }
+
+        let tiledToken = controller.workspaceManager.addWindow(
+            makeMouseEventTestWindow(windowId: 936),
+            pid: getpid(),
+            windowId: 936,
+            to: workspaceId
+        )
+        let secondTiledToken = controller.workspaceManager.addWindow(
+            makeMouseEventTestWindow(windowId: 937),
+            pid: getpid(),
+            windowId: 937,
+            to: workspaceId
+        )
+        let floatingToken = controller.workspaceManager.addWindow(
+            makeMouseEventTestWindow(windowId: 938),
+            pid: getpid(),
+            windowId: 938,
+            to: workspaceId,
+            mode: .floating
+        )
+        guard let tiledHandle = controller.workspaceManager.handle(for: tiledToken),
+              let secondTiledHandle = controller.workspaceManager.handle(for: secondTiledToken),
+              let floatingHandle = controller.workspaceManager.handle(for: floatingToken)
+        else {
+            Issue.record("Missing handles for floating pointer interaction regression test")
+            return
+        }
+
+        _ = engine.syncWindows(
+            [tiledHandle, secondTiledHandle],
+            in: workspaceId,
+            selectedNodeId: nil,
+            focusedHandle: tiledHandle
+        )
+        _ = controller.workspaceManager.setManagedFocus(floatingHandle, in: workspaceId, onMonitor: monitor.id)
+        controller.layoutRefreshController.requestImmediateRelayout(reason: .workspaceTransition)
+        await controller.layoutRefreshController.waitForRefreshWorkForTests()
+
+        guard let secondNode = engine.findNode(for: secondTiledHandle),
+              let secondFrame = secondNode.frame
+        else {
+            Issue.record("Missing tiled target frame for floating pointer interaction regression test")
+            return
+        }
+
+        let floatingFrame = CGRect(
+            x: secondFrame.midX - 120,
+            y: secondFrame.midY - 80,
+            width: 160,
+            height: 120
+        )
+        controller.workspaceManager.updateFloatingGeometry(
+            frame: floatingFrame,
+            for: floatingToken,
+            restoreToFloating: true
+        )
+
+        let tiledPointOutsideFloating = CGPoint(x: floatingFrame.maxX + 40, y: floatingFrame.midY)
+        #expect(secondFrame.contains(tiledPointOutsideFloating))
+        #expect(!floatingFrame.contains(tiledPointOutsideFloating))
+
+        controller.mouseEventHandler.dispatchMouseDown(at: floatingFrame.center, modifiers: [])
+        controller.mouseEventHandler.dispatchMouseDragged(at: tiledPointOutsideFloating)
+        await controller.layoutRefreshController.waitForRefreshWorkForTests()
+
+        #expect(controller.workspaceManager.confirmedManagedFocusToken == floatingToken)
+        #expect(controller.workspaceManager.activeFocusRequestToken == nil)
+    }
+
+    @Test @MainActor func mouseInitiatedFocusDoesNotMoveMouseToFocusedWindow() async {
+        let controller = makeMouseEventTestController()
+        controller.enableNiriLayout()
+        await controller.layoutRefreshController.waitForRefreshWorkForTests()
+        controller.syncMonitorsToNiriEngine()
+        controller.setMoveMouseToFocusedWindow(true)
+        controller.setFocusFollowsMouse(false)
+
+        guard let workspaceId = controller.interactionWorkspace()?.id,
+              let engine = controller.niriEngine,
+              let monitor = controller.workspaceManager.monitor(for: workspaceId)
+        else {
+            Issue.record("Missing Niri context for mouse-initiated focus warp regression test")
+            return
+        }
+
+        let firstToken = controller.workspaceManager.addWindow(
+            makeMouseEventTestWindow(windowId: 941),
+            pid: getpid(),
+            windowId: 941,
+            to: workspaceId
+        )
+        let secondToken = controller.workspaceManager.addWindow(
+            makeMouseEventTestWindow(windowId: 942),
+            pid: getpid(),
+            windowId: 942,
+            to: workspaceId
+        )
+        guard let firstHandle = controller.workspaceManager.handle(for: firstToken),
+              let secondHandle = controller.workspaceManager.handle(for: secondToken),
+              let secondEntry = controller.workspaceManager.entry(for: secondToken)
+        else {
+            Issue.record("Missing handles for mouse-initiated focus warp regression test")
+            return
+        }
+
+        let handles = controller.workspaceManager.entries(in: workspaceId).map(\.handle)
+        _ = engine.syncWindows(
+            handles,
+            in: workspaceId,
+            selectedNodeId: nil,
+            focusedHandle: firstHandle
+        )
+        _ = controller.workspaceManager.setManagedFocus(firstHandle, in: workspaceId, onMonitor: monitor.id)
+        controller.layoutRefreshController.requestImmediateRelayout(reason: .workspaceTransition)
+        await controller.layoutRefreshController.waitForRefreshWorkForTests()
+
+        guard let secondNode = engine.findNode(for: secondHandle),
+              let secondFrame = secondNode.frame
+        else {
+            Issue.record("Missing clicked node frame for mouse-initiated focus warp regression test")
+            return
+        }
+
+        var warpedPoints: [CGPoint] = []
+        controller.warpMouseCursorPosition = { point in
+            warpedPoints.append(point)
+        }
+
+        controller.mouseEventHandler.dispatchMouseDown(
+            at: CGPoint(x: secondFrame.midX, y: secondFrame.midY),
+            modifiers: []
+        )
+        controller.axEventHandler.handleManagedAppActivation(
+            entry: secondEntry,
+            isWorkspaceActive: true,
+            appFullscreen: false,
+            source: .focusedWindowChanged,
+            confirmRequest: true
+        )
+        await controller.layoutRefreshController.waitForRefreshWorkForTests()
+
+        #expect(controller.workspaceManager.confirmedManagedFocusToken == secondToken)
+        #expect(warpedPoints.isEmpty)
+    }
+
+    @Test @MainActor func focusFollowsMouseReactivatesLastHoveredWindowAfterGestureFocusChange() async {
+        let controller = makeMouseEventTestController()
+        controller.enableNiriLayout()
+        await controller.layoutRefreshController.waitForRefreshWorkForTests()
+        controller.syncMonitorsToNiriEngine()
+        controller.setFocusFollowsMouse(true)
+
+        guard let workspaceId = controller.interactionWorkspace()?.id,
+              let engine = controller.niriEngine,
+              let monitor = controller.workspaceManager.monitor(for: workspaceId)
+        else {
+            Issue.record("Missing Niri context for repeated hover focus regression test")
+            return
+        }
+
+        let firstToken = controller.workspaceManager.addWindow(
+            makeMouseEventTestWindow(windowId: 951),
+            pid: getpid(),
+            windowId: 951,
+            to: workspaceId
+        )
+        let secondToken = controller.workspaceManager.addWindow(
+            makeMouseEventTestWindow(windowId: 952),
+            pid: getpid(),
+            windowId: 952,
+            to: workspaceId
+        )
+        guard let firstHandle = controller.workspaceManager.handle(for: firstToken),
+              let secondHandle = controller.workspaceManager.handle(for: secondToken)
+        else {
+            Issue.record("Missing handles for repeated hover focus regression test")
+            return
+        }
+
+        let handles = controller.workspaceManager.entries(in: workspaceId).map(\.handle)
+        _ = engine.syncWindows(
+            handles,
+            in: workspaceId,
+            selectedNodeId: nil,
+            focusedHandle: firstHandle
+        )
+        _ = controller.workspaceManager.setManagedFocus(firstHandle, in: workspaceId, onMonitor: monitor.id)
+        controller.layoutRefreshController.requestImmediateRelayout(reason: .workspaceTransition)
+        await controller.layoutRefreshController.waitForRefreshWorkForTests()
+
+        guard let secondNode = engine.findNode(for: secondHandle),
+              let secondFrame = secondNode.renderedFrame ?? secondNode.frame
+        else {
+            Issue.record("Missing second node frame for repeated hover focus regression test")
+            return
+        }
+
+        let hoverPoint = CGPoint(x: secondFrame.midX, y: secondFrame.midY)
+        controller.mouseEventHandler.dispatchMouseMoved(at: hoverPoint)
+        await controller.layoutRefreshController.waitForRefreshWorkForTests()
+        #expect(controller.workspaceManager.pendingFocusedHandle == secondHandle)
+
+        _ = controller.workspaceManager.confirmManagedFocus(
+            firstToken,
+            in: workspaceId,
+            onMonitor: monitor.id,
+            appFullscreen: false,
+            activateWorkspaceOnMonitor: false
+        )
+        controller.mouseEventHandler.resetFocusFollowsMouseTimeForTesting()
+
+        controller.mouseEventHandler.dispatchMouseMoved(at: hoverPoint)
+        await controller.layoutRefreshController.waitForRefreshWorkForTests()
+
+        #expect(controller.workspaceManager.pendingFocusedHandle == secondHandle)
     }
 
     @Test @MainActor func focusFollowsMouseActivatesVisibleNiriWindowWithoutRecenteringViewport() async {

--- a/Tests/NehirTests/NiriLayoutEngineTests.swift
+++ b/Tests/NehirTests/NiriLayoutEngineTests.swift
@@ -3614,6 +3614,7 @@ private func makeCenteredCrossMonitorFixture(
         #expect(fixture.column.activeTileIdx == 2)
         #expect(fixture.column.activeVisualTileIdx == 0)
         #expect(fixture.column.activeWindow?.token == fixture.topToken)
+        #expect(fixture.controller.shouldSuppressMouseMoveToFocusedWindow(for: fixture.topToken))
         #expect(fixture.controller.workspaceManager.niriViewportState(for: fixture.workspaceId)
             .selectedNodeId == fixture.topWindow.id)
         #expect(!fixture.topWindow.isHiddenInTabbedMode)

--- a/Tests/NehirTests/WMControllerFocusTests.swift
+++ b/Tests/NehirTests/WMControllerFocusTests.swift
@@ -234,7 +234,103 @@ private func waitForFocusRefresh(on controller: WMController) async {
         }
     }
 
+    @Test @MainActor func moveMouseToFocusedWarpsToEmptyWorkspaceMonitorOnSwitch() async {
+        let operations = WindowFocusOperations(
+            activateApp: { _ in },
+            focusSpecificWindow: { _, _, _ in },
+            raiseWindow: { _ in }
+        )
+        let fixture = makeTwoMonitorFocusController(windowFocusOperations: operations)
+        let controller = fixture.controller
+        let sourceHandle = addManagedTestWindow(
+            on: controller,
+            pid: getpid(),
+            windowId: 441,
+            workspaceId: fixture.primaryWorkspaceId
+        )
+        _ = controller.workspaceManager.setManagedFocus(
+            sourceHandle,
+            in: fixture.primaryWorkspaceId,
+            onMonitor: fixture.primaryMonitor.id
+        )
+        controller.setMoveMouseToFocusedWindow(true)
 
+        var warpedPoints: [CGPoint] = []
+        controller.warpMouseCursorPosition = { point in
+            warpedPoints.append(point)
+        }
+
+        controller.workspaceNavigationHandler.switchWorkspace(index: 1)
+        await waitForFocusRefresh(on: controller)
+
+        #expect(controller.interactionWorkspace()?.id == fixture.secondaryWorkspaceId)
+        #expect(controller.workspaceManager.confirmedManagedFocusToken == nil)
+        #expect(warpedPoints == [
+            ScreenCoordinateSpace.toWindowServer(
+                point: fixture.secondaryMonitor.visibleFrame.center,
+                displayId: fixture.secondaryMonitor.displayId
+            )
+        ])
+    }
+
+    @Test @MainActor func workspaceBarWindowClickDoesNotMoveMouseToFocusedWindow() async {
+        await withAXFrameProviderIsolationForTests {
+            let operations = WindowFocusOperations(
+                activateApp: { _ in },
+                focusSpecificWindow: { _, _, _ in },
+                raiseWindow: { _ in }
+            )
+            let (controller, workspaceId, handle) = makeFocusTestController(windowFocusOperations: operations)
+            let otherHandle = addManagedTestWindow(
+                on: controller,
+                pid: getpid(),
+                windowId: 442,
+                workspaceId: workspaceId
+            )
+            guard let entry = controller.workspaceManager.entry(for: handle.id),
+                  let monitor = controller.workspaceManager.monitor(for: workspaceId),
+                  let screen = NSScreen.screens.first
+            else {
+                Issue.record("Missing workspace-bar mouse warp suppression fixture")
+                return
+            }
+            _ = controller.workspaceManager.setManagedFocus(
+                otherHandle,
+                in: workspaceId,
+                onMonitor: monitor.id
+            )
+            controller.setMoveMouseToFocusedWindow(true)
+
+            let frame = CGRect(
+                x: screen.frame.midX - 120,
+                y: screen.frame.midY - 80,
+                width: 240,
+                height: 160
+            )
+            AXWindowService.fastFrameProviderForTests = { axRef in
+                axRef.windowId == handle.id.windowId ? frame : nil
+            }
+            defer { AXWindowService.fastFrameProviderForTests = nil }
+
+            var warpedPoints: [CGPoint] = []
+            controller.warpMouseCursorPosition = { point in
+                warpedPoints.append(point)
+            }
+
+            controller.focusWindowFromBar(token: handle.id)
+            await waitForFocusRefresh(on: controller)
+            controller.axEventHandler.handleManagedAppActivation(
+                entry: entry,
+                isWorkspaceActive: true,
+                appFullscreen: false,
+                source: .focusedWindowChanged,
+                confirmRequest: true
+            )
+
+            #expect(controller.workspaceManager.confirmedManagedFocusToken == handle.id)
+            #expect(warpedPoints.isEmpty)
+        }
+    }
 
     @Test @MainActor func toggleWorkspaceBarVisibilityHidesOnlyInteractionMonitorAndPreservesSettings() async {
         let primaryMonitor = Monitor(
@@ -350,6 +446,27 @@ private func waitForFocusRefresh(on controller: WMController) async {
         #expect(controller.workspaceManager.pendingFocusedHandle == handle)
         #expect(controller.workspaceManager.isAppFullscreenActive == true)
         #expect(controller.workspaceManager.isNonManagedFocusActive == true)
+    }
+
+    @Test @MainActor func ownedWindowCloseClearsPreservedNonManagedFocus() {
+        let operations = WindowFocusOperations(
+            activateApp: { _ in },
+            focusSpecificWindow: { _, _, _ in },
+            raiseWindow: { _ in }
+        )
+        let (controller, workspaceId, handle) = makeFocusTestController(windowFocusOperations: operations)
+        _ = controller.workspaceManager.confirmManagedFocus(
+            handle.id,
+            in: workspaceId,
+            appFullscreen: false,
+            activateWorkspaceOnMonitor: false
+        )
+        _ = controller.workspaceManager.enterNonManagedFocus(appFullscreen: false, preserveFocusedToken: true)
+
+        controller.handleOwnedFocusSuppressingWindowClosed()
+
+        #expect(controller.workspaceManager.focusedHandle == handle)
+        #expect(controller.workspaceManager.isNonManagedFocusActive == false)
     }
 
     @Test @MainActor func focusWindowSelectsNativeFullscreenPlaceholderWithoutAXFocus() async {

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -403,7 +403,7 @@ When AX readback shows that a real app refused or clamped a requested resize, th
 | `commandHandler` | Routes `HotkeyCommand` cases to appropriate handler methods |
 | `axEventHandler` | Processes window create/destroy events, manages replacement correlation |
 | `mouseEventHandler` | CGEvent tap for mouse events, gestures, focus-follows-mouse |
-| `mouseWarpHandler` | Warps cursor to focused window when configured |
+| `mouseWarpHandler` | Warps cursor to focused window when configured; skipped for pointer/gesture-initiated focus and empty-workspace monitor transitions use center warp |
 | `layoutRefreshController` | Refresh scheduling, DisplayLink animation, frame application |
 | `workspaceNavigationHandler` | Workspace switching, window-to-workspace moves |
 | `windowActionHandler` | Window close, fullscreen toggle, float toggle |
@@ -601,10 +601,11 @@ The `FocusBridgeCoordinator` manages the request/confirmation part of this model
 **Mouse events** (`Sources/Nehir/Core/Controller/MouseEventHandler.swift`)
 
 Uses `CGEventTap` for system-wide mouse event interception:
-- **Focus-follows-mouse**: Debounced (100ms) focus change on mouse hover
-- **Trackpad gestures**: Three-phase state machine (`idle` → `armed` → `committed`) for workspace switching via swipe
+- **Focus-follows-mouse**: Debounced (100ms) focus change on mouse hover. Re-evaluated after scroll/swipe animation settles and after owned Nehir UI windows close, because those paths may not emit a fresh mouse-move event. Tiled hover activation is disabled while a tracked floating window is the active surface above the Niri layout, but a floating window merely visible behind the active tiled window does not block hover focus. Hover activation is also blocked when the pointer is over a visible unmanaged WindowServer window, and briefly suppressed after floating/unmanaged pointer interaction so clicking or dragging those windows does not immediately activate a tiled column behind them.
+- **Trackpad gestures**: Three-phase state machine (`idle` → `armed` → `committed`) for workspace switching via swipe. Gesture-selected focus suppresses cursor warp so the cursor does not jump to the focused column. When `focusFollowsMouse` is enabled, gesture end updates the viewport selection but does not commit managed focus; pointer hover decides final focus after the gesture/animation settles.
 - **Interactive move/resize**: Option+Shift+drag for window repositioning
 - **Event coalescing**: Transient mouse events are batched and drained in coalesced bursts
+- **Cursor warp suppression**: `moveMouseToFocusedWindow` is treated as a keyboard/command-navigation affordance. Pointer-initiated focus (hover, window click, floating click/drag, workspace bar click, tab overlay click) and gesture/scroll-initiated focus suppress warping via `suppressMouseMoveToFocusedWindow(for:)`, so the cursor does not jump under the user's hand. Empty-workspace monitor switches are the exception: with no focused window target, command navigation warps to the target monitor center.
 
 **SkyLight events** (`Sources/Nehir/Core/SkyLight/CGSEventObserver.swift`)
 


### PR DESCRIPTION
## Summary

Suppress cursor warp when focus changes originate from the mouse itself (hover, click) or from trackpad swipe/scroll gestures — the cursor should only jump on keyboard- or command-initiated focus changes. Re-evaluate focus-follows-mouse after scroll animation settles so hovering a window after a gesture activates it. Clear non-managed focus when owned UI windows (Settings, App Rules, Command Palette) close so focus-follows-mouse resumes immediately. Warp the cursor to the target monitor center when switching to an empty workspace on another display.

#21 

## Release notes

Choose one:

- [x] Added a `.changeset/*.md` for user-visible changes (`mise run changeset -- patch "..."`).
- [ ] No user-visible change; apply the `no release note` label to make CI skip intentional.

## Validation

<!-- Commands run, screenshots, or manual checks. -->

- [x] Ran relevant tests/checks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Suppress cursor warps for pointer-initiated focus (hover/click), workspace-bar/tab interactions, trackpad gestures, scroll animations, and floating-window interactions
  * Prevent focus-follows-mouse from activating tiled windows occluded by floating or unmanaged windows or after recent pointer interactions
  * Restore focus-follows-mouse after animations and when owned UI windows close
  * Warp cursor to monitor center when switching to an empty workspace

* **Documentation**
  * Added mouse-focus behavior and cursor-warp guidance

* **Tests**
  * Added regression tests for mouse/gesture/focus interactions and warp suppression
<!-- end of auto-generated comment: release notes by coderabbit.ai -->