### PR TITLE
Refactor layout refresh handling to centralize request logic

### DIFF
--- a/.changeset/20260613163338-internal-refactor-centralize-the-refreshreason-t.md
+++ b/.changeset/20260613163338-internal-refactor-centralize-the-refreshreason-t.md
@@ -1,0 +1,6 @@
+---
+"nehir": none
+
+---
+
+Internal refactor: centralize the RefreshReason to refresh-route mapping. A single RefreshReason routing table now drives route (fullRescan / relayout / immediateRelayout / visibilityRefresh / windowRemoval) and scheduling policy, exposed via a new reason-driven LayoutRefreshController.requestRefresh entry point. Adding a reason or changing refresh policy is now a one-place edit instead of scattered call sites; behavior is unchanged.

--- a/Sources/Nehir/Core/Controller/AXEventHandler.swift
+++ b/Sources/Nehir/Core/Controller/AXEventHandler.swift
@@ -684,7 +684,7 @@ final class AXEventHandler: CGSEventDelegate {
 
         debugCounters.geometryRelayoutRequests += 1
         debugCounters.scopedGeometryRelayoutRequests += 1
-        controller.layoutRefreshController.requestRelayout(
+        controller.layoutRefreshController.requestRefresh(
             reason: .axWindowChanged,
             affectedWorkspaceIds: [entry.workspaceId]
         )
@@ -880,7 +880,7 @@ final class AXEventHandler: CGSEventDelegate {
             if case let .restored(scheduledRelayout) = nativeFullscreenRestore,
                !scheduledRelayout
             {
-                controller.layoutRefreshController.requestRelayout(reason: .axWindowCreated)
+                controller.layoutRefreshController.requestRefresh(reason: .axWindowCreated)
             }
             return
         }
@@ -953,7 +953,7 @@ final class AXEventHandler: CGSEventDelegate {
             schedulePostCreateLifecycleVerification(for: trackedToken)
         }
 
-        controller.layoutRefreshController.requestRelayout(
+        controller.layoutRefreshController.requestRefresh(
             reason: .axWindowCreated,
             affectedWorkspaceIds: [trackedEntry.workspaceId]
         )
@@ -1865,7 +1865,7 @@ final class AXEventHandler: CGSEventDelegate {
                     reason: "ax_focus_confirm_request_relayout",
                     details: ["token=\(entry.token)", "isFFM=\(isFFM)"]
                 )
-                controller.layoutRefreshController.requestImmediateRelayout(reason: .layoutCommand)
+                controller.layoutRefreshController.requestRefresh(reason: .layoutCommand)
                 if state.viewOffsetPixels.isAnimating {
                     controller.layoutRefreshController.startScrollAnimation(for: wsId)
                 }
@@ -1930,7 +1930,7 @@ final class AXEventHandler: CGSEventDelegate {
             forceOrdering: true
         )
         if changed {
-            controller.layoutRefreshController.requestImmediateRelayout(
+            controller.layoutRefreshController.requestRefresh(
                 reason: .appActivationTransition,
                 affectedWorkspaceIds: [entry.workspaceId]
             )
@@ -2074,7 +2074,7 @@ final class AXEventHandler: CGSEventDelegate {
         if case let .restored(scheduledRelayout) = restore,
            !scheduledRelayout
         {
-            controller.layoutRefreshController.requestRelayout(reason: .axWindowCreated)
+            controller.layoutRefreshController.requestRefresh(reason: .axWindowCreated)
         }
     }
 
@@ -2229,7 +2229,7 @@ final class AXEventHandler: CGSEventDelegate {
         controller.focusBorderController.hide()
         controller.nativeFullscreenPlaceholderManager.remove(token)
         clearManagedFocusState(matching: token, workspaceId: unavailableRecord.workspaceId)
-        controller.layoutRefreshController.requestImmediateRelayout(
+        controller.layoutRefreshController.requestRefresh(
             reason: .appActivationTransition,
             affectedWorkspaceIds: [unavailableRecord.workspaceId]
         )
@@ -2276,7 +2276,7 @@ final class AXEventHandler: CGSEventDelegate {
         for entry in controller.workspaceManager.entries(forPid: pid) {
             controller.workspaceManager.setLayoutReason(.macosHiddenApp, for: entry.token)
         }
-        controller.layoutRefreshController.requestVisibilityRefresh(reason: .appHidden)
+        controller.layoutRefreshController.requestRefresh(reason: .appHidden)
     }
 
     func handleAppDeactivated(pid: pid_t) {
@@ -2309,7 +2309,7 @@ final class AXEventHandler: CGSEventDelegate {
                 _ = controller.workspaceManager.restoreFromNativeState(for: entry.token)
             }
         }
-        controller.layoutRefreshController.requestVisibilityRefresh(reason: .appUnhidden)
+        controller.layoutRefreshController.requestRefresh(reason: .appUnhidden)
     }
 
     func resetManagedReplacementState() {
@@ -2351,7 +2351,7 @@ final class AXEventHandler: CGSEventDelegate {
             else {
                 continue
             }
-            controller.layoutRefreshController.requestFullRescan(reason: .activeSpaceChanged)
+            controller.layoutRefreshController.requestRefresh(reason: .activeSpaceChanged)
         }
     }
 
@@ -3100,7 +3100,7 @@ final class AXEventHandler: CGSEventDelegate {
             else {
                 return
             }
-            controller.layoutRefreshController.requestFullRescan(reason: .activeSpaceChanged)
+            controller.layoutRefreshController.requestRefresh(reason: .activeSpaceChanged)
             self.cleanupClosedNativeFullscreenPlaceholderIfNeeded(record)
         }
         pendingNativeFullscreenStaleCleanupTasks[originalToken] = Task { @MainActor [weak self] in
@@ -3118,7 +3118,7 @@ final class AXEventHandler: CGSEventDelegate {
             for entry in removedEntries {
                 controller.nativeFullscreenPlaceholderManager.remove(entry.token)
             }
-            controller.layoutRefreshController.requestFullRescan(reason: .activeSpaceChanged)
+            controller.layoutRefreshController.requestRefresh(reason: .activeSpaceChanged)
         }
     }
 
@@ -3139,7 +3139,7 @@ final class AXEventHandler: CGSEventDelegate {
         for entry in removedEntries {
             controller.nativeFullscreenPlaceholderManager.remove(entry.token)
         }
-        controller.layoutRefreshController.requestFullRescan(reason: .activeSpaceChanged)
+        controller.layoutRefreshController.requestRefresh(reason: .activeSpaceChanged)
     }
 
     func cancelNativeFullscreenLifecycleTasks(for originalToken: WindowToken) {

--- a/Sources/Nehir/Core/Controller/CommandHandler.swift
+++ b/Sources/Nehir/Core/Controller/CommandHandler.swift
@@ -625,7 +625,7 @@ final class CommandHandler {
                 gaps: gaps,
                 orientation: orientation
             ) {
-                controller.layoutRefreshController.requestImmediateRelayout(reason: .layoutCommand)
+                controller.layoutRefreshController.requestRefresh(reason: .layoutCommand)
                 if engine.hasAnyWindowAnimationsRunning(in: wsId) {
                     controller.layoutRefreshController.startScrollAnimation(for: wsId)
                 }

--- a/Sources/Nehir/Core/Controller/LayoutRefreshController.swift
+++ b/Sources/Nehir/Core/Controller/LayoutRefreshController.swift
@@ -653,21 +653,52 @@ import QuartzCore
         debugCounters
     }
 
+    func requestRefresh(
+        reason: RefreshReason,
+        affectedWorkspaceIds: Set<WorkspaceDescriptor.ID> = [],
+        postLayout: PostLayoutAction? = nil
+    ) {
+        switch reason.route {
+        case .fullRescan:
+            assert(affectedWorkspaceIds.isEmpty, "Full rescan refreshes ignore affected workspace IDs")
+            scheduleFullRescan(reason: reason, postLayout: postLayout)
+        case .relayout:
+            scheduleRefreshSession(
+                reason.scheduling,
+                reason: reason,
+                affectedWorkspaceIds: affectedWorkspaceIds,
+                postLayout: postLayout
+            )
+        case .immediateRelayout:
+            enqueueRefresh(
+                .init(
+                    kind: .immediateRelayout,
+                    reason: reason,
+                    affectedWorkspaceIds: affectedWorkspaceIds,
+                    postLayout: postLayout
+                )
+            )
+        case .visibilityRefresh:
+            assert(affectedWorkspaceIds.isEmpty, "Visibility refreshes ignore affected workspace IDs")
+            enqueueRefresh(.init(kind: .visibilityRefresh, reason: reason, postLayout: postLayout))
+        case .windowRemoval:
+            assertionFailure("Use requestWindowRemoval for window-removal refreshes so payloads are supplied")
+        }
+    }
+
+    // Compatibility helpers for route-specific callers; prefer requestRefresh(reason:)
+    // so RefreshReason.route remains the single source of routing truth.
     func requestFullRescan(reason: RefreshReason) {
-        assert(reason.requestRoute == .fullRescan, "Invalid full-rescan reason: \(reason)")
-        scheduleFullRescan(reason: reason)
+        assert(reason.route == .fullRescan, "Invalid full-rescan reason: \(reason)")
+        requestRefresh(reason: reason)
     }
 
     func requestRelayout(
         reason: RefreshReason,
         affectedWorkspaceIds: Set<WorkspaceDescriptor.ID> = []
     ) {
-        assert(reason.requestRoute == .relayout, "Invalid relayout reason: \(reason)")
-        scheduleRefreshSession(
-            reason.relayoutSchedulingPolicy,
-            reason: reason,
-            affectedWorkspaceIds: affectedWorkspaceIds
-        )
+        assert(reason.route == .relayout, "Invalid relayout reason: \(reason)")
+        requestRefresh(reason: reason, affectedWorkspaceIds: affectedWorkspaceIds)
     }
 
     func requestImmediateRelayout(
@@ -675,14 +706,11 @@ import QuartzCore
         affectedWorkspaceIds: Set<WorkspaceDescriptor.ID> = [],
         postLayout: PostLayoutAction? = nil
     ) {
-        assert(reason.requestRoute == .immediateRelayout, "Invalid immediate-relayout reason: \(reason)")
-        enqueueRefresh(
-            .init(
-                kind: .immediateRelayout,
-                reason: reason,
-                affectedWorkspaceIds: affectedWorkspaceIds,
-                postLayout: postLayout
-            )
+        assert(reason.route == .immediateRelayout, "Invalid immediate-relayout reason: \(reason)")
+        requestRefresh(
+            reason: reason,
+            affectedWorkspaceIds: affectedWorkspaceIds,
+            postLayout: postLayout
         )
     }
 
@@ -690,8 +718,8 @@ import QuartzCore
         reason: RefreshReason,
         postLayout: PostLayoutAction? = nil
     ) {
-        assert(reason.requestRoute == .visibilityRefresh, "Invalid visibility-refresh reason: \(reason)")
-        enqueueRefresh(.init(kind: .visibilityRefresh, reason: reason, postLayout: postLayout))
+        assert(reason.route == .visibilityRefresh, "Invalid visibility-refresh reason: \(reason)")
+        requestRefresh(reason: reason, postLayout: postLayout)
     }
 
     func requestWindowRemoval(
@@ -701,7 +729,7 @@ import QuartzCore
         shouldRecoverFocus: Bool,
         postLayout: PostLayoutAction? = nil
     ) {
-        assert(RefreshReason.windowDestroyed.requestRoute == .windowRemoval, "Invalid window-removal reason")
+        assert(RefreshReason.windowDestroyed.route == .windowRemoval, "Invalid window-removal reason")
         enqueueRefresh(
             .init(
                 kind: .windowRemoval,
@@ -722,21 +750,26 @@ import QuartzCore
         reason: RefreshReason = .workspaceTransition,
         postLayout: PostLayoutAction? = nil
     ) {
-        requestImmediateRelayout(
+        assert(reason.route == .immediateRelayout, "Invalid workspace-transition reason: \(reason)")
+        requestRefresh(
             reason: reason,
             affectedWorkspaceIds: affectedWorkspaces,
             postLayout: postLayout
         )
     }
 
-    private func scheduleFullRescan(reason: RefreshReason) {
-        enqueueRefresh(.init(kind: .fullRescan, reason: reason))
+    private func scheduleFullRescan(
+        reason: RefreshReason,
+        postLayout: PostLayoutAction? = nil
+    ) {
+        enqueueRefresh(.init(kind: .fullRescan, reason: reason, postLayout: postLayout))
     }
 
     private func scheduleRefreshSession(
         _ policy: RelayoutSchedulingPolicy,
         reason: RefreshReason,
-        affectedWorkspaceIds: Set<WorkspaceDescriptor.ID> = []
+        affectedWorkspaceIds: Set<WorkspaceDescriptor.ID> = [],
+        postLayout: PostLayoutAction? = nil
     ) {
         if policy.shouldDropWhileBusy {
             if layoutState.isIncrementalRefreshInProgress || layoutState.isImmediateLayoutInProgress {
@@ -748,7 +781,12 @@ import QuartzCore
             }
         }
         enqueueRefresh(
-            .init(kind: .relayout, reason: reason, affectedWorkspaceIds: affectedWorkspaceIds)
+            .init(
+                kind: .relayout,
+                reason: reason,
+                affectedWorkspaceIds: affectedWorkspaceIds,
+                postLayout: postLayout
+            )
         )
     }
 
@@ -1763,7 +1801,7 @@ import QuartzCore
             case .fullRescan:
                 return try await executeFullRefresh(refresh: refresh)
             case .relayout:
-                let policy = refresh.reason.relayoutSchedulingPolicy
+                let policy = refresh.reason.scheduling
                 if policy.debounceInterval > 0 {
                     try await Task.sleep(nanoseconds: policy.debounceInterval)
                 }
@@ -2984,7 +3022,7 @@ import QuartzCore
             {
                 controller.axManager.forceApplyNextFrame(for: tiledEntry.windowId)
             }
-            requestImmediateRelayout(reason: .layoutCommand, affectedWorkspaceIds: [entry.workspaceId])
+            requestRefresh(reason: .layoutCommand, affectedWorkspaceIds: [entry.workspaceId])
         }
     }
 

--- a/Sources/Nehir/Core/Controller/LayoutRefreshController.swift
+++ b/Sources/Nehir/Core/Controller/LayoutRefreshController.swift
@@ -682,7 +682,7 @@ import QuartzCore
             assert(affectedWorkspaceIds.isEmpty, "Visibility refreshes ignore affected workspace IDs")
             enqueueRefresh(.init(kind: .visibilityRefresh, reason: reason, postLayout: postLayout))
         case .windowRemoval:
-            assertionFailure("Use requestWindowRemoval for window-removal refreshes so payloads are supplied")
+            preconditionFailure("Use requestWindowRemoval for window-removal refreshes so payloads are supplied")
         }
     }
 

--- a/Sources/Nehir/Core/Controller/MouseEventHandler.swift
+++ b/Sources/Nehir/Core/Controller/MouseEventHandler.swift
@@ -1018,7 +1018,7 @@ final class MouseEventHandler {
                 controller.workspaceManager.withNiriViewportState(for: wsId, mutate)
             }
         ) {
-            controller.layoutRefreshController.requestImmediateRelayout(reason: .interactiveGesture)
+            controller.layoutRefreshController.requestRefresh(reason: .interactiveGesture)
         }
     }
 
@@ -1050,7 +1050,7 @@ final class MouseEventHandler {
                     )
                 }
                 if didEnd {
-                    controller.layoutRefreshController.requestImmediateRelayout(reason: .interactiveGesture)
+                    controller.layoutRefreshController.requestRefresh(reason: .interactiveGesture)
                 }
             }
 
@@ -1083,7 +1083,7 @@ final class MouseEventHandler {
                 )
             }
             if hadInteractiveResize {
-                controller.layoutRefreshController.requestImmediateRelayout(reason: .interactiveGesture)
+                controller.layoutRefreshController.requestRefresh(reason: .interactiveGesture)
             }
         }
 
@@ -1571,7 +1571,7 @@ final class MouseEventHandler {
                     "phase=committed"
                 ]
             )
-            controller.layoutRefreshController.requestImmediateRelayout(reason: .interactiveGesture)
+            controller.layoutRefreshController.requestRefresh(reason: .interactiveGesture)
         }
     }
 
@@ -1632,7 +1632,7 @@ final class MouseEventHandler {
 
         if didApply {
             controller.recordRuntimeViewportTrace(workspaceId: wsId, reason: "wheel_tick")
-            controller.layoutRefreshController.requestImmediateRelayout(reason: .interactiveGesture)
+            controller.layoutRefreshController.requestRefresh(reason: .interactiveGesture)
             if shouldStartAnimation {
                 controller.layoutRefreshController.startScrollAnimation(for: wsId)
             }
@@ -1731,7 +1731,7 @@ final class MouseEventHandler {
             }
             controller.layoutRefreshController.startScrollAnimation(for: wsId)
         } else {
-            controller.layoutRefreshController.requestImmediateRelayout(reason: .interactiveGesture)
+            controller.layoutRefreshController.requestRefresh(reason: .interactiveGesture)
             if controller.focusFollowsMouseEnabled {
                 refreshFocusFollowsMouseAtCurrentPointer()
             }
@@ -1769,7 +1769,7 @@ final class MouseEventHandler {
         }
         if didCancel {
             controller.recordRuntimeViewportTrace(workspaceId: wsId, reason: "gesture_cancel")
-            controller.layoutRefreshController.requestImmediateRelayout(reason: .interactiveGesture)
+            controller.layoutRefreshController.requestRefresh(reason: .interactiveGesture)
         }
     }
 

--- a/Sources/Nehir/Core/Controller/NiriLayoutHandler.swift
+++ b/Sources/Nehir/Core/Controller/NiriLayoutHandler.swift
@@ -1134,7 +1134,7 @@ enum NiriWindowMoveResult {
                     rememberedFocusToken: nil
                 )
             )
-            controller.layoutRefreshController.requestImmediateRelayout(reason: .layoutCommand)
+            controller.layoutRefreshController.requestRefresh(reason: .layoutCommand)
             startScrollAnimationIfNeeded(for: wsId, state: state, engine: engine)
             return
         }
@@ -1180,7 +1180,7 @@ enum NiriWindowMoveResult {
 
             engine.toggleFullscreen(windowNode, motion: motion, state: &state)
 
-            controller.layoutRefreshController.requestImmediateRelayout(reason: .layoutCommand)
+            controller.layoutRefreshController.requestRefresh(reason: .layoutCommand)
             startScrollAnimationIfNeeded(for: wsId, state: state, engine: engine)
         }
     }
@@ -1202,7 +1202,7 @@ enum NiriWindowMoveResult {
                 workingFrame: workingFrame,
                 gaps: gaps
             )
-            controller.layoutRefreshController.requestImmediateRelayout(reason: .layoutCommand)
+            controller.layoutRefreshController.requestRefresh(reason: .layoutCommand)
             startScrollAnimationIfNeeded(for: wsId, state: state, engine: engine)
         }
     }
@@ -1223,7 +1223,7 @@ enum NiriWindowMoveResult {
                 workingFrame: workingFrame,
                 gaps: gaps
             )
-            controller.layoutRefreshController.requestImmediateRelayout(reason: .layoutCommand)
+            controller.layoutRefreshController.requestRefresh(reason: .layoutCommand)
             startScrollAnimationIfNeeded(for: wsId, state: state, engine: engine)
         }
     }
@@ -1242,7 +1242,7 @@ enum NiriWindowMoveResult {
                 workingFrame: workingFrame,
                 gaps: gaps
             )
-            controller.layoutRefreshController.requestImmediateRelayout(reason: .layoutCommand)
+            controller.layoutRefreshController.requestRefresh(reason: .layoutCommand)
             startScrollAnimationIfNeeded(for: wsId, state: state, engine: engine)
         }
     }
@@ -1263,7 +1263,7 @@ enum NiriWindowMoveResult {
                 workingFrame: workingFrame,
                 gaps: gaps
             )
-            controller.layoutRefreshController.requestImmediateRelayout(reason: .layoutCommand)
+            controller.layoutRefreshController.requestRefresh(reason: .layoutCommand)
             startScrollAnimationIfNeeded(for: wsId, state: state, engine: engine)
         }
     }
@@ -1284,7 +1284,7 @@ enum NiriWindowMoveResult {
                 workingFrame: workingFrame,
                 gaps: gaps
             )
-            controller.layoutRefreshController.requestImmediateRelayout(reason: .layoutCommand)
+            controller.layoutRefreshController.requestRefresh(reason: .layoutCommand)
             startScrollAnimationIfNeeded(for: wsId, state: state, engine: engine)
         }
     }
@@ -1297,7 +1297,7 @@ enum NiriWindowMoveResult {
             else { return }
 
             engine.resetWindowHeight(windowNode, in: wsId)
-            controller.layoutRefreshController.requestImmediateRelayout(reason: .layoutCommand)
+            controller.layoutRefreshController.requestRefresh(reason: .layoutCommand)
             startScrollAnimationIfNeeded(for: wsId, state: state, engine: engine)
         }
     }
@@ -1319,7 +1319,7 @@ enum NiriWindowMoveResult {
             guard state.viewOffsetPixels.isAnimating || viewOffsetChanged || state.selectedNodeId != previousSelectedNodeId else { return }
 
             let focusToken = state.selectedNodeId != previousSelectedNodeId ? selectedWindow?.token : nil
-            controller.layoutRefreshController.requestImmediateRelayout(reason: .layoutCommand) { [weak controller] in
+            controller.layoutRefreshController.requestRefresh(reason: .layoutCommand) { [weak controller] in
                 if let focusToken {
                     controller?.focusWindow(focusToken)
                 }
@@ -1349,7 +1349,7 @@ enum NiriWindowMoveResult {
                 workingFrame: workingFrame,
                 gaps: gaps
             )
-            controller.layoutRefreshController.requestImmediateRelayout(reason: .layoutCommand)
+            controller.layoutRefreshController.requestRefresh(reason: .layoutCommand)
             startScrollAnimationIfNeeded(for: wsId, state: state, engine: engine)
         }
     }
@@ -1370,7 +1370,7 @@ enum NiriWindowMoveResult {
                 workingFrame: workingFrame,
                 gaps: gaps
             )
-            controller.layoutRefreshController.requestImmediateRelayout(reason: .layoutCommand)
+            controller.layoutRefreshController.requestRefresh(reason: .layoutCommand)
             startScrollAnimationIfNeeded(for: wsId, state: state, engine: engine)
         }
     }
@@ -1389,7 +1389,7 @@ enum NiriWindowMoveResult {
                 workingFrame: workingFrame,
                 gaps: gaps
             )
-            controller.layoutRefreshController.requestImmediateRelayout(reason: .layoutCommand)
+            controller.layoutRefreshController.requestRefresh(reason: .layoutCommand)
             startScrollAnimationIfNeeded(for: wsId, state: state, engine: engine)
         }
     }
@@ -1403,7 +1403,7 @@ enum NiriWindowMoveResult {
                 workingAreaWidth: workingFrame.width,
                 gaps: gaps
             )
-            controller.layoutRefreshController.requestImmediateRelayout(reason: .layoutCommand)
+            controller.layoutRefreshController.requestRefresh(reason: .layoutCommand)
             if engine.hasAnyColumnAnimationsRunning(in: wsId) {
                 controller.layoutRefreshController.startScrollAnimation(for: wsId)
             }
@@ -1423,7 +1423,7 @@ enum NiriWindowMoveResult {
 
         syncMonitorsToNiriEngine()
 
-        controller.layoutRefreshController.requestRelayout(reason: .layoutConfigChanged)
+        controller.layoutRefreshController.requestRefresh(reason: .layoutConfigChanged)
     }
 
     func syncMonitorsToNiriEngine() {
@@ -1474,7 +1474,7 @@ enum NiriWindowMoveResult {
             defaultColumnWidth: defaultColumnWidth.map { $0.map { CGFloat($0) } }
         )
         refreshResolvedMonitorSettings()
-        controller.layoutRefreshController.requestRelayout(reason: .layoutConfigChanged)
+        controller.layoutRefreshController.requestRefresh(reason: .layoutConfigChanged)
     }
 
     // MARK: - Node Activation & Operation Context
@@ -1540,7 +1540,7 @@ enum NiriWindowMoveResult {
                     onMonitor: controller.workspaceManager.monitorId(for: workspaceId)
                 )
             }
-            controller.layoutRefreshController.requestImmediateRelayout(
+            controller.layoutRefreshController.requestRefresh(
                 reason: .layoutCommand
             ) { [weak controller] in
                 if let focusToken {
@@ -1932,7 +1932,7 @@ struct NodeActivationOptions {
             oldFrames: oldFrames,
             newFrames: newFrames
         )
-        controller.layoutRefreshController.requestImmediateRelayout(reason: .layoutCommand)
+        controller.layoutRefreshController.requestRefresh(reason: .layoutCommand)
         return hasPendingAnimationWork(state: state)
     }
 
@@ -1940,7 +1940,7 @@ struct NodeActivationOptions {
         state: ViewportState,
         oldFrames: [WindowToken: CGRect]
     ) -> Bool {
-        controller.layoutRefreshController.requestImmediateRelayout(reason: .layoutCommand)
+        controller.layoutRefreshController.requestRefresh(reason: .layoutCommand)
         let newFrames = engine.captureWindowFrames(in: wsId)
         engine.triggerMoveAnimations(
             in: wsId,
@@ -1951,7 +1951,7 @@ struct NodeActivationOptions {
     }
 
     func commitSimple(state: ViewportState) -> Bool {
-        controller.layoutRefreshController.requestImmediateRelayout(reason: .layoutCommand)
+        controller.layoutRefreshController.requestRefresh(reason: .layoutCommand)
         return hasPendingAnimationWork(state: state)
     }
 }

--- a/Sources/Nehir/Core/Controller/RefreshReason.swift
+++ b/Sources/Nehir/Core/Controller/RefreshReason.swift
@@ -31,7 +31,20 @@ enum RefreshRequestRoute: Equatable, Sendable {
     case windowRemoval
 }
 
-enum RefreshReason: String, Sendable {
+private struct RefreshRouting: Equatable, Sendable {
+    let route: RefreshRequestRoute
+    let scheduling: RelayoutSchedulingPolicy
+
+    init(
+        route: RefreshRequestRoute,
+        scheduling: RelayoutSchedulingPolicy = .plain
+    ) {
+        self.route = route
+        self.scheduling = scheduling
+    }
+}
+
+enum RefreshReason: String, CaseIterable, Sendable {
     case startup
     case appLaunched
     case unlock
@@ -55,69 +68,61 @@ enum RefreshReason: String, Sendable {
     case appHidden
     case appUnhidden
     case overviewMutation
+}
 
-    var requestRoute: RefreshRequestRoute {
-        switch self {
-        case .startup,
-             .appLaunched,
-             .unlock,
-             .activeSpaceChanged,
-             .monitorConfigurationChanged,
-             .appRulesChanged,
-             .workspaceConfigChanged,
-             .appTerminated:
-            .fullRescan
-        case .layoutConfigChanged,
-             .monitorSettingsChanged,
-             .gapsChanged,
-             .workspaceLayoutToggled,
-             .windowRuleReevaluation,
-             .axWindowCreated,
-             .axWindowChanged:
-            .relayout
-        case .workspaceTransition,
-             .appActivationTransition,
-             .layoutCommand,
-             .interactiveGesture,
-             .overviewMutation:
-            .immediateRelayout
-        case .appHidden,
-             .appUnhidden:
-            .visibilityRefresh
-        case .windowDestroyed:
-            .windowRemoval
-        }
+extension RefreshReason {
+    private static let routingTable: [RefreshReason: RefreshRouting] = [
+        .startup: .init(route: .fullRescan),
+        .appLaunched: .init(route: .fullRescan),
+        .unlock: .init(route: .fullRescan),
+        .activeSpaceChanged: .init(route: .fullRescan),
+        .monitorConfigurationChanged: .init(route: .fullRescan),
+        .appRulesChanged: .init(route: .fullRescan),
+        .workspaceConfigChanged: .init(route: .fullRescan),
+        .appTerminated: .init(route: .fullRescan),
+
+        .layoutConfigChanged: .init(route: .relayout),
+        .monitorSettingsChanged: .init(route: .relayout),
+        .gapsChanged: .init(route: .relayout),
+        .workspaceLayoutToggled: .init(route: .relayout),
+        .windowRuleReevaluation: .init(route: .relayout),
+        .axWindowCreated: .init(
+            route: .relayout,
+            scheduling: .debounced(nanoseconds: 4_000_000, dropWhileBusy: false)
+        ),
+        .axWindowChanged: .init(
+            route: .relayout,
+            scheduling: .debounced(nanoseconds: 8_000_000, dropWhileBusy: true)
+        ),
+
+        .workspaceTransition: .init(route: .immediateRelayout),
+        .appActivationTransition: .init(route: .immediateRelayout),
+        .layoutCommand: .init(route: .immediateRelayout),
+        .interactiveGesture: .init(route: .immediateRelayout),
+        .overviewMutation: .init(route: .immediateRelayout),
+
+        .appHidden: .init(route: .visibilityRefresh),
+        .appUnhidden: .init(route: .visibilityRefresh),
+
+        .windowDestroyed: .init(route: .windowRemoval)
+    ]
+
+    static var hasCompleteRoutingTable: Bool {
+        Set(routingTable.keys) == Set(allCases)
     }
 
-    var relayoutSchedulingPolicy: RelayoutSchedulingPolicy {
-        switch self {
-        case .startup,
-             .appLaunched,
-             .unlock,
-             .activeSpaceChanged,
-             .monitorConfigurationChanged,
-             .appRulesChanged,
-             .workspaceConfigChanged,
-             .layoutConfigChanged,
-             .monitorSettingsChanged,
-             .gapsChanged,
-             .workspaceTransition,
-             .appActivationTransition,
-             .workspaceLayoutToggled,
-             .appTerminated,
-             .windowRuleReevaluation,
-             .layoutCommand,
-             .interactiveGesture,
-             .appHidden,
-             .appUnhidden,
-             .overviewMutation:
-            .plain
-        case .axWindowCreated:
-            .debounced(nanoseconds: 4_000_000, dropWhileBusy: false)
-        case .axWindowChanged:
-            .debounced(nanoseconds: 8_000_000, dropWhileBusy: true)
-        case .windowDestroyed:
-            .plain
+    private var routing: RefreshRouting {
+        guard let routing = Self.routingTable[self] else {
+            preconditionFailure("Missing refresh routing for reason: \(self)")
         }
+        return routing
+    }
+
+    var route: RefreshRequestRoute {
+        routing.route
+    }
+
+    var scheduling: RelayoutSchedulingPolicy {
+        routing.scheduling
     }
 }

--- a/Sources/Nehir/Core/Controller/ServiceLifecycleManager.swift
+++ b/Sources/Nehir/Core/Controller/ServiceLifecycleManager.swift
@@ -176,7 +176,7 @@ final class ServiceLifecycleManager {
         controller.axManager.invalidateCachedFrameState()
         controller.workspaceManager.clearGeometryHiddenStates()
 
-        controller.layoutRefreshController.requestFullRescan(reason: .monitorConfigurationChanged)
+        controller.layoutRefreshController.requestRefresh(reason: .monitorConfigurationChanged)
     }
 
     func handleAppTerminated(pid: pid_t) {
@@ -200,31 +200,31 @@ final class ServiceLifecycleManager {
         }
         _ = controller.focusBorderController.refresh(forceOrdering: true)
         controller.appInfoCache.evict(pid: pid)
-        controller.layoutRefreshController.requestFullRescan(reason: .appTerminated)
+        controller.layoutRefreshController.requestRefresh(reason: .appTerminated)
     }
 
     func handleGapsChanged() {
-        controller?.layoutRefreshController.requestRelayout(reason: .gapsChanged)
+        controller?.layoutRefreshController.requestRefresh(reason: .gapsChanged)
     }
 
     func handleAppLaunched() {
-        controller?.layoutRefreshController.requestFullRescan(reason: .appLaunched)
+        controller?.layoutRefreshController.requestRefresh(reason: .appLaunched)
     }
 
     func handleUnlockDetected() {
         guard let controller else { return }
-        controller.layoutRefreshController.requestFullRescan(reason: .unlock)
+        controller.layoutRefreshController.requestRefresh(reason: .unlock)
     }
 
     func performStartupRefresh() {
-        controller?.layoutRefreshController.requestFullRescan(reason: .startup)
+        controller?.layoutRefreshController.requestRefresh(reason: .startup)
     }
 
     func handleActiveSpaceDidChange() {
         guard let controller else { return }
         controller.focusBorderController.hide()
         controller.workspaceManager.recordReconcileEvent(.activeSpaceChanged(source: .service))
-        controller.layoutRefreshController.requestFullRescan(reason: .activeSpaceChanged)
+        controller.layoutRefreshController.requestRefresh(reason: .activeSpaceChanged)
     }
 
     private func setupWorkspaceObservation() {
@@ -325,7 +325,7 @@ final class ServiceLifecycleManager {
             MainActor.assumeIsolated {
                 guard let controller = self?.controller else { return }
                 _ = controller.workspaceManager.recordReconcileEvent(.systemWake(source: .service))
-                controller.layoutRefreshController.requestFullRescan(reason: .unlock)
+                controller.layoutRefreshController.requestRefresh(reason: .unlock)
             }
         }
     }

--- a/Sources/Nehir/Core/Controller/WMController.swift
+++ b/Sources/Nehir/Core/Controller/WMController.swift
@@ -371,7 +371,7 @@ final class WMController {
         pruneHiddenWorkspaceBarMonitorIds()
         cancelPendingWorkspaceBarRefresh()
         workspaceBarManager.setup(controller: self, settings: settings)
-        layoutRefreshController.requestRelayout(reason: .monitorSettingsChanged)
+        layoutRefreshController.requestRefresh(reason: .monitorSettingsChanged)
     }
 
     func cleanupUIOnStop() {
@@ -403,7 +403,7 @@ final class WMController {
 
         cancelPendingWorkspaceBarRefresh()
         workspaceBarManager.setup(controller: self, settings: settings)
-        layoutRefreshController.requestRelayout(reason: .monitorSettingsChanged)
+        layoutRefreshController.requestRefresh(reason: .monitorSettingsChanged)
         return true
     }
 
@@ -526,7 +526,7 @@ final class WMController {
         pruneHiddenWorkspaceBarMonitorIds()
         cancelPendingWorkspaceBarRefresh()
         workspaceBarManager.updateSettings()
-        layoutRefreshController.requestRelayout(reason: .monitorSettingsChanged)
+        layoutRefreshController.requestRefresh(reason: .monitorSettingsChanged)
     }
 
     func updateWorkspaceBarAppearance() {
@@ -539,13 +539,13 @@ final class WMController {
             let orientation = settings.effectiveOrientation(for: monitor)
             niriEngine?.monitors[monitor.id]?.updateOrientation(orientation)
         }
-        layoutRefreshController.requestRelayout(reason: .monitorSettingsChanged)
+        layoutRefreshController.requestRefresh(reason: .monitorSettingsChanged)
     }
 
     func updateMonitorNiriSettings() {
         guard niriEngine != nil else { return }
         niriLayoutHandler.refreshResolvedMonitorSettings()
-        layoutRefreshController.requestRelayout(reason: .monitorSettingsChanged)
+        layoutRefreshController.requestRefresh(reason: .monitorSettingsChanged)
     }
 
     func workspaceBarItems(
@@ -705,7 +705,7 @@ final class WMController {
     func updateWorkspaceConfig() {
         workspaceManager.applySettings()
         syncMonitorsToNiriEngine()
-        layoutRefreshController.requestFullRescan(reason: .workspaceConfigChanged)
+        layoutRefreshController.requestRefresh(reason: .workspaceConfigChanged)
     }
 
     func rebuildAppRulesCache() {
@@ -714,7 +714,7 @@ final class WMController {
 
     func updateAppRules() {
         rebuildAppRulesCache()
-        layoutRefreshController.requestFullRescan(reason: .appRulesChanged)
+        layoutRefreshController.requestRefresh(reason: .appRulesChanged)
     }
 
     var hotkeyRegistrationFailures: [HotkeyCommand: HotkeyRegistrationFailureReason] {
@@ -2490,7 +2490,7 @@ final class WMController {
             )
         }
 
-        layoutRefreshController.requestFullRescan(reason: .startup)
+        layoutRefreshController.requestRefresh(reason: .startup)
     }
 
     func restartAppClearingRuntimeState(enableTracing: Bool = false) {
@@ -2871,7 +2871,7 @@ final class WMController {
         }
 
         if relayoutNeeded {
-            layoutRefreshController.requestRelayout(
+            layoutRefreshController.requestRefresh(
                 reason: .windowRuleReevaluation,
                 affectedWorkspaceIds: affectedWorkspaceIds
             )
@@ -2947,7 +2947,7 @@ final class WMController {
         hideScratchpadWindow(updatedEntry, monitor: hideMonitor)
 
         if transitionedFromTiling {
-            layoutRefreshController.requestImmediateRelayout(reason: .layoutCommand)
+            layoutRefreshController.requestRefresh(reason: .layoutCommand)
         }
 
         return .executed
@@ -2970,7 +2970,7 @@ final class WMController {
             cleanupScratchpadWindowResourcesIfNeeded(for: token)
             nativeFullscreenPlaceholderManager.remove(token)
             _ = workspaceManager.removeWindow(pid: token.pid, windowId: token.windowId)
-            layoutRefreshController.requestRelayout(
+            layoutRefreshController.requestRefresh(
                 reason: .windowRuleReevaluation,
                 affectedWorkspaceIds: [entry.workspaceId]
             )
@@ -2983,7 +2983,7 @@ final class WMController {
             preferredMonitor: monitorForInteraction(),
             applyFloatingFrame: true
         )
-        layoutRefreshController.requestRelayout(
+        layoutRefreshController.requestRefresh(
             reason: .windowRuleReevaluation,
             affectedWorkspaceIds: [entry.workspaceId]
         )
@@ -3426,7 +3426,7 @@ extension WMController {
         focusBridge.discardPendingFocus(token)
         focusBorderController.hide()
         if changed {
-            layoutRefreshController.requestImmediateRelayout(
+            layoutRefreshController.requestRefresh(
                 reason: .appActivationTransition,
                 affectedWorkspaceIds: [entry.workspaceId]
             )

--- a/Sources/Nehir/Core/Controller/WindowActionHandler.swift
+++ b/Sources/Nehir/Core/Controller/WindowActionHandler.swift
@@ -506,7 +506,7 @@ final class WindowActionHandler {
                 rememberedFocusToken: rememberedFocusToken ?? token
             )
         )
-        controller.layoutRefreshController.requestImmediateRelayout(reason: .layoutCommand) { [weak controller] in
+        controller.layoutRefreshController.requestRefresh(reason: .layoutCommand) { [weak controller] in
             controller?.focusWindow(token)
         }
         if startNiriScrollAnimation {

--- a/Sources/Nehir/Core/Controller/WorkspaceNavigationHandler.swift
+++ b/Sources/Nehir/Core/Controller/WorkspaceNavigationHandler.swift
@@ -146,7 +146,7 @@ final class WorkspaceNavigationHandler {
                 controller.focusWindow(focusToken)
                 if focusedTokenNeedsRevealRelayout {
                     controller.axManager.forceApplyNextFrame(for: focusToken.windowId)
-                    controller.layoutRefreshController.requestImmediateRelayout(
+                    controller.layoutRefreshController.requestRefresh(
                         reason: .workspaceTransition,
                         affectedWorkspaceIds: [targetWorkspaceId]
                     )

--- a/Sources/Nehir/Core/Overview/OverviewController.swift
+++ b/Sources/Nehir/Core/Overview/OverviewController.swift
@@ -1026,7 +1026,7 @@ private extension OverviewController {
             wmController.layoutRefreshController.startScrollAnimation(for: targetWsId)
         }
 
-        wmController.layoutRefreshController.requestImmediateRelayout(reason: .overviewMutation)
+        wmController.layoutRefreshController.requestRefresh(reason: .overviewMutation)
     }
 
     func overviewInsertPositionToNiri(_ position: InsertPosition) -> InsertPosition {

--- a/Tests/NehirTests/RefreshRoutingTests.swift
+++ b/Tests/NehirTests/RefreshRoutingTests.swift
@@ -616,27 +616,28 @@ private func syncNiriWorkspaceStatesForRefreshTests(
 
 @Suite(.serialized) struct RefreshRoutingTests {
     @Test func relayoutPoliciesAreExplicit() {
-        #expect(RefreshReason.axWindowChanged.relayoutSchedulingPolicy == .debounced(
+        #expect(RefreshReason.axWindowChanged.scheduling == .debounced(
             nanoseconds: 8_000_000,
             dropWhileBusy: true
         ))
-        #expect(RefreshReason.axWindowCreated.relayoutSchedulingPolicy == .debounced(
+        #expect(RefreshReason.axWindowCreated.scheduling == .debounced(
             nanoseconds: 4_000_000,
             dropWhileBusy: false
         ))
-        #expect(RefreshReason.gapsChanged.relayoutSchedulingPolicy == .plain)
-        #expect(RefreshReason.workspaceTransition.relayoutSchedulingPolicy == .plain)
-        #expect(RefreshReason.windowRuleReevaluation.relayoutSchedulingPolicy == .plain)
+        #expect(RefreshReason.gapsChanged.scheduling == .plain)
+        #expect(RefreshReason.workspaceTransition.scheduling == .plain)
+        #expect(RefreshReason.windowRuleReevaluation.scheduling == .plain)
     }
 
     @Test func refreshRoutesAreExplicit() {
-        #expect(RefreshReason.appLaunched.requestRoute == .fullRescan)
-        #expect(RefreshReason.gapsChanged.requestRoute == .relayout)
-        #expect(RefreshReason.workspaceTransition.requestRoute == .immediateRelayout)
-        #expect(RefreshReason.appHidden.requestRoute == .visibilityRefresh)
-        #expect(RefreshReason.appUnhidden.requestRoute == .visibilityRefresh)
-        #expect(RefreshReason.windowDestroyed.requestRoute == .windowRemoval)
-        #expect(RefreshReason.windowRuleReevaluation.requestRoute == .relayout)
+        #expect(RefreshReason.hasCompleteRoutingTable)
+        #expect(RefreshReason.appLaunched.route == .fullRescan)
+        #expect(RefreshReason.gapsChanged.route == .relayout)
+        #expect(RefreshReason.workspaceTransition.route == .immediateRelayout)
+        #expect(RefreshReason.appHidden.route == .visibilityRefresh)
+        #expect(RefreshReason.appUnhidden.route == .visibilityRefresh)
+        #expect(RefreshReason.windowDestroyed.route == .windowRemoval)
+        #expect(RefreshReason.windowRuleReevaluation.route == .relayout)
     }
 
     @Test @MainActor func startupRestorePreservesPersistedNiriStackedColumnsAndWidths() async throws {


### PR DESCRIPTION
## Summary

<!-- What changed and why? -->

## Release notes

Choose one:

- [x] Added a `.changeset/*.md` for user-visible changes (`mise run changeset -- patch "..."`).
- [ ] No user-visible change; apply the `no release note` label to make CI skip intentional.

## Validation

<!-- Commands run, screenshots, or manual checks. -->

- [ ] Ran relevant tests/checks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated internal layout refresh request handling through a centralized routing system. Runtime behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->