### PR TITLE
False resize minimum fix

### DIFF
--- a/.changeset/20260614100452-fix-false-resize-minimum-pin-on-terminal-cell-quantiz.md
+++ b/.changeset/20260614100452-fix-false-resize-minimum-pin-on-terminal-cell-quantiz.md
@@ -1,0 +1,9 @@
+---
+"nehir": patch
+---
+
+Fixed false resize-minimum pin on terminal windows that snap to cell rows.
+
+- Terminal/grid apps such as Ghostty round window geometry to whole cell rows. When a requested fill height fell between grid lines, the app snapped the window *up* by a few pixels and Nehir misread that small overshoot as a hard app-enforced minimum.
+- Nehir then permanently recorded an inferred resize minimum on just that window, over-constrained the Niri solver against its siblings, and pinned the window to the snapped (taller) height. This is why one Ghostty window on a multi-column workspace could end up taller than the others.
+- Small `verificationMismatch` overshoots (within ~one cell) are now treated as bidirectional cell quantization rather than a one-sided minimum: the observed snapped frame is accepted and confirmed, but no inferred minimum is recorded and the solver is no longer force-pinned. Genuine app minimums are unaffected because they are reported via `AXMinSize` and respected independently.

--- a/Sources/Nehir/Core/Controller/LayoutRefreshController.swift
+++ b/Sources/Nehir/Core/Controller/LayoutRefreshController.swift
@@ -2996,6 +2996,28 @@ import QuartzCore
             return
         }
 
+        if let observedFrame = result.writeResult.observedFrame,
+           result.writeResult.failureReason == .verificationMismatch,
+           isCellQuantizationOvershoot(target: result.targetFrame, observed: observedFrame)
+        {
+            // Terminal/grid apps (e.g. Ghostty) snap window geometry to whole cell rows. Such
+            // overshoot is bidirectional quantization, not a one-sided hard minimum: the window
+            // could be smaller (next grid line down), it just cannot land exactly on the requested
+            // size. Accept the snapped frame and do NOT record an inferred resize minimum — pinning
+            // it would over-constrain the solver and permanently break uniform fill heights among
+            // sibling windows in the same workspace.
+            controller.axManager.confirmFrameWrite(for: result.windowId, frame: observedFrame)
+            _ = controller.focusBorderController.updateFrameHint(
+                for: entry.token,
+                frame: observedFrame,
+                forceOrdering: true
+            )
+            controller.axManager.recordFrameApplyTrace(
+                "resizeMin.skipQuantization id=\(entry.windowId) target=\(LayoutTrace.rect(result.targetFrame)) observed=\(LayoutTrace.rect(observedFrame))"
+            )
+            return
+        }
+
         guard let minimumSize = inferredResizeMinimumSize(for: result, entry: entry) else { return }
 
         let previousMinimumSize = controller.workspaceManager.inferredResizeMinimumSize(for: entry.token)
@@ -3110,6 +3132,35 @@ import QuartzCore
     private func targetSizeIsSmallerThanObservedSize(_ targetSize: CGSize, observedSize: CGSize) -> Bool {
         targetSize.width + 0.5 < observedSize.width
             || targetSize.height + 0.5 < observedSize.height
+    }
+
+    /// Maximum overshoot, in points, treated as cell-row/column quantization rather than an
+    /// app-enforced minimum. Covers typical terminal cell heights; genuine minimums are reported
+    /// via `AXMinSize` and respected independently of this fallback heuristic.
+    private static let cellQuantizationOvershootThreshold: CGFloat = 32.0
+
+    /// Returns true when the only thing separating `observed` from `target` is cell-quantizing
+    /// snap: at least one size axis overshoots (a pure shrink is handled by the inferred-minimum
+    /// path, not here) and every frame component — both sizes, including any non-overshooting
+    /// axis, and the origin — stays within `cellQuantizationOvershootThreshold`. Cell-quantizing
+    /// apps (terminal emulators) snap bidirectionally to whole grid lines and do not move the
+    /// window, so a genuine quantization mismatch never undershoots past one cell or shifts the
+    /// origin; anything larger is a real refusal/minimum and must not be swallowed here.
+    private func isCellQuantizationOvershoot(target: CGRect, observed: CGRect) -> Bool {
+        let threshold = Self.cellQuantizationOvershootThreshold
+        func axisOvershoot(_ targetDimension: CGFloat, _ observedDimension: CGFloat) -> CGFloat {
+            observedDimension > targetDimension + 0.5 ? observedDimension - targetDimension : 0
+        }
+        func withinThreshold(_ targetDimension: CGFloat, _ observedDimension: CGFloat) -> Bool {
+            abs(observedDimension - targetDimension) <= threshold
+        }
+        let widthOvershoot = axisOvershoot(target.width, observed.width)
+        let heightOvershoot = axisOvershoot(target.height, observed.height)
+        return (widthOvershoot > 0 || heightOvershoot > 0)
+            && withinThreshold(target.width, observed.width)
+            && withinThreshold(target.height, observed.height)
+            && withinThreshold(target.origin.x, observed.origin.x)
+            && withinThreshold(target.origin.y, observed.origin.y)
     }
 
 


### PR DESCRIPTION
## Summary

<!-- What changed and why? -->

## Release notes

Choose one:

- [x] Added a `.changeset/*.md` for user-visible changes (`mise run changeset -- patch "..."`).
- [ ] No user-visible change; apply the `no release note` label to make CI skip intentional.

## Validation

<!-- Commands run, screenshots, or manual checks. -->

- [ ] Ran relevant tests/checks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

**Bug Fixes**
- Fixed an issue where terminal and grid windows could be wrongly pinned to a “resize minimum” after small, natural snap/quantization overshoots.
- When the observed frame slightly overshoots the target within a bounded heuristic and matches cell-aligned quantization behavior, the controller now accepts the result without recording an inferred minimum.
- Application-defined minimum sizes are still enforced as expected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->