### PR TITLE
Fix workspace assignments to monitors after configuration changes

### DIFF
--- a/.changeset/20260613142554-fixed-workspaces-staying-assigned-to-monitors-af.md
+++ b/.changeset/20260613142554-fixed-workspaces-staying-assigned-to-monitors-af.md
@@ -1,0 +1,6 @@
+---
+"nehir": patch
+
+---
+
+Fixed workspaces staying assigned to monitors after they are disconnected, which could cause stale workspace bar positioning or window reveal issues following an external display detach. Workspace-to-monitor assignments are now revalidated against the current monitor set whenever displays change.

--- a/Sources/Nehir/Core/Layout/Niri/NiriLayoutEngine+Monitors.swift
+++ b/Sources/Nehir/Core/Layout/Niri/NiriLayoutEngine+Monitors.swift
@@ -32,10 +32,12 @@ extension NiriLayoutEngine {
 
         let newIds = Set(newMonitors.map(\.id))
         monitors = monitors.filter { newIds.contains($0.key) }
+        workspaceMonitorIndex = workspaceMonitorIndex.filter { newIds.contains($0.value) }
     }
 
     func cleanupRemovedMonitor(_ monitorId: Monitor.ID) {
         monitors.removeValue(forKey: monitorId)
+        workspaceMonitorIndex = workspaceMonitorIndex.filter { $0.value != monitorId }
     }
 
     func updateMonitorOrientations(_ orientations: [Monitor.ID: Monitor.Orientation]) {
@@ -113,10 +115,15 @@ extension NiriLayoutEngine {
         _ assignments: [(workspaceId: WorkspaceDescriptor.ID, monitor: Monitor)],
         orientations: [Monitor.ID: Monitor.Orientation] = [:]
     ) {
-        var desiredOwners: [WorkspaceDescriptor.ID: Monitor.ID] = [:]
-        desiredOwners.reserveCapacity(assignments.count)
+        let validMonitorIds = orientations.isEmpty ? nil : Set(orientations.keys)
+        let validAssignments = assignments.filter { assignment in
+            validMonitorIds?.contains(assignment.monitor.id) ?? true
+        }
 
-        for assignment in assignments {
+        var desiredOwners: [WorkspaceDescriptor.ID: Monitor.ID] = [:]
+        desiredOwners.reserveCapacity(validAssignments.count)
+
+        for assignment in validAssignments {
             _ = ensureMonitor(
                 for: assignment.monitor.id,
                 monitor: assignment.monitor,
@@ -127,7 +134,7 @@ extension NiriLayoutEngine {
 
         pruneStaleWorkspaceRootCopies(desiredOwners: desiredOwners)
 
-        for assignment in assignments where desiredOwners[assignment.workspaceId] == assignment.monitor.id {
+        for assignment in validAssignments where desiredOwners[assignment.workspaceId] == assignment.monitor.id {
             let targetMonitor = monitors[assignment.monitor.id] ?? ensureMonitor(
                 for: assignment.monitor.id,
                 monitor: assignment.monitor,
@@ -138,32 +145,36 @@ extension NiriLayoutEngine {
     }
 
     func monitorContaining(workspace workspaceId: WorkspaceDescriptor.ID) -> Monitor.ID? {
-        for (monitorId, niriMonitor) in monitors {
-            if niriMonitor.containsWorkspace(workspaceId) {
-                return monitorId
-            }
+        guard let monitorId = workspaceMonitorIndex[workspaceId],
+              monitors[monitorId]?.containsWorkspace(workspaceId) == true
+        else {
+            workspaceMonitorIndex.removeValue(forKey: workspaceId)
+            return nil
         }
-        return nil
+        return monitorId
     }
 
     func monitorForWorkspace(_ workspaceId: WorkspaceDescriptor.ID) -> NiriMonitor? {
-        for niriMonitor in monitors.values {
-            if niriMonitor.containsWorkspace(workspaceId) {
-                return niriMonitor
-            }
-        }
-        return nil
+        guard let monitorId = monitorContaining(workspace: workspaceId) else { return nil }
+        return monitors[monitorId]
     }
 
     private func attachWorkspaceRootIfNeeded(
         _ workspaceId: WorkspaceDescriptor.ID,
         to targetMonitor: NiriMonitor
     ) {
+        // The root is a per-workspace singleton, so a no-op attach (target monitor
+        // already holds the same root) must still refresh the ownership index: callers
+        // like syncWorkspaceAssignments/moveWorkspace rely on this to rebuild the
+        // cache after updateMonitors/cleanupRemovedMonitor clear an entry for a
+        // disconnected monitor while a surviving duplicate root keeps workspaceRoots
+        // correct. Without this, monitorContaining returns nil for an attached
+        // workspace, breaking monitor-scoped settings, display scale, and reveal.
         let root = ensureRoot(for: workspaceId)
-        if let existing = targetMonitor.workspaceRoots[workspaceId], existing === root {
-            return
+        if targetMonitor.workspaceRoots[workspaceId] !== root {
+            targetMonitor.workspaceRoots[workspaceId] = root
         }
-        targetMonitor.workspaceRoots[workspaceId] = root
+        workspaceMonitorIndex[workspaceId] = targetMonitor.id
     }
 
     private func pruneStaleWorkspaceRootCopies(
@@ -177,6 +188,9 @@ extension NiriLayoutEngine {
             )
             for workspaceId in staleWorkspaceIds {
                 niriMonitor.workspaceRoots.removeValue(forKey: workspaceId)
+                if workspaceMonitorIndex[workspaceId] == niriMonitor.id {
+                    workspaceMonitorIndex.removeValue(forKey: workspaceId)
+                }
             }
         }
     }
@@ -187,6 +201,9 @@ extension NiriLayoutEngine {
     ) {
         for niriMonitor in monitors.values where niriMonitor.id != keepingMonitorId {
             niriMonitor.workspaceRoots.removeValue(forKey: workspaceId)
+        }
+        if keepingMonitorId == nil || workspaceMonitorIndex[workspaceId] != keepingMonitorId {
+            workspaceMonitorIndex.removeValue(forKey: workspaceId)
         }
     }
 }

--- a/Sources/Nehir/Core/Layout/Niri/NiriLayoutEngine.swift
+++ b/Sources/Nehir/Core/Layout/Niri/NiriLayoutEngine.swift
@@ -109,6 +109,7 @@ final class NiriLayoutEngine {
     private static let presetMatchTolerance: CGFloat = 0.001
 
     var monitors: [Monitor.ID: NiriMonitor] = [:]
+    var workspaceMonitorIndex: [WorkspaceDescriptor.ID: Monitor.ID] = [:]
 
     var roots: [WorkspaceDescriptor.ID: NiriRoot] = [:]
 

--- a/Tests/NehirTests/NiriLayoutEngineTests.swift
+++ b/Tests/NehirTests/NiriLayoutEngineTests.swift
@@ -3448,6 +3448,45 @@ private func makeCenteredCrossMonitorFixture(
         #expect(upperMonitor.workspaceRoots[lowerWorkspaceId] == nil)
     }
 
+    @Test func syncWorkspaceAssignmentsRepopulatesMonitorIndexOnNoOpAttach() {
+        // Reproduces the no-op-attach index gap: after the owning monitor is removed,
+        // cleanupRemovedMonitor clears the index entry while a surviving duplicate root
+        // keeps workspaceRoots correct. A subsequent sync whose target already holds that
+        // root must still repopulate the ownership cache so monitorContaining resolves.
+        let engine = NiriLayoutEngine()
+        let monitors = makeVerticalStackedTestMonitors()
+        let workspaceId = UUID()
+
+        engine.ensureMonitor(for: monitors.lower.id, monitor: monitors.lower)
+        engine.moveWorkspace(workspaceId, to: monitors.upper.id, monitor: monitors.upper)
+
+        guard let root = engine.root(for: workspaceId),
+              let lowerMonitor = engine.monitor(for: monitors.lower.id)
+        else {
+            Issue.record("Expected existing root and lower monitor before no-op index test")
+            return
+        }
+
+        // Stale duplicate root survives on the remaining monitor, mirroring a transient
+        // cross-monitor copy that pruneStaleWorkspaceRootCopies did not yet reconcile.
+        lowerMonitor.workspaceRoots[workspaceId] = root
+
+        // Disconnect the indexed owner: this removes the monitor and clears the index
+        // entry while the duplicate root on the lower monitor persists.
+        engine.cleanupRemovedMonitor(monitors.upper.id)
+        #expect(engine.workspaceMonitorIndex[workspaceId] == nil)
+        #expect(lowerMonitor.workspaceRoots[workspaceId] === root)
+
+        // Reassign to the monitor that already holds the root (no-op attach).
+        engine.syncWorkspaceAssignments(
+            [(workspaceId: workspaceId, monitor: monitors.lower)]
+        )
+
+        #expect(lowerMonitor.workspaceRoots[workspaceId] === root)
+        #expect(engine.monitorContaining(workspace: workspaceId) == monitors.lower.id)
+        #expect(engine.monitorForWorkspace(workspaceId)?.id == monitors.lower.id)
+    }
+
     @Test func moveWorkspaceDoesNotPruneUnrelatedWorkspaceRoots() {
         let engine = NiriLayoutEngine()
         let monitors = makeHorizontalNeighboringTestMonitors()


### PR DESCRIPTION
## Summary

<!-- What changed and why? -->

## Release notes

Choose one:

- [x] Added a `.changeset/*.md` for user-visible changes (`mise run changeset -- patch "..."`).
- [ ] No user-visible change; apply the `no release note` label to make CI skip intentional.

## Validation

<!-- Commands run, screenshots, or manual checks. -->

- [ ] Ran relevant tests/checks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where workspaces could remain incorrectly assigned to disconnected monitors, which could cause improper workspace positioning or window visibility problems when display configurations change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->