### PR TITLE
Refactor WorkspacesSettingsTab layout

### DIFF
--- a/.changeset/20260615201939-workspaces-settings-tab-polish-and-debounce.md
+++ b/.changeset/20260615201939-workspaces-settings-tab-polish-and-debounce.md
@@ -1,0 +1,5 @@
+---
+"nehir": patch
+---
+
+Polished the Workspaces settings tab. Editing the display name now coalesces config syncs instead of re-applying workspace settings and refreshing the layout on every keystroke. Workspaces with an empty-string display name now show "Workspace \<id\>" in the sidebar instead of a blank label, and the context-menu Delete item is disabled (rather than prompting a confirmation that then silently does nothing) for workspaces that can't be deleted.

--- a/Sources/Nehir/UI/WorkspacesSettingsTab.swift
+++ b/Sources/Nehir/UI/WorkspacesSettingsTab.swift
@@ -63,6 +63,7 @@ struct WorkspacesSettingsTab: View {
                             } label: {
                                 Label("Delete", systemImage: "trash")
                             }
+                            .disabled(!canDeleteConfiguration(config))
                         }
                 }
                 .listStyle(.sidebar)
@@ -257,7 +258,7 @@ struct WorkspaceSidebarRow: View {
                     .font(.system(.body, design: .monospaced).weight(.bold))
                     .foregroundColor(.secondary)
 
-                Text(configuration.displayName ?? "Workspace \(configuration.name)")
+                Text(configuration.displayName.flatMap { $0.isEmpty ? nil : $0 } ?? "Workspace \(configuration.name)")
                     .font(.body)
                     .lineLimit(1)
             }
@@ -329,6 +330,8 @@ struct WorkspaceDetailPane: View {
     let onDelete: () -> Void
     let onChange: () -> Void
 
+    @State private var pendingConfigSync: Task<Void, Never>?
+
     var body: some View {
         Form {
             Section {
@@ -369,6 +372,15 @@ struct WorkspaceDetailPane: View {
         }
         .formStyle(.grouped)
         .onChange(of: configuration) { _, _ in
+            debouncedConfigSync()
+        }
+    }
+
+    private func debouncedConfigSync() {
+        pendingConfigSync?.cancel()
+        pendingConfigSync = Task { @MainActor in
+            try? await Task.sleep(for: .milliseconds(16))
+            guard !Task.isCancelled else { return }
             onChange()
         }
     }
@@ -469,7 +481,7 @@ struct HomeMonitorPicker: View {
     }
 }
 
-func monitorAssignmentLabel(_ assignment: MonitorAssignment, monitors: [Monitor]) -> String {
+private func monitorAssignmentLabel(_ assignment: MonitorAssignment, monitors: [Monitor]) -> String {
     switch assignment {
     case .main:
         return "Main"

--- a/Sources/Nehir/UI/WorkspacesSettingsTab.swift
+++ b/Sources/Nehir/UI/WorkspacesSettingsTab.swift
@@ -46,78 +46,104 @@ struct WorkspacesSettingsTab: View {
     @Bindable var settings: SettingsStore
     @Bindable var controller: WMController
 
-    @State private var editingConfig: WorkspaceConfiguration?
-    @State private var isAddingNew = false
+    @State private var selectedConfigId: WorkspaceConfiguration.ID?
+    @State private var addDraft: WorkspaceConfiguration?
     @State private var pendingDeleteConfig: WorkspaceConfiguration?
     @State private var connectedMonitors: [Monitor] = Monitor.sortedByPosition(Monitor.current())
 
     var body: some View {
-        Form {
-            Section {
-                if settings.workspaceConfigurations.isEmpty {
-                    Text("No workspaces configured")
-                        .foregroundColor(.secondary)
-                        .italic()
-                        .frame(maxWidth: .infinity, alignment: .center)
-                        .padding(.vertical, 8)
-                } else {
-                    ForEach(sortedConfigurations) { config in
-                        WorkspaceConfigurationRow(
-                            configuration: config,
-                            connectedMonitors: connectedMonitors,
-                            canDelete: canDeleteConfiguration(config),
-                            deleteHelp: deleteConfigurationHelp(config),
-                            onEdit: { editingConfig = config },
-                            onDelete: { pendingDeleteConfig = config }
-                        )
-                    }
+        HStack(spacing: 0) {
+            VStack(spacing: 0) {
+                List(sortedConfigurations, selection: $selectedConfigId) { config in
+                    WorkspaceSidebarRow(configuration: config, connectedMonitors: connectedMonitors)
+                        .tag(config.id)
+                        .contextMenu {
+                            Button(role: .destructive) {
+                                pendingDeleteConfig = config
+                            } label: {
+                                Label("Delete", systemImage: "trash")
+                            }
+                        }
                 }
-            } header: {
-                HStack {
-                    Text("Workspace Configurations")
-                    Spacer()
-                    Button(action: { isAddingNew = true }) {
-                        Label("Add workspace", systemImage: "plus.circle")
-                            .labelStyle(.iconOnly)
+                .listStyle(.sidebar)
+
+                Divider()
+
+                HStack(spacing: 0) {
+                    Button(action: startAdding) {
+                        Image(systemName: "plus")
+                            .frame(width: 28, height: 24)
                     }
-                    .buttonStyle(.plain)
+                    .buttonStyle(.borderless)
                     .help(addButtonHelp)
                     .accessibilityLabel("Add workspace")
+
+                    Divider().frame(height: 16)
+
+                    Button {
+                        if let config = selectedConfig {
+                            pendingDeleteConfig = config
+                        }
+                    } label: {
+                        Image(systemName: "minus")
+                            .frame(width: 28, height: 24)
+                    }
+                    .buttonStyle(.borderless)
+                    .help(minusButtonHelp)
+                    .accessibilityLabel("Remove selected workspace")
+                    .disabled(selectedConfig == nil || !canDeleteSelected)
+
+                    Spacer()
                 }
-            } footer: {
-                Text(WorkspaceConfigurationAddPolicy.footerText)
-                    .font(.caption)
-                    .foregroundColor(.secondary)
+                .padding(.horizontal, 4)
+                .padding(.vertical, 2)
             }
+            .frame(minWidth: 160, maxWidth: 240)
+
+            Divider()
+
+            Group {
+                if let draft = addDraft {
+                    WorkspaceAddPane(
+                        initialConfiguration: draft,
+                        connectedMonitors: connectedMonitors,
+                        onSave: { newConfig in
+                            addConfiguration(newConfig)
+                            selectedConfigId = newConfig.id
+                            addDraft = nil
+                        },
+                        onCancel: { addDraft = nil }
+                    )
+                } else if let configId = selectedConfigId,
+                          let configIndex = settings.workspaceConfigurations.firstIndex(where: { $0.id == configId })
+                {
+                    let config = settings.workspaceConfigurations[configIndex]
+                    WorkspaceDetailPane(
+                        configuration: $settings.workspaceConfigurations[configIndex],
+                        connectedMonitors: connectedMonitors,
+                        canDelete: canDeleteConfiguration(config),
+                        deleteHelp: deleteConfigurationHelp(config),
+                        onDelete: { pendingDeleteConfig = config },
+                        onChange: { controller.updateWorkspaceConfig() }
+                    )
+                    .id(configId)
+                } else {
+                    WorkspacesEmptyState(onAdd: startAdding)
+                }
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .omniBackgroundExtensionEffect()
         }
-        .formStyle(.grouped)
-        .sheet(item: $editingConfig) { config in
-            WorkspaceEditSheet(
-                configuration: config,
-                isNew: false,
-                connectedMonitors: connectedMonitors,
-                onSave: { updated in
-                    updateConfiguration(updated)
-                    editingConfig = nil
-                },
-                onCancel: { editingConfig = nil }
-            )
-        }
-        .sheet(isPresented: $isAddingNew) {
-            WorkspaceEditSheet(
-                configuration: WorkspaceConfiguration(
-                    name: WorkspaceConfigurationAddPolicy
-                        .nextAvailableWorkspaceName(in: settings.workspaceConfigurations),
-                    monitorAssignment: .main
-                ),
-                isNew: true,
-                connectedMonitors: connectedMonitors,
-                onSave: { newConfig in
-                    addConfiguration(newConfig)
-                    isAddingNew = false
-                },
-                onCancel: { isAddingNew = false }
-            )
+        .onKeyPress(.escape) {
+            if addDraft != nil {
+                addDraft = nil
+                return .handled
+            }
+            if selectedConfigId != nil {
+                selectedConfigId = nil
+                return .handled
+            }
+            return .ignored
         }
         .confirmationDialog(
             "Delete workspace?",
@@ -137,6 +163,25 @@ struct WorkspacesSettingsTab: View {
         settings.workspaceConfigurations.sorted { WorkspaceIDPolicy.sortsBefore($0.name, $1.name) }
     }
 
+    private var selectedConfig: WorkspaceConfiguration? {
+        guard let id = selectedConfigId else { return nil }
+        return settings.workspaceConfigurations.first(where: { $0.id == id })
+    }
+
+    private var canDeleteSelected: Bool {
+        guard let config = selectedConfig else { return false }
+        return canDeleteConfiguration(config)
+    }
+
+    private var minusButtonHelp: String {
+        guard let config = selectedConfig else { return "Remove selected workspace" }
+        return deleteConfigurationHelp(config)
+    }
+
+    private var addButtonHelp: String {
+        WorkspaceConfigurationAddPolicy.addButtonHelp
+    }
+
     private var isConfirmingDelete: Binding<Bool> {
         Binding(
             get: { pendingDeleteConfig != nil },
@@ -148,8 +193,12 @@ struct WorkspacesSettingsTab: View {
         )
     }
 
-    private var addButtonHelp: String {
-        WorkspaceConfigurationAddPolicy.addButtonHelp
+    private func startAdding() {
+        addDraft = WorkspaceConfiguration(
+            name: WorkspaceConfigurationAddPolicy.nextAvailableWorkspaceName(in: settings.workspaceConfigurations),
+            monitorAssignment: .main
+        )
+        selectedConfigId = nil
     }
 
     private func deleteConfirmationMessage(for config: WorkspaceConfiguration) -> String {
@@ -183,14 +232,6 @@ struct WorkspacesSettingsTab: View {
         controller.updateWorkspaceConfig()
     }
 
-    private func updateConfiguration(_ config: WorkspaceConfiguration) {
-        if let index = settings.workspaceConfigurations.firstIndex(where: { $0.id == config.id }) {
-            settings.workspaceConfigurations[index] = config
-            settings.workspaceConfigurations.sort { WorkspaceIDPolicy.sortsBefore($0.name, $1.name) }
-            controller.updateWorkspaceConfig()
-        }
-    }
-
     private func deleteConfiguration(_ config: WorkspaceConfiguration) {
         guard canDeleteConfiguration(config) else { return }
         settings.workspaceConfigurations.removeAll { $0.id == config.id }
@@ -199,152 +240,245 @@ struct WorkspacesSettingsTab: View {
         }
         controller.updateWorkspaceConfig()
         controller.updateAppRules()
+        if selectedConfigId == config.id {
+            selectedConfigId = nil
+        }
     }
 }
 
-struct WorkspaceConfigurationRow: View {
+struct WorkspaceSidebarRow: View {
     let configuration: WorkspaceConfiguration
     let connectedMonitors: [Monitor]
-    let canDelete: Bool
-    let deleteHelp: String
-    let onEdit: () -> Void
-    let onDelete: () -> Void
 
     var body: some View {
-        HStack(spacing: 12) {
-            VStack(alignment: .leading, spacing: 2) {
-                HStack(spacing: 6) {
-                    Text("WS \(configuration.name)")
-                        .font(.caption.monospaced())
-                        .foregroundColor(.secondary)
-                    Text(configuration.effectiveDisplayName)
-                        .font(.body.weight(.medium))
-                }
+        VStack(alignment: .leading, spacing: 4) {
+            HStack(alignment: .firstTextBaseline, spacing: 6) {
+                Text(configuration.name)
+                    .font(.system(.body, design: .monospaced).weight(.bold))
+                    .foregroundColor(.secondary)
+
+                Text(configuration.displayName ?? "Workspace \(configuration.name)")
+                    .font(.body)
+                    .lineLimit(1)
             }
-            .frame(minWidth: 60, alignment: .leading)
 
-            Divider()
-                .frame(height: 24)
-
-            Text(monitorDisplayName(configuration.monitorAssignment))
-                .font(.system(.caption, design: .monospaced))
-                .foregroundColor(.secondary)
-                .frame(minWidth: 70, alignment: .leading)
-
-            Divider()
-                .frame(height: 24)
-
-            Spacer()
-
-            Button(action: onEdit) {
-                Label("Edit \(configuration.effectiveDisplayName)", systemImage: "pencil.circle")
-                    .labelStyle(.iconOnly)
+            HStack(spacing: 4) {
+                Circle()
+                    .fill(monitorColor.opacity(0.8))
+                    .frame(width: 6, height: 6)
+                Text(monitorLabel)
+                    .font(.caption2)
+                    .foregroundColor(.secondary)
             }
-            .buttonStyle(.plain)
-            .help("Edit workspace configuration")
-            .accessibilityLabel("Edit \(configuration.effectiveDisplayName)")
-
-            Button(action: onDelete) {
-                Label("Delete \(configuration.effectiveDisplayName)", systemImage: "trash.circle")
-                    .labelStyle(.iconOnly)
-                    .foregroundColor(.red)
-            }
-            .buttonStyle(.plain)
-            .help(deleteHelp)
-            .disabled(!canDelete)
         }
         .padding(.vertical, 4)
     }
 
-    private func monitorDisplayName(_ assignment: MonitorAssignment) -> String {
-        switch assignment {
-        case .main:
-            return "Main"
-        case .secondary:
-            return "Secondary"
-        case let .specificDisplay(output):
-            if let monitor = output.resolveMonitor(in: connectedMonitors) {
-                return monitor.name
+    private var monitorLabel: String {
+        monitorAssignmentLabel(configuration.monitorAssignment, monitors: connectedMonitors)
+    }
+
+    private var monitorColor: Color {
+        if case let .specificDisplay(output) = configuration.monitorAssignment,
+           output.resolveMonitor(in: connectedMonitors) == nil
+        {
+            return .orange
+        }
+        return .indigo
+    }
+}
+
+struct WorkspacesEmptyState: View {
+    let onAdd: () -> Void
+
+    var body: some View {
+        ScrollView {
+            VStack(spacing: 16) {
+                Image(systemName: "square.grid.2x2")
+                    .font(.system(size: 48))
+                    .foregroundColor(.secondary)
+                Text("No Workspace Selected")
+                    .font(.headline)
+                Text("Select a workspace from the sidebar to edit it,\nor add a new workspace to get started.")
+                    .font(.subheadline)
+                    .foregroundColor(.secondary)
+                    .multilineTextAlignment(.center)
+                Button("Add Workspace", action: onAdd)
+                    .buttonStyle(.borderedProminent)
+
+                GroupBox {
+                    Text(WorkspaceConfigurationAddPolicy.footerText)
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                        .multilineTextAlignment(.center)
+                        .frame(maxWidth: .infinity)
+                }
+                .frame(maxWidth: 480)
             }
-            return "\(output.name) (Disconnected)"
+            .padding()
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
         }
     }
 }
 
-struct WorkspaceEditSheet: View {
+struct WorkspaceDetailPane: View {
+    @Binding var configuration: WorkspaceConfiguration
+    let connectedMonitors: [Monitor]
+    let canDelete: Bool
+    let deleteHelp: String
+    let onDelete: () -> Void
+    let onChange: () -> Void
+
+    var body: some View {
+        Form {
+            Section {
+                TextField("Display Name", text: displayNameBinding, prompt: Text("Workspace \(configuration.name)"))
+                    .textFieldStyle(.roundedBorder)
+                    .font(.title3.weight(.medium))
+
+                LabeledContent("Internal ID") {
+                    Text(configuration.name)
+                        .font(.system(.body, design: .monospaced))
+                        .foregroundColor(.secondary)
+                }
+            } header: {
+                Text("Identity")
+            } footer: {
+                Text("A custom name to help identify this workspace in the overview and sidebar.")
+            }
+
+            Section("Home Monitor") {
+                HomeMonitorPicker(
+                    assignment: $configuration.monitorAssignment,
+                    connectedMonitors: connectedMonitors
+                )
+
+                SettingsCaption("Main follows the current main display. Secondary follows the first non-main display. Specific Display pins this workspace to the selected monitor when available.")
+            }
+
+            Section {
+                Button(role: .destructive, action: onDelete) {
+                    Label("Delete Workspace", systemImage: "trash")
+                }
+                .disabled(!canDelete)
+
+                if !canDelete {
+                    SettingsCaption(deleteHelp)
+                }
+            }
+        }
+        .formStyle(.grouped)
+        .onChange(of: configuration) { _, _ in
+            onChange()
+        }
+    }
+
+    private var displayNameBinding: Binding<String> {
+        Binding(
+            get: { configuration.displayName ?? "" },
+            set: { configuration.displayName = $0.isEmpty ? nil : $0 }
+        )
+    }
+}
+
+struct WorkspaceAddPane: View {
     @State private var configuration: WorkspaceConfiguration
-    let isNew: Bool
     let connectedMonitors: [Monitor]
     let onSave: (WorkspaceConfiguration) -> Void
     let onCancel: () -> Void
 
     init(
-        configuration: WorkspaceConfiguration,
-        isNew: Bool,
+        initialConfiguration: WorkspaceConfiguration,
         connectedMonitors: [Monitor],
         onSave: @escaping (WorkspaceConfiguration) -> Void,
         onCancel: @escaping () -> Void
     ) {
-        _configuration = State(initialValue: configuration)
-        self.isNew = isNew
+        _configuration = State(initialValue: initialConfiguration)
         self.connectedMonitors = connectedMonitors
         self.onSave = onSave
         self.onCancel = onCancel
     }
 
     var body: some View {
-        VStack(spacing: 16) {
-            Text(isNew ? "Add Workspace" : "Edit Workspace")
-                .font(.headline)
+        Form {
+            Section {
+                TextField("Display Name", text: displayNameBinding, prompt: Text("Workspace \(configuration.name)"))
+                    .textFieldStyle(.roundedBorder)
+                    .font(.title3.weight(.medium))
 
-            Form {
-                LabeledContent("Workspace ID") {
+                LabeledContent("Internal ID") {
                     Text(configuration.name)
                         .font(.system(.body, design: .monospaced))
                         .foregroundColor(.secondary)
                 }
-
-                TextField("Display Name (optional)", text: Binding(
-                    get: { configuration.displayName ?? "" },
-                    set: { configuration.displayName = $0.isEmpty ? nil : $0 }
-                ))
-                .textFieldStyle(.roundedBorder)
-
-                Picker("Home Monitor", selection: $configuration.monitorAssignment) {
-                    Text("Main").tag(MonitorAssignment.main)
-                    Text("Secondary").tag(MonitorAssignment.secondary)
-                    Divider()
-                    ForEach(connectedMonitors, id: \.id) { monitor in
-                        HStack {
-                            Text(monitor.name)
-                            if monitor.isMain {
-                                Text("(Main)").foregroundColor(.secondary)
-                            }
-                        }
-                        .tag(MonitorAssignment.specificDisplay(OutputId(from: monitor)))
-                    }
-                }
-
-                Text(
-                    "Main follows the current main display. Secondary follows the first non-main display. Specific Display pins this workspace to the selected monitor when available."
-                )
-                .font(.caption)
-                .foregroundColor(.secondary)
+            } header: {
+                Text("Identity")
+            } footer: {
+                Text("A custom name to help identify this workspace in the overview and sidebar.")
             }
 
-            HStack {
-                Button("Cancel", action: onCancel)
-                    .keyboardShortcut(.cancelAction)
+            Section("Home Monitor") {
+                HomeMonitorPicker(
+                    assignment: $configuration.monitorAssignment,
+                    connectedMonitors: connectedMonitors
+                )
 
-                Spacer()
+                SettingsCaption("Main follows the current main display. Secondary follows the first non-main display. Specific Display pins this workspace to the selected monitor when available.")
+            }
 
-                Button(isNew ? "Add" : "Save") {
+            Section {
+                Button("Add Workspace") {
                     onSave(configuration)
                 }
                 .keyboardShortcut(.defaultAction)
+
+                Button("Cancel", role: .cancel, action: onCancel)
+                    .keyboardShortcut(.cancelAction)
             }
         }
-        .padding()
-        .frame(minWidth: 420)
+        .formStyle(.grouped)
+    }
+
+    private var displayNameBinding: Binding<String> {
+        Binding(
+            get: { configuration.displayName ?? "" },
+            set: { configuration.displayName = $0.isEmpty ? nil : $0 }
+        )
+    }
+}
+
+struct HomeMonitorPicker: View {
+    @Binding var assignment: MonitorAssignment
+    let connectedMonitors: [Monitor]
+
+    var body: some View {
+        Picker("Home Monitor", selection: $assignment) {
+            Text("Main").tag(MonitorAssignment.main)
+            Text("Secondary").tag(MonitorAssignment.secondary)
+            Divider()
+            ForEach(connectedMonitors, id: \.id) { monitor in
+                HStack {
+                    Text(monitor.name)
+                    if monitor.isMain {
+                        Text("(Main)").foregroundColor(.secondary)
+                    }
+                }
+                .tag(MonitorAssignment.specificDisplay(OutputId(from: monitor)))
+            }
+        }
+    }
+}
+
+func monitorAssignmentLabel(_ assignment: MonitorAssignment, monitors: [Monitor]) -> String {
+    switch assignment {
+    case .main:
+        return "Main"
+    case .secondary:
+        return "Secondary"
+    case let .specificDisplay(output):
+        if output.resolveMonitor(in: monitors) != nil {
+            return output.name
+        }
+        return "\(output.name) (Disconnected)"
     }
 }


### PR DESCRIPTION
## Summary

<!-- What changed and why? -->

## Release notes

Choose one:

- [x] Added a `.changeset/*.md` for user-visible changes (`mise run changeset -- patch "..."`).
- [ ] No user-visible change; apply the `no release note` label to make CI skip intentional.

## Validation

<!-- Commands run, screenshots, or manual checks. -->

- [ ] Ran relevant tests/checks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Workspace settings interface redesigned with sidebar + detail-pane layout for improved navigation

* **New Features**
  * Workspace addition now operates inline instead of modal dialog
  * Added Escape key support to dismiss workspace addition or clear selection
  * New empty state display when no workspace is selected

* **Improvements**
  * Delete button state management enhanced with contextual help awareness

<!-- end of auto-generated comment: release notes by coderabbit.ai -->