### PR TITLE
Add developer menu options for resetting and restarting runtime state

### DIFF
--- a/.changeset/20260613005436-added-reset-runtime-state-and-restart-clearing-s.md
+++ b/.changeset/20260613005436-added-reset-runtime-state-and-restart-clearing-s.md
@@ -3,4 +3,6 @@
 
 ---
 
-Added Reset Runtime State and Restart Clearing State menu items to the status bar menu when Developer Mode is enabled.
+Added Reset Runtime State and Restart Clearing State developer menu items to the status bar menu (visible when Developer Mode is enabled). Both actions require confirmation when triggered from the status bar menu or command palette. The restart dialog includes an Enable Tracing checkbox that starts runtime trace capture as early as possible during app bootstrap.
+
+Moved Reveal Config Folder and Edit settings.toml from the status bar menu to a dedicated Config Files section in Settings.

--- a/Sources/Nehir/App/AppDelegate.swift
+++ b/Sources/Nehir/App/AppDelegate.swift
@@ -39,11 +39,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     func bootstrapApplication() {
         switch AppBootstrapPlanner.decision() {
         case .boot:
-            finishBootstrap()
+            finishBootstrap(
+                enableTracing: ProcessInfo.processInfo.arguments.contains(WMController.traceLaunchArgument)
+            )
         }
     }
 
-    func finishBootstrap() {
+    func finishBootstrap(enableTracing: Bool = false) {
         let storagePaths = NehirStoragePaths.live
 
         let runtimeState = RuntimeStateStore(directory: storagePaths.stateDirectory)
@@ -56,6 +58,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         let controller = WMController(
             settings: settings
         )
+        if enableTracing {
+            _ = controller.toggleRuntimeTraceCapture(desiredState: .active)
+        }
         controller.applyPersistedSettings(settings)
         let cliManager = AppCLIManager()
         self.cliManager = cliManager

--- a/Sources/Nehir/Core/Controller/CommandHandler.swift
+++ b/Sources/Nehir/Core/Controller/CommandHandler.swift
@@ -31,6 +31,13 @@ final class CommandHandler {
     }
 
     @discardableResult
+    func performRestartClearingRuntimeState(enableTracing: Bool = false) -> ExternalCommandResult {
+        guard let controller else { return .notFound }
+        controller.restartAppClearingRuntimeState(enableTracing: enableTracing)
+        return .executed
+    }
+
+    @discardableResult
     func performCommand(_ command: HotkeyCommand) -> ExternalCommandResult {
         guard let controller else { return .notFound }
         guard controller.isEnabled else { return .ignoredDisabled }

--- a/Sources/Nehir/Core/Controller/WMController.swift
+++ b/Sources/Nehir/Core/Controller/WMController.swift
@@ -2479,11 +2479,11 @@ final class WMController {
         layoutRefreshController.requestFullRescan(reason: .startup)
     }
 
-    func restartAppClearingRuntimeState() {
+    func restartAppClearingRuntimeState(enableTracing: Bool = false) {
         resetRuntimeState()
         workspaceManager.prepareForRestartClearingRuntimeState()
 
-        guard relaunchCurrentApplication() else {
+        guard relaunchCurrentApplication(extraArguments: enableTracing ? [Self.traceLaunchArgument] : []) else {
             Self.runtimeDebugLogger.error("Failed to schedule relaunch after runtime reset")
             return
         }
@@ -2623,17 +2623,18 @@ final class WMController {
         return baseDirectory.appendingPathComponent(filename, isDirectory: false)
     }
 
-    private func relaunchCurrentApplication() -> Bool {
+    private func relaunchCurrentApplication(extraArguments: [String] = []) -> Bool {
         let executablePath = (Bundle.main.executableURL?.path).flatMap { $0.isEmpty ? nil : $0 }
             ?? ProcessInfo.processInfo.arguments.first
         guard let executablePath else { return false }
 
-        let executableArguments = ProcessInfo.processInfo.arguments.dropFirst()
-            .map(Self.shellQuote)
-            .joined(separator: " ")
-        let command = executableArguments.isEmpty
+        var allArguments = ProcessInfo.processInfo.arguments.dropFirst()
+            .filter { $0 != Self.traceLaunchArgument }
+        allArguments.append(contentsOf: extraArguments)
+        let quotedArguments = allArguments.map(Self.shellQuote).joined(separator: " ")
+        let command = quotedArguments.isEmpty
             ? "sleep 0.5; \(Self.shellQuote(executablePath)) >/dev/null 2>&1 &"
-            : "sleep 0.5; \(Self.shellQuote(executablePath)) \(executableArguments) >/dev/null 2>&1 &"
+            : "sleep 0.5; \(Self.shellQuote(executablePath)) \(quotedArguments) >/dev/null 2>&1 &"
 
         let process = Process()
         process.executableURL = URL(fileURLWithPath: "/bin/sh")
@@ -2647,6 +2648,8 @@ final class WMController {
             return false
         }
     }
+
+    static let traceLaunchArgument = "--nehir-trace"
 
     private static func shellQuote(_ value: String) -> String {
         "'" + value.replacingOccurrences(of: "'", with: "'\\''") + "'"

--- a/Sources/Nehir/UI/CommandPalette/CommandPaletteController.swift
+++ b/Sources/Nehir/UI/CommandPalette/CommandPaletteController.swift
@@ -866,6 +866,25 @@ final class CommandPaletteController: NSObject, ObservableObject, NSWindowDelega
                 environment.performMenuAction(element)
             }
         case let .executeCommand(wmController, command):
+            switch command {
+            case .debugResetRuntimeState:
+                guard DestructiveConfirmationAlert.confirm(
+                    title: "Reset Runtime State",
+                    message: "This will clear all runtime state and rebootstrap from a rescan. Continue?",
+                    confirmTitle: "Reset"
+                ) else { return }
+            case .debugRestartClearingRuntimeState:
+                let result = DestructiveConfirmationAlert.confirmRestart(
+                    title: "Restart Clearing Runtime State",
+                    message: "This will clear runtime state and relaunch the app. Continue?",
+                    confirmTitle: "Restart"
+                )
+                guard result.confirmed else { return }
+                wmController.commandHandler.performRestartClearingRuntimeState(enableTracing: result.enableTracing)
+                return
+            default:
+                break
+            }
             wmController.commandHandler.handleCommand(command)
         }
     }

--- a/Sources/Nehir/UI/ConfigFilesSettingsTab.swift
+++ b/Sources/Nehir/UI/ConfigFilesSettingsTab.swift
@@ -1,0 +1,78 @@
+import SwiftUI
+
+struct ConfigFilesSettingsTab: View {
+    @Bindable var settings: SettingsStore
+
+    @State private var resultStatus: SettingsFileStatus?
+    @State private var resultVisible = false
+    @State private var dismissTask: DispatchWorkItem?
+
+    var body: some View {
+        Form {
+            Section("Configuration") {
+                LabeledContent("Config Folder") {
+                    HStack {
+                        Text(settings.configDirectoryURL.path)
+                            .font(.system(.caption, design: .monospaced))
+                            .foregroundStyle(.secondary)
+                            .lineLimit(1)
+                            .truncationMode(.middle)
+                        Button("Reveal in Finder") {
+                            performAction(.revealConfigFolder)
+                        }
+                    }
+                }
+
+                LabeledContent("Settings File") {
+                    HStack {
+                        Text(settings.settingsFileURL.path)
+                            .font(.system(.caption, design: .monospaced))
+                            .foregroundStyle(.secondary)
+                            .lineLimit(1)
+                            .truncationMode(.middle)
+                        Button("Edit") {
+                            performAction(.openMainSettingsFile)
+                        }
+                    }
+                }
+            }
+        }
+        .formStyle(.grouped)
+        .overlay {
+            if resultVisible, let status = resultStatus {
+                VStack {
+                    Spacer()
+                    HStack(spacing: 6) {
+                        Image(systemName: status.icon)
+                            .foregroundStyle(status.color)
+                        Text(status.message)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 6)
+                    .background(.regularMaterial, in: Capsule())
+                    .transition(.move(edge: .bottom).combined(with: .opacity))
+                }
+                .padding(.bottom, 16)
+            }
+        }
+    }
+
+    private func performAction(_ action: SettingsFileAction) {
+        dismissTask?.cancel()
+        withAnimation { resultVisible = false }
+        do {
+            let status = try SettingsFileWorkflow.perform(action, settings: settings)
+            resultStatus = status
+        } catch {
+            resultStatus = .error(error.localizedDescription)
+        }
+        withAnimation { resultVisible = true }
+        let task = DispatchWorkItem {
+            withAnimation { self.resultVisible = false }
+        }
+        dismissTask = task
+        DispatchQueue.main.asyncAfter(deadline: .now() + 2, execute: task)
+    }
+}

--- a/Sources/Nehir/UI/DestructiveConfirmationAlert.swift
+++ b/Sources/Nehir/UI/DestructiveConfirmationAlert.swift
@@ -1,0 +1,41 @@
+import AppKit
+
+@MainActor
+enum DestructiveConfirmationAlert {
+    static func confirmRestart(
+        title: String,
+        message: String,
+        confirmTitle: String
+    ) -> (confirmed: Bool, enableTracing: Bool) {
+        let alert = NSAlert()
+        alert.alertStyle = .warning
+        alert.messageText = title
+        alert.informativeText = message
+
+        let traceCheckbox = NSButton(frame: NSRect(x: 0, y: -4, width: 200, height: 18))
+        traceCheckbox.setButtonType(.switch)
+        traceCheckbox.title = "Enable Tracing"
+        alert.accessoryView = traceCheckbox
+
+        alert.addButton(withTitle: confirmTitle)
+        alert.addButton(withTitle: "Cancel")
+        NSApp.activate(ignoringOtherApps: true)
+        let confirmed = alert.runModal() == .alertFirstButtonReturn
+        return (confirmed, traceCheckbox.state == .on)
+    }
+
+    static func confirm(
+        title: String,
+        message: String,
+        confirmTitle: String
+    ) -> Bool {
+        let alert = NSAlert()
+        alert.alertStyle = .warning
+        alert.messageText = title
+        alert.informativeText = message
+        alert.addButton(withTitle: confirmTitle)
+        alert.addButton(withTitle: "Cancel")
+        NSApp.activate(ignoringOtherApps: true)
+        return alert.runModal() == .alertFirstButtonReturn
+    }
+}

--- a/Sources/Nehir/UI/SettingsDetailView.swift
+++ b/Sources/Nehir/UI/SettingsDetailView.swift
@@ -39,6 +39,8 @@ struct SettingsDetailView: View {
             AppRulesView(settings: settings, controller: controller)
         case .hotkeys:
             HotkeySettingsView(settings: settings, controller: controller)
+        case .configFiles:
+            ConfigFilesSettingsTab(settings: settings)
         case .diagnostics:
             DisplayDiagnosticsSettingsTab()
         }

--- a/Sources/Nehir/UI/SettingsSection.swift
+++ b/Sources/Nehir/UI/SettingsSection.swift
@@ -10,6 +10,7 @@ enum SettingsSection: String, CaseIterable, Identifiable {
     case bar
     case appRules
     case hotkeys
+    case configFiles
     case diagnostics
 
     var id: String {
@@ -27,6 +28,7 @@ enum SettingsSection: String, CaseIterable, Identifiable {
         case .bar: "Workspace Bar"
         case .appRules: "App Rules"
         case .hotkeys: "Hotkeys"
+        case .configFiles: "Config Files"
         case .diagnostics: "Diagnostics"
         }
     }
@@ -42,6 +44,7 @@ enum SettingsSection: String, CaseIterable, Identifiable {
         case .bar: "menubar.rectangle"
         case .appRules: "list.bullet.rectangle"
         case .hotkeys: "keyboard"
+        case .configFiles: "folder"
         case .diagnostics: "exclamationmark.triangle"
         }
     }
@@ -64,7 +67,7 @@ enum SettingsSectionGroup: String, CaseIterable, Identifiable {
     var sections: [SettingsSection] {
         switch self {
         case .app:
-            [.general, .diagnostics]
+            [.general, .configFiles, .diagnostics]
         case .layouts:
             [.layout, .monitors, .workspaces, .appRules]
         case .appearance:

--- a/Sources/Nehir/UI/StatusBar/StatusBarController.swift
+++ b/Sources/Nehir/UI/StatusBar/StatusBarController.swift
@@ -68,7 +68,11 @@ final class StatusBarController: NSObject {
     private func showMenu() {
         rebuildMenu()
         guard let button = statusItem?.button, let menu else { return }
-        menu.popUp(positioning: nil, at: NSPoint(x: 0, y: button.bounds.height + 5), in: button)
+        // Anchor the menu at the button edge. Offsetting it below the status item
+        // makes AppKit think the menu is partially outside the usable menu area on
+        // some displays, so it initially draws the menu's scroll affordance until
+        // the mouse moves over the menu.
+        menu.popUp(positioning: nil, at: NSPoint(x: 0, y: button.bounds.height), in: button)
     }
 
     private func handleRightClick() {

--- a/Sources/Nehir/UI/StatusBar/StatusBarMenu.swift
+++ b/Sources/Nehir/UI/StatusBar/StatusBarMenu.swift
@@ -18,7 +18,7 @@ final class StatusBarMenuBuilder {
     private weak var controller: WMController?
     var infoAlertPresenter: (String, String) -> Void
     var confirmationAlertPresenter: (String, String, String, String) -> Bool
-    var settingsFileActionPerformer: (SettingsFileAction, SettingsStore) throws -> SettingsFileStatus
+    var restartConfirmationPresenter: (String, String, String, String) -> (confirmed: Bool, enableTracing: Bool)
     private var toggleViews: [String: MenuToggleRowView] = [:]
 
     init(settings: SettingsStore, controller: WMController) {
@@ -33,21 +33,11 @@ final class StatusBarMenuBuilder {
             NSApplication.shared.activate(ignoringOtherApps: true)
             _ = alert.runModal()
         }
-        confirmationAlertPresenter = { title, message, confirmTitle, cancelTitle in
-            let alert = NSAlert()
-            alert.alertStyle = .warning
-            alert.messageText = title
-            alert.informativeText = message
-            alert.addButton(withTitle: confirmTitle)
-            alert.addButton(withTitle: cancelTitle)
-            NSApplication.shared.activate(ignoringOtherApps: true)
-            return alert.runModal() == .alertFirstButtonReturn
+        confirmationAlertPresenter = { title, message, confirmTitle, _ in
+            DestructiveConfirmationAlert.confirm(title: title, message: message, confirmTitle: confirmTitle)
         }
-        settingsFileActionPerformer = { action, settings in
-            try SettingsFileWorkflow.perform(
-                action,
-                settings: settings
-            )
+        restartConfirmationPresenter = { title, message, confirmTitle, _ in
+            DestructiveConfirmationAlert.confirmRestart(title: title, message: message, confirmTitle: confirmTitle)
         }
     }
 
@@ -205,39 +195,6 @@ final class StatusBarMenuBuilder {
         let settingsItem = NSMenuItem()
         settingsItem.view = settingsRow
         menu.addItem(settingsItem)
-
-        menu.addItem(createSectionLabel("CONFIG FILES"))
-
-        let revealSettingsFileRow = MenuActionRowView(
-            icon: "folder",
-            label: "Reveal Config Folder",
-        ) { [weak self] in
-            self?.performSettingsFileAction(.revealConfigFolder)
-        }
-        let revealSettingsFileItem = NSMenuItem()
-        revealSettingsFileItem.view = revealSettingsFileRow
-        menu.addItem(revealSettingsFileItem)
-
-        let openSettingsFileRow = MenuActionRowView(
-            icon: "pencil",
-            label: "Edit settings.toml",
-        ) { [weak self] in
-            self?.performSettingsFileAction(.openMainSettingsFile)
-        }
-        let openSettingsFileItem = NSMenuItem()
-        openSettingsFileItem.view = openSettingsFileRow
-        menu.addItem(openSettingsFileItem)
-    }
-
-    func performSettingsFileAction(_ action: SettingsFileAction) {
-        do {
-            _ = try settingsFileActionPerformer(
-                action,
-                settings
-            )
-        } catch {
-            NSLog("Nehir settings file action failed: \(error.localizedDescription)")
-        }
     }
 
     private func presentInfoAlert(title: String, message: String) {
@@ -271,14 +228,14 @@ final class StatusBarMenuBuilder {
             isDestructive: true
         ) { [weak self] in
             guard let self, let controller = self.controller else { return }
-            let confirmed = self.confirmationAlertPresenter(
+            let result = self.restartConfirmationPresenter(
                 "Restart Clearing Runtime State",
                 "This will clear runtime state and relaunch the app. Continue?",
                 "Restart",
                 "Cancel"
             )
-            guard confirmed else { return }
-            _ = controller.commandHandler.performCommand(.debugRestartClearingRuntimeState)
+            guard result.confirmed else { return }
+            _ = controller.commandHandler.performRestartClearingRuntimeState(enableTracing: result.enableTracing)
         }
         let restartItem = NSMenuItem()
         restartItem.view = restartRow

--- a/Tests/NehirTests/StatusBarMenuTests.swift
+++ b/Tests/NehirTests/StatusBarMenuTests.swift
@@ -26,75 +26,24 @@ import Testing
         #expect(try #require(darkMenu.items.dropFirst(3).first?.view).appearance?.name == .darkAqua)
     }
 
-    @Test func buildMenuIncludesSettingsFileActions() {
+    @Test func resetActionRequiresConfirmation() throws {
         let controller = makeLayoutPlanTestController()
+        controller.settings.developerModeEnabled = true
         let builder = StatusBarMenuBuilder(settings: controller.settings, controller: controller)
+        var confirmationRequested = false
+        builder.confirmationAlertPresenter = { _, _, _, _ in
+            confirmationRequested = true
+            return false
+        }
 
         let menu = builder.buildMenu()
         let labels = menu.items.compactMap(\.view).flatMap(textLabels(in:))
+        #expect(labels.contains("Reset Runtime State"))
+        #expect(labels.contains("Restart Clearing State"))
 
-        #expect(labels.contains("CONFIG FILES"))
-        #expect(labels.contains("Reveal Config Folder"))
-        #expect(labels.contains("Edit settings.toml"))
-        #expect(labels.allSatisfy { !$0.localizedCaseInsensitiveContains("export") })
-        #expect(labels.allSatisfy { !$0.localizedCaseInsensitiveContains("import") })
-    }
-
-    @Test func settingsFileMenuRowsDelegateExpectedActions() throws {
-        let controller = makeLayoutPlanTestController()
-        let settings = controller.settings
-        let builder = StatusBarMenuBuilder(settings: settings, controller: controller)
-        var performedActions: [SettingsFileAction] = []
-        builder.settingsFileActionPerformer = { action, receivedSettings in
-            #expect(receivedSettings.settingsFileURL == settings.settingsFileURL)
-            performedActions.append(action)
-            return action == .revealConfigFolder ? .revealedConfigFolder : .openedSettingsFile
-        }
-
-        let menu = builder.buildMenu()
-
-        try actionRow(in: menu, labeled: "Reveal Config Folder").performActionForTests()
-        try actionRow(in: menu, labeled: "Edit settings.toml").performActionForTests()
-
-        #expect(performedActions == [.revealConfigFolder, .openMainSettingsFile])
-    }
-
-    @Test func revealActionDoesNotPresentPopup() {
-        let controller = makeLayoutPlanTestController()
-        let settings = controller.settings
-        let builder = StatusBarMenuBuilder(settings: settings, controller: controller)
-        var didPresentAlert = false
-        var performedAction: SettingsFileAction?
-        builder.infoAlertPresenter = { _, _ in
-            didPresentAlert = true
-        }
-        builder.settingsFileActionPerformer = { action, receivedSettings in
-            performedAction = action
-            #expect(receivedSettings.settingsFileURL == settings.settingsFileURL)
-            return .revealedConfigFolder
-        }
-
-        builder.performSettingsFileAction(.revealConfigFolder)
-
-        #expect(performedAction == .revealConfigFolder)
-        #expect(didPresentAlert == false)
-        #expect(settings.settingsFileURL.lastPathComponent == "settings.toml")
-    }
-
-    @Test func openActionFailureDoesNotPresentPopup() {
-        let controller = makeLayoutPlanTestController()
-        let builder = StatusBarMenuBuilder(settings: controller.settings, controller: controller)
-        var didPresentAlert = false
-        builder.infoAlertPresenter = { _, _ in
-            didPresentAlert = true
-        }
-        builder.settingsFileActionPerformer = { _, _ in
-            throw CocoaError(.fileNoSuchFile)
-        }
-
-        builder.performSettingsFileAction(.openMainSettingsFile)
-
-        #expect(didPresentAlert == false)
+        // Declining confirmation should prevent execution
+        try actionRow(in: menu, labeled: "Reset Runtime State").performActionForTests()
+        #expect(confirmationRequested == true)
     }
 
     @Test func statusBarTitleUsesInteractionMonitorWorkspaceAndFocusedApp() {


### PR DESCRIPTION
## Summary

<!-- What changed and why? -->

## Release notes

Choose one:

- [x] Added a `.changeset/*.md` for user-visible changes (`mise run changeset -- patch "..."`).
- [ ] No user-visible change; apply the `no release note` label to make CI skip intentional.

## Validation

<!-- Commands run, screenshots, or manual checks. -->

- [ ] Ran relevant tests/checks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Reset Runtime State and Restart Clearing State developer actions with confirmation dialogs
  * Added "Enable Tracing" checkbox option in Restart Clearing State flow
  * Added Config Files settings section with config folder and settings file management
  * Runtime trace capture now available via `--nehir-trace` command-line argument

* **Refactor**
  * Relocated config file actions from status bar menu to Config Files settings section

<!-- end of auto-generated comment: release notes by coderabbit.ai -->