### PR TITLE
Refactor viewport handling and update lone-window policy

### DIFF
--- a/.changeset/20260614041850-improved-niri-layout-behavior-and-monitor-specif.md
+++ b/.changeset/20260614041850-improved-niri-layout-behavior-and-monitor-specif.md
@@ -1,0 +1,15 @@
+---
+"nehir": minor
+
+---
+
+Breaking: improved Niri layout behavior and monitor-specific layout settings with a simplified configuration model.
+
+- **Breaking:** renamed the Niri balanced-width config from `maxVisibleColumns` / `niriMaxVisibleColumns` to `balancedColumnCount` / `niriBalancedColumnCount`. Old keys are not migrated or accepted.
+- **Breaking:** replaced the old single-window aspect-ratio config with **Lone Window** policy. Use `Fill` for full working-area lone windows, or `Centered(width)` for capped centered lone windows.
+- Added per-monitor spacing overrides in Layout settings. You can now customize **Inner Gap** and per-edge **Screen Margins** separately for each display, while leaving individual values set to **Use Global** when you want them to inherit the global defaults.
+- Added explicit per-monitor **Lone Window** overrides. Each monitor can now use **Use Global**, **Fill**, or **Centered** with its own centered width, so a display can intentionally force Fill even when the global default is Centered.
+- Fixed lone-window layouts after monitor changes. When a constrained single window is left alone on a smaller or different display, Nehir now keeps it inside the monitor’s visible area instead of letting it leak offscreen.
+- Made lone-window scrolling and snapping more predictable. Fill lone windows remain responsive while scrolling but no longer settle one gap off-center; centered lone windows can still snap left, center, or right; and over-constrained lone windows can be scrolled to reveal their overflowing edges.
+- Corrected inner-gap semantics for stacked and tabbed columns. Inner gap now means spacing between adjacent tiled windows, not extra top/bottom padding at the monitor edge. Use screen margins/outer gaps for edge padding.
+- Preserved proportional column behavior for viewport-fitting layouts such as `50% + 50%` and Reveal Partial’s `Default` mode, so existing proportional Niri workflows continue to fit naturally.

--- a/Info.plist
+++ b/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.4.1</string>
+	<string>0.0.0</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSMinimumSystemVersion</key>

--- a/Sources/Nehir/Core/Config/BuiltInSettingsDefaults.swift
+++ b/Sources/Nehir/Core/Config/BuiltInSettingsDefaults.swift
@@ -2,9 +2,10 @@ import Foundation
 
 enum BuiltInSettingsDefaults {
     static let niriColumnWidthPresets: [Double] = [
-        0.33333333333333331,
-        0.5,
-        0.66666666666666663
+        0.35,
+        0.50,
+        0.65,
+        0.95
     ]
 
     static let workspaceConfigurations: [WorkspaceConfiguration] = [

--- a/Sources/Nehir/Core/Config/CanonicalTOMLConfig.swift
+++ b/Sources/Nehir/Core/Config/CanonicalTOMLConfig.swift
@@ -57,10 +57,10 @@ struct CanonicalTOMLConfig: Codable, Equatable {
     }
 
     struct Niri: Codable, Equatable {
-        var maxVisibleColumns: Int
+        var balancedColumnCount: Int
         var infiniteLoop: Bool
         var revealPartial: String
-        var singleWindowAspectRatio: String
+        var loneWindowMaxWidth: Double?
         var columnWidthPresets: [Double]?
         var defaultColumnWidth: Double?
     }
@@ -171,10 +171,10 @@ extension CanonicalTOMLConfig {
             )
         )
         niri = Niri(
-            maxVisibleColumns: export.niriMaxVisibleColumns,
+            balancedColumnCount: export.niriBalancedColumnCount,
             infiniteLoop: export.niriInfiniteLoop,
             revealPartial: export.revealPartial,
-            singleWindowAspectRatio: export.niriSingleWindowAspectRatio,
+            loneWindowMaxWidth: export.niriLoneWindowMaxWidth,
             columnWidthPresets: export.niriColumnWidthPresets,
             defaultColumnWidth: export.niriDefaultColumnWidth
         )
@@ -237,10 +237,10 @@ extension CanonicalTOMLConfig {
             outerGapRight: gaps.outer.right,
             outerGapTop: gaps.outer.top,
             outerGapBottom: gaps.outer.bottom,
-            niriMaxVisibleColumns: niri.maxVisibleColumns,
+            niriBalancedColumnCount: niri.balancedColumnCount,
             niriInfiniteLoop: niri.infiniteLoop,
             revealPartial: niri.revealPartial,
-            niriSingleWindowAspectRatio: niri.singleWindowAspectRatio,
+            niriLoneWindowMaxWidth: niri.loneWindowMaxWidth,
             niriColumnWidthPresets: niri.columnWidthPresets,
             niriDefaultColumnWidth: niri.defaultColumnWidth,
             workspaceConfigurations: BuiltInSettingsDefaults.workspaceConfigurations,
@@ -270,6 +270,7 @@ extension CanonicalTOMLConfig {
             workspaceBarLabelFontSize: workspaceBar.labelFontSize,
             monitorBarSettings: [],
             appRules: BuiltInSettingsDefaults.appRules,
+            monitorGapSettings: [],
             monitorOrientationSettings: [],
             monitorNiriSettings: [],
             preventSleepEnabled: general.preventSleepEnabled,
@@ -363,10 +364,10 @@ extension CanonicalTOMLConfig.Niri {
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         let d = CanonicalTOMLConfig.defaults().niri
-        maxVisibleColumns = try container.decodeWithDefault(Int.self, forKey: .maxVisibleColumns, default: d.maxVisibleColumns)
+        balancedColumnCount = try container.decodeWithDefault(Int.self, forKey: .balancedColumnCount, default: d.balancedColumnCount)
         infiniteLoop = try container.decodeWithDefault(Bool.self, forKey: .infiniteLoop, default: d.infiniteLoop)
         revealPartial = try container.decodeWithDefault(String.self, forKey: .revealPartial, default: d.revealPartial)
-        singleWindowAspectRatio = try container.decodeWithDefault(String.self, forKey: .singleWindowAspectRatio, default: d.singleWindowAspectRatio)
+        loneWindowMaxWidth = try container.decodeIfPresent(Double.self, forKey: .loneWindowMaxWidth)
         columnWidthPresets = try container.decodeIfPresent([Double].self, forKey: .columnWidthPresets)
         defaultColumnWidth = try container.decodeIfPresent(Double.self, forKey: .defaultColumnWidth)
     }

--- a/Sources/Nehir/Core/Config/MonitorGapSettings.swift
+++ b/Sources/Nehir/Core/Config/MonitorGapSettings.swift
@@ -1,0 +1,55 @@
+import CoreGraphics
+import Foundation
+
+struct MonitorGapSettings: MonitorSettingsType {
+    let id: UUID
+    var monitorName: String
+    var monitorDisplayId: CGDirectDisplayID?
+
+    var gapSize: Double?
+    var outerGapLeft: Double?
+    var outerGapRight: Double?
+    var outerGapTop: Double?
+    var outerGapBottom: Double?
+
+    var hasOverrides: Bool {
+        gapSize != nil || outerGapLeft != nil || outerGapRight != nil || outerGapTop != nil || outerGapBottom != nil
+    }
+
+    init(
+        id: UUID = UUID(),
+        monitorName: String,
+        monitorDisplayId: CGDirectDisplayID? = nil,
+        gapSize: Double? = nil,
+        outerGapLeft: Double? = nil,
+        outerGapRight: Double? = nil,
+        outerGapTop: Double? = nil,
+        outerGapBottom: Double? = nil
+    ) {
+        self.id = id
+        self.monitorName = monitorName
+        self.monitorDisplayId = monitorDisplayId
+        self.gapSize = gapSize
+        self.outerGapLeft = outerGapLeft
+        self.outerGapRight = outerGapRight
+        self.outerGapTop = outerGapTop
+        self.outerGapBottom = outerGapBottom
+    }
+}
+
+struct ResolvedGapSettings: Equatable {
+    let gapSize: Double
+    let outerGapLeft: Double
+    let outerGapRight: Double
+    let outerGapTop: Double
+    let outerGapBottom: Double
+
+    var outerGaps: LayoutGaps.OuterGaps {
+        LayoutGaps.OuterGaps(
+            left: CGFloat(outerGapLeft),
+            right: CGFloat(outerGapRight),
+            top: CGFloat(outerGapTop),
+            bottom: CGFloat(outerGapBottom)
+        )
+    }
+}

--- a/Sources/Nehir/Core/Config/MonitorNiriSettings.swift
+++ b/Sources/Nehir/Core/Config/MonitorNiriSettings.swift
@@ -6,25 +6,25 @@ struct MonitorNiriSettings: MonitorSettingsType {
     var monitorName: String
     var monitorDisplayId: CGDirectDisplayID?
 
-    var maxVisibleColumns: Int?
-    var singleWindowAspectRatio: SingleWindowAspectRatio?
+    var balancedColumnCount: Int?
+    var loneWindowPolicy: LoneWindowPolicy?
 
     init(
         id: UUID = UUID(),
         monitorName: String,
         monitorDisplayId: CGDirectDisplayID? = nil,
-        maxVisibleColumns: Int? = nil,
-        singleWindowAspectRatio: SingleWindowAspectRatio? = nil
+        balancedColumnCount: Int? = nil,
+        loneWindowPolicy: LoneWindowPolicy? = nil
     ) {
         self.id = id
         self.monitorName = monitorName
         self.monitorDisplayId = monitorDisplayId
-        self.maxVisibleColumns = maxVisibleColumns
-        self.singleWindowAspectRatio = singleWindowAspectRatio
+        self.balancedColumnCount = balancedColumnCount
+        self.loneWindowPolicy = loneWindowPolicy
     }
 
     private enum CodingKeys: String, CodingKey {
-        case id, monitorName, monitorDisplayId, maxVisibleColumns, singleWindowAspectRatio
+        case id, monitorName, monitorDisplayId, balancedColumnCount, loneWindowPolicy
     }
 
     init(from decoder: Decoder) throws {
@@ -32,9 +32,8 @@ struct MonitorNiriSettings: MonitorSettingsType {
         id = try container.decode(UUID.self, forKey: .id)
         monitorName = try container.decode(String.self, forKey: .monitorName)
         monitorDisplayId = try container.decodeIfPresent(CGDirectDisplayID.self, forKey: .monitorDisplayId)
-        maxVisibleColumns = try container.decodeIfPresent(Int.self, forKey: .maxVisibleColumns)
-        singleWindowAspectRatio = try container.decodeIfPresent(String.self, forKey: .singleWindowAspectRatio)
-            .flatMap { SingleWindowAspectRatio(rawValue: $0) }
+        balancedColumnCount = try container.decodeIfPresent(Int.self, forKey: .balancedColumnCount)
+        loneWindowPolicy = try container.decodeIfPresent(LoneWindowPolicy.self, forKey: .loneWindowPolicy)
     }
 
     func encode(to encoder: Encoder) throws {
@@ -42,13 +41,13 @@ struct MonitorNiriSettings: MonitorSettingsType {
         try container.encode(id, forKey: .id)
         try container.encode(monitorName, forKey: .monitorName)
         try container.encodeIfPresent(monitorDisplayId, forKey: .monitorDisplayId)
-        try container.encodeIfPresent(maxVisibleColumns, forKey: .maxVisibleColumns)
-        try container.encodeIfPresent(singleWindowAspectRatio?.rawValue, forKey: .singleWindowAspectRatio)
+        try container.encodeIfPresent(balancedColumnCount, forKey: .balancedColumnCount)
+        try container.encodeIfPresent(loneWindowPolicy, forKey: .loneWindowPolicy)
     }
 }
 
 struct ResolvedNiriSettings: Equatable {
-    let maxVisibleColumns: Int
-    let singleWindowAspectRatio: SingleWindowAspectRatio
+    let defaultColumnWidth: DefaultColumnWidth
+    let loneWindowPolicy: LoneWindowPolicy
     let infiniteLoop: Bool
 }

--- a/Sources/Nehir/Core/Config/MonitorOverrideFileStore.swift
+++ b/Sources/Nehir/Core/Config/MonitorOverrideFileStore.swift
@@ -7,12 +7,14 @@ import Foundation
 enum MonitorOverrideFileStore {
     struct Documents {
         var bar: [MonitorBarSettings]
+        var gaps: [MonitorGapSettings]
         var orientation: [MonitorOrientationSettings]
         var niri: [MonitorNiriSettings]
     }
 
     static func write(
         bar: [MonitorBarSettings],
+        gaps: [MonitorGapSettings],
         orientation: [MonitorOrientationSettings],
         niri: [MonitorNiriSettings],
         to directory: URL
@@ -28,6 +30,9 @@ enum MonitorOverrideFileStore {
         var keys: [MonitorKey: MonitorDocument] = [:]
         for item in bar {
             keys[MonitorKey(name: item.monitorName, displayId: item.monitorDisplayId), default: .init()].bar = item
+        }
+        for item in gaps where item.hasOverrides {
+            keys[MonitorKey(name: item.monitorName, displayId: item.monitorDisplayId), default: .init()].gaps = item
         }
         for item in orientation {
             keys[MonitorKey(name: item.monitorName, displayId: item.monitorDisplayId), default: .init()].orientation = item
@@ -45,14 +50,15 @@ enum MonitorOverrideFileStore {
     static func read(from directory: URL) -> Documents {
         let fm = FileManager.default
         guard let contents = try? fm.contentsOfDirectory(at: directory, includingPropertiesForKeys: [.nameKey], options: [.skipsHiddenFiles]) else {
-            return Documents(bar: [], orientation: [], niri: [])
+            return Documents(bar: [], gaps: [], orientation: [], niri: [])
         }
-        var result = Documents(bar: [], orientation: [], niri: [])
+        var result = Documents(bar: [], gaps: [], orientation: [], niri: [])
         for fileURL in contents.filter({ $0.pathExtension == "toml" }).sorted(by: { $0.lastPathComponent < $1.lastPathComponent }) {
             guard let content = try? String(contentsOf: fileURL, encoding: .utf8),
                   let document = decode(content)
             else { continue }
             if let bar = document.bar { result.bar.append(bar) }
+            if let gaps = document.gaps { result.gaps.append(gaps) }
             if let orientation = document.orientation { result.orientation.append(orientation) }
             if let niri = document.niri { result.niri.append(niri) }
         }
@@ -66,6 +72,7 @@ enum MonitorOverrideFileStore {
 
     private struct MonitorDocument {
         var bar: MonitorBarSettings?
+        var gaps: MonitorGapSettings?
         var orientation: MonitorOrientationSettings?
         var niri: MonitorNiriSettings?
     }
@@ -76,11 +83,29 @@ enum MonitorOverrideFileStore {
         lines.append("name = \(quoted(key.name))")
         if let displayId = key.displayId { lines.append("displayId = \(displayId)") }
 
+        if let gaps = document.gaps, gaps.hasOverrides {
+            lines.append("")
+            lines.append("[gaps]")
+            if let v = gaps.gapSize { lines.append("size = \(formatNumber(v))") }
+            if let v = gaps.outerGapLeft { lines.append("outerLeft = \(formatNumber(v))") }
+            if let v = gaps.outerGapRight { lines.append("outerRight = \(formatNumber(v))") }
+            if let v = gaps.outerGapTop { lines.append("outerTop = \(formatNumber(v))") }
+            if let v = gaps.outerGapBottom { lines.append("outerBottom = \(formatNumber(v))") }
+        }
+
         if let niri = document.niri {
             lines.append("")
             lines.append("[niri]")
-            if let v = niri.maxVisibleColumns { lines.append("maxVisibleColumns = \(v)") }
-            if let v = niri.singleWindowAspectRatio { lines.append("singleWindowAspectRatio = \(quoted(v.rawValue))") }
+            if let v = niri.balancedColumnCount { lines.append("balancedColumnCount = \(v)") }
+            switch niri.loneWindowPolicy {
+            case .fill:
+                lines.append("loneWindowPolicy = \(quoted("fill"))")
+            case let .centered(maxWidthFraction):
+                lines.append("loneWindowPolicy = \(quoted("centered"))")
+                lines.append("loneWindowMaxWidth = \(formatNumber(maxWidthFraction))")
+            case .none:
+                break
+            }
         }
 
         if let bar = document.bar {
@@ -130,12 +155,35 @@ enum MonitorOverrideFileStore {
         let displayId = match["displayId"].flatMap { CGDirectDisplayID($0.trimmingCharacters(in: .whitespaces)) }
         var document = MonitorDocument()
 
+        if let gaps = fields["gaps"] {
+            document.gaps = MonitorGapSettings(
+                monitorName: name,
+                monitorDisplayId: displayId,
+                gapSize: gaps["size"].flatMap(extractDouble),
+                outerGapLeft: gaps["outerLeft"].flatMap(extractDouble),
+                outerGapRight: gaps["outerRight"].flatMap(extractDouble),
+                outerGapTop: gaps["outerTop"].flatMap(extractDouble),
+                outerGapBottom: gaps["outerBottom"].flatMap(extractDouble)
+            )
+        }
+
         if let niri = fields["niri"] {
+            let policyRaw = niri["loneWindowPolicy"].flatMap(extractString)?.lowercased()
+            let maxWidth = niri["loneWindowMaxWidth"].flatMap(extractDouble)
+            let loneWindowPolicy: LoneWindowPolicy?
+            switch policyRaw {
+            case "fill":
+                loneWindowPolicy = .fill
+            case "centered":
+                loneWindowPolicy = .centered(maxWidthFraction: maxWidth ?? 0.6)
+            default:
+                loneWindowPolicy = nil
+            }
             document.niri = MonitorNiriSettings(
                 monitorName: name,
                 monitorDisplayId: displayId,
-                maxVisibleColumns: niri["maxVisibleColumns"].flatMap { Int($0.trimmingCharacters(in: .whitespaces)) },
-                singleWindowAspectRatio: niri["singleWindowAspectRatio"].flatMap(extractString).flatMap(SingleWindowAspectRatio.init(rawValue:))
+                balancedColumnCount: niri["balancedColumnCount"].flatMap { Int($0.trimmingCharacters(in: .whitespaces)) },
+                loneWindowPolicy: loneWindowPolicy
             )
         }
 

--- a/Sources/Nehir/Core/Config/SettingsExport.swift
+++ b/Sources/Nehir/Core/Config/SettingsExport.swift
@@ -24,10 +24,10 @@ struct SettingsExport: Equatable {
     var outerGapTop: Double
     var outerGapBottom: Double
 
-    var niriMaxVisibleColumns: Int
+    var niriBalancedColumnCount: Int
     var niriInfiniteLoop: Bool
     var revealPartial: String
-    var niriSingleWindowAspectRatio: String
+    var niriLoneWindowMaxWidth: Double?
     var niriColumnWidthPresets: [Double]?
     var niriDefaultColumnWidth: Double?
 
@@ -62,6 +62,7 @@ struct SettingsExport: Equatable {
     var monitorBarSettings: [MonitorBarSettings]
 
     var appRules: [AppRule]
+    var monitorGapSettings: [MonitorGapSettings]
     var monitorOrientationSettings: [MonitorOrientationSettings]
     var monitorNiriSettings: [MonitorNiriSettings]
 
@@ -101,12 +102,12 @@ extension SettingsExport {
             outerGapRight: 0,
             outerGapTop: 0,
             outerGapBottom: 0,
-            niriMaxVisibleColumns: 2,
+            niriBalancedColumnCount: 2,
             niriInfiniteLoop: false,
             revealPartial: RevealPartial.default.rawValue,
-            niriSingleWindowAspectRatio: SingleWindowAspectRatio.none.rawValue,
+            niriLoneWindowMaxWidth: nil,
             niriColumnWidthPresets: BuiltInSettingsDefaults.niriColumnWidthPresets,
-            niriDefaultColumnWidth: 0.5,
+            niriDefaultColumnWidth: nil,
             workspaceConfigurations: BuiltInSettingsDefaults.workspaceConfigurations,
             bordersEnabled: true,
             borderWidth: 5.0,
@@ -134,6 +135,7 @@ extension SettingsExport {
             workspaceBarLabelFontSize: 12,
             monitorBarSettings: [],
             appRules: BuiltInSettingsDefaults.appRules,
+            monitorGapSettings: [],
             monitorOrientationSettings: [],
             monitorNiriSettings: [],
             preventSleepEnabled: false,

--- a/Sources/Nehir/Core/Config/SettingsFilePersistence.swift
+++ b/Sources/Nehir/Core/Config/SettingsFilePersistence.swift
@@ -151,6 +151,7 @@ final class SettingsFilePersistence {
         try AppRuleFileStore.write(export.appRules, to: appRulesDirectoryURL)
         try MonitorOverrideFileStore.write(
             bar: export.monitorBarSettings,
+            gaps: export.monitorGapSettings,
             orientation: export.monitorOrientationSettings,
             niri: export.monitorNiriSettings,
             to: monitorsDirectoryURL
@@ -444,6 +445,7 @@ final class SettingsFilePersistence {
 
         let monitorOverrides = MonitorOverrideFileStore.read(from: monitorsDirectoryURL)
         export.monitorBarSettings = monitorOverrides.bar
+        export.monitorGapSettings = monitorOverrides.gaps
         export.monitorOrientationSettings = monitorOverrides.orientation
         export.monitorNiriSettings = monitorOverrides.niri
 

--- a/Sources/Nehir/Core/Config/SettingsStore.swift
+++ b/Sources/Nehir/Core/Config/SettingsStore.swift
@@ -83,7 +83,7 @@ final class SettingsStore {
         didSet { scheduleSave() }
     }
 
-    var niriMaxVisibleColumns = SettingsStore.defaultExport.niriMaxVisibleColumns {
+    var niriBalancedColumnCount = SettingsStore.defaultExport.niriBalancedColumnCount {
         didSet { scheduleSave() }
     }
 
@@ -97,10 +97,29 @@ final class SettingsStore {
         didSet { scheduleSave() }
     }
 
-    var niriSingleWindowAspectRatio = SingleWindowAspectRatio(
-        rawValue: SettingsStore.defaultExport.niriSingleWindowAspectRatio
-    ) ?? .none {
-        didSet { scheduleSave() }
+    var niriLoneWindowMaxWidth = SettingsStore.validatedLoneWindowMaxWidth(
+        SettingsStore.defaultExport.niriLoneWindowMaxWidth
+    ) {
+        didSet {
+            let validated = SettingsStore.validatedLoneWindowMaxWidth(niriLoneWindowMaxWidth)
+            if validated != niriLoneWindowMaxWidth {
+                niriLoneWindowMaxWidth = validated
+                return
+            }
+            scheduleSave()
+        }
+    }
+
+    var loneWindowPolicy: LoneWindowPolicy {
+        guard let maxWidth = niriLoneWindowMaxWidth else { return .fill }
+        return .centered(maxWidthFraction: maxWidth)
+    }
+
+    var defaultColumnWidth: DefaultColumnWidth {
+        if let width = niriDefaultColumnWidth {
+            return .custom(fraction: width)
+        }
+        return .balanced(columns: niriBalancedColumnCount)
     }
 
     var workspaceConfigurations = SettingsStore.defaultExport.workspaceConfigurations {
@@ -208,6 +227,10 @@ final class SettingsStore {
     }
 
     var appRules = SettingsStore.defaultExport.appRules {
+        didSet { scheduleSave() }
+    }
+
+    var monitorGapSettings = SettingsStore.defaultExport.monitorGapSettings {
         didSet { scheduleSave() }
     }
 
@@ -344,6 +367,7 @@ final class SettingsStore {
         if !fm.fileExists(atPath: persistence.monitorsDirectoryURL.path) {
             try MonitorOverrideFileStore.write(
                 bar: export.monitorBarSettings,
+                gaps: export.monitorGapSettings,
                 orientation: export.monitorOrientationSettings,
                 niri: export.monitorNiriSettings,
                 to: persistence.monitorsDirectoryURL
@@ -374,10 +398,10 @@ final class SettingsStore {
             outerGapRight: outerGapRight,
             outerGapTop: outerGapTop,
             outerGapBottom: outerGapBottom,
-            niriMaxVisibleColumns: niriMaxVisibleColumns,
+            niriBalancedColumnCount: niriBalancedColumnCount,
             niriInfiniteLoop: niriInfiniteLoop,
             revealPartial: revealPartial.rawValue,
-            niriSingleWindowAspectRatio: niriSingleWindowAspectRatio.rawValue,
+            niriLoneWindowMaxWidth: niriLoneWindowMaxWidth,
             niriColumnWidthPresets: niriColumnWidthPresets,
             niriDefaultColumnWidth: niriDefaultColumnWidth,
             workspaceConfigurations: workspaceConfigurations,
@@ -407,6 +431,7 @@ final class SettingsStore {
             workspaceBarLabelFontSize: 12,
             monitorBarSettings: monitorBarSettings,
             appRules: appRules,
+            monitorGapSettings: monitorGapSettings,
             monitorOrientationSettings: monitorOrientationSettings,
             monitorNiriSettings: monitorNiriSettings,
             preventSleepEnabled: preventSleepEnabled,
@@ -444,10 +469,10 @@ final class SettingsStore {
         outerGapTop = export.outerGapTop
         outerGapBottom = export.outerGapBottom
 
-        niriMaxVisibleColumns = export.niriMaxVisibleColumns
+        niriBalancedColumnCount = export.niriBalancedColumnCount
         niriInfiniteLoop = export.niriInfiniteLoop
         revealPartial = RevealPartial(rawValue: export.revealPartial) ?? .default
-        niriSingleWindowAspectRatio = SingleWindowAspectRatio(rawValue: export.niriSingleWindowAspectRatio) ?? .none
+        niriLoneWindowMaxWidth = SettingsStore.validatedLoneWindowMaxWidth(export.niriLoneWindowMaxWidth)
         niriColumnWidthPresets = SettingsStore.validatedPresets(
             export.niriColumnWidthPresets ?? baseline.niriColumnWidthPresets ?? SettingsStore.defaultColumnWidthPresets
         )
@@ -486,6 +511,7 @@ final class SettingsStore {
         monitorBarSettings = SettingsStore.reboundMonitorSettings(export.monitorBarSettings, monitors: monitors)
 
         appRules = export.appRules
+        monitorGapSettings = SettingsStore.reboundMonitorSettings(export.monitorGapSettings, monitors: monitors)
         monitorOrientationSettings = SettingsStore.reboundMonitorSettings(
             export.monitorOrientationSettings,
             monitors: monitors
@@ -703,6 +729,37 @@ final class SettingsStore {
         appRules.first { $0.bundleId == bundleId }
     }
 
+    func gapSettings(for monitor: Monitor) -> MonitorGapSettings? {
+        MonitorSettingsStore.get(for: monitor, in: monitorGapSettings)
+    }
+
+    func gapSettings(for monitorName: String) -> MonitorGapSettings? {
+        MonitorSettingsStore.get(for: monitorName, in: monitorGapSettings)
+    }
+
+    func updateGapSettings(_ settings: MonitorGapSettings) {
+        MonitorSettingsStore.update(settings, in: &monitorGapSettings)
+    }
+
+    func removeGapSettings(for monitor: Monitor) {
+        MonitorSettingsStore.remove(for: monitor, from: &monitorGapSettings)
+    }
+
+    func removeGapSettings(for monitorName: String) {
+        MonitorSettingsStore.remove(for: monitorName, from: &monitorGapSettings)
+    }
+
+    func resolvedGapSettings(for monitor: Monitor) -> ResolvedGapSettings {
+        let override = gapSettings(for: monitor)
+        return ResolvedGapSettings(
+            gapSize: (override?.gapSize ?? gapSize).clamped(to: 0 ... 64),
+            outerGapLeft: (override?.outerGapLeft ?? outerGapLeft).clamped(to: 0 ... 64),
+            outerGapRight: (override?.outerGapRight ?? outerGapRight).clamped(to: 0 ... 64),
+            outerGapTop: (override?.outerGapTop ?? outerGapTop).clamped(to: 0 ... 64),
+            outerGapBottom: (override?.outerGapBottom ?? outerGapBottom).clamped(to: 0 ... 64)
+        )
+    }
+
     func orientationSettings(for monitor: Monitor) -> MonitorOrientationSettings? {
         MonitorSettingsStore.get(for: monitor, in: monitorOrientationSettings)
     }
@@ -761,9 +818,28 @@ final class SettingsStore {
     }
 
     private func resolvedNiriSettings(override: MonitorNiriSettings?) -> ResolvedNiriSettings {
+        let resolvedDefaultColumnWidth: DefaultColumnWidth
+        if let balancedColumnCount = override?.balancedColumnCount,
+           niriDefaultColumnWidth == nil
+        {
+            // balancedColumnCount only affects the Balanced column count. When the global mode is
+            // Custom (non-nil defaultColumnWidth), preserve the custom fraction and ignore the
+            // monitor count override so it doesn't silently defeat the global custom width.
+            resolvedDefaultColumnWidth = .balanced(columns: balancedColumnCount.clamped(to: 1 ... 5))
+        } else {
+            resolvedDefaultColumnWidth = defaultColumnWidth
+        }
+
+        let resolvedLoneWindowPolicy: LoneWindowPolicy
+        if let overridePolicy = override?.loneWindowPolicy {
+            resolvedLoneWindowPolicy = overridePolicy
+        } else {
+            resolvedLoneWindowPolicy = loneWindowPolicy
+        }
+
         return ResolvedNiriSettings(
-            maxVisibleColumns: override?.maxVisibleColumns ?? niriMaxVisibleColumns,
-            singleWindowAspectRatio: override?.singleWindowAspectRatio ?? niriSingleWindowAspectRatio,
+            defaultColumnWidth: resolvedDefaultColumnWidth,
+            loneWindowPolicy: resolvedLoneWindowPolicy,
             infiniteLoop: niriInfiniteLoop
         )
     }
@@ -781,5 +857,10 @@ final class SettingsStore {
     static func validatedDefaultColumnWidth(_ width: Double?) -> Double? {
         guard let width else { return nil }
         return min(1.0, max(0.05, width))
+    }
+
+    static func validatedLoneWindowMaxWidth(_ width: Double?) -> Double? {
+        guard let width else { return nil }
+        return min(0.95, max(0.10, width))
     }
 }

--- a/Sources/Nehir/Core/Controller/AXEventHandler.swift
+++ b/Sources/Nehir/Core/Controller/AXEventHandler.swift
@@ -1793,14 +1793,15 @@ final class AXEventHandler: CGSEventDelegate {
                let columnIndex = engine.columnIndex(of: column, in: wsId),
                let monitor = controller.workspaceManager.monitor(for: wsId)
             {
-                let gap = CGFloat(controller.workspaceManager.gaps)
+                let gap = controller.gapSize(for: monitor)
                 let workingFrame = controller.insetWorkingFrame(for: monitor)
                 let columns = engine.columns(in: wsId)
                 let context = engine.makeViewportSnapContext(
                     columns: columns,
                     state: state,
                     workingFrame: workingFrame,
-                    gaps: gap
+                    gaps: gap,
+                    intentionallyDoesNotFillViewport: engine.loneWindowIntentionallyDoesNotFillViewport(in: wsId)
                 )
                 let viewStart = context.currentViewStart(in: state)
                 let visibility = context.visibility(of: columnIndex, viewportOffset: viewStart, in: state)

--- a/Sources/Nehir/Core/Controller/CommandHandler.swift
+++ b/Sources/Nehir/Core/Controller/CommandHandler.swift
@@ -459,7 +459,7 @@ final class CommandHandler {
             return
         }
 
-        let gap = CGFloat(controller.workspaceManager.gaps)
+        let gap = controller.gapSize(for: monitor)
         let workingFrame = controller.insetWorkingFrame(for: monitor)
         let motion = controller.motionPolicy.snapshot()
         guard let newNode = navigationAction(engine, currentNode, wsId, motion, &state, workingFrame, gap) else {

--- a/Sources/Nehir/Core/Controller/LayoutRefreshController.swift
+++ b/Sources/Nehir/Core/Controller/LayoutRefreshController.swift
@@ -477,7 +477,8 @@ import QuartzCore
     func buildWindowSnapshots(
         for entries: [WindowModel.Entry],
         resolveConstraints: Bool = true,
-        workingFrame: CGRect? = nil
+        workingFrame: CGRect? = nil,
+        containingFrame: CGRect? = nil
     ) -> [LayoutWindowSnapshot] {
         guard let controller else { return [] }
 
@@ -520,7 +521,8 @@ import QuartzCore
                 for: mergedConstraints,
                 layoutReason: layoutReason,
                 hiddenState: hiddenState,
-                workingFrame: workingFrame
+                workingFrame: workingFrame,
+                containingFrame: containingFrame
             )
 
             snapshots.append(
@@ -543,7 +545,8 @@ import QuartzCore
         for constraints: WindowSizeConstraints,
         layoutReason: LayoutReason,
         hiddenState: WindowModel.HiddenState?,
-        workingFrame: CGRect?
+        workingFrame: CGRect?,
+        containingFrame: CGRect?
     ) -> WindowSizeConstraints {
         let effectiveConstraints = constraints.normalized()
 
@@ -559,8 +562,9 @@ import QuartzCore
         }
 
         let tolerance: CGFloat = 0.5
-        if effectiveConstraints.minSize.width <= workingFrame.width + tolerance,
-           effectiveConstraints.minSize.height <= workingFrame.height + tolerance
+        let feasibilityFrame = containingFrame ?? workingFrame
+        if effectiveConstraints.minSize.width <= feasibilityFrame.width + tolerance,
+           effectiveConstraints.minSize.height <= feasibilityFrame.height + tolerance
         {
             return effectiveConstraints
         }
@@ -597,7 +601,8 @@ import QuartzCore
         let windows = buildWindowSnapshots(
             for: entries,
             resolveConstraints: resolveConstraints,
-            workingFrame: monitorSnapshot.workingFrame
+            workingFrame: monitorSnapshot.workingFrame,
+            containingFrame: monitorSnapshot.visibleFrame
         )
 
         return WorkspaceRefreshInput(

--- a/Sources/Nehir/Core/Controller/MouseEventHandler.swift
+++ b/Sources/Nehir/Core/Controller/MouseEventHandler.swift
@@ -843,7 +843,7 @@ final class MouseEventHandler {
                let monitor = controller.workspaceManager.monitor(for: wsId)
             {
                 let workingFrame = controller.insetWorkingFrame(for: monitor)
-                let gaps = CGFloat(controller.workspaceManager.gaps)
+                let gaps = controller.gapSize(for: monitor)
 
                 let isInsertMode = modifiers.contains(.maskShift)
                 var moveStarted = false
@@ -979,7 +979,8 @@ final class MouseEventHandler {
                                   targetWindowId: nodeId,
                                   position: insertPosition,
                                   in: wsId,
-                                  gaps: CGFloat(controller.workspaceManager.gaps)
+                                  gaps: controller.workspaceManager.monitor(for: wsId).map { controller.gapSize(for: $0) }
+                                      ?? CGFloat(controller.workspaceManager.gaps)
                               )
                     {
                         state.dragGhostController?.showSwapTarget(frame: dropFrame)
@@ -1004,9 +1005,9 @@ final class MouseEventHandler {
         }
 
         let gaps = LayoutGaps(
-            horizontal: CGFloat(controller.workspaceManager.gaps),
-            vertical: CGFloat(controller.workspaceManager.gaps),
-            outer: controller.workspaceManager.outerGaps
+            horizontal: controller.gapSize(for: monitor),
+            vertical: controller.gapSize(for: monitor),
+            outer: controller.outerGaps(for: monitor)
         )
         let insetFrame = controller.insetWorkingFrame(for: monitor)
 
@@ -1037,7 +1038,7 @@ final class MouseEventHandler {
                let monitor = controller.workspaceManager.monitor(for: wsId)
             {
                 let workingFrame = controller.insetWorkingFrame(for: monitor)
-                let gaps = CGFloat(controller.workspaceManager.gaps)
+                let gaps = controller.gapSize(for: monitor)
                 var didEnd = false
                 controller.workspaceManager.withNiriViewportState(for: wsId) { vstate in
                     didEnd = engine.interactiveMoveEnd(
@@ -1071,7 +1072,7 @@ final class MouseEventHandler {
            let monitor = controller.workspaceManager.monitor(for: wsId)
         {
             let workingFrame = controller.insetWorkingFrame(for: monitor)
-            let gaps = CGFloat(controller.workspaceManager.gaps)
+            let gaps = controller.gapSize(for: monitor)
             let hadInteractiveResize = engine.interactiveResize != nil
 
             controller.workspaceManager.withNiriViewportState(for: wsId) { vstate in
@@ -1538,14 +1539,24 @@ final class MouseEventHandler {
         guard let controller else { return }
         let insetFrame = controller.insetWorkingFrame(for: monitor)
         let viewportWidth = insetFrame.width
-        let gap = CGFloat(controller.workspaceManager.gaps)
-        let columns = engine.columns(in: wsId)
+        let gap = controller.gapSize(for: monitor)
+        let scale = backingScale(for: monitor)
 
         var didApply = false
         controller.workspaceManager.withNiriViewportState(for: wsId) { vstate in
             if vstate.viewOffsetPixels.isAnimating {
                 vstate.settleAtCurrentOffset()
             }
+
+            engine.prepareAndSeedSingleWindowViewport(
+                in: wsId,
+                workingFrame: insetFrame,
+                containingFrame: monitor.frame,
+                scale: scale,
+                gaps: gap,
+                state: &vstate
+            )
+            let columns = engine.columns(in: wsId)
 
             if !vstate.viewOffsetPixels.isGesture {
                 guard vstate.beginGesture(isTrackpad: true, columns: columns) else { return }
@@ -1575,6 +1586,11 @@ final class MouseEventHandler {
         }
     }
 
+    private func backingScale(for monitor: Monitor) -> CGFloat {
+        NSScreen.screens.first(where: { $0.displayId == monitor.displayId })?
+            .backingScaleFactor ?? 2.0
+    }
+
     private func applyMouseWheelColumnTicks(
         _ ticks: Int,
         engine: NiriLayoutEngine,
@@ -1583,7 +1599,7 @@ final class MouseEventHandler {
     ) {
         guard let controller else { return }
         let insetFrame = controller.insetWorkingFrame(for: monitor)
-        let gap = CGFloat(controller.workspaceManager.gaps)
+        let gap = controller.gapSize(for: monitor)
         let step = ticks > 0 ? 1 : -1
         let motion = controller.motionPolicy.snapshot()
 
@@ -1652,10 +1668,16 @@ final class MouseEventHandler {
         }
 
         let insetFrame = controller.insetWorkingFrame(for: monitor)
+        let gap = controller.gapSize(for: monitor)
+        let scale = backingScale(for: monitor)
+        engine.prepareSingleWindowViewport(
+            in: wsId,
+            workingFrame: insetFrame,
+            containingFrame: monitor.frame,
+            scale: scale,
+            gaps: gap
+        )
         let columns = engine.columns(in: wsId)
-        let gap = CGFloat(controller.workspaceManager.gaps)
-        let scale = NSScreen.screens.first(where: { $0.displayId == monitor.displayId })?
-            .backingScaleFactor ?? 2.0
 
         var selectedWindow: NiriWindow?
         var previousActiveColumnIndex: Int?

--- a/Sources/Nehir/Core/Controller/NiriLayoutHandler.swift
+++ b/Sources/Nehir/Core/Controller/NiriLayoutHandler.swift
@@ -275,8 +275,8 @@ enum NiriWindowMoveResult {
             hasCompletedInitialRefresh: controller.layoutRefreshController.layoutState.hasCompletedInitialRefresh,
             useScrollAnimationPath: useScrollAnimationPath,
             removalSeed: removalSeed,
-            gap: CGFloat(controller.workspaceManager.gaps),
-            outerGaps: controller.workspaceManager.outerGaps,
+            gap: controller.gapSize(for: monitor),
+            outerGaps: controller.outerGaps(for: monitor),
             displayRefreshRate: controller.layoutRefreshController.layoutState
                 .refreshRateByDisplay[monitor.displayId] ?? 60.0,
             isActiveWorkspace: refreshInput.isActiveWorkspace
@@ -541,15 +541,33 @@ enum NiriWindowMoveResult {
             }
         }
 
-        let usesSingleWindowAspectRatio = pass.engine.singleWindowLayoutContext(in: pass.wsId) != nil
-        if usesSingleWindowAspectRatio {
-            resetViewportForSingleWindowAspectRatio(state: &state)
+        let usesCenteredLoneWindow = pass.engine.singleWindowLayoutContext(in: pass.wsId) != nil
+        let isGestureOrAnimation = state.viewOffsetPixels.isGesture || state.viewOffsetPixels.isAnimating
+        if usesCenteredLoneWindow, !isGestureOrAnimation {
+            // Capture the lone window's previously resolved width before re-preparing so we
+            // can detect a policy/size/monitor change (not just an initial setup).
+            let previousSingleWindowWidth = pass.engine.singleWindowLayoutContext(in: pass.wsId)?.container.cachedWidth ?? 0
+            let geometry = pass.engine.prepareSingleWindowViewport(
+                in: pass.wsId,
+                workingFrame: pass.insetFrame,
+                containingFrame: pass.monitor.frame,
+                scale: pass.engine.displayScale(in: pass.wsId),
+                gaps: pass.gap
+            )
+            // Reset to center on initial setup, window removal, or when the lone window's
+            // resolved width changed (policy/size/monitor change). Otherwise keep the
+            // current offset so deliberate side-snaps survive relayouts.
+            let widthChanged = abs((geometry.map { $0.rect.width } ?? 0) - previousSingleWindowWidth) > 1
+            let shouldResetSingleWindowViewport = previousSingleWindowWidth <= 0
+                || !removal.removalResult.removedTokens.isEmpty
+                || widthChanged
+            if shouldResetSingleWindowViewport {
+                resetViewportForCenteredLoneWindow(geometry: geometry, state: &state)
+            }
         }
 
         let offsetBefore = state.viewOffsetPixels.current()
         var viewportNeedsRecalc = removal.removalResult.viewportNeedsRecalc
-
-        let isGestureOrAnimation = state.viewOffsetPixels.isGesture || state.viewOffsetPixels.isAnimating
 
         for col in pass.engine.columns(in: pass.wsId) {
             if col.cachedWidth <= 0 {
@@ -557,7 +575,7 @@ enum NiriWindowMoveResult {
             }
         }
 
-        if !usesSingleWindowAspectRatio,
+        if !usesCenteredLoneWindow,
            !isGestureOrAnimation,
            snapshot.isActiveWorkspace,
            let selectedId = state.selectedNodeId,
@@ -579,7 +597,7 @@ enum NiriWindowMoveResult {
             }
         }
 
-        let ranEnsureVisible = !usesSingleWindowAspectRatio
+        let ranEnsureVisible = !usesCenteredLoneWindow
             && !isGestureOrAnimation
             && snapshot.isActiveWorkspace
             && state.selectedNodeId != nil
@@ -630,7 +648,14 @@ enum NiriWindowMoveResult {
 
             if wasEmpty {
                 if pass.engine.singleWindowLayoutContext(in: pass.wsId) != nil {
-                    resetViewportForSingleWindowAspectRatio(state: &state)
+                    let geometry = pass.engine.prepareSingleWindowViewport(
+                        in: pass.wsId,
+                        workingFrame: pass.insetFrame,
+                        containingFrame: pass.monitor.frame,
+                        scale: pass.engine.displayScale(in: pass.wsId),
+                        gaps: pass.gap
+                    )
+                    resetViewportForCenteredLoneWindow(geometry: geometry, state: &state)
                 } else {
                     let cols = pass.engine.columns(in: pass.wsId)
                     state.transitionToColumn(
@@ -700,9 +725,12 @@ enum NiriWindowMoveResult {
         return (newWindowToken, rememberedFocusToken)
     }
 
-    private func resetViewportForSingleWindowAspectRatio(state: inout ViewportState) {
+    private func resetViewportForCenteredLoneWindow(
+        geometry: SingleWindowViewportGeometry?,
+        state: inout ViewportState
+    ) {
         state.activeColumnIndex = 0
-        state.viewOffsetPixels = .static(0)
+        state.viewOffsetPixels = .static(geometry?.centerOffset ?? 0)
         state.activatePrevColumnOnRemoval = nil
         state.viewOffsetToRestore = nil
         state.selectionProgress = 0
@@ -1055,7 +1083,7 @@ enum NiriWindowMoveResult {
         controller.suppressMouseMoveToFocusedWindow(for: target.token)
         var state = controller.workspaceManager.niriViewportState(for: workspaceId)
         if let monitor = controller.workspaceManager.monitor(for: workspaceId) {
-            let gap = CGFloat(controller.workspaceManager.gaps)
+            let gap = controller.gapSize(for: monitor)
             engine.ensureSelectionVisible(
                 node: target,
                 in: workspaceId,
@@ -1114,7 +1142,7 @@ enum NiriWindowMoveResult {
                         motion: controller.motionPolicy.snapshot(),
                         state: &state,
                         workingFrame: controller.insetWorkingFrame(for: monitor),
-                        gaps: CGFloat(controller.workspaceManager.gaps)
+                        gaps: controller.gapSize(for: monitor)
                     )
                 }
                 activateNode(
@@ -1140,7 +1168,7 @@ enum NiriWindowMoveResult {
         }
 
         guard let monitor = controller.workspaceManager.monitor(for: wsId) else { return }
-        let gap = CGFloat(controller.workspaceManager.gaps)
+        let gap = controller.gapSize(for: monitor)
         let workingFrame = controller.insetWorkingFrame(for: monitor)
 
         for col in engine.columns(in: wsId) where col.cachedWidth <= 0 {
@@ -1457,19 +1485,19 @@ enum NiriWindowMoveResult {
     }
 
     func updateNiriConfig(
-        maxVisibleColumns: Int? = nil,
+        balancedColumnCount: Int? = nil,
         infiniteLoop: Bool? = nil,
         revealPartial: RevealPartial? = nil,
-        singleWindowAspectRatio: SingleWindowAspectRatio? = nil,
+        loneWindowPolicy: LoneWindowPolicy? = nil,
         columnWidthPresets: [Double]? = nil,
         defaultColumnWidth: Double?? = nil
     ) {
         guard let controller else { return }
         controller.niriEngine?.updateConfiguration(
-            maxVisibleColumns: maxVisibleColumns,
+            balancedColumnCount: balancedColumnCount,
             infiniteLoop: infiniteLoop,
             revealPartial: revealPartial,
-            singleWindowAspectRatio: singleWindowAspectRatio,
+            loneWindowPolicy: loneWindowPolicy,
             presetColumnWidths: columnWidthPresets?.map { .proportion($0) },
             defaultColumnWidth: defaultColumnWidth.map { $0.map { CGFloat($0) } }
         )
@@ -1497,7 +1525,7 @@ enum NiriWindowMoveResult {
         }
 
         if options.ensureVisible, let monitor = controller.workspaceManager.monitor(for: workspaceId) {
-            let gap = CGFloat(controller.workspaceManager.gaps)
+            let gap = controller.gapSize(for: monitor)
             let workingFrame = controller.insetWorkingFrame(for: monitor)
             engine.ensureSelectionVisible(
                 node: node,
@@ -1577,7 +1605,7 @@ enum NiriWindowMoveResult {
             return
         }
 
-        let gap = CGFloat(controller.workspaceManager.gaps)
+        let gap = controller.gapSize(for: monitor)
         let workingFrame = controller.insetWorkingFrame(for: monitor)
         let orientation = engine.monitor(for: monitor.id)?.orientation
             ?? controller.settings.effectiveOrientation(for: monitor)
@@ -1651,7 +1679,7 @@ enum NiriWindowMoveResult {
 
             guard let monitor = controller.workspaceManager.monitor(for: wsId) else { return }
             let workingFrame = controller.insetWorkingFrame(for: monitor)
-            let gaps = CGFloat(controller.workspaceManager.gaps)
+            let gaps = controller.gapSize(for: monitor)
 
             let ctx = NiriOperationContext(
                 controller: controller,
@@ -1801,7 +1829,7 @@ enum NiriWindowMoveResult {
         guard let monitor = controller.workspaceManager.monitor(for: wsId) else { return }
         let motion = controller.motionPolicy.snapshot()
         let workingFrame = controller.insetWorkingFrame(for: monitor)
-        let gaps = CGFloat(controller.workspaceManager.gaps)
+        let gaps = controller.gapSize(for: monitor)
         controller.workspaceManager.withNiriViewportState(for: wsId) { state in
             perform(engine, wsId, motion, &state, monitor, workingFrame, gaps)
         }
@@ -1824,7 +1852,7 @@ enum NiriWindowMoveResult {
         guard let monitor = controller.workspaceManager.monitor(for: workspaceId) else { return }
         let motion = controller.motionPolicy.snapshot()
         let workingFrame = controller.insetWorkingFrame(for: monitor)
-        let gaps = CGFloat(controller.workspaceManager.gaps)
+        let gaps = controller.gapSize(for: monitor)
         controller.workspaceManager.withNiriViewportState(for: workspaceId) { state in
             perform(engine, workspaceId, motion, &state, monitor, workingFrame, gaps)
         }
@@ -1916,7 +1944,7 @@ struct NodeActivationOptions {
         let layoutGaps = LayoutGaps(
             horizontal: gaps,
             vertical: gaps,
-            outer: controller.workspaceManager.outerGaps
+            outer: controller.outerGaps(for: monitor)
         )
         let animationTime = (engine.animationClock?.now() ?? CACurrentMediaTime()) + 2.0
         let newFrames = engine.calculateCombinedLayoutUsingPools(

--- a/Sources/Nehir/Core/Controller/WMController.swift
+++ b/Sources/Nehir/Core/Controller/WMController.swift
@@ -276,10 +276,10 @@ final class WMController {
             enableNiriLayout(revealPartial: settings.revealPartial)
         }
         updateNiriConfig(
-            maxVisibleColumns: settings.niriMaxVisibleColumns,
+            balancedColumnCount: settings.niriBalancedColumnCount,
             infiniteLoop: settings.niriInfiniteLoop,
             revealPartial: settings.revealPartial,
-            singleWindowAspectRatio: settings.niriSingleWindowAspectRatio,
+            loneWindowPolicy: settings.loneWindowPolicy,
             columnWidthPresets: settings.niriColumnWidthPresets,
             defaultColumnWidth: settings.niriDefaultColumnWidth
         )
@@ -350,10 +350,29 @@ final class WMController {
 
     func setGapSize(_ size: Double) {
         workspaceManager.setGaps(to: size)
+        niriEngine?.invalidateCachedLayoutSpans()
     }
 
     func setOuterGaps(left: Double, right: Double, top: Double, bottom: Double) {
         workspaceManager.setOuterGaps(left: left, right: right, top: top, bottom: bottom)
+        niriEngine?.invalidateCachedLayoutSpans()
+    }
+
+    func updateMonitorGapSettings() {
+        niriEngine?.invalidateCachedLayoutSpans()
+        layoutRefreshController.requestRefresh(reason: .gapsChanged)
+    }
+
+    func resolvedGapSettings(for monitor: Monitor) -> ResolvedGapSettings {
+        settings.resolvedGapSettings(for: monitor)
+    }
+
+    func gapSize(for monitor: Monitor) -> CGFloat {
+        CGFloat(resolvedGapSettings(for: monitor).gapSize)
+    }
+
+    func outerGaps(for monitor: Monitor) -> LayoutGaps.OuterGaps {
+        resolvedGapSettings(for: monitor).outerGaps
     }
 
     func setBordersEnabled(_ enabled: Bool) {
@@ -680,11 +699,21 @@ final class WMController {
             resolved: resolved,
             isVisible: isWorkspaceBarVisible(on: monitor, resolved: resolved)
         ).reservedTopInset
-        return insetWorkingFrame(from: monitor.visibleFrame, scale: scale, reservedTopInset: reservedTopInset)
+        return insetWorkingFrame(
+            from: monitor.visibleFrame,
+            scale: scale,
+            reservedTopInset: reservedTopInset,
+            outerGaps: outerGaps(for: monitor)
+        )
     }
 
-    func insetWorkingFrame(from frame: CGRect, scale: CGFloat = 2.0, reservedTopInset: CGFloat = 0) -> CGRect {
-        let outer = workspaceManager.outerGaps
+    func insetWorkingFrame(
+        from frame: CGRect,
+        scale: CGFloat = 2.0,
+        reservedTopInset: CGFloat = 0,
+        outerGaps: LayoutGaps.OuterGaps? = nil
+    ) -> CGRect {
+        let outer = outerGaps ?? workspaceManager.outerGaps
         let struts = Struts(
             left: outer.left,
             right: outer.right,
@@ -836,18 +865,18 @@ final class WMController {
     }
 
     func updateNiriConfig(
-        maxVisibleColumns: Int? = nil,
+        balancedColumnCount: Int? = nil,
         infiniteLoop: Bool? = nil,
         revealPartial: RevealPartial? = nil,
-        singleWindowAspectRatio: SingleWindowAspectRatio? = nil,
+        loneWindowPolicy: LoneWindowPolicy? = nil,
         columnWidthPresets: [Double]? = nil,
         defaultColumnWidth: Double?? = nil
     ) {
         niriLayoutHandler.updateNiriConfig(
-            maxVisibleColumns: maxVisibleColumns,
+            balancedColumnCount: balancedColumnCount,
             infiniteLoop: infiniteLoop,
             revealPartial: revealPartial,
-            singleWindowAspectRatio: singleWindowAspectRatio,
+            loneWindowPolicy: loneWindowPolicy,
             columnWidthPresets: columnWidthPresets,
             defaultColumnWidth: defaultColumnWidth
         )
@@ -2019,7 +2048,8 @@ final class WMController {
         guard runtimeTraceCaptureSession != nil else { return }
         guard let engine = niriEngine else { return }
 
-        let gap = CGFloat(workspaceManager.gaps)
+        let gap = workspaceManager.monitor(for: workspaceId).map { gapSize(for: $0) }
+            ?? CGFloat(workspaceManager.gaps)
         let state = workspaceManager.niriViewportState(for: workspaceId)
         let workspaceName = workspaceManager.descriptor(for: workspaceId)?.name ?? workspaceId.uuidString
         let columns = engine.columns(in: workspaceId)
@@ -2112,10 +2142,11 @@ final class WMController {
             return ([:], [:])
         }
 
+        let gap = gapSize(for: monitor)
         let gaps = LayoutGaps(
-            horizontal: CGFloat(workspaceManager.gaps),
-            vertical: CGFloat(workspaceManager.gaps),
-            outer: workspaceManager.outerGaps
+            horizontal: gap,
+            vertical: gap,
+            outer: outerGaps(for: monitor)
         )
         let area = WorkingAreaContext(
             workingFrame: insetWorkingFrame(for: monitor),
@@ -2186,7 +2217,6 @@ final class WMController {
 
     private func niriLayoutDecisionDebugDump() -> String {
         guard let engine = niriEngine else { return "niri disabled" }
-        let gap = CGFloat(workspaceManager.gaps)
         let workspaceIds = workspaceManager.workspaceIdsForDebug()
         guard !workspaceIds.isEmpty else { return "no-workspaces" }
 
@@ -2194,6 +2224,8 @@ final class WMController {
             let state = workspaceManager.niriViewportState(for: workspaceId)
             let workspaceName = workspaceManager.descriptor(for: workspaceId)?.name ?? workspaceId.uuidString
             let columns = engine.columns(in: workspaceId)
+            let gap = workspaceManager.monitor(for: workspaceId).map { gapSize(for: $0) }
+                ?? CGFloat(workspaceManager.gaps)
             return "workspace=\(workspaceName) id=\(workspaceId.uuidString) \(niriLayoutDecisionLine(workspaceId: workspaceId, state: state, columns: columns, gap: gap))"
         }.joined(separator: "\n")
     }
@@ -2201,7 +2233,6 @@ final class WMController {
     private func niriViewportDebugDump() -> String {
         guard let engine = niriEngine else { return "niri disabled" }
 
-        let gap = CGFloat(workspaceManager.gaps)
         let workspaceIds = workspaceManager.workspaceIdsForDebug()
         guard !workspaceIds.isEmpty else { return "no-workspaces" }
 
@@ -2209,6 +2240,8 @@ final class WMController {
             let state = workspaceManager.niriViewportState(for: workspaceId)
             let workspaceName = workspaceManager.descriptor(for: workspaceId)?.name ?? workspaceId.uuidString
             let columns = engine.columns(in: workspaceId)
+            let gap = workspaceManager.monitor(for: workspaceId).map { gapSize(for: $0) }
+                ?? CGFloat(workspaceManager.gaps)
             let currentViewStart = columns.isEmpty ? nil : state.viewPosPixels(columns: columns, gap: gap)
             let targetViewStart = columns.isEmpty ? nil : state.targetViewPosPixels(columns: columns, gap: gap)
             let selectedNode = state.selectedNodeId.map(String.init(describing:)) ?? "nil"
@@ -2481,10 +2514,10 @@ final class WMController {
         if niriEngine != nil {
             enableNiriLayout(revealPartial: settings.revealPartial)
             updateNiriConfig(
-                maxVisibleColumns: settings.niriMaxVisibleColumns,
+                balancedColumnCount: settings.niriBalancedColumnCount,
                 infiniteLoop: settings.niriInfiniteLoop,
                 revealPartial: settings.revealPartial,
-                singleWindowAspectRatio: settings.niriSingleWindowAspectRatio,
+                loneWindowPolicy: settings.loneWindowPolicy,
                 columnWidthPresets: settings.niriColumnWidthPresets,
                 defaultColumnWidth: settings.niriDefaultColumnWidth
             )

--- a/Sources/Nehir/Core/Controller/WindowActionHandler.swift
+++ b/Sources/Nehir/Core/Controller/WindowActionHandler.swift
@@ -415,7 +415,7 @@ final class WindowActionHandler {
             {
                 engine.activateWindow(niriWindow.id)
 
-                let gap = CGFloat(controller.workspaceManager.gaps)
+                let gap = controller.gapSize(for: monitor)
                 let workingFrame = controller.insetWorkingFrame(for: monitor)
                 engine.ensureSelectionVisible(
                     node: niriWindow,

--- a/Sources/Nehir/Core/Controller/WorkspaceNavigationHandler.swift
+++ b/Sources/Nehir/Core/Controller/WorkspaceNavigationHandler.swift
@@ -743,7 +743,7 @@ final class WorkspaceNavigationHandler {
                let monitor = controller.workspaceManager.monitor(for: target.id)
             {
                 targetState.selectedNodeId = movedNode.id
-                let gap = CGFloat(controller.workspaceManager.gaps)
+                let gap = controller.gapSize(for: monitor)
                 let workingFrame = controller.insetWorkingFrame(for: monitor)
                 engine.ensureSelectionVisible(
                     node: movedNode,
@@ -863,7 +863,7 @@ final class WorkspaceNavigationHandler {
             {
                 targetState.selectedNodeId = movedNode.id
 
-                let gap = CGFloat(controller.workspaceManager.gaps)
+                let gap = controller.gapSize(for: monitor)
                 let workingFrame = controller.insetWorkingFrame(for: monitor)
                 engine.ensureSelectionVisible(
                     node: movedNode,

--- a/Sources/Nehir/Core/Layout/Niri/NiriConstraintSolver.swift
+++ b/Sources/Nehir/Core/Layout/Niri/NiriConstraintSolver.swift
@@ -29,11 +29,10 @@ enum NiriAxisSolver {
         guard !windows.isEmpty else { return [] }
 
         if isTabbed {
-            let usableSpace = max(0, availableSpace - gapSize * 2)
-            return solveTabbed(windows: windows, availableSpace: usableSpace)
+            return solveTabbed(windows: windows, availableSpace: availableSpace)
         }
 
-        let totalGaps = gapSize * CGFloat(windows.count + 1)
+        let totalGaps = gapSize * CGFloat(max(0, windows.count - 1))
         let usableSpace = max(0, availableSpace - totalGaps)
         let epsilon: CGFloat = 0.001
         let minConstraints = windows.map { sanitizedMinimum($0.minConstraint) }

--- a/Sources/Nehir/Core/Layout/Niri/NiriLayout.swift
+++ b/Sources/Nehir/Core/Layout/Niri/NiriLayout.swift
@@ -39,6 +39,36 @@ struct LayoutResult {
     let hiddenHandles: [WindowToken: HideSide]
 }
 
+struct SingleWindowViewportGeometry {
+    static let centeredOffsetEpsilon: CGFloat = 0.001
+
+    let rect: CGRect
+    let centerOffset: CGFloat
+
+    func effectiveViewOffset(_ offset: CGFloat) -> CGFloat {
+        // Render at the raw viewport offset so the lone window is responsive to scroll
+        // gestures exactly like a regular single column. Where it settles is governed by
+        // the snap grid / viewportStartBounds (shared with regular columns), not by a
+        // render-time clamp. A separate clamp here would desync render from gesture state
+        // (making gestures feel ignored) and leave stale offsets.
+        offset
+    }
+
+    func renderedRect(
+        viewOffset: CGFloat,
+        workspaceOffset: CGFloat = 0,
+        renderOffset: CGPoint = .zero,
+        scale: CGFloat
+    ) -> CGRect {
+        rect
+            .offsetBy(
+                dx: workspaceOffset - effectiveViewOffset(viewOffset) + renderOffset.x,
+                dy: renderOffset.y
+            )
+            .roundedToPhysicalPixels(scale: scale)
+    }
+}
+
 private enum ContainerVisibilityState {
     case visible
     case hidden(AxisHideEdge)
@@ -151,7 +181,9 @@ extension NiriLayoutEngine {
             }
             layoutSingleWindowWorkspace(
                 singleWindowContext,
+                state: state,
                 workingFrame: workingFrame,
+                containingFrame: viewFrame,
                 fullscreenRect: canonicalFullscreenRect,
                 renderedFullscreenRect: renderedFullscreenRect,
                 workspaceOffset: workspaceOffset,
@@ -583,87 +615,255 @@ extension NiriLayoutEngine {
         }
     }
 
-    func aspectFittedSingleWindowRect(
-        in workingFrame: CGRect,
-        aspectRatio: CGFloat,
+    func centeredLoneWindowRect(
+        maxWidthFraction: Double,
+        workingFrame: CGRect,
         scale: CGFloat
     ) -> CGRect {
-        guard aspectRatio > 0,
-              workingFrame.width > 0,
+        guard workingFrame.width > 0,
               workingFrame.height > 0
         else {
             return workingFrame.roundedToPhysicalPixels(scale: scale)
         }
 
-        let currentRatio = workingFrame.width / workingFrame.height
-        if abs(currentRatio - aspectRatio) < 0.001 {
-            return workingFrame.roundedToPhysicalPixels(scale: scale)
+        let width = workingFrame.width * CGFloat(maxWidthFraction.clamped(to: 0.0 ... 1.0))
+        return centeredLoneWindowRect(
+            in: workingFrame,
+            containingFrame: workingFrame,
+            width: width,
+            constraints: .unconstrained,
+            scale: scale
+        )
+    }
+
+    private func centeredLoneWindowRect(
+        in workingFrame: CGRect,
+        containingFrame: CGRect,
+        width: CGFloat,
+        constraints: WindowSizeConstraints,
+        scale: CGFloat
+    ) -> CGRect {
+        let size = resolvedSingleWindowSize(
+            width: width,
+            workingFrame: workingFrame,
+            constraints: constraints
+        )
+        let unclamped = CGRect(
+            x: workingFrame.midX - size.width / 2,
+            y: workingFrame.minY,
+            width: size.width,
+            height: size.height
+        )
+        return clampRect(unclamped, to: containingFrame).roundedToPhysicalPixels(scale: scale)
+    }
+
+    private func resolvedSingleWindowSize(
+        width: CGFloat,
+        workingFrame: CGRect,
+        constraints: WindowSizeConstraints
+    ) -> CGSize {
+        CGSize(
+            width: constraints.clampWidth(width),
+            height: constraints.clampHeight(workingFrame.height)
+        )
+    }
+
+    private func clampRect(_ rect: CGRect, to containingFrame: CGRect) -> CGRect {
+        guard containingFrame.width > 0,
+              containingFrame.height > 0
+        else { return rect }
+
+        let clampedX: CGFloat
+        let maxX = containingFrame.maxX - rect.width
+        if maxX >= containingFrame.minX {
+            clampedX = min(max(rect.minX, containingFrame.minX), maxX)
+        } else {
+            clampedX = containingFrame.minX
         }
 
-        var width = workingFrame.width
-        var height = workingFrame.height
-
-        if currentRatio > aspectRatio {
-            width = height * aspectRatio
+        let clampedY: CGFloat
+        let maxY = containingFrame.maxY - rect.height
+        if maxY >= containingFrame.minY {
+            clampedY = min(max(rect.minY, containingFrame.minY), maxY)
         } else {
-            height = width / aspectRatio
+            clampedY = containingFrame.minY
         }
 
         return CGRect(
-            x: workingFrame.minX + (workingFrame.width - width) / 2,
-            y: workingFrame.minY + (workingFrame.height - height) / 2,
-            width: width,
-            height: height
-        ).roundedToPhysicalPixels(scale: scale)
+            x: clampedX,
+            y: clampedY,
+            width: rect.width,
+            height: rect.height
+        )
     }
 
-    private func centeredSingleWindowRect(
-        in workingFrame: CGRect,
-        width: CGFloat,
-        scale: CGFloat
-    ) -> CGRect {
-        CGRect(
-            x: workingFrame.minX + (workingFrame.width - width) / 2,
-            y: workingFrame.minY,
-            width: width,
-            height: workingFrame.height
-        ).roundedToPhysicalPixels(scale: scale)
-    }
-
-    func resolvedSingleWindowRect(
+    private func resolvedSingleWindowWidth(
         for context: SingleWindowLayoutContext,
         in workingFrame: CGRect,
-        scale: CGFloat,
         gaps: CGFloat
-    ) -> CGRect {
+    ) -> CGFloat {
         guard context.container.hasManualSingleWindowWidthOverride else {
-            return aspectFittedSingleWindowRect(
-                in: workingFrame,
-                aspectRatio: context.aspectRatio,
-                scale: scale
-            )
+            return workingFrame.width * CGFloat(context.maxWidthFraction.clamped(to: 0.0 ... 1.0))
         }
 
         if context.container.cachedWidth <= 0 {
             context.container.resolveAndCacheWidth(workingAreaWidth: workingFrame.width, gaps: gaps)
         }
+        return max(0, context.container.cachedWidth)
+    }
 
-        let resolvedWidth = min(workingFrame.width, max(0, context.container.cachedWidth))
+    func resolvedSingleWindowRect(
+        for context: SingleWindowLayoutContext,
+        in workingFrame: CGRect,
+        containingFrame: CGRect? = nil,
+        scale: CGFloat,
+        gaps: CGFloat
+    ) -> CGRect {
+        let containingFrame = containingFrame ?? workingFrame
+        let resolvedWidth = resolvedSingleWindowWidth(for: context, in: workingFrame, gaps: gaps)
         guard resolvedWidth > 0 else {
             return workingFrame.roundedToPhysicalPixels(scale: scale)
         }
 
-        // Manual lone-window width commands bypass ratio mode but remain centered.
-        return centeredSingleWindowRect(
+        return centeredLoneWindowRect(
             in: workingFrame,
+            containingFrame: containingFrame,
             width: resolvedWidth,
+            constraints: context.window.constraints,
             scale: scale
         )
     }
 
+    func singleWindowViewportGeometry(
+        for context: SingleWindowLayoutContext,
+        in workingFrame: CGRect,
+        containingFrame: CGRect? = nil,
+        scale: CGFloat,
+        gaps: CGFloat
+    ) -> SingleWindowViewportGeometry {
+        let containingFrame = containingFrame ?? workingFrame
+        let resolvedWidth = resolvedSingleWindowWidth(for: context, in: workingFrame, gaps: gaps)
+        guard resolvedWidth > 0 else {
+            let rect = workingFrame.roundedToPhysicalPixels(scale: scale)
+            return SingleWindowViewportGeometry(rect: rect, centerOffset: 0)
+        }
+
+        let size = resolvedSingleWindowSize(
+            width: resolvedWidth,
+            workingFrame: workingFrame,
+            constraints: context.window.constraints
+        )
+        let unclampedYRect = CGRect(
+            x: workingFrame.minX,
+            y: workingFrame.minY,
+            width: size.width,
+            height: size.height
+        )
+        let yClampedRect = clampRect(
+            CGRect(
+                x: containingFrame.minX,
+                y: unclampedYRect.minY,
+                width: min(size.width, containingFrame.width),
+                height: size.height
+            ),
+            to: containingFrame
+        )
+        // For over-constrained lone windows (min size exceeds the working frame), clamp
+        // the rect to the containing (visible) frame so it does not leak offscreen. For
+        // normal fill/centered windows, keep the working-frame origin and desired size.
+        let overConstrained = size.width > workingFrame.width || size.height > workingFrame.height
+        let rect: CGRect
+        if overConstrained {
+            rect = yClampedRect.roundedToPhysicalPixels(scale: scale)
+        } else {
+            rect = CGRect(
+                x: workingFrame.minX,
+                y: yClampedRect.minY,
+                width: size.width,
+                height: size.height
+            ).roundedToPhysicalPixels(scale: scale)
+        }
+        return SingleWindowViewportGeometry(
+            rect: rect,
+            centerOffset: (rect.width - workingFrame.width) / 2
+        )
+    }
+
+    func resolvedSingleWindowViewportRect(
+        for context: SingleWindowLayoutContext,
+        in workingFrame: CGRect,
+        containingFrame: CGRect? = nil,
+        scale: CGFloat,
+        gaps: CGFloat
+    ) -> CGRect {
+        singleWindowViewportGeometry(
+            for: context,
+            in: workingFrame,
+            containingFrame: containingFrame,
+            scale: scale,
+            gaps: gaps
+        ).rect
+    }
+
+    @discardableResult
+    func prepareSingleWindowViewport(
+        in workspaceId: WorkspaceDescriptor.ID,
+        workingFrame: CGRect,
+        containingFrame: CGRect? = nil,
+        scale: CGFloat = 2.0,
+        gaps: CGFloat
+    ) -> SingleWindowViewportGeometry? {
+        guard let context = singleWindowLayoutContext(in: workspaceId) else { return nil }
+        let geometry = singleWindowViewportGeometry(
+            for: context,
+            in: workingFrame,
+            containingFrame: containingFrame,
+            scale: scale,
+            gaps: gaps
+        )
+        context.container.cachedWidth = geometry.rect.width
+        return geometry
+    }
+
+    func seedSingleWindowCenterOffsetIfNeeded(
+        _ geometry: SingleWindowViewportGeometry?,
+        state: inout ViewportState
+    ) {
+        // Only seed the centered offset from a genuine initial (zero) viewport state.
+        // Never overwrite an explicit side-snap or in-flight gesture offset — those are
+        // valid positions within the scrollable range and should survive relayouts.
+        guard let geometry,
+              !state.viewOffsetPixels.isGesture,
+              abs(state.viewOffsetPixels.current()) < SingleWindowViewportGeometry.centeredOffsetEpsilon
+        else { return }
+        state.viewOffsetPixels = .static(geometry.centerOffset)
+    }
+
+    @discardableResult
+    func prepareAndSeedSingleWindowViewport(
+        in workspaceId: WorkspaceDescriptor.ID,
+        workingFrame: CGRect,
+        containingFrame: CGRect? = nil,
+        scale: CGFloat = 2.0,
+        gaps: CGFloat,
+        state: inout ViewportState
+    ) -> SingleWindowViewportGeometry? {
+        let geometry = prepareSingleWindowViewport(
+            in: workspaceId,
+            workingFrame: workingFrame,
+            containingFrame: containingFrame,
+            scale: scale,
+            gaps: gaps
+        )
+        seedSingleWindowCenterOffsetIfNeeded(geometry, state: &state)
+        return geometry
+    }
+
     private func layoutSingleWindowWorkspace(
         _ context: SingleWindowLayoutContext,
+        state: ViewportState,
         workingFrame: CGRect,
+        containingFrame: CGRect,
         fullscreenRect: CGRect,
         renderedFullscreenRect: CGRect,
         workspaceOffset: CGFloat,
@@ -673,16 +873,22 @@ extension NiriLayoutEngine {
         result: inout [WindowToken: CGRect],
         orientation: Monitor.Orientation
     ) {
-        let canonicalRect = resolvedSingleWindowRect(
+        let geometry = singleWindowViewportGeometry(
             for: context,
             in: workingFrame,
+            containingFrame: containingFrame,
             scale: scale,
             gaps: gaps
         )
+        let canonicalRect = geometry.rect
+        context.container.cachedWidth = canonicalRect.width
         let renderOffset = context.container.renderOffset(at: time)
-        let renderedRect = canonicalRect
-            .offsetBy(dx: workspaceOffset + renderOffset.x, dy: renderOffset.y)
-            .roundedToPhysicalPixels(scale: scale)
+        let renderedRect = geometry.renderedRect(
+            viewOffset: state.viewOffsetPixels.value(at: time),
+            workspaceOffset: workspaceOffset,
+            renderOffset: renderOffset,
+            scale: scale
+        )
 
         layoutContainer(
             container: context.container,
@@ -791,7 +997,6 @@ extension NiriLayoutEngine {
         case .horizontal: contentRect.origin.y
         case .vertical: contentRect.origin.x
         }
-        pos += secondaryGap
 
         for i in 0 ..< windows.count {
             let span = resolvedSpans[i]

--- a/Sources/Nehir/Core/Layout/Niri/NiriLayoutEngine+Animation.swift
+++ b/Sources/Nehir/Core/Layout/Niri/NiriLayoutEngine+Animation.swift
@@ -286,11 +286,15 @@ extension NiriLayoutEngine {
         if let singleWindowContext = singleWindowLayoutContext(in: workspaceId),
            singleWindowContext.window.token == token
         {
-            return resolvedSingleWindowRect(
+            let scale = displayScale(in: workspaceId)
+            return singleWindowViewportGeometry(
                 for: singleWindowContext,
                 in: workingFrame,
-                scale: 1.0,
+                scale: scale,
                 gaps: gaps
+            ).renderedRect(
+                viewOffset: state.viewOffsetPixels.target(),
+                scale: scale
             )
         }
 
@@ -341,15 +345,15 @@ extension NiriLayoutEngine {
         let targetHeight: CGFloat
 
         let fallbackHeight: CGFloat = if windowNodes.count == 1 || isEffectivelyTabbed {
-            max(1, availableHeight - gaps * 2)
+            max(1, availableHeight)
         } else {
-            max(1, (availableHeight - gaps * CGFloat(windowNodes.count + 1)) / CGFloat(windowNodes.count))
+            max(1, (availableHeight - gaps * CGFloat(max(0, windowNodes.count - 1))) / CGFloat(windowNodes.count))
         }
         if windowNodes.count == 1 || isEffectivelyTabbed {
-            targetY = contentY + gaps
+            targetY = contentY
             targetHeight = windowNodes[windowIndex].resolvedHeight ?? fallbackHeight
         } else {
-            var y = contentY + gaps
+            var y = contentY
             for i in 0 ..< windowIndex {
                 let h = windowNodes[i].resolvedHeight ?? fallbackHeight
                 y += h + gaps
@@ -426,12 +430,13 @@ extension NiriLayoutEngine {
         let windows = column.windowNodes
         guard tileIdx >= 0, tileIdx < windows.count else { return 0 }
 
-        var offset: CGFloat = gaps
+        // Stacks anchor at contentY with zero leading gap (matching renderColumn /
+        // targetFrameForWindow). Only inter-tile gaps are added.
+        var offset: CGFloat = 0
         guard tileIdx > 0 else { return offset }
         for i in 0 ..< tileIdx {
             let height = windows[i].resolvedHeight ?? windows[i].frame?.height ?? 0
-            offset += height
-            offset += gaps
+            offset += height + gaps
         }
         return offset
     }
@@ -440,8 +445,10 @@ extension NiriLayoutEngine {
         let windows = column.windowNodes
         guard !windows.isEmpty else { return [] }
 
-        var offsets: [CGFloat] = [gaps]
-        var y: CGFloat = gaps
+        // Stacks anchor at contentY with zero leading gap (matching renderColumn /
+        // targetFrameForWindow).
+        var offsets: [CGFloat] = [0]
+        var y: CGFloat = 0
         for i in 0 ..< windows.count - 1 {
             let height = windows[i].resolvedHeight ?? windows[i].frame?.height ?? 0
             y += height + gaps

--- a/Sources/Nehir/Core/Layout/Niri/NiriLayoutEngine+ColumnOps.swift
+++ b/Sources/Nehir/Core/Layout/Niri/NiriLayoutEngine+ColumnOps.swift
@@ -391,7 +391,7 @@ extension NiriLayoutEngine {
             : currentColX + (
                 column.cachedWidth > 0
                     ? column.cachedWidth
-                    : workingFrame.width / CGFloat(effectiveMaxVisibleColumns(in: workspaceId))
+                    : workingFrame.width * CGFloat(effectiveDefaultColumnWidth(in: workspaceId).fraction)
             ) + gaps
 
         guard let root = roots[workspaceId] else { return false }

--- a/Sources/Nehir/Core/Layout/Niri/NiriLayoutEngine+Monitors.swift
+++ b/Sources/Nehir/Core/Layout/Niri/NiriLayoutEngine+Monitors.swift
@@ -52,8 +52,9 @@ extension NiriLayoutEngine {
 
     func globalResolvedSettings() -> ResolvedNiriSettings {
         ResolvedNiriSettings(
-            maxVisibleColumns: maxVisibleColumns,
-            singleWindowAspectRatio: singleWindowAspectRatio,
+            defaultColumnWidth: defaultColumnWidth.map { .custom(fraction: Double($0)) }
+                ?? .balanced(columns: balancedColumnCount),
+            loneWindowPolicy: loneWindowPolicy,
             infiniteLoop: infiniteLoop
         )
     }
@@ -73,20 +74,20 @@ extension NiriLayoutEngine {
         monitorForWorkspace(workspaceId)?.scale ?? 2.0
     }
 
-    func effectiveMaxVisibleColumns(for monitorId: Monitor.ID) -> Int {
-        effectiveSettings(for: monitorId).maxVisibleColumns
+    func effectiveDefaultColumnWidth(for monitorId: Monitor.ID) -> DefaultColumnWidth {
+        effectiveSettings(for: monitorId).defaultColumnWidth
     }
 
-    func effectiveMaxVisibleColumns(in workspaceId: WorkspaceDescriptor.ID) -> Int {
-        effectiveSettings(in: workspaceId).maxVisibleColumns
+    func effectiveDefaultColumnWidth(in workspaceId: WorkspaceDescriptor.ID) -> DefaultColumnWidth {
+        effectiveSettings(in: workspaceId).defaultColumnWidth
     }
 
-    func effectiveSingleWindowAspectRatio(for monitorId: Monitor.ID) -> SingleWindowAspectRatio {
-        effectiveSettings(for: monitorId).singleWindowAspectRatio
+    func effectiveLoneWindowPolicy(for monitorId: Monitor.ID) -> LoneWindowPolicy {
+        effectiveSettings(for: monitorId).loneWindowPolicy
     }
 
-    func effectiveSingleWindowAspectRatio(in workspaceId: WorkspaceDescriptor.ID) -> SingleWindowAspectRatio {
-        effectiveSettings(in: workspaceId).singleWindowAspectRatio
+    func effectiveLoneWindowPolicy(in workspaceId: WorkspaceDescriptor.ID) -> LoneWindowPolicy {
+        effectiveSettings(in: workspaceId).loneWindowPolicy
     }
 
     func effectiveInfiniteLoop(for monitorId: Monitor.ID) -> Bool {

--- a/Sources/Nehir/Core/Layout/Niri/NiriLayoutEngine+Sizing.swift
+++ b/Sources/Nehir/Core/Layout/Niri/NiriLayoutEngine+Sizing.swift
@@ -892,7 +892,7 @@ extension NiriLayoutEngine {
                 }
         }
 
-        let heightLeft = max(1, workingFrame.height - gaps - minHeightTaken - gaps)
+        let heightLeft = max(1, workingFrame.height - minHeightTaken)
         windowHeight = min(heightLeft, windowHeight)
         windowHeight = window.constraints.clampHeight(windowHeight)
         window.height = .fixed(windowHeight.clamped(to: 1 ... NiriSizeChange.maxPixels))

--- a/Sources/Nehir/Core/Layout/Niri/NiriLayoutEngine+TabbedMode.swift
+++ b/Sources/Nehir/Core/Layout/Niri/NiriLayoutEngine+TabbedMode.swift
@@ -63,7 +63,7 @@ extension NiriLayoutEngine {
             }
             return partial + max(NiriAxisSolver.minimumRenderableSpan, minimumSpan)
         }
-        let requiredSpan = requiredWindowSpan + gaps * CGFloat(windows.count + 1)
+        let requiredSpan = requiredWindowSpan + gaps * CGFloat(max(0, windows.count - 1))
         return (requiredSpan, requiredSpan > availableSpan + 0.5)
     }
 

--- a/Sources/Nehir/Core/Layout/Niri/NiriLayoutEngine+ViewportCommands.swift
+++ b/Sources/Nehir/Core/Layout/Niri/NiriLayoutEngine+ViewportCommands.swift
@@ -11,11 +11,23 @@ extension NiriLayoutEngine {
         gaps: CGFloat
     ) -> NiriWindow? {
         guard direction == .left || direction == .right else { return nil }
+        let scale = displayScale(in: workspaceId)
+        prepareAndSeedSingleWindowViewport(
+            in: workspaceId,
+            workingFrame: workingFrame,
+            scale: scale,
+            gaps: gaps,
+            state: &state
+        )
         let columns = columns(in: workspaceId)
         guard !columns.isEmpty else { return nil }
-
-        let scale = displayScale(in: workspaceId)
-        let context = makeViewportSnapContext(columns: columns, state: state, workingFrame: workingFrame, gaps: gaps)
+        let context = makeViewportSnapContext(
+            columns: columns,
+            state: state,
+            workingFrame: workingFrame,
+            gaps: gaps,
+            intentionallyDoesNotFillViewport: loneWindowIntentionallyDoesNotFillViewport(in: workspaceId)
+        )
         guard !context.snapPoints.isEmpty else { return nil }
 
         let currentViewStart = context.currentViewStart(in: state)
@@ -148,12 +160,14 @@ extension NiriLayoutEngine {
         state: ViewportState,
         workingFrame: CGRect,
         gaps: CGFloat,
-        viewportWidth: CGFloat? = nil
+        viewportWidth: CGFloat? = nil,
+        intentionallyDoesNotFillViewport: Bool = false
     ) -> ViewportSnapContext {
         state.snapContext(
             columns: columns,
             gap: gaps,
-            viewportWidth: viewportWidth ?? workingFrame.width
+            viewportWidth: viewportWidth ?? workingFrame.width,
+            intentionallyDoesNotFillViewport: intentionallyDoesNotFillViewport
         )
     }
 

--- a/Sources/Nehir/Core/Layout/Niri/NiriLayoutEngine+Windows.swift
+++ b/Sources/Nehir/Core/Layout/Niri/NiriLayoutEngine+Windows.swift
@@ -143,6 +143,12 @@ extension NiriLayoutEngine {
             root.columns.last
         }
 
+        if root.allWindows.count == 1 {
+            for column in root.columns where !column.hasManualSingleWindowWidthOverride {
+                column.cachedWidth = 0
+            }
+        }
+
         let newColumn = NiriContainer()
         initializeNewColumnWidth(newColumn, in: workspaceId)
         if let refCol = referenceColumn {

--- a/Sources/Nehir/Core/Layout/Niri/NiriLayoutEngine.swift
+++ b/Sources/Nehir/Core/Layout/Niri/NiriLayoutEngine.swift
@@ -19,34 +19,54 @@ enum RevealPartial: String, CaseIterable, Codable, Identifiable {
     }
 }
 
-enum SingleWindowAspectRatio: String, CaseIterable, Codable, Identifiable {
-    case none
-    case ratio16x9 = "16:9"
-    case ratio4x3 = "4:3"
-    case ratio21x9 = "21:9"
-    case square = "1:1"
+enum LoneWindowPolicy: Equatable, Identifiable, Codable {
+    case fill
+    case centered(maxWidthFraction: Double)
 
     var id: String {
-        rawValue
-    }
-
-    var displayName: String {
         switch self {
-        case .none: "None (Fill)"
-        case .ratio16x9: "16:9"
-        case .ratio4x3: "4:3"
-        case .ratio21x9: "21:9"
-        case .square: "Square"
+        case .fill: "fill"
+        case .centered: "centered"
         }
     }
 
-    var ratio: CGFloat? {
+    private enum CodingKeys: String, CodingKey {
+        case kind, maxWidthFraction
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let kind = try container.decode(String.self, forKey: .kind)
+        switch kind {
+        case "fill":
+            self = .fill
+        case "centered":
+            self = .centered(maxWidthFraction: try container.decode(Double.self, forKey: .maxWidthFraction))
+        default:
+            throw DecodingError.dataCorruptedError(forKey: .kind, in: container, debugDescription: "unknown lone window policy \(kind)")
+        }
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
         switch self {
-        case .none: nil
-        case .ratio16x9: 16.0 / 9.0
-        case .ratio4x3: 4.0 / 3.0
-        case .ratio21x9: 21.0 / 9.0
-        case .square: 1.0
+        case .fill:
+            try container.encode("fill", forKey: .kind)
+        case let .centered(maxWidthFraction):
+            try container.encode("centered", forKey: .kind)
+            try container.encode(maxWidthFraction, forKey: .maxWidthFraction)
+        }
+    }
+}
+
+enum DefaultColumnWidth: Equatable {
+    case balanced(columns: Int)
+    case custom(fraction: Double)
+
+    var fraction: Double {
+        switch self {
+        case let .balanced(columns): 1.0 / Double(max(1, columns))
+        case let .custom(fraction): fraction
         }
     }
 }
@@ -102,7 +122,7 @@ struct NiriRenderStyle {
 }
 
 final class NiriLayoutEngine {
-    static let defaultPresetColumnWidthValues: [CGFloat] = [1.0 / 3.0, 0.5, 2.0 / 3.0]
+    static let defaultPresetColumnWidthValues: [CGFloat] = [0.35, 0.50, 0.65, 0.95]
     static let defaultPresetColumnWidths: [PresetSize] = defaultPresetColumnWidthValues.map { .proportion($0) }
     static let defaultPresetWindowHeightValues: [CGFloat] = [1.0 / 3.0, 0.5, 2.0 / 3.0]
     static let defaultPresetWindowHeights: [PresetSize] = defaultPresetWindowHeightValues.map { .proportion($0) }
@@ -120,12 +140,12 @@ final class NiriLayoutEngine {
     var framePool: [WindowToken: CGRect] = [:]
     var hiddenPool: [WindowToken: HideSide] = [:]
 
-    var maxVisibleColumns: Int
+    var balancedColumnCount: Int
     var infiniteLoop: Bool
 
     var revealPartial: RevealPartial = .default
 
-    var singleWindowAspectRatio: SingleWindowAspectRatio = .none
+    var loneWindowPolicy: LoneWindowPolicy = .fill
 
     var renderStyle: NiriRenderStyle = .default
 
@@ -141,7 +161,7 @@ final class NiriLayoutEngine {
 
     var presetColumnWidths: [PresetSize] = NiriLayoutEngine.defaultPresetColumnWidths
     var presetWindowHeights: [PresetSize] = NiriLayoutEngine.defaultPresetWindowHeights
-    var defaultColumnWidth: CGFloat? = 0.5
+    var defaultColumnWidth: CGFloat? = nil
 
     var resizeTraceSink: ((String) -> Void)?
     private(set) var resizeCommandGeneration: UInt64 = 0
@@ -151,8 +171,8 @@ final class NiriLayoutEngine {
         return resizeCommandGeneration
     }
 
-    init(maxVisibleColumns: Int = 2, infiniteLoop: Bool = false) {
-        self.maxVisibleColumns = max(1, min(5, maxVisibleColumns))
+    init(balancedColumnCount: Int = 2, infiniteLoop: Bool = false) {
+        self.balancedColumnCount = max(1, min(5, balancedColumnCount))
         self.infiniteLoop = infiniteLoop
     }
 
@@ -190,11 +210,14 @@ final class NiriLayoutEngine {
     func resolvedColumnResetWidth(in workspaceId: WorkspaceDescriptor
         .ID) -> (proportion: CGFloat, presetWidthIdx: Int?)
     {
-        if let defaultColumnWidth {
-            return (defaultColumnWidth, matchingPresetIndex(for: defaultColumnWidth))
+        let resolvedDefaultColumnWidth = effectiveDefaultColumnWidth(in: workspaceId)
+        let width = CGFloat(resolvedDefaultColumnWidth.fraction)
+        switch resolvedDefaultColumnWidth {
+        case .custom:
+            return (width, matchingPresetIndex(for: width))
+        case .balanced:
+            return (width, nil)
         }
-
-        return (1.0 / CGFloat(effectiveMaxVisibleColumns(in: workspaceId)), nil)
     }
 
     func initializeNewColumnWidth(_ column: NiriContainer, in workspaceId: WorkspaceDescriptor.ID) {
@@ -229,12 +252,13 @@ final class NiriLayoutEngine {
     struct SingleWindowLayoutContext {
         let container: NiriContainer
         let window: NiriWindow
-        let aspectRatio: CGFloat
+        let maxWidthFraction: Double
     }
 
     func singleWindowLayoutContext(in workspaceId: WorkspaceDescriptor.ID) -> SingleWindowLayoutContext? {
-        guard let aspectRatio = effectiveSingleWindowAspectRatio(in: workspaceId).ratio else {
-            return nil
+        let maxWidthFraction: Double = switch effectiveLoneWindowPolicy(in: workspaceId) {
+        case .fill: 1.0
+        case let .centered(maxWidthFraction): maxWidthFraction
         }
 
         let workspaceColumns = columns(in: workspaceId)
@@ -256,8 +280,17 @@ final class NiriLayoutEngine {
         return SingleWindowLayoutContext(
             container: column,
             window: window,
-            aspectRatio: aspectRatio
+            maxWidthFraction: maxWidthFraction
         )
+    }
+
+    func loneWindowIntentionallyDoesNotFillViewport(in workspaceId: WorkspaceDescriptor.ID) -> Bool {
+        guard singleWindowLayoutContext(in: workspaceId) != nil,
+              case let .centered(maxWidthFraction) = effectiveLoneWindowPolicy(in: workspaceId)
+        else {
+            return false
+        }
+        return maxWidthFraction < 1.0
     }
 
     func wrapIndex(_ idx: Int, total: Int, in workspaceId: WorkspaceDescriptor.ID) -> Int? {
@@ -326,15 +359,15 @@ final class NiriLayoutEngine {
     }
 
     func updateConfiguration(
-        maxVisibleColumns: Int? = nil,
+        balancedColumnCount: Int? = nil,
         infiniteLoop: Bool? = nil,
         revealPartial: RevealPartial? = nil,
-        singleWindowAspectRatio: SingleWindowAspectRatio? = nil,
+        loneWindowPolicy: LoneWindowPolicy? = nil,
         presetColumnWidths: [PresetSize]? = nil,
         defaultColumnWidth: CGFloat?? = nil
     ) {
-        if let max = maxVisibleColumns {
-            self.maxVisibleColumns = max.clamped(to: 1 ... 5)
+        if let max = balancedColumnCount {
+            self.balancedColumnCount = max.clamped(to: 1 ... 5)
         }
         if let loop = infiniteLoop {
             self.infiniteLoop = loop
@@ -342,8 +375,8 @@ final class NiriLayoutEngine {
         if let revealPartial {
             self.revealPartial = revealPartial
         }
-        if let aspectRatio = singleWindowAspectRatio {
-            self.singleWindowAspectRatio = aspectRatio
+        if let loneWindowPolicy {
+            self.loneWindowPolicy = loneWindowPolicy
         }
         // Double optional distinguishes "no config change" from "set Auto/nil".
         if let defaultColumnWidth {
@@ -353,6 +386,16 @@ final class NiriLayoutEngine {
         if let presets = presetColumnWidths, !presets.isEmpty {
             self.presetColumnWidths = presets
             resetAllPresetWidthIndices()
+        }
+    }
+
+    func invalidateCachedLayoutSpans() {
+        for root in roots.values {
+            for child in root.children {
+                guard let column = child as? NiriContainer else { continue }
+                column.cachedWidth = 0
+                column.cachedHeight = 0
+            }
         }
     }
 

--- a/Sources/Nehir/Core/Layout/Niri/NiriNode.swift
+++ b/Sources/Nehir/Core/Layout/Niri/NiriNode.swift
@@ -48,6 +48,10 @@ enum ProportionalSize: Codable, Equatable, Sendable {
         // then each proportional column contributes one gap of slack. A contiguous
         // group whose proportions sum to 1.0 spans availableSpace - 2 * gaps after
         // internal gaps are added, independent of the number of columns in the group.
+        // This 2*gap slack is intentional: it keeps proportional column groups inside
+        // the working frame against sub-pixel rounding and matches the fillsViewport
+        // tolerance (2*gap), which is what makes Reveal Partial "Default" treat a
+        // visible 50/50 pair as filling the screen.
         (availableSpace - gaps) * proportion - gaps
     }
 }

--- a/Sources/Nehir/Core/Layout/Niri/ViewportState+Geometry.swift
+++ b/Sources/Nehir/Core/Layout/Niri/ViewportState+Geometry.swift
@@ -70,6 +70,7 @@ struct ViewportSnapContext {
     let gap: CGFloat
     let viewportWidth: CGFloat
     let snapPoints: [SnapPoint]
+    let intentionallyDoesNotFillViewport: Bool
 
     func currentViewStart(in state: ViewportState) -> CGFloat {
         state.targetViewPosPixels(columns: columns, gap: gap)
@@ -133,6 +134,8 @@ struct ViewportSnapContext {
     }
 
     func fillsViewport(at viewportStart: CGFloat, in state: ViewportState, pixelTolerance: CGFloat = 0.5) -> Bool {
+        if intentionallyDoesNotFillViewport { return false }
+
         let viewportEnd = viewportStart + viewportWidth
         var fullColumnIndices: [Int] = []
 
@@ -550,7 +553,8 @@ extension ViewportState {
         columns: [NiriContainer],
         gap: CGFloat,
         viewportWidth: CGFloat,
-        pixelTolerance: CGFloat = 0.5
+        pixelTolerance: CGFloat = 0.5,
+        intentionallyDoesNotFillViewport: Bool = false
     ) -> ViewportSnapContext {
         ViewportSnapContext(
             columns: columns,
@@ -561,7 +565,8 @@ extension ViewportState {
                 gap: gap,
                 viewportWidth: viewportWidth,
                 pixelTolerance: pixelTolerance
-            )
+            ),
+            intentionallyDoesNotFillViewport: intentionallyDoesNotFillViewport
         )
     }
 
@@ -586,8 +591,17 @@ extension ViewportState {
                 continue
             }
 
-            points.append(SnapPoint(offset: bounded(columnX - gap), columnIndex: index, kind: .leftEdge))
-            points.append(SnapPoint(offset: bounded(columnX + width + gap - viewportWidth), columnIndex: index, kind: .rightEdge))
+            // Edge snaps at columnX ± gap exist to park a narrower-than-viewport column with a
+            // gap sliver visible (the niri overscroll idiom). For a column that approximately
+            // fills the viewport there is no neighbor to reveal, so a ±gap shift only loses
+            // working-area margin — omit them. Over-wide columns (wider than the viewport due
+            // to an app minimum or fixed size) still need their edge snaps so clipped
+            // leading/trailing content can be reached via scrollViewport.
+            let columnApproximatelyFillsViewport = abs(width - viewportWidth) <= pixelTolerance
+            if !columnApproximatelyFillsViewport {
+                points.append(SnapPoint(offset: bounded(columnX - gap), columnIndex: index, kind: .leftEdge))
+                points.append(SnapPoint(offset: bounded(columnX + width + gap - viewportWidth), columnIndex: index, kind: .rightEdge))
+            }
             if width > 0.30 * viewportWidth {
                 points.append(SnapPoint(
                     offset: bounded(columnX + width / 2 - viewportWidth / 2),

--- a/Sources/Nehir/UI/LayoutSettingsTab.swift
+++ b/Sources/Nehir/UI/LayoutSettingsTab.swift
@@ -6,81 +6,28 @@ struct LayoutSettingsTab: View {
 
     @State private var selectedMonitor: Monitor.ID?
     @State private var connectedMonitors: [Monitor] = Monitor.current()
+    @State private var draftGapSize: Double?
+    @State private var draftOuterGapLeft: Double?
+    @State private var draftOuterGapRight: Double?
+    @State private var draftOuterGapTop: Double?
+    @State private var draftOuterGapBottom: Double?
+
+    private var effectiveGapSize: Double { draftGapSize ?? settings.gapSize }
+    private var effectiveOuterGapLeft: Double { draftOuterGapLeft ?? settings.outerGapLeft }
+    private var effectiveOuterGapRight: Double { draftOuterGapRight ?? settings.outerGapRight }
+    private var effectiveOuterGapTop: Double { draftOuterGapTop ?? settings.outerGapTop }
+    private var effectiveOuterGapBottom: Double { draftOuterGapBottom ?? settings.outerGapBottom }
 
     var body: some View {
         Form {
-            Section("Inner Gaps") {
-                SettingsSliderRow(
-                    label: "Gap Size",
-                    value: $settings.gapSize,
-                    range: 0 ... 32,
-                    step: 1,
-                    valueText: "\(Int(settings.gapSize)) px",
-                    valueWidth: 64
-                )
-                .onChange(of: settings.gapSize) { _, newValue in
-                    controller.setGapSize(newValue)
-                }
-                SettingsCaption("Space between tiled windows.")
-            }
-
-            Section("Outer Margins") {
-                SettingsSliderRow(
-                    label: "Left",
-                    value: $settings.outerGapLeft,
-                    range: 0 ... 64,
-                    step: 1,
-                    valueText: "\(Int(settings.outerGapLeft)) px",
-                    valueWidth: 64
-                )
-                .onChange(of: settings.outerGapLeft) { _, _ in
-                    syncOuterGaps()
-                }
-
-                SettingsSliderRow(
-                    label: "Right",
-                    value: $settings.outerGapRight,
-                    range: 0 ... 64,
-                    step: 1,
-                    valueText: "\(Int(settings.outerGapRight)) px",
-                    valueWidth: 64
-                )
-                .onChange(of: settings.outerGapRight) { _, _ in
-                    syncOuterGaps()
-                }
-
-                SettingsSliderRow(
-                    label: "Top",
-                    value: $settings.outerGapTop,
-                    range: 0 ... 64,
-                    step: 1,
-                    valueText: "\(Int(settings.outerGapTop)) px",
-                    valueWidth: 64
-                )
-                .onChange(of: settings.outerGapTop) { _, _ in
-                    syncOuterGaps()
-                }
-
-                SettingsSliderRow(
-                    label: "Bottom",
-                    value: $settings.outerGapBottom,
-                    range: 0 ... 64,
-                    step: 1,
-                    valueText: "\(Int(settings.outerGapBottom)) px",
-                    valueWidth: 64
-                )
-                .onChange(of: settings.outerGapBottom) { _, _ in
-                    syncOuterGaps()
-                }
-                SettingsCaption("Inset the entire tiled layout from the screen edges.")
-            }
-
             MonitorScopeSection(
                 selectedMonitor: $selectedMonitor,
                 monitors: connectedMonitors,
-                hasOverrides: { settings.niriSettings(for: $0) != nil },
+                hasOverrides: { settings.niriSettings(for: $0) != nil || settings.gapSettings(for: $0)?.hasOverrides == true },
                 reset: { monitor in
+                    settings.removeGapSettings(for: monitor)
                     settings.removeNiriSettings(for: monitor)
+                    controller.updateMonitorGapSettings()
                     controller.updateMonitorNiriSettings()
                 }
             )
@@ -88,12 +35,20 @@ struct LayoutSettingsTab: View {
             if let monitorId = selectedMonitor,
                let monitor = connectedMonitors.first(where: { $0.id == monitorId })
             {
+                MonitorGapSettingsSection(
+                    settings: settings,
+                    controller: controller,
+                    monitor: monitor
+                )
+
                 MonitorNiriSettingsSection(
                     settings: settings,
                     controller: controller,
                     monitor: monitor
                 )
             } else {
+                globalSpacingSections
+
                 GlobalNiriSettingsSection(
                     settings: settings,
                     controller: controller
@@ -106,12 +61,216 @@ struct LayoutSettingsTab: View {
         }
     }
 
-    private func syncOuterGaps() {
-        controller.setOuterGaps(
-            left: settings.outerGapLeft,
-            right: settings.outerGapRight,
-            top: settings.outerGapTop,
-            bottom: settings.outerGapBottom
+    @ViewBuilder
+    private var globalSpacingSections: some View {
+        Section("Spacing Between Windows") {
+            SettingsSliderRow(
+                label: "Inner Gap",
+                value: Binding(
+                    get: { effectiveGapSize },
+                    set: { newValue in
+                        draftGapSize = newValue
+                    }
+                ),
+                range: 0 ... 32,
+                step: 1,
+                valueText: "\(Int(effectiveGapSize)) px",
+                valueWidth: 64,
+                onEditingChanged: { editing in
+                    if !editing { commitGapSizeDraft() }
+                }
+            )
+            SettingsCaption("Global default spacing between neighboring tiled windows. Select a monitor above to override this for that display.")
+        }
+
+        Section("Screen Margins") {
+            SettingsSliderRow(
+                label: "Left",
+                value: Binding(
+                    get: { effectiveOuterGapLeft },
+                    set: { newValue in
+                        draftOuterGapLeft = newValue
+                    }
+                ),
+                range: 0 ... 64,
+                step: 1,
+                valueText: "\(Int(effectiveOuterGapLeft)) px",
+                valueWidth: 64,
+                onEditingChanged: { editing in
+                    if !editing { commitOuterGapDrafts() }
+                }
+            )
+
+            SettingsSliderRow(
+                label: "Right",
+                value: Binding(
+                    get: { effectiveOuterGapRight },
+                    set: { newValue in
+                        draftOuterGapRight = newValue
+                    }
+                ),
+                range: 0 ... 64,
+                step: 1,
+                valueText: "\(Int(effectiveOuterGapRight)) px",
+                valueWidth: 64,
+                onEditingChanged: { editing in
+                    if !editing { commitOuterGapDrafts() }
+                }
+            )
+
+            SettingsSliderRow(
+                label: "Top",
+                value: Binding(
+                    get: { effectiveOuterGapTop },
+                    set: { newValue in
+                        draftOuterGapTop = newValue
+                    }
+                ),
+                range: 0 ... 64,
+                step: 1,
+                valueText: "\(Int(effectiveOuterGapTop)) px",
+                valueWidth: 64,
+                onEditingChanged: { editing in
+                    if !editing { commitOuterGapDrafts() }
+                }
+            )
+
+            SettingsSliderRow(
+                label: "Bottom",
+                value: Binding(
+                    get: { effectiveOuterGapBottom },
+                    set: { newValue in
+                        draftOuterGapBottom = newValue
+                    }
+                ),
+                range: 0 ... 64,
+                step: 1,
+                valueText: "\(Int(effectiveOuterGapBottom)) px",
+                valueWidth: 64,
+                onEditingChanged: { editing in
+                    if !editing { commitOuterGapDrafts() }
+                }
+            )
+            SettingsCaption("Global default margins for the tiled working area. Select a monitor above to override individual edges for that display.")
+        }
+    }
+
+    private func commitGapSizeDraft() {
+        guard let draftGapSize else { return }
+        settings.gapSize = draftGapSize
+        controller.setGapSize(draftGapSize)
+        self.draftGapSize = nil
+    }
+
+    private func commitOuterGapDrafts() {
+        let left = effectiveOuterGapLeft
+        let right = effectiveOuterGapRight
+        let top = effectiveOuterGapTop
+        let bottom = effectiveOuterGapBottom
+
+        if draftOuterGapLeft != nil { settings.outerGapLeft = left }
+        if draftOuterGapRight != nil { settings.outerGapRight = right }
+        if draftOuterGapTop != nil { settings.outerGapTop = top }
+        if draftOuterGapBottom != nil { settings.outerGapBottom = bottom }
+
+        controller.setOuterGaps(left: left, right: right, top: top, bottom: bottom)
+
+        draftOuterGapLeft = nil
+        draftOuterGapRight = nil
+        draftOuterGapTop = nil
+        draftOuterGapBottom = nil
+    }
+}
+
+struct MonitorGapSettingsSection: View {
+    @Bindable var settings: SettingsStore
+    @Bindable var controller: WMController
+    let monitor: Monitor
+
+    private var monitorSettings: MonitorGapSettings {
+        settings.gapSettings(for: monitor) ?? MonitorGapSettings(
+            monitorName: monitor.name,
+            monitorDisplayId: monitor.displayId
         )
+    }
+
+    private func updateSetting(_ update: (inout MonitorGapSettings) -> Void) {
+        var ms = monitorSettings
+        ms.monitorName = monitor.name
+        ms.monitorDisplayId = monitor.displayId
+        update(&ms)
+        if ms.hasOverrides {
+            settings.updateGapSettings(ms)
+        } else {
+            settings.removeGapSettings(for: monitor)
+        }
+        controller.updateMonitorGapSettings()
+    }
+
+    var body: some View {
+        let ms = monitorSettings
+
+        Section("Monitor Spacing") {
+            OverridableSlider(
+                label: "Inner Gap",
+                value: ms.gapSize,
+                globalValue: settings.gapSize,
+                range: 0 ... 32,
+                step: 1,
+                formatter: { "\(Int($0)) px" },
+                commitOnEditingEnd: true,
+                onChange: { newValue in updateSetting { $0.gapSize = newValue } },
+                onReset: { updateSetting { $0.gapSize = nil } }
+            )
+            SettingsCaption("Overrides spacing between tiled windows on this monitor.")
+        }
+
+        Section("Monitor Screen Margins") {
+            OverridableSlider(
+                label: "Left",
+                value: ms.outerGapLeft,
+                globalValue: settings.outerGapLeft,
+                range: 0 ... 64,
+                step: 1,
+                formatter: { "\(Int($0)) px" },
+                commitOnEditingEnd: true,
+                onChange: { newValue in updateSetting { $0.outerGapLeft = newValue } },
+                onReset: { updateSetting { $0.outerGapLeft = nil } }
+            )
+            OverridableSlider(
+                label: "Right",
+                value: ms.outerGapRight,
+                globalValue: settings.outerGapRight,
+                range: 0 ... 64,
+                step: 1,
+                formatter: { "\(Int($0)) px" },
+                commitOnEditingEnd: true,
+                onChange: { newValue in updateSetting { $0.outerGapRight = newValue } },
+                onReset: { updateSetting { $0.outerGapRight = nil } }
+            )
+            OverridableSlider(
+                label: "Top",
+                value: ms.outerGapTop,
+                globalValue: settings.outerGapTop,
+                range: 0 ... 64,
+                step: 1,
+                formatter: { "\(Int($0)) px" },
+                commitOnEditingEnd: true,
+                onChange: { newValue in updateSetting { $0.outerGapTop = newValue } },
+                onReset: { updateSetting { $0.outerGapTop = nil } }
+            )
+            OverridableSlider(
+                label: "Bottom",
+                value: ms.outerGapBottom,
+                globalValue: settings.outerGapBottom,
+                range: 0 ... 64,
+                step: 1,
+                formatter: { "\(Int($0)) px" },
+                commitOnEditingEnd: true,
+                onChange: { newValue in updateSetting { $0.outerGapBottom = newValue } },
+                onReset: { updateSetting { $0.outerGapBottom = nil } }
+            )
+            SettingsCaption("Overrides tiled working-area margins on this monitor.")
+        }
     }
 }

--- a/Sources/Nehir/UI/OverridableControls.swift
+++ b/Sources/Nehir/UI/OverridableControls.swift
@@ -60,11 +60,14 @@ struct SettingsSliderRow: View {
     let step: Double
     let valueText: String
     var valueWidth: CGFloat = 56
+    var onEditingChanged: ((Bool) -> Void)? = nil
 
     var body: some View {
         LabeledContent(label) {
             HStack {
-                Slider(value: $value, in: range, step: step) {
+                Slider(value: $value, in: range, step: step, onEditingChanged: { editing in
+                    onEditingChanged?(editing)
+                }) {
                     Text(label)
                 }
                 .labelsHidden()
@@ -166,10 +169,34 @@ struct ResetIconButton: View {
         }
         .buttonStyle(.borderless)
         .controlSize(.regular)
-        .frame(width: 44, height: 44)
+        .frame(width: OverrideStatusIndicator.width, height: OverrideStatusIndicator.height)
         .contentShape(Rectangle())
         .help(title)
         .accessibilityLabel(title)
+    }
+}
+
+struct OverrideStatusIndicator: View {
+    static let width: CGFloat = 45
+    static let height: CGFloat = 44
+
+    let isOverridden: Bool
+    let resetTitle: String
+    let globalAccessibilityLabel: String
+    let onReset: () -> Void
+
+    var body: some View {
+        ZStack {
+            if isOverridden {
+                ResetIconButton(title: resetTitle, action: onReset)
+            } else {
+                Text("Global")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .accessibilityLabel(globalAccessibilityLabel)
+            }
+        }
+        .frame(width: Self.width, height: Self.height)
     }
 }
 
@@ -205,17 +232,13 @@ struct OverridableToggle: View {
         }
     }
 
-    @ViewBuilder
     private var overrideStatus: some View {
-        if isOverridden {
-            ResetIconButton(title: "Reset \(label) to global default", action: onReset)
-        } else {
-            Text("Global")
-                .font(.caption)
-                .foregroundStyle(.secondary)
-                .frame(minWidth: 45)
-                .accessibilityLabel("\(label) uses global default")
-        }
+        OverrideStatusIndicator(
+            isOverridden: isOverridden,
+            resetTitle: "Reset \(label) to global default",
+            globalAccessibilityLabel: "\(label) uses global default",
+            onReset: onReset
+        )
     }
 }
 
@@ -255,17 +278,13 @@ struct OverridablePicker<T: Hashable & Identifiable>: View {
         }
     }
 
-    @ViewBuilder
     private var overrideStatus: some View {
-        if isOverridden {
-            ResetIconButton(title: "Reset \(label) to global default", action: onReset)
-        } else {
-            Text("Global")
-                .font(.caption)
-                .foregroundStyle(.secondary)
-                .frame(minWidth: 45)
-                .accessibilityLabel("\(label) uses global default")
-        }
+        OverrideStatusIndicator(
+            isOverridden: isOverridden,
+            resetTitle: "Reset \(label) to global default",
+            globalAccessibilityLabel: "\(label) uses global default",
+            onReset: onReset
+        )
     }
 }
 
@@ -276,15 +295,18 @@ struct OverridableSlider: View {
     let range: ClosedRange<Double>
     let step: Double
     let formatter: (Double) -> String
+    var commitOnEditingEnd = false
     let onChange: (Double) -> Void
     let onReset: () -> Void
 
+    @State private var draftValue: Double?
+
     private var effectiveValue: Double {
-        value ?? globalValue
+        draftValue ?? value ?? globalValue
     }
 
     private var isOverridden: Bool {
-        value != nil
+        draftValue != nil || value != nil
     }
 
     var body: some View {
@@ -293,8 +315,18 @@ struct OverridableSlider: View {
                 let displayValue = formatter(effectiveValue)
                 Slider(value: Binding(
                     get: { effectiveValue },
-                    set: { onChange($0) }
-                ), in: range, step: step) {
+                    set: { newValue in
+                        if commitOnEditingEnd {
+                            draftValue = newValue
+                        } else {
+                            onChange(newValue)
+                        }
+                    }
+                ), in: range, step: step, onEditingChanged: { editing in
+                    guard commitOnEditingEnd, !editing, let draftValue else { return }
+                    onChange(draftValue)
+                    self.draftValue = nil
+                }) {
                     Text(label)
                 }
                 .labelsHidden()
@@ -307,16 +339,14 @@ struct OverridableSlider: View {
         }
     }
 
-    @ViewBuilder
     private var overrideStatus: some View {
-        if isOverridden {
-            ResetIconButton(title: "Reset \(label) to global default", action: onReset)
-        } else {
-            Text("Global")
-                .font(.caption)
-                .foregroundStyle(.secondary)
-                .frame(minWidth: 45)
-                .accessibilityLabel("\(label) uses global default")
+        OverrideStatusIndicator(
+            isOverridden: isOverridden,
+            resetTitle: "Reset \(label) to global default",
+            globalAccessibilityLabel: "\(label) uses global default"
+        ) {
+            draftValue = nil
+            onReset()
         }
     }
 }
@@ -372,16 +402,12 @@ struct OverridableStepper: View {
         )
     }
 
-    @ViewBuilder
     private var overrideStatus: some View {
-        if isOverridden {
-            ResetIconButton(title: "Reset \(label) to global default", action: onReset)
-        } else {
-            Text("Global")
-                .font(.caption)
-                .foregroundStyle(.secondary)
-                .frame(minWidth: 45)
-                .accessibilityLabel("\(label) uses global default")
-        }
+        OverrideStatusIndicator(
+            isOverridden: isOverridden,
+            resetTitle: "Reset \(label) to global default",
+            globalAccessibilityLabel: "\(label) uses global default",
+            onReset: onReset
+        )
     }
 }

--- a/Sources/Nehir/UI/SettingsView.swift
+++ b/Sources/Nehir/UI/SettingsView.swift
@@ -268,15 +268,54 @@ struct NiriSettingsTab: View {
     }
 }
 
+private enum DefaultColumnWidthMode: String, CaseIterable, Identifiable {
+    case balanced
+    case custom
+
+    var id: String { rawValue }
+}
+
+private enum LoneWindowMode: String, CaseIterable, Identifiable {
+    case fill
+    case centered
+
+    var id: String { rawValue }
+}
+
+private enum LoneWindowOverrideMode: String, CaseIterable, Identifiable {
+    case inherit
+    case fill
+    case centered
+
+    var id: String { rawValue }
+}
+
+private struct StableSettingsControlRow<Content: View>: View {
+    let label: String
+    @ViewBuilder let content: () -> Content
+
+    init(_ label: String, @ViewBuilder content: @escaping () -> Content) {
+        self.label = label
+        self.content = content
+    }
+
+    var body: some View {
+        LabeledContent(label) {
+            content()
+                .frame(minHeight: 32, alignment: .center)
+        }
+    }
+}
+
 struct GlobalNiriSettingsSection: View {
     @Bindable var settings: SettingsStore
     @Bindable var controller: WMController
 
     var body: some View {
-        let useAutoDefaultColumnWidth = Binding(
-            get: { settings.niriDefaultColumnWidth == nil },
-            set: { useAuto in
-                settings.niriDefaultColumnWidth = useAuto ? nil : (settings.niriDefaultColumnWidth ?? 0.5)
+        let defaultColumnWidthMode = Binding(
+            get: { settings.niriDefaultColumnWidth == nil ? DefaultColumnWidthMode.balanced : .custom },
+            set: { mode in
+                settings.niriDefaultColumnWidth = mode == .balanced ? nil : (settings.niriDefaultColumnWidth ?? 0.5)
                 controller.updateNiriConfig(defaultColumnWidth: settings.niriDefaultColumnWidth)
             }
         )
@@ -287,50 +326,48 @@ struct GlobalNiriSettingsSection: View {
                 controller.updateNiriConfig(defaultColumnWidth: settings.niriDefaultColumnWidth)
             }
         )
+        let niriBalancedColumnCount = Binding(
+            get: { settings.niriBalancedColumnCount },
+            set: { newValue in
+                settings.niriBalancedColumnCount = newValue.clamped(to: 1 ... 5)
+                controller.updateNiriConfig(balancedColumnCount: settings.niriBalancedColumnCount)
+            }
+        )
+        let loneWindowMode = Binding(
+            get: { settings.niriLoneWindowMaxWidth == nil ? LoneWindowMode.fill : .centered },
+            set: { mode in
+                settings.niriLoneWindowMaxWidth = mode == .fill ? nil : (settings.niriLoneWindowMaxWidth ?? 0.6)
+                controller.updateNiriConfig(loneWindowPolicy: settings.loneWindowPolicy)
+            }
+        )
+        let loneWindowMaxWidthPercent = Binding(
+            get: { Int((settings.niriLoneWindowMaxWidth ?? 0.6) * 100) },
+            set: { newPercent in
+                settings.niriLoneWindowMaxWidth = Double(min(95, max(10, newPercent))) / 100.0
+                controller.updateNiriConfig(loneWindowPolicy: settings.loneWindowPolicy)
+            }
+        )
         let presets = settings.niriColumnWidthPresets
 
-        Section("Column Layout") {
-            SettingsSliderRow(
-                label: "Visible Columns",
-                value: Binding(
-                    get: { Double(settings.niriMaxVisibleColumns) },
-                    set: { settings.niriMaxVisibleColumns = Int($0) }
-                ),
-                range: 1 ... 5,
-                step: 1,
-                valueText: "\(settings.niriMaxVisibleColumns)",
-                valueWidth: 32
-            )
-            .onChange(of: settings.niriMaxVisibleColumns) { _, newValue in
-                controller.updateNiriConfig(maxVisibleColumns: newValue)
-            }
-
-            Picker("Single Window Width", selection: $settings.niriSingleWindowAspectRatio) {
-                ForEach(SingleWindowAspectRatio.allCases, id: \.self) { ratio in
-                    Text(ratio.displayName).tag(ratio)
-                }
-            }
-            .onChange(of: settings.niriSingleWindowAspectRatio) { _, newValue in
-                controller.updateNiriConfig(singleWindowAspectRatio: newValue)
-            }
-            SettingsCaption("Column width used when a window has no siblings on the same workspace.")
-        }
-
-        Section("Default New Column Width") {
-            LabeledContent("Width Mode") {
-                Picker("Width Mode", selection: useAutoDefaultColumnWidth) {
-                    Text("Auto").tag(true)
-                    Text("Custom").tag(false)
+        Section("Default Column Width") {
+            LabeledContent("Mode") {
+                Picker("Default Column Width Mode", selection: defaultColumnWidthMode) {
+                    Text("Balanced").tag(DefaultColumnWidthMode.balanced)
+                    Text("Custom").tag(DefaultColumnWidthMode.custom)
                 }
                 .labelsHidden()
                 .pickerStyle(.segmented)
                 .frame(maxWidth: 220)
             }
 
-            if settings.niriDefaultColumnWidth != nil {
-                LabeledContent("Custom Width") {
+            if settings.niriDefaultColumnWidth == nil {
+                StableSettingsControlRow("Columns to Fit") {
+                    Stepper("\(settings.niriBalancedColumnCount)", value: niriBalancedColumnCount, in: 1 ... 5)
+                }
+            } else {
+                StableSettingsControlRow("Width") {
                     HStack {
-                        TextField("Custom Width", value: defaultColumnWidthPercent, format: .number)
+                        TextField("Width", value: defaultColumnWidthPercent, format: .number)
                             .labelsHidden()
                             .textFieldStyle(.roundedBorder)
                             .frame(width: 48)
@@ -341,14 +378,38 @@ struct GlobalNiriSettingsSection: View {
                 }
             }
 
-            SettingsCaption(
-                settings.niriDefaultColumnWidth == nil
-                    ? "Auto uses the balanced width for the current Visible Columns setting."
-                    : "New or claimed columns start at this width until you resize them."
-            )
+            SettingsCaption("Applies when a column is created or reset. Existing columns are not resized by this setting.")
         }
 
-        Section("Column Width Cycle Presets") {
+        Section("Single-Window Default") {
+            LabeledContent("Mode") {
+                Picker("Single-Window Default Mode", selection: loneWindowMode) {
+                    Text("Fill").tag(LoneWindowMode.fill)
+                    Text("Centered").tag(LoneWindowMode.centered)
+                }
+                .labelsHidden()
+                .pickerStyle(.segmented)
+                .frame(maxWidth: 220)
+            }
+
+            if settings.niriLoneWindowMaxWidth != nil {
+                StableSettingsControlRow("Centered Width") {
+                    HStack {
+                        TextField("Centered Width", value: loneWindowMaxWidthPercent, format: .number)
+                            .labelsHidden()
+                            .textFieldStyle(.roundedBorder)
+                            .frame(width: 48)
+                            .multilineTextAlignment(.trailing)
+                        Text("%")
+                            .foregroundStyle(.secondary)
+                    }
+                }
+            }
+
+            SettingsCaption("Applies only while a workspace has exactly one normal, non-tabbed window. Manual width changes override it.")
+        }
+
+        Section("Resize Presets") {
             ForEach(presets.indices, id: \.self) { index in
                 LabeledContent("Preset \(index + 1)") {
                     HStack {
@@ -391,12 +452,12 @@ struct GlobalNiriSettingsSection: View {
                     settings.niriColumnWidthPresets = presets
                     controller.updateNiriConfig(columnWidthPresets: settings.niriColumnWidthPresets)
                 }
-                Button("Reset Cycle Presets") {
+                Button("Reset Resize Presets") {
                     settings.niriColumnWidthPresets = SettingsStore.defaultColumnWidthPresets
                     controller.updateNiriConfig(columnWidthPresets: settings.niriColumnWidthPresets)
                 }
             }
-            SettingsCaption("Resize commands cycle through these presets in order. Duplicates are allowed.")
+            SettingsCaption("Used only by width-cycle commands. These do not affect default column width.")
         }
         .id(settings.niriColumnWidthPresets.count)
     }
@@ -426,27 +487,103 @@ struct MonitorNiriSettingsSection: View {
     var body: some View {
         let ms = monitorSettings
 
-        Section("Column Layout") {
-            OverridableSlider(
-                label: "Visible Columns",
-                value: ms.maxVisibleColumns.map { Double($0) },
-                globalValue: Double(settings.niriMaxVisibleColumns),
+        let loneWindowOverrideMode = Binding<LoneWindowOverrideMode>(
+            get: {
+                if let policy = ms.loneWindowPolicy {
+                    switch policy {
+                    case .fill: return .fill
+                    case .centered: return .centered
+                    }
+                }
+                return .inherit
+            },
+            set: { mode in
+                updateSetting {
+                    switch mode {
+                    case .inherit:
+                        $0.loneWindowPolicy = nil
+                    case .fill:
+                        $0.loneWindowPolicy = .fill
+                    case .centered:
+                        let existingWidth: Double
+                        if case let .centered(widthFraction) = ms.loneWindowPolicy {
+                            existingWidth = widthFraction
+                        } else if let globalWidth = settings.niriLoneWindowMaxWidth {
+                            existingWidth = globalWidth
+                        } else {
+                            existingWidth = 0.6
+                        }
+                        $0.loneWindowPolicy = .centered(maxWidthFraction: existingWidth)
+                    }
+                }
+            }
+        )
+        let loneWindowMaxWidthPercent = Binding(
+            get: {
+                let fraction: Double
+                if case let .centered(widthFraction) = ms.loneWindowPolicy {
+                    fraction = widthFraction
+                } else {
+                    fraction = settings.niriLoneWindowMaxWidth ?? 0.6
+                }
+                return Int(fraction * 100)
+            },
+            set: { newPercent in
+                updateSetting {
+                    $0.loneWindowPolicy = .centered(maxWidthFraction: Double(min(95, max(10, newPercent))) / 100.0)
+                }
+            }
+        )
+
+        Section("Monitor Column Defaults") {
+            OverridableStepper(
+                label: "Columns to Fit",
+                value: ms.balancedColumnCount.map { Double($0) },
+                globalValue: Double(settings.niriBalancedColumnCount),
                 range: 1 ... 5,
                 step: 1,
                 formatter: { "\(Int($0))" },
-                onChange: { newValue in updateSetting { $0.maxVisibleColumns = Int(newValue) } },
-                onReset: { updateSetting { $0.maxVisibleColumns = nil } }
+                onChange: { newValue in updateSetting { $0.balancedColumnCount = Int(newValue) } },
+                onReset: { updateSetting { $0.balancedColumnCount = nil } }
             )
+            SettingsCaption("Overrides the Balanced column count on this monitor. Used only when Default Column Width is Balanced.")
+        }
 
-            OverridablePicker(
-                label: "Single Window Width",
-                value: ms.singleWindowAspectRatio,
-                globalValue: settings.niriSingleWindowAspectRatio,
-                options: SingleWindowAspectRatio.allCases,
-                displayName: { $0.displayName },
-                onChange: { newValue in updateSetting { $0.singleWindowAspectRatio = newValue } },
-                onReset: { updateSetting { $0.singleWindowAspectRatio = nil } }
-            )
+        Section("Monitor Single-Window Default") {
+            LabeledContent("Mode") {
+                HStack {
+                    Picker("Single-Window Default Mode", selection: loneWindowOverrideMode) {
+                        Text("Use Global").tag(LoneWindowOverrideMode.inherit)
+                        Text("Fill").tag(LoneWindowOverrideMode.fill)
+                        Text("Centered").tag(LoneWindowOverrideMode.centered)
+                    }
+                    .labelsHidden()
+
+                    OverrideStatusIndicator(
+                        isOverridden: ms.loneWindowPolicy != nil,
+                        resetTitle: "Reset one-window layout to global default",
+                        globalAccessibilityLabel: "Single-window default uses global setting"
+                    ) {
+                        updateSetting { $0.loneWindowPolicy = nil }
+                    }
+                }
+            }
+
+            if case .centered = ms.loneWindowPolicy {
+                StableSettingsControlRow("Centered Width") {
+                    HStack {
+                        TextField("Centered Width", value: loneWindowMaxWidthPercent, format: .number)
+                            .labelsHidden()
+                            .textFieldStyle(.roundedBorder)
+                            .frame(width: 48)
+                            .multilineTextAlignment(.trailing)
+                        Text("%")
+                            .foregroundStyle(.secondary)
+                    }
+                }
+            }
+
+            SettingsCaption("Use Global inherits the main setting. Fill or Centered overrides only this monitor's single-window default.")
         }
     }
 }

--- a/Sources/Nehir/UI/WorkspaceBarSettingsTab.swift
+++ b/Sources/Nehir/UI/WorkspaceBarSettingsTab.swift
@@ -121,7 +121,7 @@ private struct GlobalBarSettingsSection: View {
                     .onChange(of: settings.workspaceBarReserveLayoutSpace) { _, _ in
                         controller.updateWorkspaceBarSettings()
                     }
-                SettingsCaption("Prevents tiled windows from appearing behind the bar.")
+                SettingsCaption("Prevents tiled windows from appearing behind the bar. For finer control, adjust the top margin in Layout settings.")
             }
 
             Section("Position Offset") {
@@ -366,6 +366,7 @@ private struct MonitorBarSettingsSection: View {
                 onChange: { newValue in updateSetting { $0.reserveLayoutSpace = newValue } },
                 onReset: { updateSetting { $0.reserveLayoutSpace = nil } }
             )
+            .help("Prevents tiled windows from appearing behind the bar. For finer control, adjust the top margin in Layout settings.")
         }
 
         Section("Position Offset") {

--- a/Tests/NehirTests/AXEventHandlerTests.swift
+++ b/Tests/NehirTests/AXEventHandlerTests.swift
@@ -822,7 +822,7 @@ private func waitUntilAXEventTest(
         controller.hasStartedServices = true
         controller.setBordersEnabled(true)
         controller.enableNiriLayout()
-        controller.updateNiriConfig(maxVisibleColumns: 1)
+        controller.updateNiriConfig(balancedColumnCount: 1)
         await controller.layoutRefreshController.waitForRefreshWorkForTests()
         controller.syncMonitorsToNiriEngine()
         controller.niriEngine?.presetColumnWidths = [.proportion(1.0), .proportion(1.0)]
@@ -973,7 +973,7 @@ private func waitUntilAXEventTest(
         }
 
         controller.enableNiriLayout()
-        controller.updateNiriConfig(maxVisibleColumns: 1)
+        controller.updateNiriConfig(balancedColumnCount: 1)
         await controller.layoutRefreshController.waitForRefreshWorkForTests()
         controller.syncMonitorsToNiriEngine()
 
@@ -1066,7 +1066,7 @@ private func waitUntilAXEventTest(
         controller.hasStartedServices = true
         controller.setBordersEnabled(true)
         controller.enableNiriLayout()
-        controller.updateNiriConfig(maxVisibleColumns: 1)
+        controller.updateNiriConfig(balancedColumnCount: 1)
         await controller.layoutRefreshController.waitForRefreshWorkForTests()
         controller.syncMonitorsToNiriEngine()
         controller.niriEngine?.presetColumnWidths = [.proportion(1.0), .proportion(1.0)]
@@ -1854,7 +1854,7 @@ private func waitUntilAXEventTest(
         controller.hasStartedServices = true
         controller.setBordersEnabled(true)
         controller.enableNiriLayout()
-        controller.updateNiriConfig(maxVisibleColumns: 1)
+        controller.updateNiriConfig(balancedColumnCount: 1)
         await controller.layoutRefreshController.waitForRefreshWorkForTests()
         controller.syncMonitorsToNiriEngine()
 
@@ -1926,7 +1926,7 @@ private func waitUntilAXEventTest(
         controller.hasStartedServices = true
         controller.setBordersEnabled(true)
         controller.enableNiriLayout()
-        controller.updateNiriConfig(maxVisibleColumns: 1)
+        controller.updateNiriConfig(balancedColumnCount: 1)
         await controller.layoutRefreshController.waitForRefreshWorkForTests()
         controller.syncMonitorsToNiriEngine()
 

--- a/Tests/NehirTests/Fixtures/canonical-settings.toml
+++ b/Tests/NehirTests/Fixtures/canonical-settings.toml
@@ -46,12 +46,10 @@ margin = 1
 monitorOrder = []
 
 [niri]
-columnWidthPresets = [0.3333333333333333, 0.5, 0.6666666666666666]
-defaultColumnWidth = 0.5
+balancedColumnCount = 2
+columnWidthPresets = [0.35, 0.5, 0.65, 0.95]
 infiniteLoop = false
-maxVisibleColumns = 2
 revealPartial = "default"
-singleWindowAspectRatio = "none"
 
 [statusBar]
 showAppNames = false

--- a/Tests/NehirTests/MouseEventHandlerTests.swift
+++ b/Tests/NehirTests/MouseEventHandlerTests.swift
@@ -908,7 +908,7 @@ private func prepareMouseWheelScrollFixtureWithDefaultSensitivity() async -> (
 
         let originalWidth = column.cachedWidth
         let insetFrame = fixture.controller.insetWorkingFrame(for: monitor)
-        let maxWidth = insetFrame.width - CGFloat(fixture.controller.workspaceManager.gaps)
+        let maxWidth = insetFrame.width
         let expectedWidth = min(originalWidth + 24, maxWidth)
         let start = CGPoint(x: fixture.nodeFrame.maxX - 20, y: fixture.nodeFrame.midY)
         let end = CGPoint(x: start.x + 24, y: start.y)
@@ -939,7 +939,7 @@ private func prepareMouseWheelScrollFixtureWithDefaultSensitivity() async -> (
         fixture.controller.settings.mouseResizeModifierKey = .controlShift
         let originalWidth = column.cachedWidth
         let insetFrame = fixture.controller.insetWorkingFrame(for: monitor)
-        let maxWidth = insetFrame.width - CGFloat(fixture.controller.workspaceManager.gaps)
+        let maxWidth = insetFrame.width
         let expectedWidth = min(originalWidth + 24, maxWidth)
         let start = CGPoint(x: fixture.nodeFrame.maxX - 20, y: fixture.nodeFrame.midY)
         let end = CGPoint(x: start.x + 24, y: start.y)
@@ -1041,7 +1041,7 @@ private func prepareMouseWheelScrollFixtureWithDefaultSensitivity() async -> (
 
         let originalWidth = column.cachedWidth
         let insetFrame = fixture.controller.insetWorkingFrame(for: monitor)
-        let maxWidth = insetFrame.width - CGFloat(fixture.controller.workspaceManager.gaps)
+        let maxWidth = insetFrame.width
         let expectedWidth = min(originalWidth + 24, maxWidth)
 
         #expect(engine.interactiveResizeBegin(
@@ -1113,7 +1113,7 @@ private func prepareMouseWheelScrollFixtureWithDefaultSensitivity() async -> (
         )
         await fixture.controller.layoutRefreshController.waitForRefreshWorkForTests()
 
-        #expect(abs(column.cachedWidth - cappedWidth) < 0.001)
+        #expect(abs(column.cachedWidth - originalWidth) < 0.001)
         #expect(fixture.handler.state.isResizing == false)
     }
 
@@ -1947,7 +1947,7 @@ private func prepareMouseWheelScrollFixtureWithDefaultSensitivity() async -> (
                 in: fixture.workspaceId,
                 state: &state,
                 workingFrame: fixture.controller.insetWorkingFrame(for: monitor),
-                gaps: CGFloat(fixture.controller.workspaceManager.gaps)
+                gaps: fixture.controller.gapSize(for: monitor)
             )
         }
         #expect(moveStarted)

--- a/Tests/NehirTests/NiriLayoutEngineTests.swift
+++ b/Tests/NehirTests/NiriLayoutEngineTests.swift
@@ -295,7 +295,7 @@ private func makeCenteredCrossMonitorFixture(
     suppressAutomaticRefreshExecution(on: controller)
     controller.enableNiriLayout()
     controller.updateNiriConfig(
-        maxVisibleColumns: 2,
+        balancedColumnCount: 2,
         defaultColumnWidth: .some(0.85)
     )
     await waitForLayoutPlanRefreshWork(on: controller)
@@ -384,7 +384,7 @@ private func makeCenteredCrossMonitorFixture(
         }
 
         controller.enableNiriLayout()
-        controller.updateNiriConfig(maxVisibleColumns: 3)
+        controller.updateNiriConfig(balancedColumnCount: 3)
         await waitForLayoutPlanRefreshWork(on: controller)
         controller.layoutRefreshController.stopAllScrollAnimations()
         controller.syncMonitorsToNiriEngine()
@@ -569,7 +569,7 @@ private func makeCenteredCrossMonitorFixture(
         gaps: LayoutGaps,
         area: WorkingAreaContext
     ) {
-        let engine = NiriLayoutEngine(maxVisibleColumns: visibleCount)
+        let engine = NiriLayoutEngine(balancedColumnCount: visibleCount)
 
         let workspaceId = UUID()
         var windows: [NiriWindow] = []
@@ -629,7 +629,7 @@ private func makeCenteredCrossMonitorFixture(
 
     @MainActor
     private func makeNavigateToWindowViewportFixture(
-        maxVisibleColumns: Int,
+        balancedColumnCount: Int,
         windowCount: Int,
         outerGapLeft: Double = 0,
         outerGapRight: Double = 0
@@ -649,11 +649,11 @@ private func makeCenteredCrossMonitorFixture(
             fatalError("Missing monitor or active workspace for navigate-to-window viewport fixture")
         }
 
-        controller.settings.niriMaxVisibleColumns = maxVisibleColumns
+        controller.settings.niriBalancedColumnCount = balancedColumnCount
         controller.setOuterGaps(left: outerGapLeft, right: outerGapRight, top: 0, bottom: 0)
         controller.enableNiriLayout()
         controller.updateNiriConfig(
-            maxVisibleColumns: maxVisibleColumns
+            balancedColumnCount: balancedColumnCount
         )
         await waitForLayoutPlanRefreshWork(on: controller)
         controller.syncMonitorsToNiriEngine()
@@ -678,8 +678,8 @@ private func makeCenteredCrossMonitorFixture(
         let gap = CGFloat(controller.workspaceManager.gaps)
         let workingFrame = controller.insetWorkingFrame(for: monitor)
         let fixedWidth = (
-            workingFrame.width - gap * CGFloat(maxVisibleColumns - 1)
-        ) / CGFloat(maxVisibleColumns)
+            workingFrame.width - gap * CGFloat(balancedColumnCount - 1)
+        ) / CGFloat(balancedColumnCount)
         for column in engine.columns(in: workspaceId) {
             column.width = .fixed(fixedWidth)
             column.cachedWidth = fixedWidth
@@ -852,14 +852,14 @@ private func makeCenteredCrossMonitorFixture(
 
     private func resolvedSettings(
         for engine: NiriLayoutEngine,
-        maxVisibleColumns: Int? = nil,
-        singleWindowAspectRatio: SingleWindowAspectRatio? = nil,
+        defaultColumnWidth: DefaultColumnWidth? = nil,
+        loneWindowPolicy: LoneWindowPolicy? = nil,
         infiniteLoop: Bool? = nil
     ) -> ResolvedNiriSettings {
         let global = engine.globalResolvedSettings()
         return ResolvedNiriSettings(
-            maxVisibleColumns: maxVisibleColumns ?? global.maxVisibleColumns,
-            singleWindowAspectRatio: singleWindowAspectRatio ?? global.singleWindowAspectRatio,
+            defaultColumnWidth: defaultColumnWidth ?? global.defaultColumnWidth,
+            loneWindowPolicy: loneWindowPolicy ?? global.loneWindowPolicy,
             infiniteLoop: infiniteLoop ?? global.infiniteLoop
         )
     }
@@ -899,7 +899,7 @@ private func makeCenteredCrossMonitorFixture(
         withAnimationClock: Bool = false,
         pidBase: pid_t = 51
     ) -> NeighboringMonitorRevealFixture {
-        let engine = NiriLayoutEngine(maxVisibleColumns: 1)
+        let engine = NiriLayoutEngine(balancedColumnCount: 1)
         if withAnimationClock {
             engine.animationClock = AnimationClock()
         }
@@ -916,7 +916,7 @@ private func makeCenteredCrossMonitorFixture(
                 engine: engine,
                 resolvedSettings: resolvedSettings(
             for: engine,
-            maxVisibleColumns: 2
+            defaultColumnWidth: .balanced(columns: 2)
         )
             )
             _ = engine.ensureMonitor(for: monitors.secondary.id, monitor: monitors.secondary)
@@ -930,7 +930,7 @@ private func makeCenteredCrossMonitorFixture(
                 engine: engine,
                 resolvedSettings: resolvedSettings(
             for: engine,
-            maxVisibleColumns: 2
+            defaultColumnWidth: .balanced(columns: 2)
         )
             )
             owningMonitor = monitors.secondary
@@ -967,7 +967,7 @@ private func makeCenteredCrossMonitorFixture(
         withAnimationClock: Bool = false,
         pidBase: pid_t = 161
     ) -> NeighboringMonitorRevealFixture {
-        let engine = NiriLayoutEngine(maxVisibleColumns: 1)
+        let engine = NiriLayoutEngine(balancedColumnCount: 1)
         if withAnimationClock {
             engine.animationClock = AnimationClock()
         }
@@ -984,7 +984,7 @@ private func makeCenteredCrossMonitorFixture(
                 engine: engine,
                 resolvedSettings: resolvedSettings(
             for: engine,
-            maxVisibleColumns: 2
+            defaultColumnWidth: .balanced(columns: 2)
         )
             )
             _ = engine.ensureMonitor(for: monitors.upper.id, monitor: monitors.upper)
@@ -998,7 +998,7 @@ private func makeCenteredCrossMonitorFixture(
                 engine: engine,
                 resolvedSettings: resolvedSettings(
             for: engine,
-            maxVisibleColumns: 2
+            defaultColumnWidth: .balanced(columns: 2)
         )
             )
             owningMonitor = monitors.upper
@@ -1054,10 +1054,10 @@ private func makeCenteredCrossMonitorFixture(
     }
 
     @Test func firstWindowUsesBalancedWidthWhenDefaultWidthIsAutoWhenSingleWindowRatioIsDisabled() {
-        let engine = NiriLayoutEngine(maxVisibleColumns: 3)
+        let engine = NiriLayoutEngine(balancedColumnCount: 3)
         engine.presetColumnWidths = [.proportion(0.85), .proportion(1.0), .proportion(0.5)]
         engine.defaultColumnWidth = nil
-        engine.singleWindowAspectRatio = .none
+        engine.loneWindowPolicy = .fill
         let wsId = UUID()
 
         let window = engine.addWindow(handle: makeTestHandle(), to: wsId, afterSelection: nil)
@@ -1071,18 +1071,18 @@ private func makeCenteredCrossMonitorFixture(
         #expect(column.presetWidthIdx == nil)
     }
 
-    @Test func firstWindowUsesResolvedMonitorMaxVisibleColumnsWhenDefaultWidthIsAuto() {
-        let engine = NiriLayoutEngine(maxVisibleColumns: 1)
+    @Test func firstWindowUsesResolvedMonitorBalancedColumnCountWhenDefaultWidthIsAuto() {
+        let engine = NiriLayoutEngine(balancedColumnCount: 1)
         engine.presetColumnWidths = [.proportion(0.85), .proportion(1.0), .proportion(0.5)]
         engine.defaultColumnWidth = nil
-        engine.singleWindowAspectRatio = .none
+        engine.loneWindowPolicy = .fill
         let wsId = UUID()
         let monitor = makeTestMonitor(displayId: 501, name: "Override", x: 0)
         attachWorkspace(
             wsId,
             to: monitor,
             engine: engine,
-            resolvedSettings: resolvedSettings(for: engine, maxVisibleColumns: 3)
+            resolvedSettings: resolvedSettings(for: engine, defaultColumnWidth: .balanced(columns: 3))
         )
 
         let window = engine.addWindow(handle: makeTestHandle(), to: wsId, afterSelection: nil)
@@ -1096,19 +1096,27 @@ private func makeCenteredCrossMonitorFixture(
         #expect(column.presetWidthIdx == nil)
     }
 
-    @Test func singleWindowAspectRatioCentersLoneWindowFrame() {
-        let engine = NiriLayoutEngine(maxVisibleColumns: 3)
+    @Test func centeredLoneWindowPolicyCentersLoneWindowFrame() {
+        let engine = NiriLayoutEngine(balancedColumnCount: 3)
         engine.defaultColumnWidth = nil
-        engine.singleWindowAspectRatio = .ratio4x3
+        engine.loneWindowPolicy = .centered(maxWidthFraction: 0.75)
         let wsId = UUID()
         let window = engine.addWindow(handle: makeTestHandle(), to: wsId, afterSelection: nil)
         let monitor = makeLayoutPlanTestMonitor()
+
+        // Centered lone windows are centered via viewport offset. Seed the center offset so
+        // the rendered frame is horizontally centered (matching what the controller does).
+        let workingFrameWidth: CGFloat = monitor.visibleFrame.width
+        let expectedWidth = (workingFrameWidth * 0.75).roundedToPhysicalPixel(scale: 1)
+        let centerOffset = (expectedWidth - workingFrameWidth) / 2
+        var state = ViewportState()
+        state.viewOffsetPixels = .static(centerOffset)
 
         let layout = engine.calculateCombinedLayoutWithVisibility(
             in: wsId,
             monitor: monitor,
             gaps: LayoutGaps(horizontal: 8, vertical: 8),
-            state: ViewportState()
+            state: state
         )
 
         guard let frame = layout.frames[window.token] else {
@@ -1116,13 +1124,142 @@ private func makeCenteredCrossMonitorFixture(
             return
         }
 
-        #expect(frame == CGRect(x: 240, y: 0, width: 1440, height: 1080))
+        #expect(abs(frame.minX - (workingFrameWidth - expectedWidth) / 2) < 1.0)
+        #expect(abs(frame.width - expectedWidth) < 1.0)
+    }
+
+    @Test func singleWindowMinimumLargerThanWorkingAreaClampsToVisibleFrame() {
+        let engine = NiriLayoutEngine(balancedColumnCount: 3)
+        engine.defaultColumnWidth = nil
+        let wsId = UUID()
+        let window = engine.addWindow(handle: makeTestHandle(), to: wsId, afterSelection: nil)
+        let monitor = makeLayoutPlanTestMonitor(width: 2056, height: 1290)
+        let workingFrame = CGRect(x: 10, y: 0, width: 2036, height: 1280)
+        let area = WorkingAreaContext(
+            workingFrame: workingFrame,
+            viewFrame: monitor.visibleFrame,
+            scale: 1
+        )
+
+        engine.updateWindowConstraints(
+            for: window.token,
+            constraints: WindowSizeConstraints(
+                minSize: CGSize(width: 2056, height: 1290),
+                maxSize: .zero,
+                isFixed: false
+            )
+        )
+
+        let layout = engine.calculateCombinedLayoutWithVisibility(
+            in: wsId,
+            monitor: monitor,
+            gaps: LayoutGaps(horizontal: 10, vertical: 10),
+            state: ViewportState(),
+            workingArea: area
+        )
+
+        #expect(layout.frames[window.token] == monitor.visibleFrame)
+    }
+
+    @Test func singleWindowFillRendersRawScrollOffsetDuringGesture() {
+        let engine = NiriLayoutEngine(balancedColumnCount: 3)
+        engine.defaultColumnWidth = nil
+        let wsId = UUID()
+        let window = engine.addWindow(handle: makeTestHandle(), to: wsId, afterSelection: nil)
+        let monitor = makeLayoutPlanTestMonitor(width: 2056, height: 1290)
+        let workingFrame = CGRect(x: 10, y: 0, width: 2036, height: 1280)
+        let area = WorkingAreaContext(
+            workingFrame: workingFrame,
+            viewFrame: monitor.visibleFrame,
+            scale: 1
+        )
+
+        // During a gesture, the lone fill window should visibly follow the viewport
+        // offset. Snap-grid rules decide where it settles after release.
+        var scrolledState = ViewportState()
+        scrolledState.viewOffsetPixels = .static(247)
+        let layout = engine.calculateCombinedLayoutWithVisibility(
+            in: wsId,
+            monitor: monitor,
+            gaps: LayoutGaps(horizontal: 8, vertical: 8),
+            state: scrolledState,
+            workingArea: area
+        )
+
+        #expect(layout.frames[window.token] == workingFrame.offsetBy(dx: -247, dy: 0))
+    }
+
+    @Test func singleWindowCenteredHonorsSideSnapOffsets() {
+        let engine = NiriLayoutEngine(balancedColumnCount: 3)
+        engine.defaultColumnWidth = nil
+        let wsId = UUID()
+        let window = engine.addWindow(handle: makeTestHandle(), to: wsId, afterSelection: nil)
+        let monitor = makeLayoutPlanTestMonitor(width: 2056, height: 1290)
+        let workingFrame = CGRect(x: 10, y: 0, width: 2036, height: 1280)
+        let area = WorkingAreaContext(
+            workingFrame: workingFrame,
+            viewFrame: monitor.visibleFrame,
+            scale: 1
+        )
+
+        // Centered 60%: window width = 0.6 * 2036 = 1221.6, centerOffset = -407.2.
+        engine.loneWindowPolicy = .centered(maxWidthFraction: 0.6)
+        let expectedWidth: CGFloat = (2036 * 0.6).roundedToPhysicalPixel(scale: 1)
+        let centerOffset = (expectedWidth - workingFrame.width) / 2
+
+        // Centered snap.
+        var centeredState = ViewportState()
+        centeredState.viewOffsetPixels = .static(centerOffset)
+        let centeredLayout = engine.calculateCombinedLayoutWithVisibility(
+            in: wsId,
+            monitor: monitor,
+            gaps: LayoutGaps(horizontal: 8, vertical: 8),
+            state: centeredState,
+            workingArea: area
+        )
+        guard let centeredFrame = centeredLayout.frames[window.token] else {
+            Issue.record("Expected a centered lone-window frame")
+            return
+        }
+        #expect(abs(centeredFrame.midX - workingFrame.midX) < 1.0)
+
+        // Left-edge snap (offset 0): window left aligns to working-frame left.
+        var leftState = ViewportState()
+        leftState.viewOffsetPixels = .static(0)
+        let leftLayout = engine.calculateCombinedLayoutWithVisibility(
+            in: wsId,
+            monitor: monitor,
+            gaps: LayoutGaps(horizontal: 8, vertical: 8),
+            state: leftState,
+            workingArea: area
+        )
+        guard let leftFrame = leftLayout.frames[window.token] else {
+            Issue.record("Expected a left-snapped lone-window frame")
+            return
+        }
+        #expect(abs(leftFrame.minX - workingFrame.minX) < 1.0)
+
+        // Right-edge snap (offset 2*centerOffset): window right aligns to working-frame right.
+        var rightState = ViewportState()
+        rightState.viewOffsetPixels = .static(2 * centerOffset)
+        let rightLayout = engine.calculateCombinedLayoutWithVisibility(
+            in: wsId,
+            monitor: monitor,
+            gaps: LayoutGaps(horizontal: 8, vertical: 8),
+            state: rightState,
+            workingArea: area
+        )
+        guard let rightFrame = rightLayout.frames[window.token] else {
+            Issue.record("Expected a right-snapped lone-window frame")
+            return
+        }
+        #expect(abs(rightFrame.maxX - workingFrame.maxX) < 1.0)
     }
 
     @Test func singleWindowManualWidthOverrideKeepsWindowCenteredWhenAlwaysCenterSingleColumnDisabled() {
-        let engine = NiriLayoutEngine(maxVisibleColumns: 3)
+        let engine = NiriLayoutEngine(balancedColumnCount: 3)
         engine.defaultColumnWidth = nil
-        engine.singleWindowAspectRatio = .ratio4x3
+        engine.loneWindowPolicy = .centered(maxWidthFraction: 0.75)
         engine.animationClock = AnimationClock()
         let wsId = UUID()
         let gap: CGFloat = 8
@@ -1165,15 +1302,15 @@ private func makeCenteredCrossMonitorFixture(
         }
 
         #expect(column.hasManualSingleWindowWidthOverride)
-        #expect(abs(frame.width - 948) < 0.6)
+        #expect(abs(frame.width - column.cachedWidth) < 1.0)
         #expect(abs(frame.midX - monitor.visibleFrame.midX) < 0.6)
         #expect(frame.height == monitor.visibleFrame.height)
     }
 
     @Test func singleWindowFullWidthRoundTripRestoresPriorManualWidthAndCentering() {
-        let engine = NiriLayoutEngine(maxVisibleColumns: 3)
+        let engine = NiriLayoutEngine(balancedColumnCount: 3)
         engine.defaultColumnWidth = nil
-        engine.singleWindowAspectRatio = .ratio4x3
+        engine.loneWindowPolicy = .centered(maxWidthFraction: 0.75)
         engine.animationClock = AnimationClock()
         let wsId = UUID()
         let gap: CGFloat = 8
@@ -1278,9 +1415,9 @@ private func makeCenteredCrossMonitorFixture(
     }
 
     @Test func singleWindowManualWidthTargetFrameMatchesRenderedFrame() {
-        let engine = NiriLayoutEngine(maxVisibleColumns: 3)
+        let engine = NiriLayoutEngine(balancedColumnCount: 3)
         engine.defaultColumnWidth = nil
-        engine.singleWindowAspectRatio = .ratio4x3
+        engine.loneWindowPolicy = .centered(maxWidthFraction: 0.75)
         engine.animationClock = AnimationClock()
         let wsId = UUID()
         let gap: CGFloat = 8
@@ -1333,15 +1470,15 @@ private func makeCenteredCrossMonitorFixture(
         #expect(renderedFrame == targetFrame)
     }
 
-    @Test func defaultColumnWidthMatchingPresetKeepsSingleWindowAspectRatioUntilManualResize() {
-        let engine = NiriLayoutEngine(maxVisibleColumns: 3)
+    @Test func defaultColumnWidthMatchingPresetKeepsCenteredLoneWindowUntilManualResize() {
+        let engine = NiriLayoutEngine(balancedColumnCount: 3)
         engine.presetColumnWidths = [
             .proportion(0.85),
             .proportion(1.0),
             .proportion(0.5)
         ]
         engine.defaultColumnWidth = 0.85
-        engine.singleWindowAspectRatio = .ratio4x3
+        engine.loneWindowPolicy = .centered(maxWidthFraction: 0.75)
         let wsId = UUID()
         let window = engine.addWindow(handle: makeTestHandle(), to: wsId, afterSelection: nil)
         let monitor = makeLayoutPlanTestMonitor()
@@ -1351,11 +1488,18 @@ private func makeCenteredCrossMonitorFixture(
             return
         }
 
+        // Seed the centered viewport offset (matching what the controller does).
+        let workingFrameWidth: CGFloat = monitor.visibleFrame.width
+        let expectedWidth = (workingFrameWidth * 0.75).roundedToPhysicalPixel(scale: 1)
+        let centerOffset = (expectedWidth - workingFrameWidth) / 2
+        var state = ViewportState()
+        state.viewOffsetPixels = .static(centerOffset)
+
         let layout = engine.calculateCombinedLayoutWithVisibility(
             in: wsId,
             monitor: monitor,
             gaps: LayoutGaps(horizontal: 8, vertical: 8),
-            state: ViewportState()
+            state: state
         )
 
         guard let frame = layout.frames[window.token] else {
@@ -1365,13 +1509,14 @@ private func makeCenteredCrossMonitorFixture(
 
         #expect(column.presetWidthIdx == 0)
         #expect(!column.hasManualSingleWindowWidthOverride)
-        #expect(frame == CGRect(x: 240, y: 0, width: 1440, height: 1080))
+        #expect(abs(frame.midX - monitor.visibleFrame.midX) < 1.0)
+        #expect(abs(frame.width - expectedWidth) < 1.0)
     }
 
     @Test func addingSecondWindowReturnsToNormalColumnSizingAfterSingleWindowOverride() {
-        let engine = NiriLayoutEngine(maxVisibleColumns: 3)
+        let engine = NiriLayoutEngine(balancedColumnCount: 3)
         engine.defaultColumnWidth = nil
-        engine.singleWindowAspectRatio = .ratio4x3
+        engine.loneWindowPolicy = .centered(maxWidthFraction: 0.75)
         let wsId = UUID()
         let gap: CGFloat = 8
         let firstWindow = engine.addWindow(handle: makeTestHandle(), to: wsId, afterSelection: nil)
@@ -1406,12 +1551,12 @@ private func makeCenteredCrossMonitorFixture(
         #expect(firstFrame.width < singleFrame.width)
         #expect(abs(firstFrame.width - expectedColumnWidth) < 0.6)
         #expect(abs(secondFrame.width - expectedColumnWidth) < 0.6)
-        #expect(firstFrame.height == monitor.visibleFrame.height - gap * 2)
-        #expect(secondFrame.height == monitor.visibleFrame.height - gap * 2)
+        #expect(firstFrame.height == monitor.visibleFrame.height)
+        #expect(secondFrame.height == monitor.visibleFrame.height)
     }
 
     @Test func additionalWindowUsesExplicitDefaultWidthWhenCreatingNewColumn() {
-        let engine = NiriLayoutEngine(maxVisibleColumns: 3)
+        let engine = NiriLayoutEngine(balancedColumnCount: 3)
         engine.presetColumnWidths = [.proportion(0.85), .proportion(1.0), .proportion(0.5)]
         engine.defaultColumnWidth = 0.6
         let wsId = UUID()
@@ -1904,8 +2049,8 @@ private func makeCenteredCrossMonitorFixture(
         #expect(abs(column.cachedWidth - 700) < 0.001)
     }
 
-    @Test func tabbedColumnUsesOnlyOuterGapsForSharedTileFrame() {
-        let engine = NiriLayoutEngine(maxVisibleColumns: 1)
+    @Test func tabbedColumnDoesNotUseInnerGapsForSharedTileFrameEdges() {
+        let engine = NiriLayoutEngine(balancedColumnCount: 1)
         let workspaceId = UUID()
         let root = NiriRoot(workspaceId: workspaceId)
         engine.roots[workspaceId] = root
@@ -1937,14 +2082,14 @@ private func makeCenteredCrossMonitorFixture(
             return
         }
 
-        #expect(abs(bottomFrame.minY - 8) < 0.001)
-        #expect(abs(topFrame.minY - 8) < 0.001)
-        #expect(abs(bottomFrame.height - 884) < 0.001)
-        #expect(abs(topFrame.height - 884) < 0.001)
+        #expect(abs(bottomFrame.minY) < 0.001)
+        #expect(abs(topFrame.minY) < 0.001)
+        #expect(abs(bottomFrame.height - 900) < 0.001)
+        #expect(abs(topFrame.height - 900) < 0.001)
     }
 
-    @Test func verticalTabbedColumnUsesOnlyOuterGapsForSharedTileFrame() {
-        let engine = NiriLayoutEngine(maxVisibleColumns: 1)
+    @Test func verticalTabbedColumnDoesNotUseInnerGapsForSharedTileFrameEdges() {
+        let engine = NiriLayoutEngine(balancedColumnCount: 1)
         let workspaceId = UUID()
         let root = NiriRoot(workspaceId: workspaceId)
         engine.roots[workspaceId] = root
@@ -1976,10 +2121,10 @@ private func makeCenteredCrossMonitorFixture(
             return
         }
 
-        #expect(abs(bottomFrame.minX - 8) < 0.001)
-        #expect(abs(topFrame.minX - 8) < 0.001)
-        #expect(abs(bottomFrame.width - 884) < 0.001)
-        #expect(abs(topFrame.width - 884) < 0.001)
+        #expect(abs(bottomFrame.minX) < 0.001)
+        #expect(abs(topFrame.minX) < 0.001)
+        #expect(abs(bottomFrame.width - 900) < 0.001)
+        #expect(abs(topFrame.width - 900) < 0.001)
     }
 
     @Test func syncWindowsIdempotency() {
@@ -2729,7 +2874,7 @@ private func makeCenteredCrossMonitorFixture(
         }
 
         controller.enableNiriLayout()
-        controller.updateNiriConfig(maxVisibleColumns: 3)
+        controller.updateNiriConfig(balancedColumnCount: 3)
         await waitForLayoutPlanRefreshWork(on: controller)
         controller.layoutRefreshController.stopAllScrollAnimations()
         controller.syncMonitorsToNiriEngine()
@@ -2807,7 +2952,10 @@ private func makeCenteredCrossMonitorFixture(
         }
 
         let workingFrame = controller.insetWorkingFrame(for: monitor)
-        #expect(appliedFrame == settledFrame)
+        #expect(abs(appliedFrame.minX - settledFrame.minX) < 1.0)
+        #expect(abs(appliedFrame.minY - settledFrame.minY) < 1.0)
+        #expect(abs(appliedFrame.width - settledFrame.width) < 1.0)
+        #expect(abs(appliedFrame.height - settledFrame.height) < 1.0)
         #expect(workingFrame.intersects(appliedFrame))
     }
 
@@ -2821,7 +2969,7 @@ private func makeCenteredCrossMonitorFixture(
         }
 
         controller.enableNiriLayout()
-        controller.updateNiriConfig(maxVisibleColumns: 3)
+        controller.updateNiriConfig(balancedColumnCount: 3)
         await waitForLayoutPlanRefreshWork(on: controller)
         controller.layoutRefreshController.stopAllScrollAnimations()
         controller.syncMonitorsToNiriEngine()
@@ -3520,7 +3668,7 @@ private func makeCenteredCrossMonitorFixture(
     }
 
     @Test func moveWindowToWorkspaceUsesExplicitDefaultWidthForTargetColumn() {
-        let engine = NiriLayoutEngine(maxVisibleColumns: 3)
+        let engine = NiriLayoutEngine(balancedColumnCount: 3)
         engine.presetColumnWidths = [.proportion(0.85), .proportion(1.0), .proportion(0.5)]
         engine.defaultColumnWidth = 0.7
         let sourceWorkspaceId = UUID()
@@ -3577,8 +3725,8 @@ private func makeCenteredCrossMonitorFixture(
         #expect(targetState.selectedNodeId == window.id)
     }
 
-    @Test @MainActor func relayoutPlanUsesResolvedMonitorSingleWindowAspectRatio() async throws {
-        let monitor = makeLayoutPlanTestMonitor(name: "SquareTest")
+    @Test @MainActor func relayoutPlanUsesResolvedMonitorLoneWindowOverride() async throws {
+        let monitor = makeLayoutPlanTestMonitor(name: "LoneWindowOverrideTest")
         let controller = makeLayoutPlanTestController(monitors: [monitor])
         guard let workspaceId = controller.workspaceManager.activeWorkspaceOrFirst(on: monitor.id)?.id
         else {
@@ -3587,11 +3735,8 @@ private func makeCenteredCrossMonitorFixture(
         }
 
         controller.enableNiriLayout()
-        controller.settings.niriSingleWindowAspectRatio = .ratio4x3
-        controller.updateNiriConfig(
-            maxVisibleColumns: 3,
-            singleWindowAspectRatio: .ratio4x3
-        )
+        controller.settings.niriLoneWindowMaxWidth = 0.6
+        controller.updateNiriConfig(loneWindowPolicy: .centered(maxWidthFraction: 0.6))
         await waitForLayoutPlanRefreshWork(on: controller)
         controller.syncMonitorsToNiriEngine()
 
@@ -3611,7 +3756,7 @@ private func makeCenteredCrossMonitorFixture(
             MonitorNiriSettings(
                 monitorName: monitor.name,
                 monitorDisplayId: monitor.displayId,
-                singleWindowAspectRatio: .square
+                loneWindowPolicy: .centered(maxWidthFraction: 0.4)
             )
         )
         controller.updateMonitorNiriSettings()
@@ -3627,33 +3772,73 @@ private func makeCenteredCrossMonitorFixture(
         }
 
         #expect(baselineFrame.width > overrideFrame.width)
-        #expect(abs(overrideFrame.width - overrideFrame.height) < 0.5)
     }
 
 
-    @Test @MainActor func globalSingleWindowAspectRatioUpdatesResolvedMonitorSettingsImmediately() async {
-        let monitor = makeLayoutPlanTestMonitor(name: "AspectRatioTest")
+    @Test @MainActor func globalLoneWindowPolicyUpdatesResolvedMonitorSettingsImmediately() async {
+        let monitor = makeLayoutPlanTestMonitor(name: "LoneWindowPolicyTest")
         let controller = makeLayoutPlanTestController(monitors: [monitor])
-        controller.settings.niriSingleWindowAspectRatio = .ratio4x3
+        controller.settings.niriLoneWindowMaxWidth = 0.6
 
         controller.enableNiriLayout()
-        controller.updateNiriConfig(singleWindowAspectRatio: .ratio4x3)
+        controller.updateNiriConfig(loneWindowPolicy: .centered(maxWidthFraction: 0.6))
         await waitForLayoutPlanRefreshWork(on: controller)
         controller.syncMonitorsToNiriEngine()
 
         guard let engine = controller.niriEngine else {
-            Issue.record("Missing Niri engine for global single-window-aspect-ratio test")
+            Issue.record("Missing Niri engine for global lone-window-policy test")
             return
         }
 
         #expect(controller.settings.niriSettings(for: monitor) == nil)
-        #expect(engine.effectiveSingleWindowAspectRatio(for: monitor.id) == .ratio4x3)
+        #expect(engine.effectiveLoneWindowPolicy(for: monitor.id) == .centered(maxWidthFraction: 0.6))
 
-        controller.settings.niriSingleWindowAspectRatio = .square
-        controller.updateNiriConfig(singleWindowAspectRatio: .square)
+        controller.settings.niriLoneWindowMaxWidth = nil
+        controller.updateNiriConfig(loneWindowPolicy: .fill)
         await waitForLayoutPlanRefreshWork(on: controller)
 
-        #expect(engine.effectiveSingleWindowAspectRatio(for: monitor.id) == .square)
+        #expect(engine.effectiveLoneWindowPolicy(for: monitor.id) == .fill)
+    }
+
+    @Test @MainActor func monitorLoneWindowOverrideCanExplicitlyFillAgainstCenteredGlobal() async throws {
+        let monitor = makeLayoutPlanTestMonitor(name: "ExplicitFillOverrideTest")
+        let controller = makeLayoutPlanTestController(monitors: [monitor])
+        guard let workspaceId = controller.workspaceManager.activeWorkspaceOrFirst(on: monitor.id)?.id
+        else {
+            Issue.record("Missing active workspace for explicit-fill override test")
+            return
+        }
+
+        controller.enableNiriLayout()
+        controller.settings.niriLoneWindowMaxWidth = 0.6
+        controller.updateNiriConfig(loneWindowPolicy: .centered(maxWidthFraction: 0.6))
+        await waitForLayoutPlanRefreshWork(on: controller)
+        controller.syncMonitorsToNiriEngine()
+
+        let token = addLayoutPlanTestWindow(on: controller, workspaceId: workspaceId, windowId: 882)
+
+        controller.settings.updateNiriSettings(
+            MonitorNiriSettings(
+                monitorName: monitor.name,
+                monitorDisplayId: monitor.displayId,
+                loneWindowPolicy: .fill
+            )
+        )
+        controller.updateMonitorNiriSettings()
+
+        let overridePlans = try await controller.niriLayoutHandler.layoutWithNiriEngine(
+            activeWorkspaces: [workspaceId]
+        )
+        guard let overridePlan = overridePlans.first,
+              let overrideFrame = overridePlan.diff.frameChanges.first(where: { $0.token == token })?.frame
+        else {
+            Issue.record("Expected a Niri frame after applying explicit-fill override")
+            return
+        }
+
+        // With global centered at 0.6 but an explicit .fill override, the lone window
+        // must span the full working area, not the capped centered width.
+        #expect(overrideFrame.width > monitor.visibleFrame.width * 0.6)
     }
 
     @Test @MainActor func nativeFullscreenSuspendedWindowEmitsPlaceholderInsteadOfFrameChangeInNiri() async throws {
@@ -3742,7 +3927,7 @@ private func makeCenteredCrossMonitorFixture(
 
         controller.setBordersEnabled(true)
         controller.enableNiriLayout()
-        controller.updateNiriConfig(maxVisibleColumns: 1)
+        controller.updateNiriConfig(balancedColumnCount: 1)
         await waitForLayoutPlanRefreshWork(on: controller)
         controller.syncMonitorsToNiriEngine()
         controller.niriEngine?.presetColumnWidths = [.proportion(1.0), .proportion(1.0)]
@@ -3849,7 +4034,7 @@ private func makeCenteredCrossMonitorFixture(
             return
         }
 
-        engine.maxVisibleColumns = 3
+        engine.balancedColumnCount = 3
 
         for windowId in 511 ... 515 {
             _ = addLayoutPlanTestWindow(on: controller, workspaceId: workspaceId, windowId: windowId)
@@ -3862,16 +4047,16 @@ private func makeCenteredCrossMonitorFixture(
 
         let workingFrame = controller.insetWorkingFrame(for: monitor)
         let gap = CGFloat(controller.workspaceManager.gaps)
-        let fixedWidth = (workingFrame.width - gap * CGFloat(engine.maxVisibleColumns - 1)) /
-            CGFloat(engine.maxVisibleColumns)
+        let fixedWidth = (workingFrame.width - gap * CGFloat(engine.balancedColumnCount - 1)) /
+            CGFloat(engine.balancedColumnCount)
         for column in engine.columns(in: workspaceId) {
             column.width = .fixed(fixedWidth)
             column.cachedWidth = fixedWidth
         }
 
         let columns = engine.columns(in: workspaceId)
-        guard columns.indices.contains(engine.maxVisibleColumns - 1),
-              let targetWindow = columns[engine.maxVisibleColumns - 1].windowNodes.first
+        guard columns.indices.contains(engine.balancedColumnCount - 1),
+              let targetWindow = columns[engine.balancedColumnCount - 1].windowNodes.first
         else {
             Issue.record("Expected a right visible-column target for fullscreen hide-diff regression test")
             return
@@ -3974,12 +4159,12 @@ private func makeCenteredCrossMonitorFixture(
         let hiddenLeftTokens = tokens.filter { hiddenHandles[$0] == .left }
         #expect(!hiddenLeftTokens.isEmpty)
         for token in hiddenLeftTokens {
-            #expect(frames[token]?.origin.y == workingFrame.minY + gaps.vertical)
+            #expect(frames[token]?.origin.y == workingFrame.minY)
         }
     }
 
     @Test func hiddenLeftRevealPreservesBottomTileHeightOnFirstVisibleFrame() {
-        let engine = NiriLayoutEngine(maxVisibleColumns: 1)
+        let engine = NiriLayoutEngine(balancedColumnCount: 1)
         let wsId = UUID()
 
         let root = NiriRoot(workspaceId: wsId)
@@ -4124,7 +4309,7 @@ private func makeCenteredCrossMonitorFixture(
     }
 
     @Test func fullscreenBottomTileUsesFullMonitorHeightWithoutCarryoverOffset() {
-        let engine = NiriLayoutEngine(maxVisibleColumns: 1)
+        let engine = NiriLayoutEngine(balancedColumnCount: 1)
         engine.animationClock = AnimationClock()
         let wsId = UUID()
 
@@ -4652,7 +4837,7 @@ private func makeCenteredCrossMonitorFixture(
             gaps: 8
         )
 
-        #expect(selected.height == .fixed(576))
+        #expect(selected.height == .fixed(592))
         #expect(other.height.isAuto)
     }
 
@@ -4730,7 +4915,7 @@ private func makeCenteredCrossMonitorFixture(
     }
 
     @Test func splitUsesExplicitDefaultWidthAndExpelInheritsSourceWidth() {
-        let engine = NiriLayoutEngine(maxVisibleColumns: 3)
+        let engine = NiriLayoutEngine(balancedColumnCount: 3)
         engine.presetColumnWidths = [.proportion(0.85), .proportion(1.0), .proportion(0.5)]
         engine.defaultColumnWidth = 0.7
         let wsId = UUID()
@@ -4795,7 +4980,7 @@ private func makeCenteredCrossMonitorFixture(
     }
 
     @Test func expelWindowCopiesFullWidthRestoreState() {
-        let engine = NiriLayoutEngine(maxVisibleColumns: 3)
+        let engine = NiriLayoutEngine(balancedColumnCount: 3)
         let wsId = UUID()
         let root = NiriRoot(workspaceId: wsId)
         engine.roots[wsId] = root
@@ -4841,7 +5026,7 @@ private func makeCenteredCrossMonitorFixture(
     }
 
     @Test func expelWindowCopiesDesiredWidthButRecomputesCachedWidthFromConstraints() {
-        let engine = NiriLayoutEngine(maxVisibleColumns: 3)
+        let engine = NiriLayoutEngine(balancedColumnCount: 3)
         let wsId = UUID()
         let root = NiriRoot(workspaceId: wsId)
         engine.roots[wsId] = root
@@ -5224,7 +5409,7 @@ private func makeCenteredCrossMonitorFixture(
     }
 
     @Test func insertWindowInNewColumnUsesExplicitDefaultWidth() {
-        let engine = NiriLayoutEngine(maxVisibleColumns: 3)
+        let engine = NiriLayoutEngine(balancedColumnCount: 3)
         engine.presetColumnWidths = [.proportion(0.85), .proportion(1.0), .proportion(0.5)]
         engine.defaultColumnWidth = 0.7
         let wsId = UUID()
@@ -5263,7 +5448,7 @@ private func makeCenteredCrossMonitorFixture(
     }
 
     @Test func insertWindowInNewColumnPlacesWindowImmediatelyRightOfFocusedColumn() {
-        let engine = NiriLayoutEngine(maxVisibleColumns: 3)
+        let engine = NiriLayoutEngine(balancedColumnCount: 3)
         let wsId = UUID()
         let root = NiriRoot(workspaceId: wsId)
         engine.roots[wsId] = root
@@ -5308,7 +5493,7 @@ private func makeCenteredCrossMonitorFixture(
     }
 
     @Test func moveColumnRightNoOpsAtEdgeEvenWhenInfiniteLoopIsEnabled() {
-        let engine = NiriLayoutEngine(maxVisibleColumns: 2, infiniteLoop: true)
+        let engine = NiriLayoutEngine(balancedColumnCount: 2, infiniteLoop: true)
         let wsId = UUID()
         let root = NiriRoot(workspaceId: wsId)
         engine.roots[wsId] = root
@@ -5348,7 +5533,7 @@ private func makeCenteredCrossMonitorFixture(
     }
 
     @Test func moveColumnRightUsesRemoveInsertOrderAndPreservesViewport() {
-        let engine = NiriLayoutEngine(maxVisibleColumns: 3)
+        let engine = NiriLayoutEngine(balancedColumnCount: 3)
         let wsId = UUID()
         let root = NiriRoot(workspaceId: wsId)
         engine.roots[wsId] = root
@@ -5405,7 +5590,7 @@ private func makeCenteredCrossMonitorFixture(
     }
 
     @Test func moveColumnToIndexUsesNiriOneBasedClamping() {
-        let engine = NiriLayoutEngine(maxVisibleColumns: 3)
+        let engine = NiriLayoutEngine(balancedColumnCount: 3)
         let wsId = UUID()
         let root = NiriRoot(workspaceId: wsId)
         engine.roots[wsId] = root
@@ -5519,7 +5704,7 @@ private func makeCenteredCrossMonitorFixture(
     }
 
     @Test func moveWindowToWorkspaceThenInsertColumnPreservesSourceFallbackSelection() {
-        let engine = NiriLayoutEngine(maxVisibleColumns: 3)
+        let engine = NiriLayoutEngine(balancedColumnCount: 3)
         let sourceWorkspaceId = UUID()
         let targetWorkspaceId = UUID()
 
@@ -5571,7 +5756,7 @@ private func makeCenteredCrossMonitorFixture(
     }
 
     @Test func toggleColumnWidthFollowsOrderedDuplicatePresetsFromExplicitDefaultMatch() {
-        let engine = NiriLayoutEngine(maxVisibleColumns: 3)
+        let engine = NiriLayoutEngine(balancedColumnCount: 3)
         engine.presetColumnWidths = [
             .proportion(0.85),
             .proportion(1.0),
@@ -5628,7 +5813,7 @@ private func makeCenteredCrossMonitorFixture(
     }
 
     @Test func toggleColumnWidthWrapsAtPresetBoundaries() {
-        let engine = NiriLayoutEngine(maxVisibleColumns: 3)
+        let engine = NiriLayoutEngine(balancedColumnCount: 3)
         engine.presetColumnWidths = [
             .proportion(1.0 / 3.0),
             .proportion(0.5),
@@ -5679,7 +5864,7 @@ private func makeCenteredCrossMonitorFixture(
     }
 
     @Test func balanceSizesUsesExplicitDefaultWidthAndResetsManualState() {
-        let engine = NiriLayoutEngine(maxVisibleColumns: 3)
+        let engine = NiriLayoutEngine(balancedColumnCount: 3)
         engine.presetColumnWidths = [
             .proportion(0.85),
             .proportion(1.0),
@@ -5724,7 +5909,7 @@ private func makeCenteredCrossMonitorFixture(
     }
 
     @Test func explicitDefaultOutsidePresetListReanchorsOnFirstResize() {
-        let engine = NiriLayoutEngine(maxVisibleColumns: 3)
+        let engine = NiriLayoutEngine(balancedColumnCount: 3)
         engine.presetColumnWidths = [
             .proportion(0.5),
             .proportion(0.85),
@@ -5757,7 +5942,7 @@ private func makeCenteredCrossMonitorFixture(
     }
 
     @Test func balanceSizesFallsBackToAutoWidthWhenDefaultWidthIsAuto() {
-        let engine = NiriLayoutEngine(maxVisibleColumns: 4)
+        let engine = NiriLayoutEngine(balancedColumnCount: 4)
         engine.defaultColumnWidth = nil
         let wsId = UUID()
 
@@ -5778,7 +5963,11 @@ private func makeCenteredCrossMonitorFixture(
 
         engine.balanceSizes(in: wsId, workingAreaWidth: 1600, gaps: 8)
 
-        let expectedWidth = 1.0 / CGFloat(engine.effectiveMaxVisibleColumns(in: wsId))
+        guard case let .balanced(count) = engine.effectiveDefaultColumnWidth(in: wsId) else {
+            Issue.record("Expected balanced default column width")
+            return
+        }
+        let expectedWidth = 1.0 / CGFloat(count)
         for column in columns {
             #expect(column.width == .proportion(expectedWidth))
             #expect(column.presetWidthIdx == nil)
@@ -5786,7 +5975,7 @@ private func makeCenteredCrossMonitorFixture(
     }
 
     @Test func balanceSizesUsesExplicitDefaultWidthWithoutPresetMatch() {
-        let engine = NiriLayoutEngine(maxVisibleColumns: 3)
+        let engine = NiriLayoutEngine(balancedColumnCount: 3)
         engine.presetColumnWidths = [
             .proportion(0.5),
             .proportion(0.85),
@@ -5959,7 +6148,7 @@ private func makeCenteredCrossMonitorFixture(
     }
 
     @Test func partialRevealRemainsVisibleWhenViewportEdgeHasNoNeighboringMonitor() {
-        let engine = NiriLayoutEngine(maxVisibleColumns: 1)
+        let engine = NiriLayoutEngine(balancedColumnCount: 1)
         let wsId = UUID()
         let monitor = makeLayoutPlanTestMonitor(width: 1600, height: 900)
         attachWorkspace(
@@ -5968,7 +6157,7 @@ private func makeCenteredCrossMonitorFixture(
             engine: engine,
             resolvedSettings: resolvedSettings(
             for: engine,
-            maxVisibleColumns: 2
+            defaultColumnWidth: .balanced(columns: 2)
         )
         )
 
@@ -6024,7 +6213,7 @@ private func makeCenteredCrossMonitorFixture(
     }
 
     @Test func renderOffsetRevealRemainsVisibleWhenViewportEdgeHasNoNeighboringMonitor() {
-        let engine = NiriLayoutEngine(maxVisibleColumns: 1)
+        let engine = NiriLayoutEngine(balancedColumnCount: 1)
         engine.animationClock = AnimationClock()
         let wsId = UUID()
         let monitor = makeLayoutPlanTestMonitor(width: 1600, height: 900)
@@ -6034,7 +6223,7 @@ private func makeCenteredCrossMonitorFixture(
             engine: engine,
             resolvedSettings: resolvedSettings(
             for: engine,
-            maxVisibleColumns: 2
+            defaultColumnWidth: .balanced(columns: 2)
         )
         )
 
@@ -6310,7 +6499,7 @@ private func makeCenteredCrossMonitorFixture(
     }
 
     @Test func partialRevealRemainsVisibleAtOpenVerticalEdgesWithoutNeighboringMonitor() {
-        let engine = NiriLayoutEngine(maxVisibleColumns: 1)
+        let engine = NiriLayoutEngine(balancedColumnCount: 1)
         let wsId = UUID()
         let monitor = makeLayoutPlanTestMonitor(width: 900, height: 1600)
         attachWorkspace(
@@ -6319,7 +6508,7 @@ private func makeCenteredCrossMonitorFixture(
             engine: engine,
             resolvedSettings: resolvedSettings(
             for: engine,
-            maxVisibleColumns: 2
+            defaultColumnWidth: .balanced(columns: 2)
         )
         )
 
@@ -6461,7 +6650,7 @@ private func makeCenteredCrossMonitorFixture(
         #expect(!fullyContainedFrame.intersects(upperMonitor.frame))
     }
 
-    @Test @MainActor func visibilityChangesOnlyEmitOnActualTransitions() async throws {
+    @Test @MainActor func visibilityChangesReflectCurrentHiddenState() async throws {
         let monitor = makeLayoutPlanTestMonitor(width: 1600, height: 900)
         let controller = makeLayoutPlanTestController(monitors: [monitor])
         guard let workspaceId = controller.workspaceManager.activeWorkspaceOrFirst(on: monitor.id)?.id
@@ -6532,10 +6721,10 @@ private func makeCenteredCrossMonitorFixture(
             return
         }
 
-        #expect(!hasAnyVisibilityChange(stableHiddenPlan.diff.visibilityChanges, token: transitioningToken))
+        #expect(hasHideVisibilityChange(stableHiddenPlan.diff.visibilityChanges, token: transitioningToken, side: .right))
 
         controller.workspaceManager.withNiriViewportState(for: workspaceId) { state in
-            state.viewOffsetPixels = .static(20)
+            state.viewOffsetPixels = .static(100)
         }
 
         let revealPlans = try await controller.niriLayoutHandler.layoutWithNiriEngine(
@@ -6546,13 +6735,12 @@ private func makeCenteredCrossMonitorFixture(
             return
         }
 
-        #expect(hasShowVisibilityChange(revealPlan.diff.visibilityChanges, token: transitioningToken))
-        #expect(!hasHideVisibilityChange(revealPlan.diff.visibilityChanges, token: transitioningToken))
+        #expect(!hasAnyVisibilityChange(revealPlan.diff.visibilityChanges, token: transitioningToken))
         await executeAndSettleLayoutPlans(revealPlans, on: controller)
         controller.workspaceManager.withNiriViewportState(for: workspaceId) { state in
             state.selectedNodeId = firstNode.id
             state.activeColumnIndex = 0
-            state.viewOffsetPixels = .static(20)
+            state.viewOffsetPixels = .static(100)
         }
 
         let stableVisiblePlans = try await controller.niriLayoutHandler.layoutWithNiriEngine(
@@ -6586,7 +6774,7 @@ private func makeCenteredCrossMonitorFixture(
 
         let primaryColumns = fixture.engine.columns(in: fixture.targetWorkspaceId)
         for column in primaryColumns {
-            #expect(column.width == .proportion(0.85))
+            #expect(column.width == .proportion(0.5))
             #expect(column.presetWidthIdx == nil)
         }
         guard primaryColumns.count >= 3,
@@ -6652,7 +6840,7 @@ private func makeCenteredCrossMonitorFixture(
 
         let secondaryColumns = fixture.engine.columns(in: fixture.targetWorkspaceId)
         for column in secondaryColumns {
-            #expect(column.width == .proportion(0.85))
+            #expect(column.width == .proportion(0.5))
             #expect(column.presetWidthIdx == nil)
         }
         guard secondaryColumns.count >= 4,
@@ -6989,7 +7177,7 @@ private func makeCenteredCrossMonitorFixture(
     }
 
 
-    @Test @MainActor func activateNodeWithoutVisibilityRebasesActiveColumnPreservingViewportStart() async throws {
+    @Test @MainActor func activateNodeWithoutVisibilityRebasesActiveColumnWithGapAdjustedViewportStart() async throws {
         let controller = makeLayoutPlanTestController()
         guard let monitor = controller.workspaceManager.monitors.first,
               let workspaceId = controller.workspaceManager.activeWorkspaceOrFirst(on: monitor.id)?.id
@@ -6999,7 +7187,7 @@ private func makeCenteredCrossMonitorFixture(
         }
 
         controller.enableNiriLayout()
-        controller.updateNiriConfig(maxVisibleColumns: 2)
+        controller.updateNiriConfig(balancedColumnCount: 2)
         await waitForLayoutPlanRefreshWork(on: controller)
         controller.syncMonitorsToNiriEngine()
 
@@ -7064,11 +7252,11 @@ private func makeCenteredCrossMonitorFixture(
         let updatedState = controller.workspaceManager.niriViewportState(for: workspaceId)
         #expect(updatedState.selectedNodeId == windows[3].id)
         #expect(updatedState.activeColumnIndex == 3)
-        #expect(abs(viewportStart(for: updatedState, columns: columns, gap: gap) - initialViewStart) < 0.1)
+        #expect(abs(viewportStart(for: updatedState, columns: columns, gap: gap) - initialViewStart) <= 2 * gap + 0.1)
     }
 
     @Test @MainActor func navigateToWindowInternalAdvancesViewportToTarget() async throws {
-        let fixture = try await makeNavigateToWindowViewportFixture(maxVisibleColumns: 2,
+        let fixture = try await makeNavigateToWindowViewportFixture(balancedColumnCount: 2,
             windowCount: 4,
             outerGapLeft: 12,
             outerGapRight: 20
@@ -7110,7 +7298,7 @@ private func makeCenteredCrossMonitorFixture(
     }
 
     @Test @MainActor func navigateToWindowInternalRevealsTargetColumn() async throws {
-        let fixture = try await makeNavigateToWindowViewportFixture(maxVisibleColumns: 2,
+        let fixture = try await makeNavigateToWindowViewportFixture(balancedColumnCount: 2,
             windowCount: 4
         )
         let startIndex = 0
@@ -7148,7 +7336,7 @@ private func makeCenteredCrossMonitorFixture(
     }
 
     @Test @MainActor func navigateToWindowInternalHandlesSingleColumn() async throws {
-        let fixture = try await makeNavigateToWindowViewportFixture(maxVisibleColumns: 2,
+        let fixture = try await makeNavigateToWindowViewportFixture(balancedColumnCount: 2,
             windowCount: 1
         )
         let startIndex = 0
@@ -7189,7 +7377,7 @@ private func makeCenteredCrossMonitorFixture(
         }
 
         controller.enableNiriLayout()
-        controller.updateNiriConfig(maxVisibleColumns: 2)
+        controller.updateNiriConfig(balancedColumnCount: 2)
         await waitForLayoutPlanRefreshWork(on: controller)
         controller.syncMonitorsToNiriEngine()
 

--- a/Tests/NehirTests/OverviewProjectionTests.swift
+++ b/Tests/NehirTests/OverviewProjectionTests.swift
@@ -574,7 +574,7 @@ private func makeNiriOverviewLayout(
             title: "Focused"
         )
 
-        let engine = NiriLayoutEngine(maxVisibleColumns: 3)
+        let engine = NiriLayoutEngine(balancedColumnCount: 3)
         let movedNode = engine.addWindow(token: moved.handle.id, to: sourceWorkspaceId, afterSelection: nil)
         let fallbackNode = engine.addWindow(
             token: fallback.handle.id,

--- a/Tests/NehirTests/RefreshRoutingTests.swift
+++ b/Tests/NehirTests/RefreshRoutingTests.swift
@@ -1150,7 +1150,7 @@ private func syncNiriWorkspaceStatesForRefreshTests(
 
         resetRefreshSpies(on: controller, recorder: recorder)
 
-        controller.updateNiriConfig(maxVisibleColumns: 3)
+        controller.updateNiriConfig(balancedColumnCount: 3)
         await waitForRefreshWork(on: controller)
 
         #expect(controller.layoutRefreshController.debugCounters.relayoutExecutions == 1)

--- a/Tests/NehirTests/SettingsStoreTests.swift
+++ b/Tests/NehirTests/SettingsStoreTests.swift
@@ -191,24 +191,24 @@ struct MonitorSettingsStoreTests {
 
     @Test func updateReplacesExistingAtSameIndex() {
         var settings = [
-            MonitorNiriSettings(monitorName: "A", maxVisibleColumns: 2),
-            MonitorNiriSettings(monitorName: "B", maxVisibleColumns: 3)
+            MonitorNiriSettings(monitorName: "A", balancedColumnCount: 2),
+            MonitorNiriSettings(monitorName: "B", balancedColumnCount: 3)
         ]
-        let updated = MonitorNiriSettings(monitorName: "A", maxVisibleColumns: 5)
+        let updated = MonitorNiriSettings(monitorName: "A", balancedColumnCount: 5)
         MonitorSettingsStore.update(updated, in: &settings)
         #expect(settings.count == 2)
         #expect(settings[0].monitorName == "A")
-        #expect(settings[0].maxVisibleColumns == 5)
+        #expect(settings[0].balancedColumnCount == 5)
         #expect(settings[1].monitorName == "B")
     }
 
     @Test func updateAppendsWhenNotFound() {
         var settings = [MonitorNiriSettings(monitorName: "A")]
-        let newItem = MonitorNiriSettings(monitorName: "B", maxVisibleColumns: 4)
+        let newItem = MonitorNiriSettings(monitorName: "B", balancedColumnCount: 4)
         MonitorSettingsStore.update(newItem, in: &settings)
         #expect(settings.count == 2)
         #expect(settings[1].monitorName == "B")
-        #expect(settings[1].maxVisibleColumns == 4)
+        #expect(settings[1].balancedColumnCount == 4)
     }
 
     @Test func removeDeletesAllMatches() {
@@ -225,39 +225,39 @@ struct MonitorSettingsStoreTests {
     @Test func monitorLookupPrefersDisplayIdOverNameFallback() {
         let monitor = makeSettingsTestMonitor(displayId: 42, name: "Studio Display")
         let settings = [
-            MonitorNiriSettings(monitorName: "Studio Display", maxVisibleColumns: 1),
-            MonitorNiriSettings(monitorName: "Studio Display", monitorDisplayId: 42, maxVisibleColumns: 3)
+            MonitorNiriSettings(monitorName: "Studio Display", balancedColumnCount: 1),
+            MonitorNiriSettings(monitorName: "Studio Display", monitorDisplayId: 42, balancedColumnCount: 3)
         ]
 
         let result = MonitorSettingsStore.get(for: monitor, in: settings)
-        #expect(result?.maxVisibleColumns == 3)
+        #expect(result?.balancedColumnCount == 3)
     }
 
     @Test func monitorLookupFallsBackToNameWhenDisplayIdMissing() {
         let monitor = makeSettingsTestMonitor(displayId: 99, name: "Fallback")
         let settings = [
-            MonitorNiriSettings(monitorName: "Fallback", maxVisibleColumns: 2)
+            MonitorNiriSettings(monitorName: "Fallback", balancedColumnCount: 2)
         ]
 
         let result = MonitorSettingsStore.get(for: monitor, in: settings)
-        #expect(result?.maxVisibleColumns == 2)
+        #expect(result?.balancedColumnCount == 2)
     }
 
     @Test func updateMigratesNameEntryToDisplayIdEntry() {
         var settings = [
-            MonitorNiriSettings(monitorName: "Studio Display", maxVisibleColumns: 1)
+            MonitorNiriSettings(monitorName: "Studio Display", balancedColumnCount: 1)
         ]
 
         let updated = MonitorNiriSettings(
             monitorName: "Studio Display",
             monitorDisplayId: 77,
-            maxVisibleColumns: 4
+            balancedColumnCount: 4
         )
         MonitorSettingsStore.update(updated, in: &settings)
 
         #expect(settings.count == 1)
         #expect(settings[0].monitorDisplayId == 77)
-        #expect(settings[0].maxVisibleColumns == 4)
+        #expect(settings[0].balancedColumnCount == 4)
     }
 }
 
@@ -313,10 +313,9 @@ struct SettingsExportTests {
         #expect(defaults.outerGapRight == 0)
         #expect(defaults.outerGapTop == 0)
         #expect(defaults.outerGapBottom == 0)
-        // niriAlwaysCenterSingleColumn removed in refactor; revealPartial replaces scroll-reveal
         #expect(defaults.revealPartial == RevealPartial.default.rawValue)
-        #expect(defaults.niriSingleWindowAspectRatio == SingleWindowAspectRatio.none.rawValue)
-        #expect(defaults.niriDefaultColumnWidth == 0.5)
+        #expect(defaults.niriLoneWindowMaxWidth == nil)
+        #expect(defaults.niriDefaultColumnWidth == nil)
         #expect(defaults.workspaceConfigurations == BuiltInSettingsDefaults.workspaceConfigurations)
         #expect(defaults.bordersEnabled == true)
         #expect(defaults.borderWidth == 5.0)

--- a/Tests/NehirTests/SettingsTOMLCodecTests.swift
+++ b/Tests/NehirTests/SettingsTOMLCodecTests.swift
@@ -65,7 +65,7 @@ private extension String {
         export.workspaceConfigurations = [WorkspaceConfiguration(name: "10", monitorAssignment: .secondary)]
         export.monitorBarSettings = [MonitorBarSettings(monitorName: "Display", enabled: false)]
         export.monitorOrientationSettings = [MonitorOrientationSettings(monitorName: "Display", orientation: .vertical)]
-        export.monitorNiriSettings = [MonitorNiriSettings(monitorName: "Display", maxVisibleColumns: 4)]
+        export.monitorNiriSettings = [MonitorNiriSettings(monitorName: "Display", balancedColumnCount: 4)]
 
         let output = try #require(String(data: SettingsTOMLCodec.encode(export), encoding: .utf8))
 
@@ -88,13 +88,13 @@ private extension String {
 
     @Test func unknownNiriKeysAreIgnoredAndNotReencoded() throws {
         var export = SettingsExport.defaults()
-        export.niriMaxVisibleColumns = 4
+        export.niriBalancedColumnCount = 4
 
         let output = try #require(String(data: SettingsTOMLCodec.encode(export), encoding: .utf8))
         let unknownKey = "maxWindows" + "PerColumn"
         let edited = output.replacingOccurrences(
-            of: "maxVisibleColumns = 4",
-            with: "maxVisibleColumns = 4\n\(unknownKey) = 7"
+            of: "balancedColumnCount = 4",
+            with: "balancedColumnCount = 4\n\(unknownKey) = 7"
         )
 
         let decoded = try SettingsTOMLCodec.decode(Data(edited.utf8))

--- a/Tests/NehirTests/ViewportSnapContextTests.swift
+++ b/Tests/NehirTests/ViewportSnapContextTests.swift
@@ -57,6 +57,28 @@ private func makeContext(
         #expect(context.snapPoints.contains { $0.kind == .center })
     }
 
+    @Test func fullWidthColumnOmitsGapEdgeSnapPoints() {
+        let context = makeContext(widths: [1000], gap: 8, viewportWidth: 1000)
+        let offsets = context.snapPoints.map(\.offset)
+
+        // A full-width column should not get the synthetic ±gap edge snaps: snapping to
+        // those offsets shifts the column by one gap and loses working-area margins.
+        // Center and far overscroll boundary points may still exist.
+        #expect(!offsets.contains { abs($0 - 8) < 0.5 })
+        #expect(!offsets.contains { abs($0 + 8) < 0.5 })
+        #expect(offsets.contains { abs($0) < 0.5 })
+    }
+
+    @Test func overWideColumnKeepsEdgeSnapPoints() {
+        let context = makeContext(widths: [1400], gap: 8, viewportWidth: 1000)
+
+        // A column wider than the viewport needs its edge snaps so clipped leading/trailing
+        // content can be reached via scrollViewport. Only columns that approximately fill the
+        // viewport have their edge snaps omitted.
+        #expect(context.snapPoints.contains { $0.kind == .leftEdge })
+        #expect(context.snapPoints.contains { $0.kind == .rightEdge })
+    }
+
     @Test func narrowColumnOmitsCenterSnap() {
         // Column width = 300, viewportWidth = 1000. 300 > 0.30 * 1000 = 300? No (strictly >)
         let context = makeContext(widths: [300], gap: 8, viewportWidth: 1000)
@@ -377,7 +399,7 @@ private func makeContext(
 
 @Suite struct ScrollViewportTests {
     @Test func scrollViewportRightAdvancesToNextSnap() {
-        let engine = NiriLayoutEngine(maxVisibleColumns: 3)
+        let engine = NiriLayoutEngine(balancedColumnCount: 3)
         engine.animationClock = AnimationClock()
         let wsId = UUID()
 
@@ -411,7 +433,7 @@ private func makeContext(
     }
 
     @Test func scrollViewportLeftReturnsNilAtStart() {
-        let engine = NiriLayoutEngine(maxVisibleColumns: 3)
+        let engine = NiriLayoutEngine(balancedColumnCount: 3)
         engine.animationClock = AnimationClock()
         let wsId = UUID()
 
@@ -445,7 +467,7 @@ private func makeContext(
     }
 
     @Test func scrollViewportClampsAtStripEnd() {
-        let engine = NiriLayoutEngine(maxVisibleColumns: 3)
+        let engine = NiriLayoutEngine(balancedColumnCount: 3)
         engine.animationClock = AnimationClock()
         let wsId = UUID()
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -77,14 +77,14 @@ Sources/
 │   │   ├── Animation/               Spring, cubic & workspace-switch animations (6 files)
 │   │   ├── Ax/                      Accessibility wrappers, DefaultFloatingApps (10 files)
 │   │   ├── Border/                  Focused window border rendering (3 files)
-│   │   ├── Config/                  Settings store, export, per-monitor settings (16 files)
+│   │   ├── Config/                  Settings store, export, per-monitor settings (26 files)
 │   │   ├── Controller/              WMController, event handlers, refresh pipeline (17 files)
 │   │   ├── Input/                   Hotkey action catalog, binding persistence (7 files)
 │   │   ├── Layout/
 │   │   │   ├── DNode.swift          Shared types: WindowToken, WindowHandle
 │   │   │   ├── LayoutBoundary.swift Layout snapshots & workspace geometry
 │   │   │   ├── SideHiding.swift     Side-hiding edge types
-│   │   │   ├── Niri/                Scrolling columns layout engine (28 files)
+│   │   │   ├── Niri/                Scrolling columns layout engine (31 files)
 │   │   ├── LockScreen/              Lock screen detection (1 file)
 │   │   ├── Menu/                    Menu extraction for MenuAnywhere (3 files)
 │   │   ├── Monitor/                 Display detection, OutputId, restore assignments (5 files)
@@ -522,7 +522,18 @@ All three types inherit from `NiriNode` (base class with `id: NodeId`, `parent`,
 
 **Viewport scrolling:** The viewport tracks which columns are visible separately from the command/focus target. User gestures (trackpad swipe/scroll) drive the viewport via `ViewGesture` → `SwipeTracker`, which accumulates deltas and produces spring animations. Gesture release, viewport scroll commands, keyboard/AX reveal, resize adjustment, and column transitions share `ViewportSnapContext` snap geometry. During an active gesture Nehir keeps selection, border, hotkey target, and keyboard focus stable so the border does not jump under the fingers. On release, the viewport snaps to the nearest snap point unless the Mouse Modifier is held to bypass snap for that trackpad gesture. Focus-follows-mouse never reveals, relayouts, or scrolls the viewport; duplicate AX confirmations for an FFM target are treated as FFM for a short freshness window.
 
-**File Organization (28 files):**
+**Centralization boundaries:** Keep layout rules in their owning layer rather than re-deriving them in controllers.
+
+| Rule family | Source of truth | Notes for contributors |
+|-------------|-----------------|------------------------|
+| Proportional width gap accounting | `ProportionalSize.resolveProportionalSpan(...)` | Do not duplicate `(availableSpace - gap) * proportion - gap`; Reveal Partial `.default` depends on the same `2 * gap` fit tolerance so 50% + 50% columns remain viewport-fitting. |
+| Stacked/tiled secondary-axis sizing | `NiriAxisSolver` and the tabbed/shared-frame layout helpers | Inner gaps are between adjacent stacked tiles only (`count - 1` gaps). Top/bottom monitor-edge padding comes from outer gaps, not inner gap. |
+| Snap points, viewport bounds, and full-width-column snap exceptions | `ViewportState+Geometry.swift` (`computeSnapGrid`, `viewportStartBounds`, `clampedViewportStart`) and `ViewportSnapContext` | Gesture release, scroll commands, reveal, resize adjustment, and column transitions must share this geometry. Do not add ad-hoc `±gap` snaps elsewhere; columns that approximately fill the viewport intentionally omit synthetic edge snaps that would only lose margins, while over-wide columns keep theirs so clipped content stays reachable. |
+| Lone-window viewport rect and render offset | `SingleWindowViewportGeometry` plus `singleWindowViewportGeometry(...)`, `resolvedSingleWindowViewportRect(...)`, `prepareSingleWindowViewport(...)`, and `prepareAndSeedSingleWindowViewport(...)` in `NiriLayout.swift` | Controllers may prepare/seed geometry, but must not re-derive centered width, center offset, or rendered frame offset. Lone-window rendering follows the raw viewport offset; the shared snap grid decides where it settles. |
+| Monitor-aware gap resolution | `SettingsStore.resolvedGapSettings(for:)`, exposed at runtime through `WMController.gapSize(for:)` and `WMController.outerGaps(for:)` | Use these helpers when a monitor is known. Direct `workspaceManager.gaps` / `workspaceManager.outerGaps` access should be limited to no-monitor fallback paths. |
+| Monitor-aware Niri settings and lone-window override resolution | `SettingsStore.resolvedNiriSettings(for:)` and `MonitorNiriSettings.loneWindowPolicy` | `nil` means inherit global policy; `.fill` and `.centered(maxWidthFraction:)` are explicit per-monitor overrides. Do not infer override mode from nullable centered width. |
+
+**File Organization (31 files):**
 
 The Niri directory is the largest subsystem. Files are organized by responsibility:
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -219,7 +219,7 @@ Monitor overrides use `[match]` / `[niri]` / `[bar]` / `[orientation]` sections:
 name = "LG HDR 5K"
 
 [niri]
-maxVisibleColumns = 3
+balancedColumnCount = 3
 ```
 
 ### 5. Live reload

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -24,6 +24,29 @@ In the [layout notation](viewport-navigation-spec.md#layout-notation), clipped c
 
 ---
 
+## default column width
+
+`DefaultColumnWidth` is the width assigned to a new or newly claimed column before manual resizing. It has two modes:
+
+- **balanced** — fit `N` columns across the working area, so each column starts at `1/N` width
+- **custom** — use an explicit working-area width fraction
+
+Column-width resolution (highest wins):
+
+1. `LoneWindowPolicy.fill` / `.centered` — only when the lone-window predicate holds
+2. `DefaultColumnWidth.custom(fraction)`
+3. `DefaultColumnWidth.balanced(columns)` → `1/N`
+
+---
+
+## far overscroll boundary
+
+A snap point at the scrollable start or end of the whole column strip, produced from `viewportStartBounds(...)`. It is not a per-column edge snap: it represents the farthest legal viewport position for the current layout, including the small overscroll/reveal allowance used by Niri-style scrolling.
+
+See also: [snap grid](#snap-grid), [viewport offset](#viewport-offset).
+
+---
+
 ## focused window
 
 The macOS window currently receiving keyboard input, as reported by the Accessibility API. Nehir tracks this via `AXEventHandler`.
@@ -32,9 +55,54 @@ See also: [active column](#active-column).
 
 ---
 
+## inner gap
+
+The spacing between adjacent tiled surfaces inside the layout. In stacked/tiled columns, inner gap applies only between neighboring tiles on the secondary axis (`count - 1` gaps). It is not monitor-edge padding.
+
+Primary-axis proportional column widths intentionally keep Niri-compatible gap accounting through `ProportionalSize.resolveProportionalSpan(...)`; do not reinterpret that formula when changing secondary-axis gap behavior.
+
+See also: [outer gap](#outer-gap), [proportional span](#proportional-span).
+
+---
+
 ## focus follows mouse (FFM)
 
 A mode where keyboard focus moves to whichever tiled window is under the cursor as the cursor moves. When FFM triggers a focus change, the viewport does **not** scroll — the cursor is already in the visible portion of the target column. FFM can only activate fully visible or [clipped](glossary.md#clipped-column) columns; [parked](glossary.md#parked-window) windows are offscreen and unreachable by the cursor. See [Reveal on Focus](viewport-navigation-spec.md#reveal-on-focus).
+
+---
+
+## lone-window policy
+
+`LoneWindowPolicy` controls a normal, non-tabbed workspace with exactly one column and exactly one window.
+
+- **fill** — make the lone window fill the working area
+- **centered** — cap the lone window to a max working-area width fraction and keep it horizontally centered
+
+The policy defines only the default initial lone-window rect. After a manual resize, the window keeps the requested width (still centered) and is not capped by the policy max width.
+
+Per-monitor lone-window overrides are tri-state through `MonitorNiriSettings.loneWindowPolicy`:
+
+- `nil` — inherit the global policy
+- `.fill` — explicitly use fill on that monitor
+- `.centered(maxWidthFraction:)` — explicitly use centered on that monitor
+
+Do not infer this override state from a nullable centered width; `SettingsStore.resolvedNiriSettings(for:)` is the source of truth.
+
+See also: [single-window viewport geometry](#single-window-viewport-geometry).
+
+---
+
+## monitor gap settings
+
+Per-monitor gap overrides stored as `MonitorGapSettings` and resolved to `ResolvedGapSettings`. `SettingsStore.resolvedGapSettings(for:)` merges global defaults with per-monitor overrides; runtime code should consume this through `WMController.gapSize(for:)` and `WMController.outerGaps(for:)` when a monitor is known.
+
+---
+
+## outer gap
+
+Monitor-edge padding around the working area. Outer gaps are represented as `LayoutGaps.OuterGaps` and are applied when computing monitor working frames/insets.
+
+Outer gap is distinct from [inner gap](#inner-gap): top/bottom edge padding must come from outer gaps, not from secondary-axis tile spacing.
 
 ---
 
@@ -45,6 +113,18 @@ A window the layout engine has moved to an offscreen resting position. Parked wi
 Represented internally as `ContainerVisibilityState.hidden(AxisHideEdge)` with a `layoutTransient` hidden reason. The edge (`.left` / `.right`) records which side the window is parked on.
 
 In the [layout notation](viewport-navigation-spec.md#layout-notation), columns that are fully outside the viewport and have been parked appear as plain numbers outside `[]`, e.g. `30 [...]` — the `30` is a parked column on the left. A [clipped column](#clipped-column) (partially visible) is distinct and uses the split notation.
+
+---
+
+## proportional span
+
+A proportional column/window span resolved by `ProportionalSize.resolveProportionalSpan(...)` using Niri-compatible gap accounting:
+
+```text
+resolvedSpan = (availableSpace - gap) * proportion - gap
+```
+
+This rule is intentionally centralized. Reveal Partial `.default` relies on the same `2 * gap` fit tolerance so groups such as 50% + 50% remain viewport-fitting.
 
 ---
 
@@ -61,9 +141,25 @@ See [Reveal on Focus](viewport-navigation-spec.md#reveal-on-focus).
 
 ---
 
+## single-window viewport geometry
+
+The centralized geometry model for a workspace containing exactly one normal non-tabbed window. `SingleWindowViewportGeometry` owns:
+
+- the resolved lone-window viewport rect
+- the center offset for initial/resting placement
+- rendered-frame offsetting relative to the current viewport offset
+
+Callers should use `singleWindowViewportGeometry(...)`, `resolvedSingleWindowViewportRect(...)`, `prepareSingleWindowViewport(...)`, or `prepareAndSeedSingleWindowViewport(...)` instead of re-deriving centered width, center offset, or frame offset rules in controllers.
+
+Lone-window rendering follows the raw viewport offset so gestures are visibly responsive. The shared [snap grid](#snap-grid), not a render-time clamp, decides where the window settles.
+
+---
+
 ## snap grid
 
-The ordered set of [snap points](#snap-point) for the current column layout. Computed from column positions and widths. The viewport targets the nearest snap point on gesture release.
+The ordered set of [snap points](#snap-point) for the current column layout. Computed from column positions and widths by `computeSnapGrid(...)` / `ViewportSnapContext`. The viewport targets the nearest snap point on gesture release.
+
+Columns that approximately fill the viewport (within pixel tolerance) intentionally omit synthetic `±gap` edge snaps; those points would only shift a full-width column by one gap and lose working-area margins. Over-wide columns (wider than the viewport) keep their edge snaps so clipped leading/trailing content can still be reached. Center and [far overscroll boundary](#far-overscroll-boundary) snaps remain in both cases.
 
 See [Snap Grid](viewport-navigation-spec.md#snap-grid).
 

--- a/docs/plans/20260613-layout-concepts-redesign.md
+++ b/docs/plans/20260613-layout-concepts-redesign.md
@@ -5,26 +5,26 @@
 Replace four overlapping column/single-window knobs with three honest concepts:
 
 1. **Default new-column width** — `.balanced(columns: Int)` (= 1/N) or `.custom(fraction: Double)`.
-   Collapses `niriMaxVisibleColumns` + `niriDefaultColumnWidth` into one mental model. The UI
+   Collapses the former `niriMaxVisibleColumns` + `niriDefaultColumnWidth` split into one mental model. The UI
    "Visible Columns" slider disappears; the "Default New Column Width" section gains a
    Balanced/Custom picker with an N-columns stepper inside Balanced.
 
 2. **Resize/cycle presets** — unchanged mechanics, updated defaults to 35/50/65/95 %.
 
-3. **Lone-window policy** — `.fill` (no constraint) or `.centered(maxWidthFraction: Double)`.
+3. **Lone-window policy** — `.fill` (fill the working area) or `.centered(maxWidthFraction: Double)`.
    Replaces `singleWindowAspectRatio` entirely. The lone-window predicate remains (1 column +
-   1 window + not-tabbed + normal sizing); the output is a width cap + centering instead of an
-   aspect-derived size.
+   1 window + not-tabbed + normal sizing); `.fill` outputs the full working area, while `.centered`
+   outputs a width cap + centering instead of an aspect-derived size.
 
 Scope: semantic redesign **and** plumbing normalization together. No backwards-compatibility
 shims — old code paths that become redundant are deleted. Old config keys that no longer exist
 will silently produce defaults.
 
 TOML shape changes:
-- Remove `single_window_aspect_ratio` key (old configs default to `.fill`).
-- Add `lone_window_max_width` (optional Double, absent = fill).
-- Keep `max_visible_columns` (Int) and `default_column_width` (optional Double) — they map
-  directly to `DefaultColumnWidth` with no migration code.
+- Remove `singleWindowAspectRatio`.
+- Add `loneWindowMaxWidth` (optional Double, absent = fill).
+- Rename `maxVisibleColumns` to `balancedColumnCount` and keep `defaultColumnWidth` (optional Double) —
+  together they map directly to `DefaultColumnWidth` with no migration code.
 
 ## Context (from discovery)
 
@@ -42,7 +42,7 @@ TOML shape changes:
 - Reveal Partial interaction: `NiriLayoutEngine+ViewportCommands.swift:72,82` — `fillsViewport`
   check must remain correct when a lone centered window doesn't fill the viewport width.
 - `NiriNode.hasManualSingleWindowWidthOverride` — stays meaningful in centered mode (manual resize
-  stays capped at `maxWidthFraction`).
+  bypasses the policy cap; the policy only defines the default initial state).
 - Glossary: `docs/glossary.md` — update with new concept names.
 - IPC: `docs/IPC-CLI.md` — check if `single_window_aspect_ratio` is exposed there.
 
@@ -62,6 +62,17 @@ TOML shape changes:
 
 ## Progress Tracking
 
+- ➕ Scope clarification: `LoneWindowPolicy.fill` now means an active lone-window layout that fills the working area, not "fall through to default column width".
+- ➕ Scope clarification: lone-window policy affects only the default initial lone-window state; manual resize overrides must be uncapped by policy.
+- ➕ UX/content pass: layout settings page copy must distinguish initial defaults, live spacing, one-window behavior, and resize presets for first-time users.
+- ➕ Bug fix: invalidate cached layout spans when inner gaps or screen margins change to prevent stale-width jumps while dragging sliders.
+- ➕ Scope addition: inner gap and screen margins now support per-monitor overrides in `monitors.d/*.toml` via `[gaps]` (`size`, `outerLeft`, `outerRight`, `outerTop`, `outerBottom`).
+- ➕ Bug fix: runtime minimum sizes that fit the monitor visible frame but not the inset working frame must still be honored; constrained lone windows clamp back into the visible frame instead of leaking offscreen.
+- ➕ Scope addition: lone-window workspaces participate in viewport snap/overscroll logic. Centering is represented as a viewport offset, not as a hard reset that ignores gestures.
+- ➕ Refactor requirement: single-window viewport math is centralized in `SingleWindowViewportGeometry`; do not duplicate center-offset, zero-offset, or rendered-frame calculations in controllers.
+- ➕ Bug fix: lone-window rendering now uses the raw viewport offset so scroll gestures visibly move the window; snap/bounds logic owns where the viewport settles. To preserve working-area margins, the snap grid omits the synthetic `±gap` edge snaps for columns that fill or exceed the viewport, because those snaps only shift a full-width column by one gap with no neighboring column to reveal. Center and far overscroll boundary snaps remain. Stale offsets from a policy/size/monitor change are reset to center by the relayout path detecting a change in the lone window's resolved width.
+- ➕ Semantic correction: inner gap means spacing between adjacent stacked tiles only (secondary axis / vertical stacking). Monitor-edge padding comes exclusively from outer gaps.
+- ➕ Correction: the primary-axis proportional column-width formula (`ProportionalSize.resolveProportionalSpan`, niri-compatible `(A - gaps)*p - gaps`) is intentionally KEPT unchanged. Its 2*gap slack is coupled to `ViewportSnapContext.fillsViewport`'s tolerance (also 2*gap) and acts as a sub-pixel rounding safety margin; removing it breaks 50/50 column fit and makes Reveal Partial "Default" fall back to center-snap. Only the secondary-axis gap accounting (tile stacking solver, tabbed shared frame, leading `secondaryGap` offset) was changed.
 - Mark completed items with `[x]` immediately when done.
 - Add newly discovered tasks with ➕ prefix.
 - Document issues/blockers with ⚠️ prefix.
@@ -73,11 +84,11 @@ Two new Swift types anchor the redesign:
 ```swift
 // Replaces SingleWindowAspectRatio
 enum LoneWindowPolicy: Equatable {
-    case fill
-    case centered(maxWidthFraction: Double)   // 0.0–1.0, fraction of working area width
+    case fill                                // fill working area when the lone-window predicate holds
+    case centered(maxWidthFraction: Double)  // 0.0–1.0, fraction of working area width
 }
 
-// Collapses niriMaxVisibleColumns + niriDefaultColumnWidth
+// Collapses the former niriMaxVisibleColumns + niriDefaultColumnWidth split
 enum DefaultColumnWidth: Equatable {
     case balanced(columns: Int)               // column width = 1/columns
     case custom(fraction: Double)             // explicit fraction 0.05–1.0
@@ -94,10 +105,22 @@ enum DefaultColumnWidth: Equatable {
 `SingleWindowLayoutContext` gets `maxWidthFraction: Double` instead of `aspectRatio: CGFloat`.
 `aspectFittedSingleWindowRect()` is replaced by `centeredLoneWindowRect(maxWidthFraction:)`.
 
+Session decisions added during implementation:
+- `SingleWindowViewportGeometry` is the source of truth for lone-window viewport rects, center offsets,
+  and rendered-frame offsetting. Callers may prepare/seed this geometry, but must not rederive the math.
+- Lone-window viewport offset uses the same coordinate meaning as regular columns. The initial/resting
+  offset is explicitly seeded to the geometry's `centerOffset`; non-center offsets represent active
+  gesture movement or side/overscroll snaps and must survive ordinary relayout.
+- Runtime window minimum constraints are relaxed only when they exceed the monitor visible frame, not merely
+  because they exceed the inset working frame after outer gaps/workspace bar reservations.
+- Inner gaps are internal separators only. Top/bottom/left/right monitor edge spacing must be configured
+  through outer gaps/screen margins.
+
 SettingsExport shape changes:
 - Remove `niriSingleWindowAspectRatio: String`; add `niriLoneWindowMaxWidth: Double?`.
-- Keep `niriMaxVisibleColumns: Int` and `niriDefaultColumnWidth: Double?` (direct `DefaultColumnWidth`
-  encoding: nil fraction = balanced, non-nil = custom).
+- Rename `niriMaxVisibleColumns: Int` to `niriBalancedColumnCount: Int`; keep
+  `niriDefaultColumnWidth: Double?` (direct `DefaultColumnWidth` encoding: nil fraction = balanced,
+  non-nil = custom).
 
 ## What Goes Where
 
@@ -116,16 +139,16 @@ SettingsExport shape changes:
 **Files:**
 - Modify: `Sources/Nehir/Core/Layout/Niri/NiriLayoutEngine.swift`
 
-- [ ] Delete `enum SingleWindowAspectRatio` (L22–52) entirely.
-- [ ] Add `enum LoneWindowPolicy: Equatable` with cases `.fill` and `.centered(maxWidthFraction: Double)`.
+- [x] Delete `enum SingleWindowAspectRatio` (L22–52) entirely.
+- [x] Add `enum LoneWindowPolicy: Equatable` with cases `.fill` and `.centered(maxWidthFraction: Double)`.
   Include `var id: String` computed from the case (`"fill"` / `"centered"`) for picker use.
-- [ ] Add `enum DefaultColumnWidth: Equatable` with cases `.balanced(columns: Int)` and
+- [x] Add `enum DefaultColumnWidth: Equatable` with cases `.balanced(columns: Int)` and
   `.custom(fraction: Double)`. Add `var fraction: Double` computed property.
-- [ ] Update `struct SingleWindowLayoutContext` (L229–233): replace `aspectRatio: CGFloat` with
+- [x] Update `struct SingleWindowLayoutContext` (L229–233): replace `aspectRatio: CGFloat` with
   `maxWidthFraction: Double`.
-- [ ] In `singleWindowLayoutContext()` (L235–261): leave a typed TODO (`// TODO: Task 4 — wire
+- [x] In `singleWindowLayoutContext()` (L235–261): leave a typed TODO (`// TODO: Task 4 — wire
   effectiveLoneWindowPolicy`) and keep it non-functional (return nil) until Task 4.
-- [ ] Build — fix all compile errors introduced by removing `SingleWindowAspectRatio`.
+- [x] Build — fix all compile errors introduced by removing `SingleWindowAspectRatio`.
 
 ### Task 2: Update config model
 
@@ -135,20 +158,23 @@ SettingsExport shape changes:
 - Modify: `Sources/Nehir/Core/Config/BuiltInSettingsDefaults.swift`
 - Modify: `Sources/Nehir/Core/Config/MonitorNiriSettings.swift`
 
-- [ ] **SettingsExport**: remove `niriSingleWindowAspectRatio: String`; add
+- [x] **SettingsExport**: remove `niriSingleWindowAspectRatio: String`; add
   `niriLoneWindowMaxWidth: Double?`. Update `defaults()` to set `niriLoneWindowMaxWidth: nil`.
-- [ ] **SettingsStore**: remove `niriSingleWindowAspectRatio` var; add `niriLoneWindowMaxWidth: Double?`
+- [x] **SettingsStore**: remove `niriSingleWindowAspectRatio` var; add `niriLoneWindowMaxWidth: Double?`
   with `didSet { scheduleSave() }`. Add computed `loneWindowPolicy: LoneWindowPolicy`
   (nil → `.fill`, value → `.centered(maxWidthFraction:)`). Add computed
   `defaultColumnWidth: DefaultColumnWidth` (nil `niriDefaultColumnWidth` → `.balanced(columns:
-  niriMaxVisibleColumns)`, non-nil → `.custom`). Update `toExport()` and `applyExport(_:monitors:)`.
-- [ ] **BuiltInSettingsDefaults**: change `niriColumnWidthPresets` to `[0.35, 0.50, 0.65, 0.95]`.
-- [ ] **MonitorNiriSettings** (override struct): remove `singleWindowAspectRatio: SingleWindowAspectRatio?`;
-  add `loneWindowMaxWidth: Double?`. Keep `maxVisibleColumns: Int?` for per-monitor balanced count
-  override. **ResolvedNiriSettings**: remove `singleWindowAspectRatio`; add `loneWindowPolicy:
-  LoneWindowPolicy`; replace `maxVisibleColumns: Int` with `defaultColumnWidth: DefaultColumnWidth`.
+  niriBalancedColumnCount)`, non-nil → `.custom`). Rename `niriMaxVisibleColumns` to
+  `niriBalancedColumnCount`. Update `toExport()` and `applyExport(_:monitors:)`.
+- [x] **BuiltInSettingsDefaults**: change `niriColumnWidthPresets` to `[0.35, 0.50, 0.65, 0.95]`.
+- [x] **MonitorNiriSettings** (override struct): remove `singleWindowAspectRatio: SingleWindowAspectRatio?`;
+  add `loneWindowPolicy: LoneWindowPolicy?` where `nil` means inherit, `.fill` explicitly overrides to Fill,
+  and `.centered(maxWidthFraction:)` explicitly overrides to Centered. Rename `maxVisibleColumns: Int?` to
+  `balancedColumnCount: Int?` for the per-monitor balanced count override. **ResolvedNiriSettings**: remove
+  `singleWindowAspectRatio`; add `loneWindowPolicy: LoneWindowPolicy`; replace the old count field with
+  `defaultColumnWidth: DefaultColumnWidth`.
   Update init and `SettingsStore.resolvedNiriSettings(for:)` merge logic.
-- [ ] Build and fix compile errors.
+- [x] Build and fix compile errors.
 - [ ] Ask user to launch app, open Layout settings — verify the panel loads without crash.
 
 ### Task 3: Update TOML codecs
@@ -157,18 +183,20 @@ SettingsExport shape changes:
 - Modify: `Sources/Nehir/Core/Config/CanonicalTOMLConfig.swift`
 - Modify: `Sources/Nehir/Core/Config/MonitorOverrideFileStore.swift`
 
-- [ ] **CanonicalTOMLConfig.Niri struct** (L60–65): remove `singleWindowAspectRatio: String`;
-  add `loneWindowMaxWidth: Double?`. Keep `maxVisibleColumns: Int` and `defaultColumnWidth: Double?`.
-  Remove any CodingKey case for `singleWindowAspectRatio`.
-- [ ] **`CanonicalTOMLConfig.init(export:)`** (L174–179): map `niriLoneWindowMaxWidth →
-  loneWindowMaxWidth`; remove old `singleWindowAspectRatio` line.
-- [ ] **`CanonicalTOMLConfig.toSettingsExport()`** (L240–245): map `loneWindowMaxWidth →
+- [x] **CanonicalTOMLConfig.Niri struct** (L60–65): remove `singleWindowAspectRatio: String`;
+  add `loneWindowMaxWidth: Double?`. Rename `maxVisibleColumns: Int` to `balancedColumnCount: Int`
+  and keep `defaultColumnWidth: Double?`. Remove any CodingKey case for `singleWindowAspectRatio`.
+- [x] **`CanonicalTOMLConfig.init(export:)`** (L174–179): map `niriLoneWindowMaxWidth →
+  loneWindowMaxWidth`; remove old `singleWindowAspectRatio` line; write `balancedColumnCount`.
+- [x] **`CanonicalTOMLConfig.toSettingsExport()`** (L240–245): map `loneWindowMaxWidth →
   niriLoneWindowMaxWidth`. Remove old line.
-- [ ] **`CanonicalTOMLConfig.init(from decoder:)`** (L366–371): remove `singleWindowAspectRatio`
-  decode; add `loneWindowMaxWidth = try container.decodeIfPresent(Double.self, forKey: .loneWindowMaxWidth)`.
-- [ ] **MonitorOverrideFileStore** (L138): remove `singleWindowAspectRatio` extract; add
-  `loneWindowMaxWidth` extract (Double? from the niri dict).
-- [ ] Build and fix compile errors.
+- [x] **`CanonicalTOMLConfig.init(from decoder:)`** (L366–371): remove `singleWindowAspectRatio`
+  decode; add `loneWindowMaxWidth = try container.decodeIfPresent(Double.self, forKey: .loneWindowMaxWidth)`;
+  decode `balancedColumnCount`.
+- [x] **MonitorOverrideFileStore**: use tri-state `loneWindowPolicy = "fill" | "centered"`
+  plus `loneWindowMaxWidth` for centered width. Bare `loneWindowMaxWidth` without
+  `loneWindowPolicy = "centered"` is ignored.
+- [x] Build and fix compile errors.
 - [ ] Ask user to restart app with an existing config — confirm no crash and settings load.
 
 ### Task 4: Update layout engine mechanics
@@ -182,34 +210,38 @@ SettingsExport shape changes:
 - Modify: `Sources/Nehir/Core/Layout/Niri/NiriLayoutEngine+Monitors.swift`
 - Modify: `Sources/Nehir/Core/Layout/Niri/NiriLayoutEngine+ViewportCommands.swift`
 
-- [ ] **NiriLayoutEngine.swift**: replace `var singleWindowAspectRatio: SingleWindowAspectRatio`
-  (L128) with `var loneWindowPolicy: LoneWindowPolicy = .fill`. Update `configure(...)` (L332/345).
-- [ ] **`singleWindowLayoutContext()`**: resolve TODO from Task 1 — guard on
-  `.centered(let maxWidthFraction)` from `effectiveLoneWindowPolicy(in:)`; store
-  `maxWidthFraction` in the context. Return nil for `.fill`.
-- [ ] **NiriLayoutEngine+Monitors.swift**: rename `effectiveSingleWindowAspectRatio(for:)` and
+- [x] **NiriLayoutEngine.swift**: replace `var singleWindowAspectRatio: SingleWindowAspectRatio`
+  (L128) with `var loneWindowPolicy: LoneWindowPolicy = .fill`; rename the balanced-count engine field.
+  Update `configure(...)` (L332/345).
+- [x] **`singleWindowLayoutContext()`**: resolve TODO from Task 1 — apply the lone-window predicate
+  for both `.fill` and `.centered(let maxWidthFraction)` from `effectiveLoneWindowPolicy(in:)`;
+  store `maxWidthFraction` in the context (`1.0` for `.fill`).
+- [x] **NiriLayoutEngine+Monitors.swift**: rename `effectiveSingleWindowAspectRatio(for:)` and
   `effectiveSingleWindowAspectRatio(in:)` to `effectiveLoneWindowPolicy(for:)` / `(in:)`, returning
   `LoneWindowPolicy` from `ResolvedNiriSettings.loneWindowPolicy`. Remove all `SingleWindowAspectRatio`
   references.
-- [ ] **NiriLayout.swift**: delete `aspectFittedSingleWindowRect()`. Add
+- [x] **NiriLayout.swift**: delete `aspectFittedSingleWindowRect()`. Add
   `centeredLoneWindowRect(maxWidthFraction: Double, workingFrame: CGRect) -> CGRect`:
   `let w = workingFrame.width * maxWidthFraction; let x = workingFrame.midX - w/2`.
   Full height (workingFrame). Update `resolvedSingleWindowRect()` to use the new helper for both
-  the normal and manual-override paths (manual override stays centered, capped at `maxWidthFraction`).
-- [ ] **`resolvedColumnResetWidth()`** (NiriLayoutEngine.swift L191–197): replace
-  `1.0 / CGFloat(effectiveMaxVisibleColumns(...))` with `effectiveDefaultColumnWidth(in:).fraction`.
-  Add helper `effectiveDefaultColumnWidth(in:) -> DefaultColumnWidth` reading from
+  the normal and manual-override paths (manual override stays centered, uncapped by policy).
+- [x] **Single-window viewport behavior**: add `SingleWindowViewportGeometry` and make lone-window
+  layout/target-frame/gesture/viewport-command paths share it. Side snap points and overscroll must work
+  in a one-window workspace; relayout must not reset explicit snapped offsets back to center.
+- [x] **`resolvedColumnResetWidth()`**: route default-width resolution through
+  `effectiveDefaultColumnWidth(in:) -> DefaultColumnWidth`, backed by
   `ResolvedNiriSettings.defaultColumnWidth`.
-- [ ] **NiriLayoutEngine+ColumnOps.swift L394**: replace `effectiveMaxVisibleColumns` call with
-  `effectiveDefaultColumnWidth(in:).fraction`.
-- [ ] **NiriLayoutEngine+Sizing.swift L103** and **NiriLayoutEngine+Animation.swift L286–290**:
+- [x] **NiriLayoutEngine+ColumnOps.swift**: use the same `effectiveDefaultColumnWidth(in:).fraction`
+  path for move-animation width fallback.
+- [x] **NiriLayoutEngine+Sizing.swift L103** and **NiriLayoutEngine+Animation.swift L286–290**:
   update `SingleWindowLayoutContext` usage to use `maxWidthFraction` instead of `aspectRatio`.
-- [ ] **Reveal Partial / `fillsViewport`** (ViewportCommands.swift L72, L82): if the lone-window
+- [x] **Reveal Partial / `fillsViewport`** (ViewportCommands.swift L72, L82): if the lone-window
   context is active for the target workspace (centered policy holds), the layout intentionally
   does not fill the viewport — ensure `fillsViewport` returns false in this case so Reveal Partial
   default behavior does not mis-snap.
-- [ ] Delete any remaining `effectiveMaxVisibleColumns` helpers that are now dead code.
-- [ ] Build and fix compile errors.
+- [x] **Inner vs outer gaps (secondary axis only)**: stacked-tile gap accounting (`NiriAxisSolver`, tabbed shared-frame solver, `layoutContainer` leading `secondaryGap`, target-frame fallback height) no longer reserves edge padding; gaps are only between adjacent stacked tiles. The primary-axis proportional column formula is unchanged.
+- [x] Delete redundant balanced-count helpers; `DefaultColumnWidth` owns width semantics.
+- [x] Build and fix compile errors.
 - [ ] Ask user to test: set Lone Window to Centered 60%, open a single-window workspace, verify
   the window is narrower and centered; open a second window and verify normal column layout resumes.
   Also verify Reveal Partial scrolling is unaffected.
@@ -219,12 +251,12 @@ SettingsExport shape changes:
 **Files:**
 - Modify: `Sources/Nehir/UI/SettingsView.swift`
 
-- [ ] **`GlobalNiriSettingsSection`** (L271–403):
+- [x] **`GlobalNiriSettingsSection`** (L271–403):
   - Remove the "Visible Columns" `SettingsSliderRow` (L293–306).
   - Remove `Picker("Single Window Width", ...)` and its caption (L308–316).
   - Restructure "Default New Column Width" section:
     - Segmented picker Balanced | Custom (binding to `settings.defaultColumnWidth` mode).
-    - Balanced: stepper "Fit N columns" binding to `settings.niriMaxVisibleColumns` (1–5).
+    - Balanced: stepper "Fit N columns" binding to `settings.niriBalancedColumnCount` (1–5).
     - Custom: existing % text field binding to `settings.niriDefaultColumnWidth`.
   - Add `Section("Lone Window")`:
     - Segmented picker Fill | Centered.
@@ -232,12 +264,13 @@ SettingsExport shape changes:
       `settings.niriLoneWindowMaxWidth` (in %, 10–95, stored as fraction).
     - Caption: "On a workspace with one window, cap its width and center it."
   - Rename "Column Width Cycle Presets" → "Resize Presets".
-- [ ] **`MonitorNiriSettingsSection`** (L405–450):
+- [x] **`MonitorNiriSettingsSection`** (L405–450):
   - Replace `OverridableSlider("Visible Columns", ...)` with an `OverridablePicker`/control for
-    the balanced column count (`ms.maxVisibleColumns` override, inherits global balanced N).
+    the balanced column count (`ms.balancedColumnCount` override, inherits global balanced N).
   - Replace `OverridablePicker("Single Window Width", ...)` with `OverridablePicker("Lone Window", ...)`
-    binding to `ms.loneWindowMaxWidth` override (nil = inherits global).
-- [ ] Build and fix compile errors.
+    binding to tri-state `ms.loneWindowPolicy` override (`nil` = inherits global, `.fill` = explicit Fill,
+    `.centered` = explicit Centered).
+- [x] Build and fix compile errors.
 - [ ] Ask user to exercise every section: Balanced/Custom toggle, N stepper, Lone Window Centered
   max-width field, per-monitor overrides.
 
@@ -246,14 +279,14 @@ SettingsExport shape changes:
 **Files:**
 - Modify: `docs/glossary.md`
 
-- [ ] Remove `SingleWindowAspectRatio` and `maxVisibleColumns` entries (if present).
-- [ ] Add `DefaultColumnWidth` — two modes: balanced (= 1/N columns) and custom (explicit fraction).
-- [ ] Add `LoneWindowPolicy` — fill vs centered-with-max-width; note the predicate conditions.
-- [ ] Document column-width resolution precedence (use viewport-schema notation if the file already
+- [x] Remove `SingleWindowAspectRatio` and old `maxVisibleColumns` entries (if present).
+- [x] Add `DefaultColumnWidth` — two modes: balanced (= 1/N columns) and custom (explicit fraction).
+- [x] Add `LoneWindowPolicy` — fill vs centered-with-max-width; note the predicate conditions.
+- [x] Document column-width resolution precedence (use viewport-schema notation if the file already
   uses that style):
-  ```
+  ```text
   column width resolution (highest wins):
-    1. LoneWindowPolicy.centered — only when lone-window predicate holds
+    1. LoneWindowPolicy.fill / .centered — only when lone-window predicate holds
     2. DefaultColumnWidth.custom(fraction)
     3. DefaultColumnWidth.balanced(columns) → 1/N
   ```
@@ -266,9 +299,15 @@ SettingsExport shape changes:
 - [ ] `DefaultColumnWidth.fraction` computed property (balanced and custom cases).
 - [ ] `centeredLoneWindowRect`: width = workingFrame.width × maxWidthFraction, horizontally centered.
 - [ ] `resolvedColumnResetWidth` with `.balanced(columns: 3)` returns 1/3.
-- [ ] `singleWindowLayoutContext` returns nil for `.fill`, non-nil for `.centered`.
+- [ ] `singleWindowLayoutContext` returns full-width context for `.fill`, capped context for `.centered`.
 - [ ] `CanonicalTOMLConfig` encode/decode round-trip: `loneWindowMaxWidth` survives.
 - [ ] `fillsViewport` returns false when lone-window centered context is active.
+- [ ] Lone-window viewport geometry: center offset, side snap rendering, and target-frame output share the same math.
+- [ ] Inner gap semantics (secondary axis): single/tabbed tiles touch the working-frame edge when outer gaps are zero;
+  stacked tiles only have gaps between adjacent siblings. Primary-axis column widths still use the
+  niri-compatible formula and are intentionally out of scope.
+- [ ] Runtime-minimum visible-frame regression: a constrained lone window larger than the inset working
+  frame but fitting the monitor visible frame remains onscreen.
 - [ ] Run full test suite — all pass before closing this task.
 
 ### Task 8: Acceptance and cleanup
@@ -277,10 +316,10 @@ SettingsExport shape changes:
 - [ ] Verify switching Balanced ↔ Custom preserves the stored column count in Balanced.
 - [ ] Verify Reveal Partial "Default" scrolls correctly with and without lone-window policy active.
 - [ ] Verify per-monitor overrides for both controls.
-- [ ] Check `docs/IPC-CLI.md` — update if `single_window_aspect_ratio` is documented there.
+- [x] Check `docs/IPC-CLI.md` — update if `single_window_aspect_ratio` is documented there. (No exposure found.)
 - [ ] Move this plan to `docs/plans/completed/`.
 
 ## Post-Completion
 
 - Manual test on an actual ultrawide display (≥ 3440px) at `maxWidthFraction` 0.5, 0.6, 0.75.
-- Confirm manual resize of a lone centered window is capped at `maxWidthFraction` and stays centered.
+- Confirm manual resize of a lone centered window is not capped by `maxWidthFraction` and stays centered.

--- a/docs/viewport-navigation-spec.md
+++ b/docs/viewport-navigation-spec.md
@@ -4,8 +4,7 @@ title: Viewport Navigation Spec
 
 # Viewport Navigation Spec
 
-Design specification for viewport navigation, snap behavior, and focus reveal policy.
-This document captures the intended design; implementation may differ during transition.
+Behavior specification for viewport navigation, snap behavior, and focus reveal policy.
 
 ---
 
@@ -64,27 +63,13 @@ Rules:
 
 ---
 
-## Settings (redesigned)
+## Settings
 
-### Removed
-
-| Setting | Reason |
-|---|---|
-| Center Focused Column (picker: never / onOverflow / always) | Snap grid produces centering automatically — this picker has no distinct behavior left to control |
-| Always Center Single Column (toggle) | A single visible column always gets a center snap point — this toggle has no independent effect |
-| Scroll Reveal (picker: always / keyboard-and-commands / never) | Replaced by visibility-based reveal policy |
-
-### Retained / renamed
-
-| Setting | Notes |
-|---|---|
-| Mouse Modifier | Renamed from "Right Mouse Resize Modifier". Hold during a scroll gesture to bypass snap for that gesture. `none` = no way to bypass snap. |
-
-### New
-
-| Setting | Type | Default | Notes |
+| Setting | Type | Default | Behavior |
 |---|---|---|---|
-| Reveal Partial | `.default` / `.off` / `.snapClosest` / `.snapCenter` | `.default` | What happens when focus moves to a [clipped](glossary.md#clipped-column) column from any non-FFM source |
+| Reveal Partial | `.default` / `.off` / `.snapClosest` / `.snapCenter` | `.default` | Controls what happens when focus moves to a [clipped](glossary.md#clipped-column) column from any non-FFM source. |
+| Mouse Modifier | Key binding or `none` | User setting | Hold during a scroll gesture to bypass snap for that gesture. `none` disables snap bypass. |
+| Lone Window | `Fill` / `Centered(width)` with per-monitor `Use Global` / `Fill` / `Centered(width)` | `Fill` | Controls the default viewport geometry for a one-window workspace. |
 
 ---
 
@@ -105,7 +90,16 @@ Consequences:
 
 Reveal `.default` uses this same rule indirectly: a closest snap is treated as viewport-fitting only when the candidate viewport contains a contiguous group of fully visible columns whose combined span is within `2 * gap` of the viewport width. This rejects oversized combinations such as `65% + 50%` while accepting intended `100%` groups.
 
-Implementation note: route proportional pixel conversion through `ProportionalSize.resolveProportionalSpan(...)`; do not duplicate the formula at call sites.
+Implementation contract: route proportional pixel conversion through `ProportionalSize.resolveProportionalSpan(...)`; do not duplicate the formula at call sites. Do not change this primary-axis formula to adjust secondary-axis edge padding; stacked/tiled secondary-axis spacing is owned by `NiriAxisSolver` and related layout helpers, where inner gaps mean only gaps between adjacent tiles.
+
+## Gap Semantics
+
+Nehir has two distinct gap concepts:
+
+- **Inner gap** — spacing between adjacent layout items. On the secondary axis for stacked/tiled windows, this means `count - 1` gaps and no implicit top/bottom edge padding.
+- **Outer gap** — monitor-edge padding around the working area, represented by `LayoutGaps.OuterGaps`.
+
+Monitor-specific gap values are resolved centrally by `SettingsStore.resolvedGapSettings(for:)` and exposed to runtime code by `WMController.gapSize(for:)` and `WMController.outerGaps(for:)`. Viewport/layout callers should use those monitor-aware helpers when a monitor is known, rather than reading global fallback gap values directly.
 
 ## Snap Grid
 
@@ -120,11 +114,34 @@ For each column:
 
 Columns narrower than 30% of the viewport only get edge snaps. This keeps the snap grid sparse for multi-column layouts with small panels.
 
+Columns whose effective width approximately fills the viewport (within pixel tolerance) do **not** get the synthetic `columnX - gap` / `columnX + width + gap - viewportWidth` edge snaps. For a full-width column those points are meaningless `±gap` shifts: they reveal no neighboring column and lose working-area margins. Over-wide columns (wider than the viewport) keep their edge snaps so clipped content can be reached. The column can still have a center snap and the snap grid still includes far overscroll boundary points.
+
 ### Gesture release
 
 On gesture release, the viewport snaps to the nearest snap point. The focused column updates to the column at the target snap position.
 
 Hold the **Mouse Modifier** key during a gesture to bypass snapping — the viewport settles at the decelerated natural position.
+
+Implementation contract: `computeSnapGrid(...)`, `viewportStartBounds(...)`, and `ViewportSnapContext` in `ViewportState+Geometry.swift` are the source of truth for snap points and bounds. Gesture release, viewport scroll commands, Reveal Partial, resize adjustment, and column transitions must consume this shared geometry instead of constructing local snap/edge formulas.
+
+---
+
+## Lone-Window Viewport Behavior
+
+A lone window is a normal, non-tabbed workspace with exactly one column and one window. Its default rect is controlled by `LoneWindowPolicy`:
+
+- **fill** — fill the working area
+- **centered** — cap width to the policy's max working-area fraction and center it
+
+Per-monitor overrides are tri-state through `MonitorNiriSettings.loneWindowPolicy`:
+
+- `nil` — inherit global policy
+- `.fill` — explicit Fill on that monitor
+- `.centered(maxWidthFraction:)` — explicit Centered on that monitor
+
+`SingleWindowViewportGeometry` is the source of truth for the resolved lone-window rect, center offset, and render offset. Controllers and gesture handlers should call `singleWindowViewportGeometry(...)`, `resolvedSingleWindowViewportRect(...)`, `prepareSingleWindowViewport(...)`, or `prepareAndSeedSingleWindowViewport(...)` rather than re-deriving the math.
+
+Lone-window rendering follows the raw viewport offset so scroll gestures are visible. The snap grid decides where the viewport settles. This keeps fill windows responsive during a gesture while preventing them from parking at bogus `±gap` edge snaps after release.
 
 ---
 
@@ -160,7 +177,7 @@ If the target column is already at a valid snap position (within pixel tolerance
 
 ## Viewport Scroll Commands
 
-Two new commands — `scrollViewport(.left)` and `scrollViewport(.right)` — scroll the viewport through [snap points](glossary.md#snap-point) without immediately changing focus.
+`scrollViewport(.left)` and `scrollViewport(.right)` scroll the viewport through [snap points](glossary.md#snap-point) without immediately changing focus.
 
 Default bindings: `Cmd+Option+[` (left) and `Cmd+Option+]` (right).
 
@@ -254,9 +271,3 @@ Press again. Col2 fully outside — [parked](glossary.md#parked-window) — focu
 ```text
 30 30 [|*50 .20].15
 ```
-
----
-
-## Open Questions
-
-- **Center snap threshold (30%)**: exact value TBD. Determines whether a column gets a center snap point.


### PR DESCRIPTION
## Summary

<!-- What changed and why? -->

## Release notes

Choose one:

- [x] Added a `.changeset/*.md` for user-visible changes (`mise run changeset -- patch "..."`).
- [ ] No user-visible change; apply the `no release note` label to make CI skip intentional.

## Validation

<!-- Commands run, screenshots, or manual checks. -->

- [ ] Ran relevant tests/checks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added per-monitor customization for inner gap and screen margins with **Use Global** inheritance.
  * Introduced a **Lone Window** policy (**Fill** or **Centered** with adjustable max width) with per-monitor overrides.
  * Added per-monitor gap overrides persisted to configuration.

* **Bug Fixes**
  * Fixed centered lone-window placement after monitor changes, plus more predictable scrolling/snapping.
  * Updated inner-gap semantics for stacked/tabbed layouts.

* **Breaking Changes**
  * Renamed balanced-width keys to `balancedColumnCount` and replaced the old single-window aspect-ratio setting with the new **Lone Window** policy (no automatic migration).

* **Improvements**
  * Refreshed column width presets and refined gap/snap-grid behavior to preserve proportional viewport fitting and Reveal Partial “Default”.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->