### PR TITLE
Implement focus-follows-mouse suppression over unmanaged overlay windows

### DIFF
--- a/.changeset/20260615135853-fixed-ffm-stealing-focus-behind-ghostty-quick-terminal.md
+++ b/.changeset/20260615135853-fixed-ffm-stealing-focus-behind-ghostty-quick-terminal.md
@@ -1,0 +1,5 @@
+---
+"nehir": patch
+---
+
+Fixed focus-follows-mouse stealing focus to the tile behind overlay windows like Ghostty's Quick terminal while the pointer is over them, and fixed trackpad scroll gestures freezing whenever a system notification was visible.

--- a/Sources/Nehir/App/OwnedWindowRegistry.swift
+++ b/Sources/Nehir/App/OwnedWindowRegistry.swift
@@ -116,6 +116,13 @@ final class OwnedWindowRegistry {
         surfaceCoordinator.contains(windowNumber: windowNumber)
     }
 
+    /// Window numbers of visible Nehir-owned pass-through surfaces (e.g. the focus
+    /// border). Consumers that treat higher-layer windows as "unmanaged" overlays
+    /// must exclude these, since they overlay real tiles but pass clicks through.
+    var passthroughSurfaceWindowNumbers: Set<Int> {
+        surfaceCoordinator.passthroughSurfaceWindowNumbers
+    }
+
     var hasFrontmostWindow: Bool {
         surfaceCoordinator.hasFrontmostSuppressingWindow
     }

--- a/Sources/Nehir/Core/Controller/MouseEventHandler.swift
+++ b/Sources/Nehir/Core/Controller/MouseEventHandler.swift
@@ -1358,6 +1358,18 @@ final class MouseEventHandler {
             abortActiveGestureIfNeeded()
             return
         }
+        // Mirror the focus-follows-mouse occlusion rule: when the pointer is over an
+        // on-screen, non-tracked, non-passthrough overlay (e.g. Ghostty's Quick
+        // terminal), the trackpad gesture must not navigate the niri tile behind it.
+        // The gesture tap is listen-only, so the OS already routes the scroll/touch to
+        // the window under the cursor; this guard only skips Nehir's column-navigation
+        // side effect. Nehir's own pass-through surfaces (the focus border) are
+        // excluded by `unmanagedWindowServerWindowCovers`, so gestures still work over
+        // the focused tile.
+        if controller.unmanagedWindowServerWindowCovers(point: location) {
+            abortActiveGestureIfNeeded()
+            return
+        }
         guard !state.isResizing, !state.isMoving else {
             abortActiveGestureIfNeeded()
             return

--- a/Sources/Nehir/Core/Controller/WMController.swift
+++ b/Sources/Nehir/Core/Controller/WMController.swift
@@ -178,8 +178,41 @@ final class WMController {
     var workspaceBarRefreshExecutionHookForTests: (() -> Void)?
     @ObservationIgnored
     var warpMouseCursorPosition: (CGPoint) -> Void = { CGWarpMouseCursorPosition($0) }
+    /// Injectable on-screen window-server snapshot consumed by the unmanaged-window
+    /// occlusion checks. Defaults to the live `CGWindowList`; tests inject synthetic
+    /// snapshots to exercise the real layer/size/onscreen predicate (see
+    /// `visibleUnmanagedWindowServerFrames(trackedWindowIds:snapshot:)`).
     @ObservationIgnored
-    var unmanagedWindowServerWindowFramesProvider: @MainActor (Set<Int>) -> [CGRect] = WMController.visibleUnmanagedWindowServerFrames
+    var windowServerSnapshotProvider: @MainActor () -> [[String: Any]] = {
+        guard let windows = CGWindowListCopyWindowInfo(.optionOnScreenOnly, kCGNullWindowID) as? [[String: Any]] else {
+            return []
+        }
+        return windows
+    }
+    /// Resolves the activation policy for a window-server owner PID. Used to keep
+    /// system chrome — Notification Center (`com.apple.notificationcenterui`), Dock,
+    /// Control Center, menu-bar/status items — out of the unmanaged-occlusion set:
+    /// those run at `.accessory` / `.prohibited` policy and are typically full-screen
+    /// transparent event surfaces, so counting them as occluders blocks the entire
+    /// display whenever a notification/banner is visible. Real overlay windows such
+    /// as Ghostty's Quick terminal belong to `.regular` apps and remain caught.
+    /// Injectable for tests.
+    @ObservationIgnored
+    var windowOwnerActivationPolicyProvider: @MainActor (pid_t) -> NSApplication.ActivationPolicy? = { pid in
+        NSRunningApplication(processIdentifier: pid)?.activationPolicy
+    }
+    /// Frame-level seam over the unmanaged-window snapshot. Tests may inject frames
+    /// directly to bypass the layer predicate; the production default routes through
+    /// `windowServerSnapshotProvider` and the pure static predicate below.
+    @ObservationIgnored
+    lazy var unmanagedWindowServerWindowFramesProvider: @MainActor (Set<Int>) -> [CGRect] = { [weak self] trackedWindowIds in
+        guard let self else { return [] }
+        return Self.visibleUnmanagedWindowServerFrames(
+            trackedWindowIds: trackedWindowIds,
+            snapshot: self.windowServerSnapshotProvider(),
+            activationPolicyProvider: self.windowOwnerActivationPolicyProvider
+        )
+    }
     @ObservationIgnored
     weak var ipcApplicationBridge: IPCApplicationBridge?
     @ObservationIgnored
@@ -2332,19 +2365,42 @@ final class WMController {
         ].joined(separator: " ")
     }
 
+    /// Pure predicate over a window-server snapshot: returns app-coordinate frames of
+    /// on-screen, ≥80×80 windows that Nehir does not manage. Any non-desktop layer
+    /// (`layer >= 0`) qualifies, so overlay levels (`.floating` = 3, `.popUpMenu` =
+    /// 101, dock / menu-bar / status-item layers, etc.) correctly count as occluding
+    /// the pointer. This is what stops focus-follows-mouse from firing through windows
+    /// such as Ghostty's Quick terminal, which never sit at layer 0. The desktop /
+    /// wallpaper lives at `kCGDesktopWindowLevel` (a large negative value) and is
+    /// therefore excluded.
     static func visibleUnmanagedWindowServerFrames(
-        trackedWindowIds: Set<Int> = []
-    ) -> [CGRect] {
-        guard let windows = CGWindowListCopyWindowInfo(.optionOnScreenOnly, kCGNullWindowID) as? [[String: Any]] else {
-            return []
+        trackedWindowIds: Set<Int> = [],
+        snapshot: [[String: Any]],
+        activationPolicyProvider: (pid_t) -> NSApplication.ActivationPolicy? = { pid in
+            NSRunningApplication(processIdentifier: pid)?.activationPolicy
         }
-
-        return windows.compactMap { info -> CGRect? in
+    ) -> [CGRect] {
+        snapshot.compactMap { info -> CGRect? in
             let windowId = (info[kCGWindowNumber as String] as? NSNumber)?.uint32Value
             guard let windowId, !trackedWindowIds.contains(Int(windowId)) else { return nil }
 
+            // Only real foreground-app windows occlude. System chrome (Notification
+            // Center, Dock, Control Center, menu-bar/status items) runs at .accessory /
+            // .prohibited policy and is typically a full-screen transparent event
+            // surface; counting it as an occluder blocks the whole display whenever a
+            // notification or banner is visible. Ghostty's Quick terminal and other
+            // real overlays belong to .regular apps and stay caught. An unresolvable
+            // owner (e.g. a synthetic test snapshot) is treated as regular so the
+            // check stays conservative.
+            if let pid = (info[kCGWindowOwnerPID as String] as? NSNumber)?.int32Value,
+               let policy = activationPolicyProvider(pid),
+               policy != .regular
+            {
+                return nil
+            }
+
             let layer = (info[kCGWindowLayer as String] as? NSNumber)?.intValue ?? 0
-            guard layer == 0 else { return nil }
+            guard layer >= 0 else { return nil }
 
             let isOnscreen = (info[kCGWindowIsOnscreen as String] as? NSNumber)?.boolValue ?? false
             guard isOnscreen else { return nil }
@@ -2365,8 +2421,14 @@ final class WMController {
     }
 
     func unmanagedWindowServerWindowCovers(point: CGPoint) -> Bool {
-        let trackedWindowIds = Set(workspaceManager.trackedWindowIdsForDebug())
-        return unmanagedWindowServerWindowFramesProvider(trackedWindowIds).contains { $0.contains(point) }
+        // Window numbers Nehir owns and therefore must not treat as "unmanaged":
+        // tracked app windows plus our own visible pass-through surfaces (e.g. the
+        // focus border, which overlays the focused tile at a non-zero layer). Without
+        // the pass-through exclusion the broader `layer >= 0` occlusion check would
+        // suppress focus-follows-mouse over the very tile the border decorates.
+        var excludedWindowIds = Set(workspaceManager.trackedWindowIdsForDebug())
+        excludedWindowIds.formUnion(ownedWindowRegistry.passthroughSurfaceWindowNumbers)
+        return unmanagedWindowServerWindowFramesProvider(excludedWindowIds).contains { $0.contains(point) }
     }
 
     private func visibleUnmanagedWindowServerDebugDump() -> String {
@@ -2374,13 +2436,24 @@ final class WMController {
             return "unavailable"
         }
 
-        let trackedWindowIds = Set(workspaceManager.trackedWindowIdsForDebug())
+        // Keep the debug dump consistent with `unmanagedWindowServerWindowCovers`:
+        // Nehir's own pass-through surfaces are not "unmanaged" windows.
+        var excludedWindowIds = Set(workspaceManager.trackedWindowIdsForDebug())
+        excludedWindowIds.formUnion(ownedWindowRegistry.passthroughSurfaceWindowNumbers)
         let visibleCandidates = windows.compactMap { info -> String? in
             let windowId = (info[kCGWindowNumber as String] as? NSNumber)?.uint32Value
-            guard let windowId, !trackedWindowIds.contains(Int(windowId)) else { return nil }
+            guard let windowId, !excludedWindowIds.contains(Int(windowId)) else { return nil }
+
+            let pid = (info[kCGWindowOwnerPID as String] as? NSNumber)?.int32Value ?? 0
+            // Mirror `visibleUnmanagedWindowServerFrames`: system chrome (Notification
+            // Center, Dock, Control Center) is not an unmanaged occluder, so keep the
+            // debug dump aligned with what the occlusion check actually considers.
+            if let policy = windowOwnerActivationPolicyProvider(pid), policy != .regular {
+                return nil
+            }
 
             let layer = (info[kCGWindowLayer as String] as? NSNumber)?.intValue ?? 0
-            guard layer == 0 else { return nil }
+            guard layer >= 0 else { return nil }
 
             let isOnscreen = (info[kCGWindowIsOnscreen as String] as? NSNumber)?.boolValue ?? false
             guard isOnscreen else { return nil }
@@ -2394,7 +2467,6 @@ final class WMController {
                   height >= 80
             else { return nil }
 
-            let pid = (info[kCGWindowOwnerPID as String] as? NSNumber)?.int32Value ?? 0
             let ownerName = info[kCGWindowOwnerName as String] as? String ?? "nil"
             let title = info[kCGWindowName as String] as? String ?? "nil"
             let runningApp = NSRunningApplication(processIdentifier: pid)

--- a/Sources/Nehir/Core/Surface/SurfaceCoordinator.swift
+++ b/Sources/Nehir/Core/Surface/SurfaceCoordinator.swift
@@ -64,6 +64,15 @@ final class SurfaceCoordinator {
         scene.contains(windowNumber: windowNumber)
     }
 
+    /// Window numbers of currently-visible Nehir-owned surfaces registered as
+    /// `.passthrough` (e.g. the focus border). These overlay real tiles but pass
+    /// clicks through, so they must not be treated as unmanaged occluders by the
+    /// focus-follows-mouse suppression check — otherwise FFM is suppressed over
+    /// the very tile the border decorates.
+    var passthroughSurfaceWindowNumbers: Set<Int> {
+        scene.passthroughSurfaceWindowNumbers
+    }
+
     func containsInteractive(point: CGPoint) -> Bool {
         scene.containsInteractive(point: point)
     }

--- a/Sources/Nehir/Core/Surface/SurfaceScene.swift
+++ b/Sources/Nehir/Core/Surface/SurfaceScene.swift
@@ -208,6 +208,18 @@ final class SurfaceScene {
         surfaceIDsByWindowNumber.removeAll()
     }
 
+    /// Window numbers of visible surfaces whose `hitTestPolicy` is `.passthrough`
+    /// (the focus border). Such surfaces sit on top of real content but do not own
+    /// pointer input, so callers that infer occlusion from the window server must
+    /// ignore them.
+    var passthroughSurfaceWindowNumbers: Set<Int> {
+        Set(
+            visibleNodes
+                .filter { $0.policy.hitTestPolicy == .passthrough }
+                .compactMap { $0.windowNumber }
+        )
+    }
+
     private func node(for window: NSWindow) -> SurfaceNode? {
         guard let id = windowIDByObject[ObjectIdentifier(window)] else { return nil }
         return nodesByID[id]

--- a/Tests/NehirTests/MouseEventHandlerTests.swift
+++ b/Tests/NehirTests/MouseEventHandlerTests.swift
@@ -1916,6 +1916,87 @@ private func prepareMouseWheelScrollFixtureWithDefaultSensitivity() async -> (
         #expect(fixture.handler.state.gesturePhase == .idle)
     }
 
+    @Test @MainActor func trackpadGestureSuppressesOverUnmanagedOverlayWindow() async {
+        // When the pointer is over an on-screen, non-tracked overlay at a non-zero
+        // layer (e.g. Ghostty's Quick terminal at layer 3), the trackpad column-
+        // navigation gesture must not fire against the niri tile behind it. The OS
+        // already routes the scroll to the overlay (the gesture tap is listen-only);
+        // Nehir simply must not perform its own column-nav side effect.
+        let fixture = await prepareMouseWheelScrollFixture()
+        let controller = fixture.controller
+
+        // Drive occlusion through the real layer predicate (makeMouseEventTestController
+        // otherwise stubs the frame provider to []).
+        controller.unmanagedWindowServerWindowFramesProvider = { [weak controller] excludedWindowIds in
+            guard let controller else { return [] }
+            return WMController.visibleUnmanagedWindowServerFrames(
+                trackedWindowIds: excludedWindowIds,
+                snapshot: controller.windowServerSnapshotProvider()
+            )
+        }
+        let overlayAppFrame = CGRect(
+            x: fixture.location.x - 200,
+            y: fixture.location.y - 150,
+            width: 400,
+            height: 300
+        )
+        controller.windowServerSnapshotProvider = {
+            [makeWindowServerSnapshotEntry(windowId: 5301, layer: 3, appKitFrame: overlayAppFrame)]
+        }
+
+        #expect(controller.unmanagedWindowServerWindowCovers(point: fixture.location))
+        sendCommittingTrackpadGesture(to: fixture.handler, at: fixture.location)
+
+        #expect(fixture.handler.state.gesturePhase == .idle)
+    }
+
+    @Test @MainActor func trackpadGestureStillCommitsOverOwnPassthroughBorder() async {
+        // Nehir's focus border is a pass-through overlay sized over the focused tile.
+        // It must not suppress trackpad gestures over the tile it decorates — the
+        // passthrough-surface exclusion in `unmanagedWindowServerWindowCovers` keeps
+        // the gesture path working, mirroring the focus-follows-mouse border case.
+        let surfaceCoordinator = SurfaceCoordinator()
+        let registry = OwnedWindowRegistry(surfaceCoordinator: surfaceCoordinator)
+        let fixture = await prepareMouseWheelScrollFixture(ownedWindowRegistry: registry)
+        let controller = fixture.controller
+
+        let borderWindowNumber: UInt32 = 5302
+        let borderAppFrame = CGRect(
+            x: fixture.location.x - 200,
+            y: fixture.location.y - 150,
+            width: 400,
+            height: 300
+        )
+        // Register the border exactly like BorderManager: `.border` kind, pass-through
+        // hit testing, excluded from capture.
+        registry.registerWindowNumber(
+            surfaceId: "test-border-surface",
+            kind: .border,
+            windowNumber: Int(borderWindowNumber),
+            frameProvider: { borderAppFrame },
+            visibilityProvider: { true },
+            hitTestPolicy: .passthrough,
+            capturePolicy: .excluded,
+            suppressesManagedFocusRecovery: false
+        )
+
+        controller.unmanagedWindowServerWindowFramesProvider = { [weak controller] excludedWindowIds in
+            guard let controller else { return [] }
+            return WMController.visibleUnmanagedWindowServerFrames(
+                trackedWindowIds: excludedWindowIds,
+                snapshot: controller.windowServerSnapshotProvider()
+            )
+        }
+        controller.windowServerSnapshotProvider = {
+            [makeWindowServerSnapshotEntry(windowId: borderWindowNumber, layer: 3, appKitFrame: borderAppFrame)]
+        }
+
+        #expect(controller.unmanagedWindowServerWindowCovers(point: fixture.location) == false)
+        sendCommittingTrackpadGesture(to: fixture.handler, at: fixture.location)
+
+        #expect(fixture.handler.state.gesturePhase == .committed)
+    }
+
     @Test @MainActor func ownedWindowDragCancelsActiveNiriMoveAndResize() async {
         var frontmostWindow: NSWindow?
         let registry = makeOwnedMouseWindowRegistry { frontmostWindow }
@@ -2321,7 +2402,308 @@ private func prepareMouseWheelScrollFixtureWithDefaultSensitivity() async -> (
         #expect(controller.workspaceManager.activeFocusRequestToken == nil)
     }
 
-    @Test @MainActor func focusFollowsMouseDoesNotActivateTiledWindowWhileFloatingWindowIsVisible() async {
+/// Builds a synthetic window-server snapshot entry (CG/Quartz-coordinate bounds)
+/// whose frame round-trips back to `appKitFrame` after
+/// `ScreenCoordinateSpace.toAppKit(rect:)` is applied by the predicate under test.
+@MainActor
+private func makeWindowServerSnapshotEntry(
+    windowId: UInt32,
+    layer: Int,
+    appKitFrame: CGRect,
+    onscreen: Bool = true,
+    ownerPid: pid_t? = nil
+) -> [String: Any] {
+    let serverFrame = ScreenCoordinateSpace.toWindowServer(rect: appKitFrame)
+    var entry: [String: Any] = [
+        kCGWindowNumber as String: NSNumber(value: windowId),
+        kCGWindowLayer as String: NSNumber(value: layer),
+        kCGWindowIsOnscreen as String: NSNumber(value: onscreen),
+        kCGWindowBounds as String: [
+            "X": NSNumber(value: Double(serverFrame.origin.x)),
+            "Y": NSNumber(value: Double(serverFrame.origin.y)),
+            "Width": NSNumber(value: Double(serverFrame.width)),
+            "Height": NSNumber(value: Double(serverFrame.height))
+        ] as [String: Any]
+    ]
+    if let ownerPid {
+        entry[kCGWindowOwnerPID as String] = NSNumber(value: ownerPid)
+    }
+    return entry
+}
+
+/// Shared fixture for the unmanaged-overlay FFM suppression tests: two tiled
+/// windows with managed focus on the first, returning the controller, both
+/// tokens, and the second (hover-target) tile's frame. Pass a dedicated
+/// `ownedWindowRegistry` to register Nehir surfaces (e.g. a pass-through border)
+/// against an isolated surface coordinator.
+@MainActor
+private func prepareUnmanagedOverlayFFMFixture(
+    ownedWindowRegistry: OwnedWindowRegistry = .shared
+) async -> (controller: WMController, firstToken: WindowToken, secondToken: WindowToken, secondFrame: CGRect)? {
+    let controller = makeMouseEventTestController(ownedWindowRegistry: ownedWindowRegistry)
+    controller.enableNiriLayout()
+    await controller.layoutRefreshController.waitForRefreshWorkForTests()
+    controller.syncMonitorsToNiriEngine()
+    controller.setFocusFollowsMouse(true)
+
+    guard let workspaceId = controller.interactionWorkspace()?.id,
+          let engine = controller.niriEngine,
+          let monitor = controller.workspaceManager.monitor(for: workspaceId)
+    else {
+        Issue.record("Missing Niri context for unmanaged overlay FFM regression test")
+        return nil
+    }
+
+    let firstToken = controller.workspaceManager.addWindow(
+        makeMouseEventTestWindow(windowId: 940),
+        pid: getpid(),
+        windowId: 940,
+        to: workspaceId
+    )
+    let secondToken = controller.workspaceManager.addWindow(
+        makeMouseEventTestWindow(windowId: 941),
+        pid: getpid(),
+        windowId: 941,
+        to: workspaceId
+    )
+    guard let firstHandle = controller.workspaceManager.handle(for: firstToken),
+          let secondHandle = controller.workspaceManager.handle(for: secondToken)
+    else {
+        Issue.record("Missing handles for unmanaged overlay FFM regression test")
+        return nil
+    }
+
+    _ = engine.syncWindows(
+        [firstHandle, secondHandle],
+        in: workspaceId,
+        selectedNodeId: nil,
+        focusedHandle: firstHandle
+    )
+    _ = controller.workspaceManager.setManagedFocus(firstHandle, in: workspaceId, onMonitor: monitor.id)
+    controller.layoutRefreshController.requestImmediateRelayout(reason: .workspaceTransition)
+    await controller.layoutRefreshController.waitForRefreshWorkForTests()
+
+    guard let secondNode = engine.findNode(for: secondHandle),
+          let secondFrame = secondNode.frame
+    else {
+        Issue.record("Missing tiled target frame for unmanaged overlay FFM regression test")
+        return nil
+    }
+
+    return (controller, firstToken, secondToken, secondFrame)
+}
+
+@MainActor
+private func assertFocusFollowsMouseSuppressedOverUnmanagedOverlay(
+    layer: Int,
+    windowId: UInt32
+) async {
+    guard let fixture = await prepareUnmanagedOverlayFFMFixture() else { return }
+    let controller = fixture.controller
+    let firstToken = fixture.firstToken
+    let secondFrame = fixture.secondFrame
+
+    // Route FFM occlusion off the injected window-server snapshot so the real
+    // `layer >= 0` predicate is exercised. (makeMouseEventTestController otherwise
+    // stubs the frame provider to [], which would bypass the layer logic entirely.)
+    controller.unmanagedWindowServerWindowFramesProvider = { [weak controller] trackedWindowIds in
+        guard let controller else { return [] }
+        return WMController.visibleUnmanagedWindowServerFrames(
+            trackedWindowIds: trackedWindowIds,
+            snapshot: controller.windowServerSnapshotProvider()
+        )
+    }
+    let overlayAppFrame = CGRect(
+        x: secondFrame.midX - 200,
+        y: secondFrame.midY - 150,
+        width: 400,
+        height: 300
+    )
+    let snapshot = [
+        makeWindowServerSnapshotEntry(windowId: windowId, layer: layer, appKitFrame: overlayAppFrame)
+    ]
+    controller.windowServerSnapshotProvider = { snapshot }
+
+    controller.mouseEventHandler.dispatchMouseMoved(at: overlayAppFrame.center)
+    await controller.layoutRefreshController.waitForRefreshWorkForTests()
+
+    #expect(controller.workspaceManager.confirmedManagedFocusToken == firstToken)
+    #expect(controller.workspaceManager.activeFocusRequestToken == nil)
+}
+
+@Test @MainActor func focusFollowsMouseSuppressesOverUnmanagedOverlayWindow() async {
+    // Ghostty's Quick terminal settles at NSWindow.Level.floating (layer 3) once
+    // its slide-in completes — it is never at layer 0, so the old filter missed it.
+    await assertFocusFollowsMouseSuppressedOverUnmanagedOverlay(layer: 3, windowId: 4242)
+}
+
+@Test @MainActor func focusFollowsMouseSuppressesOverUnmanagedPopUpMenuWindow() async {
+    // Ghostty's Quick terminal sits at NSWindow.Level.popUpMenu (layer 101) during
+    // its slide-in/out animation.
+    await assertFocusFollowsMouseSuppressedOverUnmanagedOverlay(layer: 101, windowId: 4243)
+}
+
+@Test @MainActor func focusFollowsMouseActivatesTileBehindOwnPassthroughBorder() async {
+    // Nehir's own focus border is a pass-through overlay sized to the focused tile
+    // plus padding, at layer 3 (NSWindow.Level.floating). Once the occlusion check
+    // broadened to `layer >= 0`, the border itself started suppressing
+    // focus-follows-mouse over the very tile it decorates. Registered own
+    // pass-through surface window numbers must be excluded so FFM still reaches the
+    // tile beneath them — contrasting with the third-party overlay case above.
+    let surfaceCoordinator = SurfaceCoordinator()
+    let registry = OwnedWindowRegistry(surfaceCoordinator: surfaceCoordinator)
+    guard let fixture = await prepareUnmanagedOverlayFFMFixture(ownedWindowRegistry: registry) else { return }
+    let controller = fixture.controller
+    let firstToken = fixture.firstToken
+    let secondToken = fixture.secondToken
+    let secondFrame = fixture.secondFrame
+
+    let borderWindowNumber: UInt32 = 4244
+    let borderAppFrame = CGRect(
+        x: secondFrame.midX - 200,
+        y: secondFrame.midY - 150,
+        width: 400,
+        height: 300
+    )
+    // Register the border exactly like BorderManager does: `.border` kind,
+    // pass-through hit testing, excluded from capture.
+    registry.registerWindowNumber(
+        surfaceId: "test-border-surface",
+        kind: .border,
+        windowNumber: Int(borderWindowNumber),
+        frameProvider: { borderAppFrame },
+        visibilityProvider: { true },
+        hitTestPolicy: .passthrough,
+        capturePolicy: .excluded,
+        suppressesManagedFocusRecovery: false
+    )
+
+    // Drive FFM occlusion through the real predicate via the injected snapshot, so
+    // the union of tracked ids + pass-through surface numbers is exercised.
+    controller.unmanagedWindowServerWindowFramesProvider = { [weak controller] excludedWindowIds in
+        guard let controller else { return [] }
+        return WMController.visibleUnmanagedWindowServerFrames(
+            trackedWindowIds: excludedWindowIds,
+            snapshot: controller.windowServerSnapshotProvider()
+        )
+    }
+    controller.windowServerSnapshotProvider = {
+        [makeWindowServerSnapshotEntry(windowId: borderWindowNumber, layer: 3, appKitFrame: borderAppFrame)]
+    }
+
+    controller.mouseEventHandler.dispatchMouseMoved(at: borderAppFrame.center)
+    await controller.layoutRefreshController.waitForRefreshWorkForTests()
+
+    // FFM must reach the tile under the pass-through border — focus did not stay on
+    // the first window, and a focus request was issued for the hovered tile.
+    #expect(controller.workspaceManager.confirmedManagedFocusToken == firstToken)
+    #expect(controller.workspaceManager.activeFocusRequestToken == secondToken)
+}
+
+@Test @MainActor func visibleUnmanagedWindowServerFramesIncludesOverlayLayers() {
+    // On-screen, >=80x80, untracked windows at any non-desktop layer must be
+    // reported. This is the regression guard for Ghostty's Quick terminal, which
+    // was silently dropped by the old `layer == 0` filter.
+    //
+    // Each accepted entry gets a distinct (windowId-derived) frame so the assertion
+    // can pin exactly which window IDs survive the predicate — not just the count,
+    // which would silently pass if an expected ID were swapped for a rejected one.
+    func frame(forWindowId id: UInt32) -> CGRect {
+        CGRect(x: CGFloat(id), y: 100, width: 200, height: 200)
+    }
+    let accepted: [(id: UInt32, layer: Int)] = [
+        (1001, 0),
+        (1003, 3),
+        (1025, 25),
+        (1101, 101),
+        (2000, 1000)
+    ]
+    let expectedFrames = Set(accepted.map { frame(forWindowId: $0.id) })
+    var snapshot: [[String: Any]] = accepted.map {
+        makeWindowServerSnapshotEntry(windowId: $0.id, layer: $0.layer, appKitFrame: frame(forWindowId: $0.id))
+    }
+    // Excluded: desktop-class (negative) layer — wallpaper lives below layer 0.
+    snapshot.append(makeWindowServerSnapshotEntry(windowId: 9001, layer: -1000, appKitFrame: frame(forWindowId: 9001)))
+    // Excluded: tracked by Nehir.
+    snapshot.append(makeWindowServerSnapshotEntry(windowId: 940, layer: 0, appKitFrame: frame(forWindowId: 940)))
+    // Excluded: smaller than the 80x80 floor.
+    snapshot.append(makeWindowServerSnapshotEntry(windowId: 9002, layer: 0, appKitFrame: CGRect(x: 9002, y: 100, width: 50, height: 50)))
+    // Excluded: off-screen.
+    snapshot.append(makeWindowServerSnapshotEntry(windowId: 9003, layer: 0, appKitFrame: frame(forWindowId: 9003), onscreen: false))
+
+    let frames = WMController.visibleUnmanagedWindowServerFrames(
+        trackedWindowIds: [940],
+        snapshot: snapshot
+    )
+
+    #expect(frames.count == accepted.count)
+    // Every returned frame is one we expect, and every expected frame is present —
+    // i.e. exactly the accepted window IDs survived, none of the rejected ones.
+    #expect(Set(frames) == expectedFrames)
+}
+
+@Test @MainActor func visibleUnmanagedWindowServerFramesExcludesSystemChrome() {
+    // System chrome — Notification Center (`com.apple.notificationcenterui`), Dock,
+    // Control Center — runs at `.accessory` / `.prohibited` activation policy and is
+    // typically a full-screen transparent event surface. It must NOT be treated as an
+    // occluder, or every focus-follows-mouse evaluation and trackpad gesture would be
+    // suppressed across the whole display while a notification banner is visible.
+    // Real overlay windows (Ghostty's Quick terminal) belong to `.regular` apps.
+    let coveringFrame = CGRect(x: 100, y: 100, width: 200, height: 200)
+    let snapshot: [[String: Any]] = [
+        // Ghostty-like real overlay: regular app → occludes.
+        makeWindowServerSnapshotEntry(windowId: 5001, layer: 3, appKitFrame: coveringFrame, ownerPid: 897),
+        // Notification Center: full-screen, layer 0, accessory app → must be ignored.
+        makeWindowServerSnapshotEntry(windowId: 5002, layer: 0, appKitFrame: coveringFrame, ownerPid: 886),
+        // Dock: accessory → ignored.
+        makeWindowServerSnapshotEntry(windowId: 5003, layer: 20, appKitFrame: coveringFrame, ownerPid: 900)
+    ]
+    let policyByPid: [pid_t: NSApplication.ActivationPolicy] = [
+        897: .regular,    // Ghostty
+        886: .accessory,  // Notification Center
+        900: .prohibited  // Dock
+    ]
+
+    let frames = WMController.visibleUnmanagedWindowServerFrames(
+        trackedWindowIds: [],
+        snapshot: snapshot,
+        activationPolicyProvider: { pid in policyByPid[pid] }
+    )
+    #expect(frames.count == 1)
+}
+
+@Test @MainActor func trackpadGestureIgnoresSystemNotificationWindow() async {
+    // Regression for the freeze: while a system notification is visible the
+    // Notification Center window covers the whole display at layer 0. It must not
+    // suppress the trackpad column-navigation gesture — only real app overlays do.
+    let fixture = await prepareMouseWheelScrollFixture()
+    let controller = fixture.controller
+
+    controller.unmanagedWindowServerWindowFramesProvider = { [weak controller] excludedWindowIds in
+        guard let controller else { return [] }
+        return WMController.visibleUnmanagedWindowServerFrames(
+            trackedWindowIds: excludedWindowIds,
+            snapshot: controller.windowServerSnapshotProvider(),
+            activationPolicyProvider: controller.windowOwnerActivationPolicyProvider
+        )
+    }
+    // Notification Center: full-screen, layer 0, owned by an `.accessory` app.
+    controller.windowOwnerActivationPolicyProvider = { pid in
+        pid == 886 ? .accessory : .regular
+    }
+    let fullScreen = CGRect(x: 0, y: 0, width: 1920, height: 1080)
+    controller.windowServerSnapshotProvider = {
+        [makeWindowServerSnapshotEntry(windowId: 18, layer: 0, appKitFrame: fullScreen, ownerPid: 886)]
+    }
+
+    // Not an occluder despite covering the pointer everywhere...
+    #expect(controller.unmanagedWindowServerWindowCovers(point: fixture.location) == false)
+    // ...so the gesture still commits.
+    sendCommittingTrackpadGesture(to: fixture.handler, at: fixture.location)
+    #expect(fixture.handler.state.gesturePhase == .committed)
+}
+
+@Test @MainActor func focusFollowsMouseDoesNotActivateTiledWindowWhileFloatingWindowIsVisible() async {
         let controller = makeMouseEventTestController()
         controller.enableNiriLayout()
         await controller.layoutRefreshController.waitForRefreshWorkForTests()

--- a/docs/plans/completed/20260615-ffm-suppress-over-unmanaged-overlay-windows.md
+++ b/docs/plans/completed/20260615-ffm-suppress-over-unmanaged-overlay-windows.md
@@ -1,6 +1,6 @@
 # FFM: Suppress focus-follows-mouse when hovering unmanaged overlay windows
 
-Status: **plan, not yet implemented** — investigation complete, awaiting approval.
+Status: **implemented** — see `.changeset/20260615135853-fixed-ffm-stealing-focus-behind-ghostty-quick-terminal.md`. Implementation notes appended below.
 Owner path: `Sources/Nehir/Core/Controller/{MouseEventHandler,WMController}.swift`
 
 ## TL;DR
@@ -212,3 +212,82 @@ In `Tests/NehirTests/MouseEventHandlerTests.swift`:
 - The `layer == 0` restriction also appears in `AXManager.swift:462` (app
   discovery) and `LayoutRefreshController` (`windowLevel` handling). Those are
   unrelated to FFM and should **not** be changed here; call out in review.
+
+## Implementation notes (post-merge follow-on fixes)
+
+After landing the original `layer >= 0` broadening, three issues surfaced in
+real use and were fixed against the same occlusion predicate. Captured here so
+the user-facing changeset can stay short.
+
+### 1. Exclude Nehir's own pass-through surfaces (the focus border)
+
+Broadening to `layer >= 0` made Nehir's own `BorderWindow` (layer 3, sized to
+the focused tile + padding, registered as a `.border` / `.passthrough` surface)
+count as an unmanaged occluder — suppressing FFM (and, later, gestures) over the
+very tile the border decorates. Fix: surface-coordinator now exposes
+`passthroughSurfaceWindowNumbers` (`SurfaceScene` → `SurfaceCoordinator` →
+`OwnedWindowRegistry`), and `unmanagedWindowServerWindowCovers(point:)` unions
+those numbers into the exclusion set alongside tracked window IDs. The debug
+dump uses the same exclusion. Regression tests:
+`focusFollowsMouseActivatesTileBehindOwnPassthroughBorder`,
+`trackpadGestureStillCommitsOverOwnPassthroughBorder`.
+
+Note (reviewed, deliberately not implemented): a proposal to make
+`passthroughSurfaceWindowNumbers` fall back to the live `NSWindow.windowNumber`
+when `node.windowNumber` is nil is unnecessary — the border is the only
+`.passthrough` surface, is `NSWindow`-less (SkyLight-native, window-number
+only), and its registration is gated on a resolved non-zero window number
+(`BorderManager.syncSurfaceRegistration`). The fallback could never fire.
+
+### 2. Suppress trackpad gestures over the same overlays
+
+The trackpad column-navigation gesture (`handleGestureEvent`) observes the
+system gesture tap, which is `.listenOnly` and always passes the event through —
+the OS already routes the scroll/touch to the window under the cursor. Nehir's
+own column-nav side effect should not fire against the tile *behind* an overlay,
+for the same reason FFM shouldn't. Added a mirror of the FFM occlusion guard
+right after the existing `shouldBlockOwnWindowInput` guard; it reuses
+`unmanagedWindowServerWindowCovers`, so the pass-through-border exclusion comes
+for free. Regression tests: `trackpadGestureSuppressesOverUnmanagedOverlayWindow`,
+`trackpadGestureStillCommitsOverOwnPassthroughBorder`,
+`trackpadGestureIgnoresSystemNotificationWindow`.
+
+### 3. System chrome / Notification Center freeze (the real regression)
+
+When a system notification (e.g. Telegram) appears, the Notification Center
+window (`com.apple.notificationcenterui`, full-screen 2056×1329, layer 0,
+`.accessory` activation policy) becomes on-screen and covers the entire
+display. With the guard from #2 in place, it occluded the pointer everywhere →
+every trackpad gesture frame was aborted → gestures froze completely while any
+notification was visible. This was the bug behind the “I can’t move at all”
+trace.
+
+Fix: the occlusion predicate now only counts windows owned by `.regular`
+activation-policy apps (real foreground overlays like Ghostty). System chrome —
+Notification Center, Dock, Control Center, menu-bar/status items — runs at
+`.accessory` / `.prohibited` policy and is a full-screen transparent event
+surface, so it is excluded. The owner-policy resolver is injectable
+(`windowOwnerActivationPolicyProvider`) for tests; an unresolvable owner
+(synthetic snapshot without an owner PID) is treated as regular so the check
+stays conservative. Regression tests:
+`visibleUnmanagedWindowServerFramesExcludesSystemChrome`,
+`trackpadGestureIgnoresSystemNotificationWindow`.
+
+### 4. Test hardening
+
+`visibleUnmanagedWindowServerFramesIncludesOverlayLayers` originally asserted
+only `frames.count == 5` with all windows sharing one frame — a swapped window
+ID would pass. Each accepted window now carries a distinct (id-derived) frame,
+and the assertion pins both count and the exact surviving frame set
+(`Set(frames) == expectedFrames`).
+
+### Design note: occlusion cost on the hot path
+
+Both the FFM evaluation (per mouse-move) and the gesture guard (per gesture
+frame) now resolve `unmanagedWindowServerWindowCovers(point:)`, which calls the
+snapshot provider (default: a synchronous `CGWindowListCopyWindowInfo`) and runs
+the static predicate. Traces during heavy pointer activity showed notable
+main-thread load (see `mouseMove.replay staleQueued` churn with
+`moveMouseToFocusedWindow` enabled). If this proves expensive in practice, the
+next step is to throttle/cache the snapshot (recompute ≤ ~100 ms) rather than
+re-fetching per event. Not yet implemented — noted as a candidate follow-up.


### PR DESCRIPTION
## Summary

<!-- What changed and why? -->

## Release notes

Choose one:

- [x] Added a `.changeset/*.md` for user-visible changes (`mise run changeset -- patch "..."`).
- [ ] No user-visible change; apply the `no release note` label to make CI skip intentional.

## Validation

<!-- Commands run, screenshots, or manual checks. -->

- [ ] Ran relevant tests/checks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed focus-follows-mouse stealing focus behind overlay windows (e.g., Ghostty Quick terminal).
  * Prevented trackpad gesture/scroll behavior from freezing or being suppressed by unmanaged overlay windows and system notifications.
  * Ensured gestures are not blocked when interacting over Nehir’s pass-through focus border.
* **Tests**
  * Added regression coverage for occlusion behavior across unmanaged overlay layers, pass-through overlays, and system notification windows.
* **Documentation**
  * Marked the completed fix plan and updated the corresponding release note entry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->