### PR TITLE
Fix status bar Show Workspace toggle

### DIFF
--- a/.changeset/20260615203307-fixed-status-bar-workspace-toggle-not-clearing-on-disable.md
+++ b/.changeset/20260615203307-fixed-status-bar-workspace-toggle-not-clearing-on-disable.md
@@ -1,0 +1,5 @@
+---
+"nehir": patch
+---
+
+Fixed the Status Bar "Show Workspace" toggle not clearing the workspace text when disabled — the title persisted until the app was restarted. Settings-projection refreshes now reach the status bar even when the feature is being turned off, so it clears its title immediately.

--- a/Sources/Nehir/Core/Controller/WMController.swift
+++ b/Sources/Nehir/Core/Controller/WMController.swift
@@ -497,15 +497,23 @@ final class WMController {
     private var statusBarRefreshGeneration: Int = 0
 
     private func requestFocusProjectionRefreshScheduling() {
-        requestStatusBarRefreshScheduling(reason: "focusProjection")
+        // Focus changes are only interesting while the status bar is actually
+        // displaying workspace info, so skip them when the feature is off.
+        requestStatusBarRefreshScheduling(reason: "focusProjection", requireFeatureEnabled: true)
     }
 
     private func requestSettingsProjectionRefreshScheduling() {
-        requestStatusBarRefreshScheduling(reason: "settingsProjection")
+        // Settings refreshes must run even when the feature is being turned OFF —
+        // otherwise the status bar never clears its title (it stays until restart).
+        // refreshWorkspaces() applies the current settings, including hiding.
+        requestStatusBarRefreshScheduling(reason: "settingsProjection", requireFeatureEnabled: false)
     }
 
-    private func requestStatusBarRefreshScheduling(reason: String) {
-        guard statusBarRefreshIsEnabled else { return }
+    private func requestStatusBarRefreshScheduling(reason: String, requireFeatureEnabled: Bool) {
+        guard statusBarController != nil else { return }
+        if requireFeatureEnabled {
+            guard settings.statusBarShowWorkspaceName else { return }
+        }
         guard pendingStatusBarRefreshGeneration == nil else { return }
 
         let generation = statusBarRefreshGeneration

--- a/Tests/NehirTests/RefreshRoutingTests.swift
+++ b/Tests/NehirTests/RefreshRoutingTests.swift
@@ -1092,6 +1092,48 @@ private func syncNiriWorkspaceStatesForRefreshTests(
         #expect(statusBarController.statusButtonTitleForTests() == " 1 \u{2013} Second App")
     }
 
+    @Test @MainActor func disablingStatusBarWorkspaceClearsTitleWithoutRestart() async {
+        // Regression: turning "Show Workspace" off must clear the status bar title
+        // immediately. Previously the settings refresh was gated on the feature being
+        // enabled, so the clearing refresh never ran and the title persisted until restart.
+        let controller = makeRefreshTestController()
+        controller.settings.workspaceBarEnabled = false
+        controller.settings.statusBarShowWorkspaceName = true
+
+        guard let monitor = controller.monitorForInteraction(),
+              let workspaceId = controller.interactionWorkspace()?.id
+        else {
+            Issue.record("Missing active workspace for status bar disable test")
+            return
+        }
+
+        let token = controller.workspaceManager.addWindow(
+            makeRefreshTestWindow(windowId: 601),
+            pid: 601,
+            windowId: 601,
+            to: workspaceId
+        )
+        controller.appInfoCache.storeInfoForTests(pid: 601, name: "Test App", bundleId: "com.example.test")
+        _ = controller.workspaceManager.setManagedFocus(token, in: workspaceId, onMonitor: monitor.id)
+
+        let statusBarController = makeRefreshTestStatusBarController(controller)
+        defer {
+            statusBarController.cleanup()
+            cleanupRefreshTestController(controller)
+        }
+        statusBarController.setup()
+        await controller.waitForStatusBarRefreshForTests()
+        #expect(statusBarController.statusButtonTitleForTests() == " 1")
+
+        controller.resetWorkspaceBarRefreshDebugStateForTests()
+        controller.settings.statusBarShowWorkspaceName = false
+        controller.requestSettingsProjectionRefresh(reason: "statusBarShowWorkspaceName")
+        await controller.waitForStatusBarRefreshForTests()
+
+        #expect(statusBarController.statusButtonTitleForTests() == "")
+        #expect(statusBarController.statusButtonImagePositionForTests() == .imageOnly)
+    }
+
     @Test @MainActor func interactionMonitorChangeOnUnassignedThirdDisplayDoesNotRecurseAfterMonitorExpansion() async {
         let controller = makeRefreshTestController(
             workspaceConfigurations: [


### PR DESCRIPTION
## Summary

<!-- What changed and why? -->

## Release notes

Choose one:

- [x] Added a `.changeset/*.md` for user-visible changes (`mise run changeset -- patch "..."`).
- [ ] No user-visible change; apply the `no release note` label to make CI skip intentional.

## Validation

<!-- Commands run, screenshots, or manual checks. -->

- [ ] Ran relevant tests/checks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where disabling the Status Bar "Show Workspace" toggle would not immediately clear the workspace text—it now clears instantly without requiring an app restart.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->