### PR TITLE
Fixed focus-follows-mouse getting wrong window focused after fast moves

### DIFF
--- a/.changeset/20260611215427-fixed-focus-follows-mouse-getting-stuck-on-the-w.md
+++ b/.changeset/20260611215427-fixed-focus-follows-mouse-getting-stuck-on-the-w.md
@@ -1,0 +1,6 @@
+---
+"nehir": patch
+
+---
+
+Fixed focus-follows-mouse getting stuck on the wrong window during fast pointer movement

--- a/Sources/Nehir/Core/Controller/AXEventHandler.swift
+++ b/Sources/Nehir/Core/Controller/AXEventHandler.swift
@@ -287,6 +287,7 @@ final class AXEventHandler: CGSEventDelegate {
     private static let createdWindowRetryLimit = 5
     private static let createPlacementContextTTL: TimeInterval = 15
     private static let activationRetryLimit = 5
+    private static let nativeAppSwitchLeaseRequestConfirmationGrace: TimeInterval = 0.6
     private static let createFocusTraceLimit = 128
     private static let managedReplacementTraceLimit = 128
     private static let createFocusTraceLoggingEnabled =
@@ -1283,15 +1284,6 @@ final class AXEventHandler: CGSEventDelegate {
         )
         guard controller.hasStartedServices else { return }
 
-        if source != .focusedWindowChanged {
-            controller.focusPolicyEngine.beginLease(
-                owner: .nativeAppSwitch,
-                reason: source.rawValue,
-                suppressesFocusFollowsMouse: true,
-                duration: 0.4
-            )
-        }
-
         let activeRequest = controller.focusBridge.activeManagedRequest
 
         if pid == getpid(), (controller.hasFrontmostOwnedWindow || controller.hasVisibleOwnedWindow) {
@@ -1310,6 +1302,22 @@ final class AXEventHandler: CGSEventDelegate {
 
         let axRef = resolveFocusedAXWindowRef(pid: pid)
         let observedToken = axRef.map { WindowToken(pid: pid, windowId: $0.windowId) }
+        let isActivationForManagedRequest = observedToken.map { token in
+            activeRequest?.token == token
+                || controller.focusBridge.recentlyConfirmedManagedRequest(
+                    for: token,
+                    within: Self.nativeAppSwitchLeaseRequestConfirmationGrace
+                )
+        } ?? (activeRequest?.token.pid == pid)
+        if source != .focusedWindowChanged, !isActivationForManagedRequest {
+            controller.focusPolicyEngine.beginLease(
+                owner: .nativeAppSwitch,
+                reason: source.rawValue,
+                suppressesFocusFollowsMouse: true,
+                duration: 0.4
+            )
+        }
+
         let requestDisposition = activationRequestDisposition(
             for: pid,
             token: observedToken,

--- a/Sources/Nehir/Core/Controller/KeyboardFocusLifecycleCoordinator.swift
+++ b/Sources/Nehir/Core/Controller/KeyboardFocusLifecycleCoordinator.swift
@@ -44,7 +44,13 @@ final class FocusBridgeCoordinator {
     private var pendingFocusToken: WindowToken?
     private var deferredFocusToken: WindowToken?
     private var isFocusOperationPending = false
+    private struct ConfirmedManagedRequest {
+        var token: WindowToken
+        var confirmedAt: Date
+    }
+
     private var lastFocusTime: Date = .distantPast
+    private var recentlyConfirmedManagedRequestsByPID: [pid_t: ConfirmedManagedRequest] = [:]
 
     func beginManagedRequest(
         token: WindowToken,
@@ -120,6 +126,10 @@ final class FocusBridgeCoordinator {
 
         activeManagedRequest.lastActivationSource = source
         activeManagedRequest.status = .confirmed
+        recentlyConfirmedManagedRequestsByPID[token.pid] = ConfirmedManagedRequest(
+            token: token,
+            confirmedAt: Date()
+        )
         self.activeManagedRequest = nil
         return activeManagedRequest
     }
@@ -156,6 +166,19 @@ final class FocusBridgeCoordinator {
         self.activeManagedRequest = activeManagedRequest
     }
 
+    func recentlyConfirmedManagedRequest(
+        for token: WindowToken,
+        within interval: TimeInterval
+    ) -> Bool {
+        guard let confirmation = recentlyConfirmedManagedRequestsByPID[token.pid],
+              confirmation.token == token,
+              Date().timeIntervalSince(confirmation.confirmedAt) <= interval
+        else {
+            return false
+        }
+        return true
+    }
+
     func discardPendingFocus(_ token: WindowToken) {
         if pendingFocusToken == token {
             pendingFocusToken = nil
@@ -171,6 +194,12 @@ final class FocusBridgeCoordinator {
         }
         if deferredFocusToken == oldToken {
             deferredFocusToken = newToken
+        }
+        if recentlyConfirmedManagedRequestsByPID[oldToken.pid]?.token == oldToken {
+            let confirmation = recentlyConfirmedManagedRequestsByPID.removeValue(forKey: oldToken.pid)
+            recentlyConfirmedManagedRequestsByPID[newToken.pid] = confirmation.map {
+                ConfirmedManagedRequest(token: newToken, confirmedAt: $0.confirmedAt)
+            }
         }
     }
 
@@ -210,5 +239,6 @@ final class FocusBridgeCoordinator {
         deferredFocusToken = nil
         isFocusOperationPending = false
         lastFocusTime = .distantPast
+        recentlyConfirmedManagedRequestsByPID.removeAll(keepingCapacity: true)
     }
 }

--- a/Sources/Nehir/Core/Controller/MouseEventHandler.swift
+++ b/Sources/Nehir/Core/Controller/MouseEventHandler.swift
@@ -8,6 +8,7 @@ private let niriTouchpadGestureRecognitionThreshold: CGFloat = 16.0
 private let macNormalizedTouchPositionToNiriGestureUnits: CGFloat = 500.0
 private let mouseWheelAxisEpsilon: CGFloat = 0.001
 private let niriWheelScrollTickAmount: CGFloat = 120.0
+private let queuedMouseMoveCurrentPointerTolerance: CGFloat = 2.0
 private let mouseRelevantModifierFlags: CGEventFlags = [
     .maskAlternate,
     .maskShift,
@@ -689,7 +690,7 @@ final class MouseEventHandler {
             case .mouseMoved:
                 if let location = pendingMouseMoved {
                     state.debugCounters.drainedTransientEvents += 1
-                    dispatchMouseMoved(at: location)
+                    replayQueuedMouseMoved(at: location)
                 }
             case let .mouseDragged(button):
                 let location = switch button {
@@ -714,6 +715,53 @@ final class MouseEventHandler {
                 }
             }
         }
+    }
+
+    private func replayQueuedMouseMoved(at location: CGPoint) {
+        guard !isInputSuppressed else {
+            resetHoveredEdgesIfNeeded()
+            return
+        }
+        let currentLocation = currentPointerLocation(forQueuedMouseMoveAt: location)
+        if !pointsApproximatelyEqual(location, currentLocation, tolerance: queuedMouseMoveCurrentPointerTolerance) {
+            traceMouseFocus(
+                "mouseMove.replay staleQueued queued=\(formatPoint(location)) current=\(formatPoint(currentLocation))"
+            )
+        }
+        handleMouseMovedFromTap(at: currentLocation)
+    }
+
+    private func currentPointerLocation(forQueuedMouseMoveAt location: CGPoint) -> CGPoint {
+        let currentLocation = mouseLocationProvider()
+        guard currentLocation.x.isFinite, currentLocation.y.isFinite else { return location }
+
+        guard !pointsApproximatelyEqual(
+            location,
+            currentLocation,
+            tolerance: queuedMouseMoveCurrentPointerTolerance
+        ) else {
+            return location
+        }
+        return currentLocation
+    }
+
+    private func pointsApproximatelyEqual(_ lhs: CGPoint, _ rhs: CGPoint, tolerance: CGFloat) -> Bool {
+        let dx = lhs.x - rhs.x
+        let dy = lhs.y - rhs.y
+        return dx * dx + dy * dy <= tolerance * tolerance
+    }
+
+    private func traceMouseFocus(_ message: @autoclosure () -> String) {
+        guard controller?.isRuntimeTraceCaptureActive == true else { return }
+        controller?.recordRuntimeMouseTrace(message())
+    }
+
+    private func formatPoint(_ point: CGPoint) -> String {
+        String(format: "(%.1f,%.1f)", point.x, point.y)
+    }
+
+    private func formatToken(_ token: WindowToken?) -> String {
+        token.map(String.init(describing:)) ?? "nil"
     }
 
     private func replayQueuedMouseDragged(at location: CGPoint, button: MouseButton) {
@@ -1080,31 +1128,67 @@ final class MouseEventHandler {
 
     private func handleFocusFollowsMouse(at location: CGPoint) {
         guard let controller else { return }
-        guard controller.focusPolicyEngine.evaluate(.focusFollowsMouse).allowsFocusChange else {
+        let policyDecision = controller.focusPolicyEngine.evaluate(.focusFollowsMouse)
+        guard policyDecision.allowsFocusChange else {
+            traceMouseFocus("ffm.skip reason=policy policyReason=\(policyDecision.reason ?? "nil") loc=\(formatPoint(location))")
             return
         }
-        guard !controller.workspaceManager.isNonManagedFocusActive,
-              !controller.workspaceManager.hasPendingNativeFullscreenTransition,
-              !controller.workspaceManager.isAppFullscreenActive
-        else {
+        guard !controller.workspaceManager.isNonManagedFocusActive else {
+            traceMouseFocus("ffm.skip reason=nonManaged loc=\(formatPoint(location))")
+            return
+        }
+        guard !controller.workspaceManager.hasPendingNativeFullscreenTransition else {
+            traceMouseFocus("ffm.skip reason=nativeFullscreenTransition loc=\(formatPoint(location))")
+            return
+        }
+        guard !controller.workspaceManager.isAppFullscreenActive else {
+            traceMouseFocus("ffm.skip reason=appFullscreen loc=\(formatPoint(location))")
             return
         }
 
         let now = Date()
-        guard now.timeIntervalSince(state.lastFocusFollowsMouseTime) >= state.focusFollowsMouseDebounce else {
+        let confirmedToken = controller.workspaceManager.confirmedManagedFocusToken
+        let pendingToken = controller.workspaceManager.activeFocusRequestToken
+
+        guard let target = resolveFocusFollowsMouseTarget(at: location) else {
+            traceMouseFocus(
+                "ffm.skip reason=noTarget loc=\(formatPoint(location)) confirmed=\(formatToken(confirmedToken)) pending=\(formatToken(pendingToken))"
+            )
             return
         }
-
-        guard let target = resolveFocusFollowsMouseTarget(at: location) else { return }
         let token = focusFollowsMouseToken(for: target)
 
-        guard token != controller.workspaceManager.confirmedManagedFocusToken else { return }
-        if token == state.lastFocusFollowsMouseToken,
-           token == controller.workspaceManager.activeFocusRequestToken
-        {
+        if token == confirmedToken {
+            if let pendingToken, pendingToken != token {
+                traceMouseFocus(
+                    "ffm.activate reason=reassertConfirmed loc=\(formatPoint(location)) target=\(token) confirmed=\(formatToken(confirmedToken)) pending=\(pendingToken)"
+                )
+                state.lastFocusFollowsMouseTime = now
+                state.lastFocusFollowsMouseToken = token
+                activateFocusFollowsMouseTarget(target)
+            }
             return
         }
 
+        if token == pendingToken {
+            traceMouseFocus(
+                "ffm.skip reason=duplicatePending loc=\(formatPoint(location)) target=\(token) confirmed=\(formatToken(confirmedToken)) pending=\(formatToken(pendingToken))"
+            )
+            return
+        }
+
+        if token == state.lastFocusFollowsMouseToken,
+           now.timeIntervalSince(state.lastFocusFollowsMouseTime) < state.focusFollowsMouseDebounce
+        {
+            traceMouseFocus(
+                "ffm.skip reason=debounceSameTarget loc=\(formatPoint(location)) target=\(token) confirmed=\(formatToken(confirmedToken)) pending=\(formatToken(pendingToken)) lastToken=\(formatToken(state.lastFocusFollowsMouseToken))"
+            )
+            return
+        }
+
+        traceMouseFocus(
+            "ffm.activate reason=hoverTarget loc=\(formatPoint(location)) target=\(token) confirmed=\(formatToken(confirmedToken)) pending=\(formatToken(pendingToken)) lastToken=\(formatToken(state.lastFocusFollowsMouseToken))"
+        )
         state.lastFocusFollowsMouseTime = now
         state.lastFocusFollowsMouseToken = token
         activateFocusFollowsMouseTarget(target)

--- a/Sources/Nehir/Core/Controller/WMController.swift
+++ b/Sources/Nehir/Core/Controller/WMController.swift
@@ -187,6 +187,8 @@ final class WMController {
     private var runtimeViewportTraceRecords: [String] = []
     @ObservationIgnored
     private var runtimeResizeTraceRecords: [String] = []
+    @ObservationIgnored
+    private var runtimeMouseTraceRecords: [String] = []
 
     var runtimeTraceCaptureStatus: RuntimeTraceCaptureStatus {
         RuntimeTraceCaptureStatus(
@@ -2013,6 +2015,14 @@ final class WMController {
         }
     }
 
+    func recordRuntimeMouseTrace(_ message: String) {
+        guard runtimeTraceCaptureSession != nil else { return }
+        runtimeMouseTraceRecords.append(Date().ISO8601Format() + " " + message)
+        if runtimeMouseTraceRecords.count > 400 {
+            runtimeMouseTraceRecords.removeFirst(runtimeMouseTraceRecords.count - 400)
+        }
+    }
+
     func recordRuntimeViewportTrace(
         workspaceId: WorkspaceDescriptor.ID,
         reason: String,
@@ -2395,7 +2405,7 @@ final class WMController {
             "accessibilityGranted=\(accessibilityPermissionGranted) lockScreenActive=\(isLockScreenActive) overviewOpen=\(isOverviewOpen()) startedServices=\(hasStartedServices)",
             "focusFollowsMouse=\(focusFollowsMouseEnabled) moveMouseToFocusedWindow=\(moveMouseToFocusedWindowEnabled) mouseWarpPolicyEnabled=\(isMouseWarpPolicyEnabled)",
             "isTransferringWindow=\(isTransferringWindow) hiddenAppPIDs=\(hiddenAppPIDs.count) workspaceBarHiddenMonitors=\(hiddenWorkspaceBarMonitorIds.count)",
-            "runtimeTraceCaptureActive=\(traceCaptureStatus.isActive) runtimeTraceStartedAt=\(traceCaptureStatus.startedAt?.ISO8601Format() ?? "nil") viewportTraceRecords=\(runtimeViewportTraceRecords.count) resizeTraceRecords=\(runtimeResizeTraceRecords.count)",
+            "runtimeTraceCaptureActive=\(traceCaptureStatus.isActive) runtimeTraceStartedAt=\(traceCaptureStatus.startedAt?.ISO8601Format() ?? "nil") viewportTraceRecords=\(runtimeViewportTraceRecords.count) resizeTraceRecords=\(runtimeResizeTraceRecords.count) mouseTraceRecords=\(runtimeMouseTraceRecords.count)",
             "workspaceBarRefreshDebugState requestCount=\(workspaceBarRefreshDebugState.requestCount) scheduledCount=\(workspaceBarRefreshDebugState.scheduledCount) executionCount=\(workspaceBarRefreshDebugState.executionCount) isQueued=\(workspaceBarRefreshDebugState.isQueued)",
             "-- Focus Targets --",
             focusTargetDebugDump(),
@@ -2446,6 +2456,7 @@ final class WMController {
             runtimeTraceCaptureSession = nil
             runtimeViewportTraceRecords.removeAll(keepingCapacity: true)
             runtimeResizeTraceRecords.removeAll(keepingCapacity: true)
+            runtimeMouseTraceRecords.removeAll(keepingCapacity: true)
             syncNiriResizeTraceSink()
             workspaceBarManager.update()
         }
@@ -2518,6 +2529,7 @@ final class WMController {
 
         runtimeViewportTraceRecords.removeAll(keepingCapacity: true)
         runtimeResizeTraceRecords.removeAll(keepingCapacity: true)
+        runtimeMouseTraceRecords.removeAll(keepingCapacity: true)
         let startedAt = Date()
         let startRuntimeStateDump = runtimeStateDebugDump(
             traceLimit: 0,
@@ -2554,6 +2566,9 @@ final class WMController {
         let resizeTraceDump = runtimeResizeTraceRecords.isEmpty
             ? "resize trace empty"
             : runtimeResizeTraceRecords.joined(separator: "\n")
+        let mouseTraceDump = runtimeMouseTraceRecords.isEmpty
+            ? "mouse trace empty"
+            : runtimeMouseTraceRecords.joined(separator: "\n")
         let body = [
             "Nehir runtime trace capture",
             "startedAt=\(session.startedAt.ISO8601Format())",
@@ -2571,6 +2586,9 @@ final class WMController {
             "",
             "## Niri resize trace",
             resizeTraceDump,
+            "",
+            "## Mouse focus trace",
+            mouseTraceDump,
             "",
             "## Runtime state at end",
             endRuntimeStateDump,
@@ -2593,6 +2611,7 @@ final class WMController {
         runtimeTraceCaptureSession = nil
         runtimeViewportTraceRecords.removeAll(keepingCapacity: true)
         runtimeResizeTraceRecords.removeAll(keepingCapacity: true)
+        runtimeMouseTraceRecords.removeAll(keepingCapacity: true)
         syncNiriResizeTraceSink()
         workspaceBarManager.update()
         return .executed

--- a/Tests/NehirTests/AXEventHandlerTests.swift
+++ b/Tests/NehirTests/AXEventHandlerTests.swift
@@ -1369,6 +1369,135 @@ private func waitUntilAXEventTest(
         #expect(controller.workspaceManager.isNonManagedFocusActive == false)
     }
 
+    @Test @MainActor func workspaceActivationForPendingManagedRequestDoesNotStartNativeAppSwitchLease() {
+        let controller = makeAXEventTestController()
+        controller.hasStartedServices = true
+        guard let workspaceId = controller.interactionWorkspace()?.id,
+              let monitor = controller.workspaceManager.monitors.first
+        else {
+            Issue.record("Missing managed-request activation lease fixture")
+            return
+        }
+
+        let targetPid: pid_t = 9_751
+        let targetToken = controller.workspaceManager.addWindow(
+            AXWindowRef(element: AXUIElementCreateSystemWide(), windowId: 9751),
+            pid: targetPid,
+            windowId: 9751,
+            to: workspaceId
+        )
+        _ = controller.workspaceManager.setManagedFocus(
+            targetToken,
+            in: workspaceId,
+            onMonitor: monitor.id
+        )
+        controller.axEventHandler.isFullscreenProvider = { _ in false }
+        controller.axEventHandler.focusedWindowRefProvider = { pid in
+            guard pid == targetPid else { return nil }
+            return AXWindowRef(element: AXUIElementCreateSystemWide(), windowId: targetToken.windowId)
+        }
+
+        controller.focusWindow(targetToken)
+        #expect(controller.focusBridge.activeManagedRequest?.token == targetToken)
+
+        controller.axEventHandler.handleAppActivation(
+            pid: targetPid,
+            source: .workspaceDidActivateApplication
+        )
+
+        #expect(controller.focusPolicyEngine.activeLease?.owner != .nativeAppSwitch)
+    }
+
+    @Test @MainActor func workspaceActivationAfterManagedRequestConfirmationDoesNotStartNativeAppSwitchLease() {
+        let controller = makeAXEventTestController()
+        controller.hasStartedServices = true
+        guard let workspaceId = controller.interactionWorkspace()?.id,
+              let monitor = controller.workspaceManager.monitors.first
+        else {
+            Issue.record("Missing confirmed managed-request activation lease fixture")
+            return
+        }
+
+        let targetPid: pid_t = 9_752
+        let targetToken = controller.workspaceManager.addWindow(
+            AXWindowRef(element: AXUIElementCreateSystemWide(), windowId: 9752),
+            pid: targetPid,
+            windowId: 9752,
+            to: workspaceId
+        )
+        _ = controller.workspaceManager.setManagedFocus(
+            targetToken,
+            in: workspaceId,
+            onMonitor: monitor.id
+        )
+        controller.axEventHandler.isFullscreenProvider = { _ in false }
+        controller.axEventHandler.focusedWindowRefProvider = { pid in
+            guard pid == targetPid else { return nil }
+            return AXWindowRef(element: AXUIElementCreateSystemWide(), windowId: targetToken.windowId)
+        }
+
+        controller.focusWindow(targetToken)
+        _ = controller.focusBridge.confirmManagedRequest(
+            token: targetToken,
+            source: .focusedWindowChanged
+        )
+
+        controller.axEventHandler.handleAppActivation(
+            pid: targetPid,
+            source: .workspaceDidActivateApplication
+        )
+
+        #expect(controller.focusPolicyEngine.activeLease?.owner != .nativeAppSwitch)
+    }
+
+    @Test @MainActor func samePidActivationForDifferentWindowAfterManagedConfirmationStartsNativeAppSwitchLease() {
+        let controller = makeAXEventTestController()
+        controller.hasStartedServices = true
+        guard let workspaceId = controller.interactionWorkspace()?.id,
+              let monitor = controller.workspaceManager.monitors.first
+        else {
+            Issue.record("Missing same-pid activation lease fixture")
+            return
+        }
+
+        let targetPid: pid_t = 9_753
+        let confirmedToken = controller.workspaceManager.addWindow(
+            AXWindowRef(element: AXUIElementCreateSystemWide(), windowId: 9753),
+            pid: targetPid,
+            windowId: 9753,
+            to: workspaceId
+        )
+        let otherToken = controller.workspaceManager.addWindow(
+            AXWindowRef(element: AXUIElementCreateSystemWide(), windowId: 9754),
+            pid: targetPid,
+            windowId: 9754,
+            to: workspaceId
+        )
+        _ = controller.workspaceManager.setManagedFocus(
+            confirmedToken,
+            in: workspaceId,
+            onMonitor: monitor.id
+        )
+        controller.axEventHandler.isFullscreenProvider = { _ in false }
+        controller.axEventHandler.focusedWindowRefProvider = { pid in
+            guard pid == targetPid else { return nil }
+            return AXWindowRef(element: AXUIElementCreateSystemWide(), windowId: otherToken.windowId)
+        }
+
+        controller.focusWindow(confirmedToken)
+        _ = controller.focusBridge.confirmManagedRequest(
+            token: confirmedToken,
+            source: .focusedWindowChanged
+        )
+
+        controller.axEventHandler.handleAppActivation(
+            pid: targetPid,
+            source: .workspaceDidActivateApplication
+        )
+
+        #expect(controller.focusPolicyEngine.activeLease?.owner == .nativeAppSwitch)
+    }
+
     @Test @MainActor func cgsFrontAppChangedRevealsManagedWindowOnInteractionWorkspace() async {
         let controller = makeAXEventTestController()
         controller.hasStartedServices = true
@@ -5069,9 +5198,6 @@ private func waitUntilAXEventTest(
             CGSEventObserver.shared,
             didReceive: .destroyed(windowId: 882, spaceId: 0)
         )
-
-        try? await Task.sleep(for: .milliseconds(50))
-        #expect(controller.workspaceManager.entry(for: token) != nil)
 
         await waitUntilAXEventTest(iterations: 120) {
             controller.workspaceManager.entry(for: token) == nil

--- a/Tests/NehirTests/MouseEventHandlerTests.swift
+++ b/Tests/NehirTests/MouseEventHandlerTests.swift
@@ -1972,6 +1972,141 @@ private func prepareMouseWheelScrollFixtureWithDefaultSensitivity() async -> (
         #expect(engine.interactiveResize == nil)
     }
 
+    @Test @MainActor func queuedFocusFollowsMouseUsesCurrentPointerForStaleMouseMove() async {
+        let controller = makeMouseEventTestController()
+        controller.enableNiriLayout()
+        await controller.layoutRefreshController.waitForRefreshWorkForTests()
+        controller.syncMonitorsToNiriEngine()
+        controller.setFocusFollowsMouse(true)
+
+        guard let workspaceId = controller.interactionWorkspace()?.id,
+              let engine = controller.niriEngine,
+              let monitor = controller.workspaceManager.monitor(for: workspaceId)
+        else {
+            Issue.record("Missing Niri context for stale queued focus-follow regression test")
+            return
+        }
+
+        let focusedHandle = populateNiriWorkspaceForMouseTests(
+            controller: controller,
+            engine: engine,
+            workspaceId: workspaceId,
+            monitor: monitor,
+            startingWindowId: 970,
+            count: 2
+        )
+        controller.layoutRefreshController.requestImmediateRelayout(reason: .workspaceTransition)
+        await controller.layoutRefreshController.waitForRefreshWorkForTests()
+
+        guard let focusedNode = engine.findNode(for: focusedHandle),
+              let focusedFrame = focusedNode.renderedFrame ?? focusedNode.frame,
+              let staleHoverNode = engine.columns(in: workspaceId)
+                  .flatMap(\.windowNodes)
+                  .first(where: { $0.token != focusedHandle.token }),
+              let staleHoverFrame = staleHoverNode.renderedFrame ?? staleHoverNode.frame
+        else {
+            Issue.record("Missing node frames for stale queued focus-follow regression test")
+            return
+        }
+
+        controller.mouseEventHandler.mouseLocationProvider = { focusedFrame.center }
+        controller.mouseEventHandler.receiveTapMouseMoved(at: staleHoverFrame.center)
+        controller.mouseEventHandler.flushPendingTapEventsForTests()
+        await controller.layoutRefreshController.waitForRefreshWorkForTests()
+
+        #expect(controller.workspaceManager.confirmedManagedFocusToken == focusedHandle.token)
+        #expect(controller.workspaceManager.activeFocusRequestToken == nil)
+    }
+
+    @Test @MainActor func focusFollowsMouseReassertsConfirmedWindowWhenPointerReturnsBeforePendingFocusConfirms() async {
+        let controller = makeMouseEventTestController()
+        controller.enableNiriLayout()
+        await controller.layoutRefreshController.waitForRefreshWorkForTests()
+        controller.syncMonitorsToNiriEngine()
+        controller.setFocusFollowsMouse(true)
+
+        guard let workspaceId = controller.interactionWorkspace()?.id,
+              let engine = controller.niriEngine,
+              let monitor = controller.workspaceManager.monitor(for: workspaceId)
+        else {
+            Issue.record("Missing Niri context for pending focus-follow reassertion regression test")
+            return
+        }
+
+        let focusedHandle = populateNiriWorkspaceForMouseTests(
+            controller: controller,
+            engine: engine,
+            workspaceId: workspaceId,
+            monitor: monitor,
+            startingWindowId: 980,
+            count: 2
+        )
+        controller.layoutRefreshController.requestImmediateRelayout(reason: .workspaceTransition)
+        await controller.layoutRefreshController.waitForRefreshWorkForTests()
+
+        guard let focusedNode = engine.findNode(for: focusedHandle),
+              let focusedFrame = focusedNode.renderedFrame ?? focusedNode.frame,
+              let otherNode = engine.columns(in: workspaceId)
+                  .flatMap(\.windowNodes)
+                  .first(where: { $0.token != focusedHandle.token }),
+              let otherFrame = otherNode.renderedFrame ?? otherNode.frame
+        else {
+            Issue.record("Missing node frames for pending focus-follow reassertion regression test")
+            return
+        }
+
+        controller.mouseEventHandler.dispatchMouseMoved(at: otherFrame.center)
+        #expect(controller.workspaceManager.activeFocusRequestToken == otherNode.token)
+
+        controller.mouseEventHandler.dispatchMouseMoved(at: focusedFrame.center)
+        #expect(controller.workspaceManager.confirmedManagedFocusToken == focusedHandle.token)
+        #expect(controller.workspaceManager.activeFocusRequestToken == focusedHandle.token)
+    }
+
+    @Test @MainActor func focusFollowsMouseAllowsRapidTargetChangeInsideDebounceWindow() async {
+        let controller = makeMouseEventTestController()
+        controller.enableNiriLayout()
+        await controller.layoutRefreshController.waitForRefreshWorkForTests()
+        controller.syncMonitorsToNiriEngine()
+        controller.setFocusFollowsMouse(true)
+
+        guard let workspaceId = controller.interactionWorkspace()?.id,
+              let engine = controller.niriEngine,
+              let monitor = controller.workspaceManager.monitor(for: workspaceId)
+        else {
+            Issue.record("Missing Niri context for rapid focus-follow regression test")
+            return
+        }
+
+        let focusedHandle = populateNiriWorkspaceForMouseTests(
+            controller: controller,
+            engine: engine,
+            workspaceId: workspaceId,
+            monitor: monitor,
+            startingWindowId: 990,
+            count: 2
+        )
+        controller.layoutRefreshController.requestImmediateRelayout(reason: .workspaceTransition)
+        await controller.layoutRefreshController.waitForRefreshWorkForTests()
+
+        guard let otherNode = engine.columns(in: workspaceId)
+            .flatMap(\.windowNodes)
+            .first(where: { $0.token != focusedHandle.token }),
+            let otherFrame = otherNode.renderedFrame ?? otherNode.frame
+        else {
+            Issue.record("Missing node frame for rapid focus-follow regression test")
+            return
+        }
+
+        controller.mouseEventHandler.state.lastFocusFollowsMouseTime = Date()
+        controller.mouseEventHandler.state.lastFocusFollowsMouseToken = focusedHandle.token
+
+        controller.mouseEventHandler.dispatchMouseMoved(at: otherFrame.center)
+
+        #expect(controller.workspaceManager.confirmedManagedFocusToken == focusedHandle.token)
+        #expect(controller.workspaceManager.activeFocusRequestToken == otherNode.token)
+    }
+
     @Test @MainActor func focusFollowsMouseIgnoresCoveredTileBehindManagedFullscreen() async {
         let controller = makeMouseEventTestController()
         controller.enableNiriLayout()


### PR DESCRIPTION
## Summary

<!-- What changed and why? -->

## Release notes

Choose one:

- [x] Added a `.changeset/*.md` for user-visible changes (`mise run changeset -- patch "..."`).
- [ ] No user-visible change; apply the `no release note` label to make CI skip intentional.

## Validation

<!-- Commands run, screenshots, or manual checks. -->

- [ ] Ran relevant tests/checks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed focus-follows-mouse getting stuck on the wrong window during rapid pointer movement.

* **Improvements**
  * Improved handling of managed focus confirmations to avoid spurious native app-switches.
  * More robust pointer-location reconciliation and debounce logic to prevent stale re-targeting.
  * Added in-memory mouse-focus tracing and richer runtime trace output for diagnostics.

* **Tests**
  * Added regression tests for workspace activation and focus-follow mouse scenarios.

* **Chores**
  * Added a release changeset documenting the patch.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->