### PR TITLE
Add openSettings command to access Nehir settings window

### DIFF
--- a/.changeset/20260613120820-add-open-settings-command.md
+++ b/.changeset/20260613120820-add-open-settings-command.md
@@ -1,0 +1,13 @@
+---
+"nehir": minor
+---
+
+Added an `openSettings` command for opening the Nehir settings window.
+
+The new command is surfaced everywhere other commands live:
+
+- **Command Palette** — searchable under the Commands tab (try "settings" or "preferences")
+- **Hotkeys** — assignable in Settings → Hotkeys (unassigned by default; persisted as `ui.settings` in the config)
+- **CLI / IPC** — `nehirctl command open-settings` (IPC name `open-settings`)
+
+It behaves like the other "open surface" commands (`open-command-palette`, `open-menu-anywhere`): it activates the Settings window via the shared `SettingsWindowController`, and is reachable through the same hotkey, command palette, and IPC paths. The status bar menu's existing Settings item is unchanged.

--- a/Sources/Nehir/Core/Config/HotkeyConfigMapping.swift
+++ b/Sources/Nehir/Core/Config/HotkeyConfigMapping.swift
@@ -111,6 +111,7 @@ enum HotkeyConfigMapping {
         // ui
         ("ui", "commandPalette", "openCommandPalette"),
         ("ui", "menuAnywhere", "openMenuAnywhere"),
+        ("ui", "settings", "openSettings"),
         ("ui", "toggleOverview", "toggleOverview"),
         ("ui", "toggleWorkspaceBar", "toggleWorkspaceBarVisibility"),
         // ui toggles

--- a/Sources/Nehir/Core/Controller/CommandHandler.swift
+++ b/Sources/Nehir/Core/Controller/CommandHandler.swift
@@ -185,6 +185,8 @@ final class CommandHandler {
             return controller.toggleScratchpadWindow()
         case .openMenuAnywhere:
             controller.openMenuAnywhere()
+        case .openSettings:
+            SettingsWindowController.shared.show(settings: controller.settings, controller: controller)
         case .debugDumpRuntimeState:
             controller.dumpRuntimeState()
         case .debugResetRuntimeState:

--- a/Sources/Nehir/Core/Input/ActionCatalog.swift
+++ b/Sources/Nehir/Core/Input/ActionCatalog.swift
@@ -713,6 +713,13 @@ enum ActionCatalog {
                 keywords: ["menu", "anywhere"]
             ),
             action(
+                id: "openSettings",
+                command: .openSettings,
+                category: .focus,
+                binding: .unassigned,
+                keywords: ["settings", "preferences", "configure", "config"]
+            ),
+            action(
                 id: "debug.dumpRuntimeState",
                 command: .debugDumpRuntimeState,
                 category: .debugging,
@@ -920,6 +927,7 @@ enum ActionCatalog {
         case .assignFocusedWindowToScratchpad: "Assign Focused Window to Scratchpad"
         case .toggleScratchpadWindow: "Toggle Scratchpad Window"
         case .openMenuAnywhere: "Open Menu Anywhere"
+        case .openSettings: "Open Settings"
         case .debugDumpRuntimeState: "Debug: Dump Runtime State"
         case .debugResetRuntimeState: "Debug: Reset Runtime State"
         case .debugRestartClearingRuntimeState: "Debug: Restart Clearing Runtime State"
@@ -1077,6 +1085,8 @@ enum ActionCatalog {
             .scratchpadToggle
         case .openMenuAnywhere:
             .openMenuAnywhere
+        case .openSettings:
+            .openSettings
         case .debugDumpRuntimeState:
             .debugDumpRuntimeState
         case .debugResetRuntimeState:

--- a/Sources/Nehir/Core/Input/HotkeyCommand.swift
+++ b/Sources/Nehir/Core/Input/HotkeyCommand.swift
@@ -76,6 +76,7 @@ enum HotkeyCommand: Codable, Equatable, Hashable {
     case toggleScratchpadWindow
 
     case openMenuAnywhere
+    case openSettings
 
     case debugDumpRuntimeState
     case debugResetRuntimeState

--- a/Sources/Nehir/IPC/IPCCommandRouter.swift
+++ b/Sources/Nehir/IPC/IPCCommandRouter.swift
@@ -180,6 +180,8 @@ final class IPCCommandRouter {
             return toggleScratchpad()
         case .openMenuAnywhere:
             return controller.commandHandler.performCommand(.openMenuAnywhere)
+        case .openSettings:
+            return controller.commandHandler.performCommand(.openSettings)
         case .debugDumpRuntimeState:
             guard controller.settings.developerModeEnabled else { return .requiresDeveloperMode }
             return controller.commandHandler.performCommand(.debugDumpRuntimeState)

--- a/Sources/NehirIPC/IPCAutomationManifest.swift
+++ b/Sources/NehirIPC/IPCAutomationManifest.swift
@@ -733,6 +733,7 @@ public enum IPCAutomationManifest {
         ),
         command(["scratchpad", "toggle"], name: .scratchpadToggle, summary: "Show or hide the scratchpad window."),
         command(["open-menu-anywhere"], name: .openMenuAnywhere, summary: "Open the menu surface anywhere."),
+        command(["open-settings"], name: .openSettings, summary: "Open the Nehir settings window."),
         command(["debug", "dump-runtime-state"], name: .debugDumpRuntimeState, summary: "Dump runtime debugging state to the clipboard and unified log."),
         command(["debug", "reset-runtime-state"], name: .debugResetRuntimeState, summary: "Clear runtime debugging state and rebootstrap from a startup-style rescan."),
         command(["debug", "restart-clearing-runtime-state"], name: .debugRestartClearingRuntimeState, summary: "Clear runtime debugging state, relaunch the app, and exit the current process."),

--- a/Sources/NehirIPC/IPCModels.swift
+++ b/Sources/NehirIPC/IPCModels.swift
@@ -277,6 +277,7 @@ public enum IPCCommandName: String, Codable, CaseIterable, Equatable, Sendable {
     case scratchpadAssign = "scratchpad-assign"
     case scratchpadToggle = "scratchpad-toggle"
     case openMenuAnywhere = "open-menu-anywhere"
+    case openSettings = "open-settings"
     case debugDumpRuntimeState = "debug-dump-runtime-state"
     case debugResetRuntimeState = "debug-reset-runtime-state"
     case debugRestartClearingRuntimeState = "debug-restart-clearing-runtime-state"
@@ -411,6 +412,7 @@ public enum IPCCommandRequest: Equatable, Sendable {
     case scratchpadAssign
     case scratchpadToggle
     case openMenuAnywhere
+    case openSettings
     case debugDumpRuntimeState
     case debugResetRuntimeState
     case debugRestartClearingRuntimeState
@@ -564,6 +566,8 @@ public enum IPCCommandRequest: Equatable, Sendable {
             .scratchpadToggle
         case .openMenuAnywhere:
             .openMenuAnywhere
+        case .openSettings:
+            .openSettings
         case .debugDumpRuntimeState:
             .debugDumpRuntimeState
         case .debugResetRuntimeState:
@@ -836,6 +840,9 @@ public enum IPCCommandRequest: Equatable, Sendable {
         case .openMenuAnywhere:
             try requireNoArguments()
             self = .openMenuAnywhere
+        case .openSettings:
+            try requireNoArguments()
+            self = .openSettings
         case .debugDumpRuntimeState:
             try requireNoArguments()
             self = .debugDumpRuntimeState
@@ -1076,6 +1083,8 @@ extension IPCCommandRequest: Codable {
             self = .scratchpadToggle
         case .openMenuAnywhere:
             self = .openMenuAnywhere
+        case .openSettings:
+            self = .openSettings
         case .debugDumpRuntimeState:
             self = .debugDumpRuntimeState
         case .debugResetRuntimeState:
@@ -1251,6 +1260,8 @@ extension IPCCommandRequest: Codable {
         case .scratchpadToggle:
             break
         case .openMenuAnywhere:
+            break
+        case .openSettings:
             break
         case .debugDumpRuntimeState:
             break

--- a/docs/IPC-CLI.md
+++ b/docs/IPC-CLI.md
@@ -351,6 +351,7 @@ When a managed floating window has keyboard focus, focused-window commands targe
 |---------|-----------|---------|-------------|
 | `command open-command-palette` | — | command | Toggle the command palette |
 | `command open-menu-anywhere` | — | command | Open the menu surface |
+| `command open-settings` | — | command | Open the Nehir settings window |
 | `command toggle-workspace-bar` | — | command | Toggle workspace bar visibility |
 | `command toggle-overview` | — | command | Toggle the overview surface |
 


### PR DESCRIPTION
## Summary

<!-- What changed and why? -->

## Release notes

Choose one:

- [ ] Added a `.changeset/*.md` for user-visible changes (`mise run changeset -- patch "..."`).
- [ ] No user-visible change; apply the `no release note` label to make CI skip intentional.

## Validation

<!-- Commands run, screenshots, or manual checks. -->

- [ ] Ran relevant tests/checks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an `openSettings` command to open the Settings window, accessible via the Command Palette, hotkey assignment (Settings → Hotkeys), and CLI (`nehirctl command open-settings`).

* **Documentation**
  * Updated CLI reference documentation with the new settings command.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->