### PR TITLE
Fix window placement and quick-terminal workspace jumps

### DIFF
--- a/.changeset/20260616003659-fixed-new-window-placement-and-quick-terminal-wo.md
+++ b/.changeset/20260616003659-fixed-new-window-placement-and-quick-terminal-wo.md
@@ -1,0 +1,12 @@
+---
+"nehir": patch
+---
+
+Fixed several cases where Nehir could jump to the wrong workspace or place new windows in the wrong location.
+
+- New windows now open on the workspace/monitor you are actively using, even when macOS reports AX focus before the window-create event or when an older confirmed focus belongs to another workspace.
+- Closing or hiding a quick-terminal/dropdown window no longer pulls you back to an older window or column on another workspace.
+- Layout refreshes no longer auto-activate newly rediscovered windows on inactive workspaces.
+- Workspace Bar clicks now target the exact workspace entry instead of resolving through the displayed label, so clicking later workspaces remains reliable.
+
+Also improved runtime traces for diagnosing placement and focus recovery decisions.

--- a/Sources/Nehir/Core/Ax/AppAXContext.swift
+++ b/Sources/Nehir/Core/Ax/AppAXContext.swift
@@ -107,6 +107,11 @@ final class AppAXContext {
     @MainActor static var onWindowMiniaturized: ((pid_t, Int) -> Void)?
     @MainActor static var onFocusedWindowChanged: ((pid_t) -> Void)?
 
+    /// Bounded ring of every AX notification the per-app observers deliver,
+    /// captured before the destroy/miniaturize filter. Diagnostic only — see
+    /// `RawAXNotificationRecorder`.
+    @MainActor static let rawAXNotificationRecorder = RawAXNotificationRecorder()
+
     @MainActor static var contexts: [pid_t: AppAXContext] = [:]
     @MainActor private static var inFlightCreations: [pid_t: Task<AppAXContext?, Error>] = [:]
     @MainActor static var contextFactoryForTests: ((NSRunningApplication) async throws -> AppAXContext?)?
@@ -247,6 +252,26 @@ final class AppAXContext {
         let windowId = Int(bitPattern: refcon)
         guard windowId > 0 else { return nil }
         return windowId
+    }
+
+    /// Diagnostic entry point for the raw AX notification ring. Callable from
+    /// the nonisolated AX callbacks; hops to the main actor to append.
+    nonisolated static func recordRawNotification(
+        name: String,
+        pid: pid_t,
+        windowId: Int?
+    ) {
+        scheduleOnMainRunLoop {
+            rawAXNotificationRecorder.append(name: name, pid: pid, windowId: windowId)
+        }
+    }
+
+    @MainActor static func rawAXNotificationTraceDump() -> String {
+        rawAXNotificationRecorder.dump()
+    }
+
+    @MainActor static func resetRawAXNotificationTraceForDebug() {
+        rawAXNotificationRecorder.reset()
     }
 
     nonisolated static func handleWindowDestroyedCallback(
@@ -871,12 +896,18 @@ private func axWindowNotificationCallback(
     _ refcon: UnsafeMutableRawPointer?
 ) {
     let notificationName = notification as String
+    var pid: pid_t = 0
+    guard AXUIElementGetPid(element, &pid) == .success else { return }
+
+    // Record every window-observer notification (with windowId from refcon)
+    // BEFORE the destroy/miniaturize filter — diagnostic trace for hide/close
+    // sequences. See docs/plans/completed/20260615-quick-terminal-close-switches-workspace.md.
+    let recordedWindowId = AppAXContext.destroyNotificationWindowId(from: refcon)
+    AppAXContext.recordRawNotification(name: notificationName, pid: pid, windowId: recordedWindowId)
+
     let isDestroyed = notificationName == (kAXUIElementDestroyedNotification as String)
     let isMiniaturized = notificationName == (kAXWindowMiniaturizedNotification as String)
     guard isDestroyed || isMiniaturized else { return }
-
-    var pid: pid_t = 0
-    guard AXUIElementGetPid(element, &pid) == .success else { return }
 
     if isDestroyed {
         AppAXContext.handleWindowDestroyedCallback(pid: pid, refcon: refcon)
@@ -891,10 +922,15 @@ private func axFocusedWindowChangedCallback(
     _ notification: CFString,
     _: UnsafeMutableRawPointer?
 ) {
-    guard (notification as String) == (kAXFocusedWindowChangedNotification as String) else { return }
-
+    let notificationName = notification as String
     var pid: pid_t = 0
     guard AXUIElementGetPid(element, &pid) == .success else { return }
+
+    // Focus observer carries no refcon, so windowId is unavailable without an
+    // extra AX attribute read; record pid + name for diagnostic timing.
+    AppAXContext.recordRawNotification(name: notificationName, pid: pid, windowId: nil)
+
+    guard notificationName == (kAXFocusedWindowChangedNotification as String) else { return }
 
     scheduleOnMainRunLoop {
         AppAXContext.onFocusedWindowChanged?(pid)

--- a/Sources/Nehir/Core/Ax/RawAXNotificationTrace.swift
+++ b/Sources/Nehir/Core/Ax/RawAXNotificationTrace.swift
@@ -1,0 +1,73 @@
+import Foundation
+
+/// One entry in the raw AX notification trace ring.
+///
+/// Records every AX notification the per-app observers deliver, *before* the
+/// `destroyed`/`miniaturized` filter discards anything. Exists to diagnose
+/// close/hide/order-out sequences where the triggering event is otherwise
+/// invisible — see
+/// `docs/plans/completed/20260615-quick-terminal-close-switches-workspace.md`.
+struct RawAXNotificationRecord: Equatable {
+    let sequence: UInt64
+    let timestamp: Date
+    /// Bare notification name as delivered by the observer, e.g.
+    /// `FocusedWindowChanged`, `UIElementDestroyed`, `WindowMiniaturized`.
+    let name: String
+    let pid: pid_t
+    /// Window id when recoverable (window observer encodes it in its refcon).
+    /// `nil` for app-level notifications such as `FocusedWindowChanged`, whose
+    /// observer carries no refcon.
+    let windowId: Int?
+}
+
+extension RawAXNotificationRecord: CustomStringConvertible {
+    var description: String {
+        let window = windowId.map(String.init) ?? "nil"
+        return "\(timestamp.ISO8601Format()) ax=\(name) pid=\(pid) window=\(window)"
+    }
+}
+
+/// Bounded ring of raw AX notifications, mirroring `ReconcileTraceRecorder`.
+///
+/// Always records (human-paced, bounded) so the ring is populated whenever a
+/// runtime trace capture is taken; `dump()` is only emitted into a capture on
+/// demand. The reference is constant; `append`/`reset` mutate internal state.
+@MainActor
+final class RawAXNotificationRecorder {
+    private static let defaultLimit = 256
+
+    private let limit: Int
+    private var nextSequence: UInt64 = 1
+    private var records: [RawAXNotificationRecord] = []
+
+    init(limit: Int = defaultLimit) {
+        self.limit = max(1, limit)
+    }
+
+    func append(name: String, pid: pid_t, windowId: Int?, timestamp: Date = Date()) {
+        let record = RawAXNotificationRecord(
+            sequence: nextSequence,
+            timestamp: timestamp,
+            name: name,
+            pid: pid,
+            windowId: windowId
+        )
+        nextSequence += 1
+        if records.count == limit {
+            records.removeFirst()
+        }
+        records.append(record)
+    }
+
+    func dump() -> String {
+        if records.isEmpty {
+            return "ax notification trace empty"
+        }
+        return records.map(\.description).joined(separator: "\n")
+    }
+
+    func reset() {
+        records.removeAll(keepingCapacity: true)
+        nextSequence = 1
+    }
+}

--- a/Sources/Nehir/Core/Controller/AXEventHandler.swift
+++ b/Sources/Nehir/Core/Controller/AXEventHandler.swift
@@ -47,7 +47,10 @@ struct NiriCreateFocusTraceEvent: Equatable {
             focusedMonitorId: Monitor.ID?,
             nativeSpaceMonitorId: Monitor.ID?,
             frameMonitorId: Monitor.ID?,
-            interactionMonitorId: Monitor.ID?
+            interactionMonitorId: Monitor.ID?,
+            contextSource: String?,
+            focusedWorkspaceSource: String?,
+            recentPidWorkspaceId: WorkspaceDescriptor.ID?
         )
         case candidateTracked(token: WindowToken, workspaceId: WorkspaceDescriptor.ID)
         case relayoutActivatedWindow(token: WindowToken, workspaceId: WorkspaceDescriptor.ID)
@@ -84,6 +87,9 @@ struct WindowCreatePlacementContext: Equatable {
     let focusedWorkspaceId: WorkspaceDescriptor.ID?
     let focusedMonitorId: Monitor.ID?
     let interactionMonitorId: Monitor.ID?
+    let source: String
+    let focusedWorkspaceSource: String?
+    let recentPidWorkspaceId: WorkspaceDescriptor.ID?
     let createdAt: Date
 }
 
@@ -95,6 +101,9 @@ extension WindowCreatePlacementContext: CustomStringConvertible {
             + "focused_workspace=\(focusedWorkspaceId?.uuidString ?? "nil") "
             + "focused_monitor=\(String(describing: focusedMonitorId)) "
             + "interaction_monitor=\(String(describing: interactionMonitorId)) "
+            + "source=\(source) "
+            + "focused_workspace_source=\(focusedWorkspaceSource ?? "nil") "
+            + "recent_pid_workspace=\(recentPidWorkspaceId?.uuidString ?? "nil") "
             + "createdAt=\(createdAt.ISO8601Format())"
     }
 }
@@ -115,9 +124,12 @@ extension NiriCreateFocusTraceEvent: CustomStringConvertible {
             focusedMonitorId,
             nativeSpaceMonitorId,
             frameMonitorId,
-            interactionMonitorId
+            interactionMonitorId,
+            contextSource,
+            focusedWorkspaceSource,
+            recentPidWorkspaceId
         ):
-            "create_placement_resolved token=\(token) workspace=\(workspaceId.uuidString) pending_workspace=\(pendingWorkspaceId?.uuidString ?? "nil") pending_monitor=\(String(describing: pendingMonitorId)) focused_workspace=\(focusedWorkspaceId?.uuidString ?? "nil") focused_monitor=\(String(describing: focusedMonitorId)) native_monitor=\(String(describing: nativeSpaceMonitorId)) frame_monitor=\(String(describing: frameMonitorId)) interaction_monitor=\(String(describing: interactionMonitorId))"
+            "create_placement_resolved token=\(token) workspace=\(workspaceId.uuidString) pending_workspace=\(pendingWorkspaceId?.uuidString ?? "nil") pending_monitor=\(String(describing: pendingMonitorId)) focused_workspace=\(focusedWorkspaceId?.uuidString ?? "nil") focused_monitor=\(String(describing: focusedMonitorId)) native_monitor=\(String(describing: nativeSpaceMonitorId)) frame_monitor=\(String(describing: frameMonitorId)) interaction_monitor=\(String(describing: interactionMonitorId)) context_source=\(contextSource ?? "nil") focused_workspace_source=\(focusedWorkspaceSource ?? "nil") recent_pid_workspace=\(recentPidWorkspaceId?.uuidString ?? "nil")"
         case let .candidateTracked(token, workspaceId):
             "candidate_tracked token=\(token) workspace=\(workspaceId.uuidString)"
         case let .relayoutActivatedWindow(token, workspaceId):
@@ -311,9 +323,11 @@ final class AXEventHandler: CGSEventDelegate {
     private var deferredCreatedWindowIds: Set<UInt32> = []
     private var deferredCreatedWindowOrder: [UInt32] = []
     private var createPlacementContextsByWindowId: [UInt32: WindowCreatePlacementContext] = [:]
+    private var recentManagedWorkspaceByPid: [pid_t: WorkspaceDescriptor.ID] = [:]
     private var pendingManagedReplacementBursts: [ManagedReplacementKey: PendingManagedReplacementBurst] = [:]
     private var pendingManagedReplacementTasks: [ManagedReplacementKey: Task<Void, Never>] = [:]
     private var windowCloseFocusRecoveryContext: WindowCloseFocusRecoveryContext?
+    private var deferredInactiveNativeActivationTokens: Set<WindowToken> = []
     private var pendingNativeFullscreenFollowupTasks: [WindowToken: Task<Void, Never>] = [:]
     private var pendingNativeFullscreenStaleCleanupTasks: [WindowToken: Task<Void, Never>] = [:]
     private var pendingWindowRuleReevaluationTask: Task<Void, Never>?
@@ -356,6 +370,7 @@ final class AXEventHandler: CGSEventDelegate {
 
     func cleanup() {
         resetCreatePlacementContextState()
+        recentManagedWorkspaceByPid.removeAll()
         resetManagedReplacementState()
         endWindowCloseFocusRecovery()
         resetNativeFullscreenReplacementState()
@@ -494,6 +509,7 @@ final class AXEventHandler: CGSEventDelegate {
         resetPostCreateLifecycleVerificationState()
         resetCreatedWindowRetryState()
         resetCreatePlacementContextState()
+        recentManagedWorkspaceByPid.removeAll()
         resetActivationRetryState()
         controller?.focusBridge.reset()
         createFocusTrace.removeAll(keepingCapacity: true)
@@ -1246,18 +1262,117 @@ final class AXEventHandler: CGSEventDelegate {
         controller?.focusPolicyEngine.endLease(owner: .windowCloseFocusRecovery)
     }
 
-    private func shouldSuppressObservedActivationDuringWindowCloseRecovery(
-        observedWorkspaceId: WorkspaceDescriptor.ID,
-        requestDisposition: ActivationRequestDisposition
-    ) -> Bool {
-        guard let recoveryWorkspaceId = activeWindowCloseFocusRecoveryWorkspaceId(),
-              recoveryWorkspaceId != observedWorkspaceId
+    private func armWindowCloseFocusRecoveryForFocusedWindowLossIfNeeded(
+        pid: pid_t,
+        source: ActivationEventSource
+    ) {
+        guard source == .focusedWindowChanged else { return }
+        armWindowCloseFocusRecoveryForFocusedAppEvent(pid: pid)
+    }
+
+    private func armWindowCloseFocusRecoveryForFocusedAppEvent(pid: pid_t) {
+        guard let controller,
+              let focusedToken = controller.workspaceManager.confirmedManagedFocusToken,
+              focusedToken.pid == pid,
+              let workspaceId = controller.workspaceManager.workspace(for: focusedToken)
         else {
+            return
+        }
+        beginWindowCloseFocusRecovery(in: workspaceId)
+    }
+
+    func handleManagedWindowHiddenStateChanged(
+        token: WindowToken,
+        previousState: WindowModel.HiddenState?,
+        newState: WindowModel.HiddenState?
+    ) {
+        guard previousState != newState,
+              newState?.workspaceInactive == true,
+              let controller,
+              controller.workspaceManager.confirmedManagedFocusToken == token,
+              let workspaceId = controller.workspaceManager.workspace(for: token),
+              let monitorId = controller.workspaceManager.monitorId(for: workspaceId),
+              controller.workspaceManager.activeWorkspace(on: monitorId)?.id == workspaceId
+        else {
+            return
+        }
+
+        beginWindowCloseFocusRecovery(in: workspaceId)
+    }
+
+    private func shouldSuppressObservedActivationDuringWindowCloseRecovery(
+        entry observedEntry: WindowModel.Entry,
+        requestDisposition: ActivationRequestDisposition,
+        source: ActivationEventSource
+    ) -> Bool {
+        guard let recoveryWorkspaceId = activeWindowCloseFocusRecoveryWorkspaceId() else {
             return false
         }
 
         if case .matchesActiveRequest = requestDisposition {
             return false
+        }
+
+        if recoveryWorkspaceId != observedEntry.workspaceId {
+            return true
+        }
+
+        guard source == .workspaceDidActivateApplication,
+              case .unrelatedNoRequest = requestDisposition,
+              let focusedToken = controller?.workspaceManager.confirmedManagedFocusToken,
+              focusedToken != observedEntry.token,
+              controller?.workspaceManager.workspace(for: focusedToken) == recoveryWorkspaceId
+        else {
+            return false
+        }
+
+        return true
+    }
+
+    /// Native app activation can lead the observable quick-terminal close signal.
+    ///
+    /// In the close sequence that caused workspace jumps, macOS first reported a
+    /// `workspaceDidActivateApplication` for an older managed window on an
+    /// inactive workspace, then delivered the quick-terminal hide/destroy signal
+    /// a few milliseconds later. Accepting that first activation immediately
+    /// scrolls or switches away before `windowCloseFocusRecovery` has a chance to
+    /// arm. Defer exactly that ambiguous pre-close shape briefly, then retry it:
+    /// if close recovery armed during the delay, the normal recovery suppression
+    /// handles it; if not, the retry proceeds as a real user/native activation.
+    private func shouldDeferInactiveNativeActivationBeforeCloseRecovery(
+        entry observedEntry: WindowModel.Entry,
+        isWorkspaceActive: Bool,
+        requestDisposition: ActivationRequestDisposition,
+        source: ActivationEventSource,
+        origin: ActivationCallOrigin
+    ) -> Bool {
+        guard origin == .external,
+              source == .workspaceDidActivateApplication,
+              case .unrelatedNoRequest = requestDisposition,
+              !isWorkspaceActive,
+              activeWindowCloseFocusRecoveryWorkspaceId() == nil,
+              let controller,
+              let focusedToken = controller.workspaceManager.confirmedManagedFocusToken,
+              focusedToken != observedEntry.token,
+              let focusedEntry = controller.workspaceManager.entry(for: focusedToken),
+              let focusedMonitorId = controller.workspaceManager.monitorId(for: focusedEntry.workspaceId),
+              controller.workspaceManager.activeWorkspace(on: focusedMonitorId)?.id == focusedEntry.workspaceId
+        else {
+            return false
+        }
+
+        guard !deferredInactiveNativeActivationTokens.contains(observedEntry.token) else {
+            return true
+        }
+
+        deferredInactiveNativeActivationTokens.insert(observedEntry.token)
+        Task { [weak self, token = observedEntry.token, pid = observedEntry.pid, source] in
+            try? await Task.sleep(nanoseconds: 120_000_000)
+            await MainActor.run { [weak self] in
+                guard let self else { return }
+                self.deferredInactiveNativeActivationTokens.remove(token)
+                self.handleAppActivation(pid: pid, source: source, origin: .retry)
+            }
         }
         return true
     }
@@ -1265,7 +1380,8 @@ final class AXEventHandler: CGSEventDelegate {
     private func shouldSuppressSameAppInactiveWorkspaceActivationBeforeCloseRecovery(
         entry observedEntry: WindowModel.Entry,
         isWorkspaceActive: Bool,
-        requestDisposition: ActivationRequestDisposition
+        requestDisposition: ActivationRequestDisposition,
+        source: ActivationEventSource
     ) -> Bool {
         guard case .unrelatedNoRequest = requestDisposition else { return false }
         guard let controller else { return false }
@@ -1281,17 +1397,32 @@ final class AXEventHandler: CGSEventDelegate {
         }
 
         guard !isWorkspaceActive else { return false }
-        guard let focusedToken = controller.workspaceManager.confirmedManagedFocusToken,
-              focusedToken != observedEntry.token,
-              focusedToken.pid == observedEntry.pid,
-              let focusedEntry = controller.workspaceManager.entry(for: focusedToken),
-              let focusedMonitorId = controller.workspaceManager.monitorId(for: focusedEntry.workspaceId),
-              controller.workspaceManager.activeWorkspace(on: focusedMonitorId)?.id == focusedEntry.workspaceId
-        else {
-            return false
+
+        // Same-pid confirmed focus on the active workspace anchors suppression:
+        // the user is actively working with another window of the same app.
+        if let focusedToken = controller.workspaceManager.confirmedManagedFocusToken,
+           focusedToken != observedEntry.token,
+           focusedToken.pid == observedEntry.pid,
+           let focusedEntry = controller.workspaceManager.entry(for: focusedToken),
+           let focusedMonitorId = controller.workspaceManager.monitorId(for: focusedEntry.workspaceId),
+           controller.workspaceManager.activeWorkspace(on: focusedMonitorId)?.id == focusedEntry.workspaceId
+        {
+            return true
         }
 
-        return true
+        // When the active workspace has no same-pid confirmed managed focus
+        // (empty workspace, or a different app is focused), a focusedWindowChanged
+        // that resolves to a managed window on an inactive workspace is an
+        // app-internal re-focus (quick-terminal toggle, activation churn) — not
+        // a user workspace switch. Suppress it to preserve the active workspace.
+        // A genuine user switch arrives as workspaceDidActivateApplication (which
+        // makes the workspace active first) or with a pending managed request
+        // (which is not .unrelatedNoRequest).
+        if source == .focusedWindowChanged {
+            return true
+        }
+
+        return false
     }
 
     func handleAppActivation(
@@ -1384,14 +1515,26 @@ final class AXEventHandler: CGSEventDelegate {
             if shouldSuppressSameAppInactiveWorkspaceActivationBeforeCloseRecovery(
                 entry: entry,
                 isWorkspaceActive: isWorkspaceActive,
-                requestDisposition: requestDisposition
+                requestDisposition: requestDisposition,
+                source: source
+            ) {
+                return
+            }
+
+            if shouldDeferInactiveNativeActivationBeforeCloseRecovery(
+                entry: entry,
+                isWorkspaceActive: isWorkspaceActive,
+                requestDisposition: requestDisposition,
+                source: source,
+                origin: origin
             ) {
                 return
             }
 
             if shouldSuppressObservedActivationDuringWindowCloseRecovery(
-                observedWorkspaceId: wsId,
-                requestDisposition: requestDisposition
+                entry: entry,
+                requestDisposition: requestDisposition,
+                source: source
             ) {
                 if case let .conflictsWithPendingRequest(request) = requestDisposition {
                     continueManagedFocusRequest(
@@ -1463,14 +1606,26 @@ final class AXEventHandler: CGSEventDelegate {
             if shouldSuppressSameAppInactiveWorkspaceActivationBeforeCloseRecovery(
                 entry: restoredEntry,
                 isWorkspaceActive: isWorkspaceActive,
-                requestDisposition: requestDisposition
+                requestDisposition: requestDisposition,
+                source: source
+            ) {
+                return
+            }
+
+            if shouldDeferInactiveNativeActivationBeforeCloseRecovery(
+                entry: restoredEntry,
+                isWorkspaceActive: isWorkspaceActive,
+                requestDisposition: requestDisposition,
+                source: source,
+                origin: origin
             ) {
                 return
             }
 
             if shouldSuppressObservedActivationDuringWindowCloseRecovery(
-                observedWorkspaceId: wsId,
-                requestDisposition: requestDisposition
+                entry: restoredEntry,
+                requestDisposition: requestDisposition,
+                source: source
             ) {
                 if case let .conflictsWithPendingRequest(request) = requestDisposition {
                     continueManagedFocusRequest(
@@ -1608,12 +1763,19 @@ final class AXEventHandler: CGSEventDelegate {
         }
 
         let windowInfo = resolveWindowInfo(windowId)
+        // AX focus can arrive before the matching CGS .created event. If we
+        // admit the window from this path without a context, placement loses the
+        // create-time focus/interaction inputs and falls back to frame/live state.
+        let createPlacementContext = ensureCreatePlacementContextForFocusedAdmission(
+            windowId: windowId,
+            pid: token.pid
+        )
         guard let candidate = prepareCreateCandidate(
             windowId: windowId,
             windowInfo: windowInfo,
             fallbackToken: token,
             fallbackAXRef: axRef,
-            createPlacementContext: createPlacementContextsByWindowId[windowId]
+            createPlacementContext: createPlacementContext
         ) else {
             if let windowInfo {
                 _ = scheduleCreatedWindowRetryIfNeeded(
@@ -1704,6 +1866,11 @@ final class AXEventHandler: CGSEventDelegate {
         let shouldActivateWorkspace = !isWorkspaceActive && !controller.isTransferringWindow
         let activeRequest = controller.focusBridge.activeManagedRequest(for: entry.pid)
         let shouldConfirmRequest = confirmRequest ?? true
+        // Detect re-confirmation of an already-confirmed focus token. A
+        // quick-terminal hide can cause macOS to re-focus the existing managed
+        // window; without this guard the viewport scrolls back to a column the
+        // user deliberately scrolled away from.
+        let wasAlreadyConfirmedFocus = controller.workspaceManager.confirmedManagedFocusToken == entry.token
         var confirmedRequestId: UInt64?
 
         if shouldConfirmRequest {
@@ -1734,6 +1901,7 @@ final class AXEventHandler: CGSEventDelegate {
             if let confirmedRequestId {
                 cancelActivationRetry(requestId: confirmedRequestId)
             }
+            recentManagedWorkspaceByPid[entry.pid] = wsId
             recordNiriCreateFocusTrace(
                 .init(
                     kind: .focusConfirmed(
@@ -1749,6 +1917,7 @@ final class AXEventHandler: CGSEventDelegate {
                 in: wsId,
                 onMonitor: monitorId
             )
+            recentManagedWorkspaceByPid[entry.pid] = wsId
         }
 
         let target = controller.keyboardFocusTarget(for: entry.token, axRef: entry.axRef)
@@ -1784,6 +1953,7 @@ final class AXEventHandler: CGSEventDelegate {
             }
             let preserveActiveViewport = state.viewOffsetPixels.isGesture
                 || state.viewOffsetPixels.isAnimating
+                || (wasAlreadyConfirmedFocus && source == .focusedWindowChanged)
             controller.recordRuntimeViewportTrace(
                 workspaceId: wsId,
                 reason: "ax_focus_confirm_before_activate",
@@ -1795,6 +1965,7 @@ final class AXEventHandler: CGSEventDelegate {
                     "recentFFMFresh=\(recentFFMIsFresh)",
                     "isFFM=\(isFFM)",
                     "preserveActiveViewport=\(preserveActiveViewport)",
+                    "wasAlreadyConfirmedFocus=\(wasAlreadyConfirmedFocus)",
                     "isGesture=\(state.viewOffsetPixels.isGesture)",
                     "wasAnimating=\(state.viewOffsetPixels.isAnimating)"
                 ]
@@ -2518,7 +2689,10 @@ final class AXEventHandler: CGSEventDelegate {
                     focusedMonitorId: createPlacementContext?.focusedMonitorId,
                     nativeSpaceMonitorId: createPlacementContext?.nativeSpaceMonitorId,
                     frameMonitorId: placementTraceMonitorId(for: windowFrame, controller: controller),
-                    interactionMonitorId: createPlacementContext?.interactionMonitorId
+                    interactionMonitorId: createPlacementContext?.interactionMonitorId,
+                    contextSource: createPlacementContext?.source,
+                    focusedWorkspaceSource: createPlacementContext?.focusedWorkspaceSource,
+                    recentPidWorkspaceId: createPlacementContext?.recentPidWorkspaceId
                 )
             )
         )
@@ -2601,6 +2775,12 @@ final class AXEventHandler: CGSEventDelegate {
         }
 
         guard let candidate = prepareDestroyCandidate(windowId: windowId, pidHint: pidHint) else {
+            if let destroyedPid = pidHint ?? resolvedToken?.pid {
+                // Quick-terminal hide/close can destroy an auxiliary AX element
+                // instead of the tracked managed window. Preserve the current
+                // workspace before macOS activates a successor app/window.
+                armWindowCloseFocusRecoveryForFocusedAppEvent(pid: destroyedPid)
+            }
             clearFocusedTargetForDestroyedWindow(
                 windowId: windowId,
                 resolvedToken: resolvedToken,
@@ -3392,9 +3572,54 @@ final class AXEventHandler: CGSEventDelegate {
             return
         }
 
-        let focusedWorkspaceId = resolveFocusedPlacementWorkspaceId(controller: controller)
-        createPlacementContextsByWindowId[windowId] = WindowCreatePlacementContext(
+        createPlacementContextsByWindowId[windowId] = makeCreatePlacementContext(
             nativeSpaceMonitorId: resolveNativeSpacePlacementMonitorId(spaceId: spaceId, controller: controller),
+            fallbackFocusedWorkspaceId: nil,
+            source: "cgs_created",
+            controller: controller
+        )
+    }
+
+    private func ensureCreatePlacementContextForFocusedAdmission(
+        windowId: UInt32,
+        pid: pid_t
+    ) -> WindowCreatePlacementContext? {
+        pruneExpiredCreatePlacementContexts()
+        if let context = createPlacementContextsByWindowId[windowId] {
+            return context
+        }
+        guard let controller else { return nil }
+
+        let recentPidWorkspaceId = recentManagedWorkspaceByPid[pid]
+        let context = makeCreatePlacementContext(
+            nativeSpaceMonitorId: nil,
+            fallbackFocusedWorkspaceId: recentPidWorkspaceId,
+            source: "ax_focused_admission_synthesized",
+            recentPidWorkspaceId: recentPidWorkspaceId,
+            controller: controller
+        )
+        createPlacementContextsByWindowId[windowId] = context
+        return context
+    }
+
+    private func makeCreatePlacementContext(
+        nativeSpaceMonitorId: Monitor.ID?,
+        fallbackFocusedWorkspaceId: WorkspaceDescriptor.ID?,
+        source: String,
+        recentPidWorkspaceId: WorkspaceDescriptor.ID? = nil,
+        controller: WMController
+    ) -> WindowCreatePlacementContext {
+        let confirmedFocusedWorkspaceId = resolveFocusedPlacementWorkspaceId(controller: controller)
+        let focusedWorkspaceId = confirmedFocusedWorkspaceId ?? fallbackFocusedWorkspaceId
+        let focusedWorkspaceSource: String? = if confirmedFocusedWorkspaceId != nil {
+            "confirmed_focus"
+        } else if fallbackFocusedWorkspaceId != nil {
+            "recent_pid"
+        } else {
+            nil
+        }
+        return WindowCreatePlacementContext(
+            nativeSpaceMonitorId: nativeSpaceMonitorId,
             activeFocusRequestWorkspaceId: controller.workspaceManager.activeFocusRequestWorkspaceId,
             activeFocusRequestMonitorId: resolveActiveFocusRequestPlacementMonitorId(controller: controller),
             focusedWorkspaceId: focusedWorkspaceId,
@@ -3402,6 +3627,9 @@ final class AXEventHandler: CGSEventDelegate {
                 controller.workspaceManager.monitorId(for: $0)
             },
             interactionMonitorId: controller.workspaceManager.interactionMonitorId,
+            source: source,
+            focusedWorkspaceSource: focusedWorkspaceSource,
+            recentPidWorkspaceId: recentPidWorkspaceId,
             createdAt: Date()
         )
     }
@@ -3492,6 +3720,11 @@ final class AXEventHandler: CGSEventDelegate {
             break
         }
 
+        // Dropdown/quick-terminal close paths can report focused-window=nil
+        // without destroying the managed window. Reuse close recovery so the
+        // native successor activation does not pull us to another workspace.
+        armWindowCloseFocusRecoveryForFocusedWindowLossIfNeeded(pid: pid, source: source)
+
         cancelActivationRetry()
         let fallbackFullscreen = appFullscreenForFallbackLifecyclePreservation(
             observedAppFullscreen: false
@@ -3546,7 +3779,7 @@ final class AXEventHandler: CGSEventDelegate {
             return true
         case .workspaceDidActivateApplication,
              .cgsFrontAppChanged:
-            return origin == .external
+            return origin == .external || origin == .retry
         }
     }
 
@@ -3558,6 +3791,8 @@ final class AXEventHandler: CGSEventDelegate {
     }
 
     func cleanupFocusStateForTerminatedApp(pid: pid_t) {
+        recentManagedWorkspaceByPid.removeValue(forKey: pid)
+
         guard let controller else { return }
 
         let entries = controller.workspaceManager.entries(forPid: pid)

--- a/Sources/Nehir/Core/Controller/NiriLayoutHandler.swift
+++ b/Sources/Nehir/Core/Controller/NiriLayoutHandler.swift
@@ -462,6 +462,25 @@ enum NiriWindowMoveResult {
         preferredWorkspaceFocusToken: WindowToken?
     ) -> [WindowToken] {
         let currentSelection = state.selectedNodeId
+        let columnsBeforeSync = pass.engine.columns(in: pass.wsId)
+        let selectedWindowBefore = currentSelection.flatMap { pass.engine.findNode(by: $0) as? NiriWindow }
+        let selectedColumnBefore = selectedWindowBefore
+            .flatMap { pass.engine.column(of: $0) }
+            .flatMap { pass.engine.columnIndex(of: $0, in: pass.wsId) }
+        let focusedColumnBefore = preferredWorkspaceFocusToken
+            .flatMap { pass.engine.findNode(for: $0) }
+            .flatMap { pass.engine.column(of: $0) }
+            .flatMap { pass.engine.columnIndex(of: $0, in: pass.wsId) }
+        let insertionReference: (kind: String, columnIndex: Int?) = if focusedColumnBefore != nil {
+            ("focused_token", focusedColumnBefore)
+        } else if selectedColumnBefore != nil {
+            ("selected_node", selectedColumnBefore)
+        } else if !columnsBeforeSync.isEmpty {
+            ("last_column", columnsBeforeSync.count - 1)
+        } else {
+            ("empty_workspace", nil)
+        }
+
         _ = pass.engine.syncWindows(
             windowTokens,
             in: pass.wsId,
@@ -469,6 +488,27 @@ enum NiriWindowMoveResult {
             focusedToken: preferredWorkspaceFocusToken
         )
         let newTokens = windowTokens.filter { !removal.existingHandleIds.contains($0) }
+
+        for newToken in newTokens {
+            let node = pass.engine.findNode(for: newToken)
+            let column = node.flatMap { pass.engine.column(of: $0) }
+            let columnIndex = column.flatMap { pass.engine.columnIndex(of: $0, in: pass.wsId) }
+            let columnTokens = column?.windowNodes.map { String(describing: $0.token) }.joined(separator: ",") ?? "nil"
+            controller?.recordRuntimeInsertionTrace([
+                "workspace=\(pass.wsId.uuidString)",
+                "token=\(newToken)",
+                "beforeColumns=\(columnsBeforeSync.count)",
+                "selectedNodeBefore=\(currentSelection.map(String.init(describing:)) ?? "nil")",
+                "selectedTokenBefore=\(selectedWindowBefore.map { String(describing: $0.token) } ?? "nil")",
+                "selectedColumnBefore=\(selectedColumnBefore.map(String.init) ?? "nil")",
+                "focusedTokenBefore=\(preferredWorkspaceFocusToken.map(String.init(describing:)) ?? "nil")",
+                "focusedColumnBefore=\(focusedColumnBefore.map(String.init) ?? "nil")",
+                "reference=\(insertionReference.kind)",
+                "referenceColumn=\(insertionReference.columnIndex.map(String.init) ?? "nil")",
+                "landedColumn=\(columnIndex.map(String.init) ?? "nil")",
+                "landedColumnTokens=\(columnTokens)"
+            ].joined(separator: " "))
+        }
 
         for col in pass.engine.columns(in: pass.wsId) {
             if col.cachedWidth <= 0 {
@@ -778,8 +818,19 @@ enum NiriWindowMoveResult {
         }
 
         if let newWindowToken {
+            // Only activate (focus) a newly-inserted window when this workspace
+            // is the active one on its monitor. An affected-workspace refresh can
+            // re-sync a pre-existing managed window into an inactive workspace's
+            // empty Niri layout (columns==0); activating it there would teleport
+            // the user off their current workspace.
+            let isWorkspaceActive = controller?.workspaceManager
+                .activeWorkspace(on: pass.monitor.id)?.id == pass.wsId
+            let interactionMonitorId = controller?.workspaceManager.interactionMonitorId
+            let isInteractionMonitor = interactionMonitorId == nil || interactionMonitorId == pass.monitor.id
             directives.append(.startNiriScroll(workspaceId: pass.wsId))
-            directives.append(.activateWindow(token: newWindowToken))
+            if isWorkspaceActive && isInteractionMonitor {
+                directives.append(.activateWindow(token: newWindowToken))
+            }
         }
 
         if let removalSeed = snapshot.removalSeed, !removalSeed.oldFrames.isEmpty {

--- a/Sources/Nehir/Core/Controller/WMController.swift
+++ b/Sources/Nehir/Core/Controller/WMController.swift
@@ -191,6 +191,8 @@ final class WMController {
     @ObservationIgnored
     private var runtimeResizeTraceRecords: [String] = []
     @ObservationIgnored
+    private var runtimeInsertionTraceRecords: [String] = []
+    @ObservationIgnored
     private var runtimeMouseTraceRecords: [String] = []
 
     var runtimeTraceCaptureStatus: RuntimeTraceCaptureStatus {
@@ -237,6 +239,13 @@ final class WMController {
         }
         workspaceManager.onProjectionInvalidated = { [weak self] invalidation in
             self?.requestProjectionRefresh(invalidation)
+        }
+        workspaceManager.onHiddenStateChanged = { [weak self] token, previousState, newState in
+            self?.axEventHandler.handleManagedWindowHiddenStateChanged(
+                token: token,
+                previousState: previousState,
+                newState: newState
+            )
         }
         focusPolicyEngine.onLeaseChanged = { [weak self] lease in
             self?.workspaceManager.recordReconcileEvent(
@@ -633,6 +642,10 @@ final class WMController {
 
     func focusWorkspaceFromBar(named name: String) {
         windowActionHandler.focusWorkspaceFromBar(named: name, suppressMouseWarp: true)
+    }
+
+    func focusWorkspaceFromBar(id workspaceId: WorkspaceDescriptor.ID) {
+        windowActionHandler.focusWorkspaceFromBar(id: workspaceId, suppressMouseWarp: true)
     }
 
     func focusWindowFromBar(token: WindowToken) {
@@ -1204,6 +1217,50 @@ final class WMController {
                                                         createPlacementContext?.activeFocusRequestMonitorId)
             {
                 return target
+            }
+
+            let frameMonitor = monitorForPlacementFrame(windowFrame)
+                ?? (workspaceManager.monitors.count > 1
+                    ? monitorForPlacementFrame(AXWindowService.framePreferFast(axRef))
+                    : nil)
+            if let focusedMonitorId = createPlacementContext?.focusedMonitorId {
+                if let frameMonitor,
+                   frameMonitor.id != focusedMonitorId,
+                   (createPlacementContext?.interactionMonitorId == nil
+                       || createPlacementContext?.interactionMonitorId == frameMonitor.id),
+                   let workspace = workspaceManager.activeWorkspaceOrFirst(on: frameMonitor.id)
+                {
+                    return WorkspacePlacementTarget(
+                        workspaceId: workspace.id,
+                        monitorId: frameMonitor.id,
+                        isAuthoritative: true
+                    )
+                }
+
+                if let interactionMonitorId = createPlacementContext?.interactionMonitorId,
+                   interactionMonitorId != focusedMonitorId,
+                   let workspace = workspaceManager.activeWorkspaceOrFirst(on: interactionMonitorId)
+                {
+                    return WorkspacePlacementTarget(
+                        workspaceId: workspace.id,
+                        monitorId: interactionMonitorId,
+                        isAuthoritative: true
+                    )
+                }
+            }
+
+            if let interactionMonitorId = createPlacementContext?.interactionMonitorId,
+               let activeWorkspace = workspaceManager.activeWorkspace(on: interactionMonitorId),
+               let focusedWorkspaceId = createPlacementContext?.focusedWorkspaceId,
+               activeWorkspace.id != focusedWorkspaceId,
+               (createPlacementContext?.focusedMonitorId == nil
+                   || createPlacementContext?.focusedMonitorId == interactionMonitorId)
+            {
+                return WorkspacePlacementTarget(
+                    workspaceId: activeWorkspace.id,
+                    monitorId: interactionMonitorId,
+                    isAuthoritative: true
+                )
             }
 
             if let target = managedFocusPlacementTarget(createPlacementContext?.focusedWorkspaceId,
@@ -2079,6 +2136,14 @@ final class WMController {
         }
     }
 
+    func recordRuntimeInsertionTrace(_ message: String) {
+        guard runtimeTraceCaptureSession != nil else { return }
+        runtimeInsertionTraceRecords.append(Date().ISO8601Format() + " " + message)
+        if runtimeInsertionTraceRecords.count > 400 {
+            runtimeInsertionTraceRecords.removeFirst(runtimeInsertionTraceRecords.count - 400)
+        }
+    }
+
     func recordRuntimeViewportTrace(
         workspaceId: WorkspaceDescriptor.ID,
         reason: String,
@@ -2553,7 +2618,7 @@ final class WMController {
             "accessibilityGranted=\(accessibilityPermissionGranted) lockScreenActive=\(isLockScreenActive) overviewOpen=\(isOverviewOpen()) startedServices=\(hasStartedServices)",
             "focusFollowsMouse=\(focusFollowsMouseEnabled) moveMouseToFocusedWindow=\(moveMouseToFocusedWindowEnabled) mouseWarpPolicyEnabled=\(isMouseWarpPolicyEnabled)",
             "isTransferringWindow=\(isTransferringWindow) hiddenAppPIDs=\(hiddenAppPIDs.count) workspaceBarHiddenMonitors=\(hiddenWorkspaceBarMonitorIds.count)",
-            "runtimeTraceCaptureActive=\(traceCaptureStatus.isActive) runtimeTraceStartedAt=\(traceCaptureStatus.startedAt?.ISO8601Format() ?? "nil") viewportTraceRecords=\(runtimeViewportTraceRecords.count) resizeTraceRecords=\(runtimeResizeTraceRecords.count) mouseTraceRecords=\(runtimeMouseTraceRecords.count)",
+            "runtimeTraceCaptureActive=\(traceCaptureStatus.isActive) runtimeTraceStartedAt=\(traceCaptureStatus.startedAt?.ISO8601Format() ?? "nil") viewportTraceRecords=\(runtimeViewportTraceRecords.count) resizeTraceRecords=\(runtimeResizeTraceRecords.count) insertionTraceRecords=\(runtimeInsertionTraceRecords.count) mouseTraceRecords=\(runtimeMouseTraceRecords.count)",
             "workspaceBarRefreshDebugState requestCount=\(workspaceBarRefreshDebugState.requestCount) scheduledCount=\(workspaceBarRefreshDebugState.scheduledCount) executionCount=\(workspaceBarRefreshDebugState.executionCount) isQueued=\(workspaceBarRefreshDebugState.isQueued)",
             "-- Focus Targets --",
             focusTargetDebugDump(),
@@ -2624,6 +2689,7 @@ final class WMController {
             runtimeTraceCaptureSession = nil
             runtimeViewportTraceRecords.removeAll(keepingCapacity: true)
             runtimeResizeTraceRecords.removeAll(keepingCapacity: true)
+            runtimeInsertionTraceRecords.removeAll(keepingCapacity: true)
             runtimeMouseTraceRecords.removeAll(keepingCapacity: true)
             syncNiriResizeTraceSink()
             workspaceBarManager.update()
@@ -2693,6 +2759,7 @@ final class WMController {
 
         runtimeViewportTraceRecords.removeAll(keepingCapacity: true)
         runtimeResizeTraceRecords.removeAll(keepingCapacity: true)
+        runtimeInsertionTraceRecords.removeAll(keepingCapacity: true)
         runtimeMouseTraceRecords.removeAll(keepingCapacity: true)
         let startedAt = Date()
         let startRuntimeStateDump = runtimeStateDebugDump(
@@ -2705,6 +2772,8 @@ final class WMController {
         )
         syncNiriResizeTraceSink()
         workspaceManager.resetReconcileTraceForDebug()
+        workspaceManager.resetInteractionMonitorWriteTraceForDebug()
+        AppAXContext.resetRawAXNotificationTraceForDebug()
         workspaceBarManager.update()
         return .executed
     }
@@ -2730,6 +2799,9 @@ final class WMController {
         let resizeTraceDump = runtimeResizeTraceRecords.isEmpty
             ? "resize trace empty"
             : runtimeResizeTraceRecords.joined(separator: "\n")
+        let insertionTraceDump = runtimeInsertionTraceRecords.isEmpty
+            ? "insertion trace empty"
+            : runtimeInsertionTraceRecords.joined(separator: "\n")
         let mouseTraceDump = runtimeMouseTraceRecords.isEmpty
             ? "mouse trace empty"
             : runtimeMouseTraceRecords.joined(separator: "\n")
@@ -2737,6 +2809,8 @@ final class WMController {
         let createFocusTraceDump = createFocusTraceEvents.isEmpty
             ? "create focus trace empty"
             : createFocusTraceEvents.map(\.description).joined(separator: "\n")
+        let rawAXNotificationDump = AppAXContext.rawAXNotificationTraceDump()
+        let interactionMonitorWriteDump = workspaceManager.interactionMonitorWriteTraceDump()
         let body = [
             "Nehir runtime trace capture",
             "startedAt=\(session.startedAt.ISO8601Format())",
@@ -2755,8 +2829,17 @@ final class WMController {
             "## Niri resize trace",
             resizeTraceDump,
             "",
+            "## Niri insertion trace",
+            insertionTraceDump,
+            "",
             "## Niri create focus trace",
             createFocusTraceDump,
+            "",
+            "## AX notification trace",
+            rawAXNotificationDump,
+            "",
+            "## Interaction monitor writes",
+            interactionMonitorWriteDump,
             "",
             "## Mouse focus trace",
             mouseTraceDump,
@@ -2782,6 +2865,7 @@ final class WMController {
         runtimeTraceCaptureSession = nil
         runtimeViewportTraceRecords.removeAll(keepingCapacity: true)
         runtimeResizeTraceRecords.removeAll(keepingCapacity: true)
+        runtimeInsertionTraceRecords.removeAll(keepingCapacity: true)
         runtimeMouseTraceRecords.removeAll(keepingCapacity: true)
         syncNiriResizeTraceSink()
         workspaceBarManager.update()

--- a/Sources/Nehir/Core/Controller/WindowActionHandler.swift
+++ b/Sources/Nehir/Core/Controller/WindowActionHandler.swift
@@ -521,8 +521,26 @@ final class WindowActionHandler {
         if let currentWorkspace = controller.interactionWorkspace() {
             controller.workspaceNavigationHandler.saveNiriViewportState(for: currentWorkspace.id)
         }
-
         guard let result = controller.workspaceManager.focusWorkspace(named: name) else { return false }
+        return focusWorkspaceFromBar(result: result, suppressMouseWarp: suppressMouseWarp)
+    }
+
+    @discardableResult
+    func focusWorkspaceFromBar(id workspaceId: WorkspaceDescriptor.ID, suppressMouseWarp: Bool = false) -> Bool {
+        guard let controller else { return false }
+        if let currentWorkspace = controller.interactionWorkspace() {
+            controller.workspaceNavigationHandler.saveNiriViewportState(for: currentWorkspace.id)
+        }
+        guard let result = controller.workspaceManager.focusWorkspace(id: workspaceId) else { return false }
+        return focusWorkspaceFromBar(result: result, suppressMouseWarp: suppressMouseWarp)
+    }
+
+    @discardableResult
+    private func focusWorkspaceFromBar(
+        result: (workspace: WorkspaceDescriptor, monitor: Monitor),
+        suppressMouseWarp: Bool
+    ) -> Bool {
+        guard let controller else { return false }
 
         let focusedToken = controller.resolveAndSetWorkspaceFocusToken(for: result.workspace.id)
         if suppressMouseWarp, let focusedToken {

--- a/Sources/Nehir/Core/Reconcile/ReconcileTxn.swift
+++ b/Sources/Nehir/Core/Reconcile/ReconcileTxn.swift
@@ -20,6 +20,6 @@ struct ReconcileTxn: Equatable {
     /// `snapshot.interactionMonitorId` is post-apply, so without this the trace
     /// cannot observe a transient nil that reconcile immediately recovers —
     /// which is exactly the signal needed to locate the new-window placement
-    /// nil-writer. See `docs/plans/discovery/20260615-new-window-placement-investigation.md`.
+    /// nil-writer. See `docs/plans/completed/20260615-new-window-placement-investigation.md`.
     let preInteractionMonitorId: Monitor.ID?
 }

--- a/Sources/Nehir/Core/Workspace/InteractionMonitorWriteTrace.swift
+++ b/Sources/Nehir/Core/Workspace/InteractionMonitorWriteTrace.swift
@@ -1,0 +1,80 @@
+import Foundation
+
+/// One recorded assignment to the interaction-monitor session state.
+///
+/// `WorkspaceManager` has multiple write sites for
+/// `sessionState.interactionMonitorId` (and `previousInteractionMonitorId`).
+/// This recorder captures each write directly (old→new + call-site reason) so
+/// runtime traces can distinguish a real state write from a missing/stale
+/// placement context. See
+/// `docs/plans/completed/20260615-new-window-placement-investigation.md`.
+struct InteractionMonitorWriteRecord: Equatable {
+    let sequence: UInt64
+    let timestamp: Date
+    let field: Field
+    let oldValue: Monitor.ID?
+    let newValue: Monitor.ID?
+    let reason: String
+
+    enum Field: String {
+        case interaction
+        case previous
+    }
+}
+
+extension InteractionMonitorWriteRecord: CustomStringConvertible {
+    var description: String {
+        let old = oldValue.map(String.init(describing:)) ?? "nil"
+        let new = newValue.map(String.init(describing:)) ?? "nil"
+        let arrow = oldValue == newValue ? "" : "→\(new)"
+        return "\(timestamp.ISO8601Format()) \(field.rawValue)=\(old)\(arrow) reason=\(reason)"
+    }
+}
+
+/// Bounded ring of interaction-monitor writes. Mirrors `ReconcileTraceRecorder`.
+@MainActor
+final class InteractionMonitorWriteRecorder {
+    private static let defaultLimit = 256
+
+    private let limit: Int
+    private var nextSequence: UInt64 = 1
+    private var records: [InteractionMonitorWriteRecord] = []
+
+    init(limit: Int = defaultLimit) {
+        self.limit = max(1, limit)
+    }
+
+    func append(
+        field: InteractionMonitorWriteRecord.Field,
+        oldValue: Monitor.ID?,
+        newValue: Monitor.ID?,
+        reason: String,
+        timestamp: Date = Date()
+    ) {
+        let record = InteractionMonitorWriteRecord(
+            sequence: nextSequence,
+            timestamp: timestamp,
+            field: field,
+            oldValue: oldValue,
+            newValue: newValue,
+            reason: reason
+        )
+        nextSequence += 1
+        if records.count == limit {
+            records.removeFirst()
+        }
+        records.append(record)
+    }
+
+    func dump() -> String {
+        if records.isEmpty {
+            return "interaction monitor writes empty"
+        }
+        return records.map(\.description).joined(separator: "\n")
+    }
+
+    func reset() {
+        records.removeAll(keepingCapacity: true)
+        nextSequence = 1
+    }
+}

--- a/Sources/Nehir/Core/Workspace/WorkspaceManager.swift
+++ b/Sources/Nehir/Core/Workspace/WorkspaceManager.swift
@@ -196,6 +196,7 @@ final class WorkspaceManager {
     private(set) var outerGaps: LayoutGaps.OuterGaps = .zero
     private let windows = WindowModel()
     private let reconcileTrace = ReconcileTraceRecorder()
+    private let interactionMonitorWriteTrace = InteractionMonitorWriteRecorder()
     private lazy var runtimeStore = RuntimeStore(traceRecorder: reconcileTrace)
     private let restorePlanner = RestorePlanner()
     private var bootPersistedWindowRestoreCatalog: PersistedWindowRestoreCatalog
@@ -224,6 +225,7 @@ final class WorkspaceManager {
     var onGapsChanged: (() -> Void)?
     var onSessionStateChanged: (() -> Void)?
     var onProjectionInvalidated: ((ProjectionInvalidationRequest) -> Void)?
+    var onHiddenStateChanged: ((WindowToken, WindowModel.HiddenState?, WindowModel.HiddenState?) -> Void)?
 
     private func invalidateProjection(_ kind: ProjectionInvalidation, reason: String) {
         onProjectionInvalidated?(.init(kind, reason: reason))
@@ -305,6 +307,14 @@ final class WorkspaceManager {
 
     func reconcileTraceDump(limit: Int? = nil) -> String {
         ReconcileDebugDump.trace(reconcileTrace.snapshot(), limit: limit)
+    }
+
+    func interactionMonitorWriteTraceDump() -> String {
+        interactionMonitorWriteTrace.dump()
+    }
+
+    func resetInteractionMonitorWriteTraceForDebug() {
+        interactionMonitorWriteTrace.reset()
     }
 
     func resetReconcileTraceForDebug() {
@@ -448,7 +458,7 @@ final class WorkspaceManager {
 
         sessionState.scratchpadToken = nil
         sessionState.focus = .init()
-        sessionState.previousInteractionMonitorId = nil
+        assignPreviousInteractionMonitorId(nil, reason: "resetRuntimeState")
         for workspaceId in sessionState.workspaceSessions.keys {
             sessionState.workspaceSessions[workspaceId]?.niriViewportState?.reset()
         }
@@ -638,8 +648,8 @@ final class WorkspaceManager {
         sessionState.focus.focusLease = focusSession.focusLease
         sessionState.focus.isNonManagedFocusActive = focusSession.isNonManagedFocusActive
         sessionState.focus.isAppFullscreenActive = focusSession.isAppFullscreenActive
-        sessionState.interactionMonitorId = focusSession.interactionMonitorId
-        sessionState.previousInteractionMonitorId = focusSession.previousInteractionMonitorId
+        assignInteractionMonitorId(focusSession.interactionMonitorId, reason: "applyReconciledFocusSession")
+        assignPreviousInteractionMonitorId(focusSession.previousInteractionMonitorId, reason: "applyReconciledFocusSession")
     }
 
     @discardableResult
@@ -681,8 +691,8 @@ final class WorkspaceManager {
             schedulePersistedWindowRestoreCatalogSave()
         }
 
-        sessionState.interactionMonitorId = plan.interactionMonitorId
-        sessionState.previousInteractionMonitorId = plan.previousInteractionMonitorId
+        assignInteractionMonitorId(plan.interactionMonitorId, reason: "applyRestoreRefresh")
+        assignPreviousInteractionMonitorId(plan.previousInteractionMonitorId, reason: "applyRestoreRefresh")
     }
 
     private func applyTopologyTransition(_ transition: TopologyTransitionPlan) {
@@ -703,8 +713,8 @@ final class WorkspaceManager {
 
         reconcileConfiguredVisibleWorkspaces(notify: false)
         disconnectedVisibleWorkspaceCache = transition.disconnectedVisibleWorkspaceCache
-        sessionState.interactionMonitorId = transition.interactionMonitorId
-        sessionState.previousInteractionMonitorId = transition.previousInteractionMonitorId
+        assignInteractionMonitorId(transition.interactionMonitorId, reason: "applyTopologyTransition")
+        assignPreviousInteractionMonitorId(transition.previousInteractionMonitorId, reason: "applyTopologyTransition")
         reconcileInteractionMonitorState(notify: false)
         refreshWindowMonitorReferencesForAllEntries()
         if transition.refreshRestoreIntents {
@@ -2354,6 +2364,11 @@ final class WorkspaceManager {
     func focusWorkspace(named name: String) -> (workspace: WorkspaceDescriptor, monitor: Monitor)? {
         ensureVisibleWorkspaces()
         guard let workspaceId = workspaceId(for: name, createIfMissing: false) else { return nil }
+        return focusWorkspace(id: workspaceId)
+    }
+
+    func focusWorkspace(id workspaceId: WorkspaceDescriptor.ID) -> (workspace: WorkspaceDescriptor, monitor: Monitor)? {
+        ensureVisibleWorkspaces()
         guard let targetMonitor = monitorForWorkspace(workspaceId) else { return nil }
         guard setActiveWorkspace(workspaceId, on: targetMonitor.id) else { return nil }
         guard let workspace = descriptor(for: workspaceId) else { return nil }
@@ -2919,6 +2934,9 @@ final class WorkspaceManager {
     func setHiddenState(_ state: WindowModel.HiddenState?, for token: WindowToken) {
         let previousState = windows.hiddenState(for: token)
         windows.setHiddenState(state, for: token)
+        if previousState != state {
+            onHiddenStateChanged?(token, previousState, state)
+        }
         if let workspaceId = workspace(for: token) {
             recordReconcileEvent(
                 .hiddenStateChanged(
@@ -3944,14 +3962,47 @@ final class WorkspaceManager {
            let currentMonitorId = sessionState.interactionMonitorId,
            currentMonitorId != monitorId
         {
-            sessionState.previousInteractionMonitorId = currentMonitorId
+            assignPreviousInteractionMonitorId(currentMonitorId, reason: "updateInteractionMonitor.preservePrevious")
         }
-        sessionState.interactionMonitorId = monitorId
+        assignInteractionMonitorId(monitorId, reason: "updateInteractionMonitor")
         if notify {
             notifySessionStateChanged()
         }
         invalidateWorkspaceProjection(reason: "interactionMonitorChanged")
         return true
+    }
+
+    /// Tagged assignment for `sessionState.interactionMonitorId`. Every write
+    /// routes through here so runtime traces can show whether placement saw a
+    /// real interaction-monitor write or a missing/stale create context.
+    private func assignInteractionMonitorId(
+        _ monitorId: Monitor.ID?,
+        reason: String
+    ) {
+        let oldValue = sessionState.interactionMonitorId
+        sessionState.interactionMonitorId = monitorId
+        interactionMonitorWriteTrace.append(
+            field: .interaction,
+            oldValue: oldValue,
+            newValue: monitorId,
+            reason: reason
+        )
+    }
+
+    /// Tagged assignment for `sessionState.previousInteractionMonitorId`. See
+    /// `assignInteractionMonitorId(_:reason:)`.
+    private func assignPreviousInteractionMonitorId(
+        _ monitorId: Monitor.ID?,
+        reason: String
+    ) {
+        let oldValue = sessionState.previousInteractionMonitorId
+        sessionState.previousInteractionMonitorId = monitorId
+        interactionMonitorWriteTrace.append(
+            field: .previous,
+            oldValue: oldValue,
+            newValue: monitorId,
+            reason: reason
+        )
     }
 
     private func restoreKeySortKey(_ restoreKey: MonitorRestoreKey) -> (CGFloat, CGFloat, UInt32) {
@@ -3975,8 +4026,8 @@ final class WorkspaceManager {
         let changed = sessionState.interactionMonitorId != newInteractionMonitorId
             || sessionState.previousInteractionMonitorId != newPreviousInteractionMonitorId
 
-        sessionState.interactionMonitorId = newInteractionMonitorId
-        sessionState.previousInteractionMonitorId = newPreviousInteractionMonitorId
+        assignInteractionMonitorId(newInteractionMonitorId, reason: "reconcileInteractionMonitorState")
+        assignPreviousInteractionMonitorId(newPreviousInteractionMonitorId, reason: "reconcileInteractionMonitorState")
 
         if changed, notify {
             notifySessionStateChanged()

--- a/Sources/Nehir/UI/WorkspaceBar/WorkspaceBarManager.swift
+++ b/Sources/Nehir/UI/WorkspaceBar/WorkspaceBarManager.swift
@@ -214,7 +214,7 @@ final class WorkspaceBarManager {
             rootView: WorkspaceBarView(
                 model: model,
                 onFocusWorkspace: { [weak controller] item in
-                    controller?.focusWorkspaceFromBar(named: item.name)
+                    controller?.focusWorkspaceFromBar(id: item.id)
                 },
                 onFocusWindow: { [weak controller] token in
                     controller?.focusWindowFromBar(token: token)

--- a/Tests/NehirTests/AXEventHandlerTests.swift
+++ b/Tests/NehirTests/AXEventHandlerTests.swift
@@ -1348,6 +1348,9 @@ private func waitUntilAXEventTest(
             pid: targetPid,
             source: .workspaceDidActivateApplication
         )
+        await waitUntilAXEventTest(iterations: 300) {
+            controller.workspaceManager.confirmedManagedFocusToken == targetToken
+        }
         await controller.layoutRefreshController.waitForRefreshWorkForTests()
 
         #expect(controller.interactionWorkspace()?.id == workspaceTwo)
@@ -1355,6 +1358,230 @@ private func waitUntilAXEventTest(
         #expect(controller.workspaceManager.activeFocusRequestToken == nil)
         #expect(controller.workspaceManager.rememberedTiledFocusToken(in: workspaceTwo) == targetToken)
         #expect(controller.workspaceManager.isNonManagedFocusActive == false)
+    }
+
+    @Test @MainActor func focusedWindowLossSuppressesUnrelatedInactiveWorkspaceActivation() async {
+        let controller = makeAXEventTestController()
+        controller.hasStartedServices = true
+        guard let workspaceOne = controller.workspaceManager.workspaceId(for: "1", createIfMissing: false),
+              let workspaceTwo = controller.workspaceManager.workspaceId(for: "2", createIfMissing: true),
+              let monitor = controller.workspaceManager.monitors.first
+        else {
+            Issue.record("Missing focused-window-loss recovery fixture")
+            return
+        }
+
+        let inactiveToken = controller.workspaceManager.addWindow(
+            AXWindowRef(element: AXUIElementCreateSystemWide(), windowId: 9_761),
+            pid: 9_761,
+            windowId: 9_761,
+            to: workspaceOne
+        )
+        let focusedPid: pid_t = 9_762
+        let focusedToken = controller.workspaceManager.addWindow(
+            AXWindowRef(element: AXUIElementCreateSystemWide(), windowId: 9_762),
+            pid: focusedPid,
+            windowId: 9_762,
+            to: workspaceTwo
+        )
+        #expect(controller.workspaceManager.setActiveWorkspace(workspaceTwo, on: monitor.id))
+        _ = controller.workspaceManager.setManagedFocus(
+            focusedToken,
+            in: workspaceTwo,
+            onMonitor: monitor.id
+        )
+        controller.axEventHandler.isFullscreenProvider = { _ in false }
+        controller.axEventHandler.focusedWindowRefProvider = { pid in
+            if pid == focusedPid { return nil }
+            if pid == inactiveToken.pid {
+                return AXWindowRef(element: AXUIElementCreateSystemWide(), windowId: inactiveToken.windowId)
+            }
+            return nil
+        }
+
+        controller.axEventHandler.handleAppActivation(
+            pid: focusedPid,
+            source: .focusedWindowChanged
+        )
+
+        #expect(controller.focusPolicyEngine.activeLease?.owner == .windowCloseFocusRecovery)
+        #expect(controller.interactionWorkspace()?.id == workspaceTwo)
+        #expect(controller.workspaceManager.confirmedManagedFocusToken == nil)
+        #expect(controller.workspaceManager.isNonManagedFocusActive)
+
+        controller.axEventHandler.handleAppActivation(
+            pid: inactiveToken.pid,
+            source: .workspaceDidActivateApplication
+        )
+        await controller.layoutRefreshController.waitForRefreshWorkForTests()
+
+        #expect(controller.focusPolicyEngine.activeLease?.owner == .windowCloseFocusRecovery)
+        #expect(controller.interactionWorkspace()?.id == workspaceTwo)
+        #expect(controller.workspaceManager.confirmedManagedFocusToken == nil)
+        #expect(controller.workspaceManager.isNonManagedFocusActive)
+    }
+
+    @Test @MainActor func untrackedSamePidDestroySuppressesUnrelatedInactiveWorkspaceActivation() async {
+        let controller = makeAXEventTestController()
+        controller.hasStartedServices = true
+        guard let workspaceOne = controller.workspaceManager.workspaceId(for: "1", createIfMissing: false),
+              let workspaceTwo = controller.workspaceManager.workspaceId(for: "2", createIfMissing: true),
+              let monitor = controller.workspaceManager.monitors.first
+        else {
+            Issue.record("Missing same-pid destroy recovery fixture")
+            return
+        }
+
+        let inactiveToken = controller.workspaceManager.addWindow(
+            AXWindowRef(element: AXUIElementCreateSystemWide(), windowId: 9_763),
+            pid: 9_763,
+            windowId: 9_763,
+            to: workspaceOne
+        )
+        let focusedPid: pid_t = 9_764
+        let focusedToken = controller.workspaceManager.addWindow(
+            AXWindowRef(element: AXUIElementCreateSystemWide(), windowId: 9_764),
+            pid: focusedPid,
+            windowId: 9_764,
+            to: workspaceTwo
+        )
+        #expect(controller.workspaceManager.setActiveWorkspace(workspaceTwo, on: monitor.id))
+        _ = controller.workspaceManager.setManagedFocus(
+            focusedToken,
+            in: workspaceTwo,
+            onMonitor: monitor.id
+        )
+        controller.axEventHandler.isFullscreenProvider = { _ in false }
+        controller.axEventHandler.focusedWindowRefProvider = { pid in
+            if pid == inactiveToken.pid {
+                return AXWindowRef(element: AXUIElementCreateSystemWide(), windowId: inactiveToken.windowId)
+            }
+            return nil
+        }
+
+        controller.axEventHandler.handleRemoved(pid: focusedPid, winId: 101)
+
+        #expect(controller.focusPolicyEngine.activeLease?.owner == .windowCloseFocusRecovery)
+        #expect(controller.workspaceManager.confirmedManagedFocusToken == focusedToken)
+        #expect(controller.interactionWorkspace()?.id == workspaceTwo)
+
+        controller.axEventHandler.handleAppActivation(
+            pid: inactiveToken.pid,
+            source: .workspaceDidActivateApplication
+        )
+        await controller.layoutRefreshController.waitForRefreshWorkForTests()
+
+        #expect(controller.focusPolicyEngine.activeLease?.owner == .windowCloseFocusRecovery)
+        #expect(controller.workspaceManager.confirmedManagedFocusToken == focusedToken)
+        #expect(controller.interactionWorkspace()?.id == workspaceTwo)
+    }
+
+    @Test @MainActor func focusedWindowChangedOnEmptyActiveWorkspaceSuppressesInactiveWorkspaceActivation() async {
+        let controller = makeAXEventTestController()
+        controller.hasStartedServices = true
+        guard let workspaceOne = controller.workspaceManager.workspaceId(for: "1", createIfMissing: false),
+              let workspaceTwo = controller.workspaceManager.workspaceId(for: "2", createIfMissing: true),
+              let monitor = controller.workspaceManager.monitors.first
+        else {
+            Issue.record("Missing empty-workspace suppression fixture")
+            return
+        }
+
+        let appPid: pid_t = 9_771
+        let inactiveToken = controller.workspaceManager.addWindow(
+            AXWindowRef(element: AXUIElementCreateSystemWide(), windowId: 9_772),
+            pid: appPid,
+            windowId: 9_772,
+            to: workspaceOne
+        )
+        #expect(controller.workspaceManager.setActiveWorkspace(workspaceTwo, on: monitor.id))
+        #expect(controller.workspaceManager.confirmedManagedFocusToken == nil)
+
+        controller.axEventHandler.isFullscreenProvider = { _ in false }
+        controller.axEventHandler.focusedWindowRefProvider = { pid in
+            guard pid == appPid else { return nil }
+            return AXWindowRef(element: AXUIElementCreateSystemWide(), windowId: inactiveToken.windowId)
+        }
+
+        controller.axEventHandler.handleAppActivation(pid: appPid, source: .focusedWindowChanged)
+        await controller.layoutRefreshController.waitForRefreshWorkForTests()
+
+        #expect(controller.interactionWorkspace()?.id == workspaceTwo)
+        #expect(controller.workspaceManager.confirmedManagedFocusToken == nil)
+    }
+
+    @Test @MainActor func reconfirmedFocusViaFocusedWindowChangedPreservesViewport() async {
+        let controller = makeAXEventTestController()
+        guard let monitor = controller.workspaceManager.monitors.first,
+              let workspaceId = controller.workspaceManager.activeWorkspaceOrFirst(on: monitor.id)?.id
+        else {
+            Issue.record("Missing workspace for reconfirm-viewport test")
+            return
+        }
+
+        controller.enableNiriLayout()
+        controller.updateNiriConfig(balancedColumnCount: 1)
+        await controller.layoutRefreshController.waitForRefreshWorkForTests()
+        controller.syncMonitorsToNiriEngine()
+        guard let engine = controller.niriEngine else {
+            Issue.record("Missing Niri engine")
+            return
+        }
+
+        let appPid: pid_t = 9_773
+        let focusedToken = controller.workspaceManager.addWindow(
+            AXWindowRef(element: AXUIElementCreateSystemWide(), windowId: 9_774),
+            pid: appPid,
+            windowId: 9_774,
+            to: workspaceId
+        )
+        let otherToken = controller.workspaceManager.addWindow(
+            AXWindowRef(element: AXUIElementCreateSystemWide(), windowId: 9_775),
+            pid: appPid,
+            windowId: 9_775,
+            to: workspaceId
+        )
+        guard let focusedEntry = controller.workspaceManager.entry(for: focusedToken),
+              let engine = controller.niriEngine
+        else {
+            Issue.record("Missing entry or engine for reconfirm-viewport test")
+            return
+        }
+
+        let focusedNode = engine.addWindow(token: focusedToken, to: workspaceId, afterSelection: nil, focusedToken: focusedToken)
+        _ = engine.addWindow(token: otherToken, to: workspaceId, afterSelection: focusedNode.id, focusedToken: focusedToken)
+        for column in engine.columns(in: workspaceId) {
+            column.cachedWidth = 900
+            column.cachedHeight = 800
+        }
+
+        _ = controller.workspaceManager.setManagedFocus(
+            focusedToken,
+            in: workspaceId,
+            onMonitor: monitor.id
+        )
+
+        // Scroll the viewport so the focused window (column 0) is parked offscreen.
+        let parkedOffset = Double(engine.columns(in: workspaceId)[0].cachedWidth + 16)
+        controller.workspaceManager.withNiriViewportState(for: workspaceId) { state in
+            state.selectedNodeId = engine.findNode(for: otherToken)?.id
+            state.activeColumnIndex = 1
+            state.viewOffsetPixels = .static(-parkedOffset)
+        }
+
+        controller.axEventHandler.handleManagedAppActivation(
+            entry: focusedEntry,
+            isWorkspaceActive: true,
+            appFullscreen: false,
+            source: .focusedWindowChanged
+        )
+
+        let updatedState = controller.workspaceManager.niriViewportState(for: workspaceId)
+        // Re-confirmation of an already-confirmed token via focusedWindowChanged
+        // must not scroll the viewport back to the parked column.
+        #expect(abs(updatedState.viewOffsetPixels.target() - (-parkedOffset)) < 0.5)
+        #expect(controller.workspaceManager.confirmedManagedFocusToken == focusedToken)
+        #expect(updatedState.selectedNodeId == focusedNode.id)
     }
 
     @Test @MainActor func workspaceActivationForPendingManagedRequestDoesNotStartNativeAppSwitchLease() {
@@ -6705,7 +6932,7 @@ private func waitUntilAXEventTest(
     }
 
     @Test @MainActor
-    func createdWindowUsesFocusedMonitorBeforeStaleInteractionWhenNativeSpaceAndFrameAreUnavailable() async {
+    func createdWindowUsesInteractionMonitorBeforeStaleFocusedMonitorWhenNativeSpaceAndFrameAreUnavailable() async {
         await withAXFrameProviderIsolationForTests {
             let bundleId = "com.example.focused-monitor-placement"
             let controller = makeAXEventTestController(
@@ -6777,7 +7004,7 @@ private func waitUntilAXEventTest(
             }
 
             #expect(controller.workspaceManager.entry(forPid: pid, windowId: Int(createdWindowId))?
-                .workspaceId == secondaryWorkspaceId)
+                .workspaceId == primaryWorkspaceId)
         }
     }
 
@@ -6873,7 +7100,7 @@ private func waitUntilAXEventTest(
     }
 
     @Test @MainActor
-    func createdWindowUsesFocusedWorkspaceBeforePrimaryNativeSpaceAndFrame() async {
+    func createdWindowUsesPrimaryFrameAndInteractionBeforeStaleFocusedWorkspace() async {
         let bundleId = "com.example.focus-before-native"
         let controller = makeAXEventTestController(
             trackedBundleId: bundleId,
@@ -6953,11 +7180,11 @@ private func waitUntilAXEventTest(
         }
 
         #expect(controller.workspaceManager.entry(forPid: pid, windowId: Int(createdWindowId))?
-            .workspaceId == secondaryWorkspaceId)
+            .workspaceId == primaryWorkspaceId)
     }
 
     @Test @MainActor
-    func focusedSecondaryCreateAppliesTiledFrameOnSecondaryMonitor() async {
+    func focusedSecondaryCreateAppliesTiledFrameOnInteractionMonitor() async {
         await withAXFrameProviderIsolationForTests {
             let bundleId = "com.example.secondary-create-frame"
             let controller = makeAXEventTestController(
@@ -7073,9 +7300,9 @@ private func waitUntilAXEventTest(
                 return
             }
 
-            #expect(entry.workspaceId == secondaryWorkspaceId)
+            #expect(entry.workspaceId == primaryWorkspaceId)
             #expect(controller.workspaceManager.activeWorkspace(on: primaryMonitor.id)?.id == primaryWorkspaceId)
-            #expect(secondaryMonitor.visibleFrame.contains(appliedFrame.center))
+            #expect(primaryMonitor.visibleFrame.contains(appliedFrame.center))
         }
     }
 
@@ -9780,7 +10007,7 @@ private func waitUntilAXEventTest(
         await controller.axEventHandler.drainDeferredCreatedWindows()
 
         let trace = createFocusTraceEvents(on: controller)
-        #expect(controller.workspaceManager.entry(for: admittedToken)?.workspaceId == focusedWorkspaceId)
+        #expect(controller.workspaceManager.entry(for: admittedToken)?.workspaceId == laterWorkspaceId)
         #expect(controller.workspaceManager.confirmedManagedFocusToken == admittedToken)
         #expect(controller.axEventHandler.pendingCreatePlacementContext(for: Int(admittedWindowId)) == nil)
         #expect(trace.contains { event in
@@ -9793,14 +10020,207 @@ private func waitUntilAXEventTest(
                 contextFocusedMonitorId,
                 nativeSpaceMonitorId,
                 _,
+                _,
+                _,
+                _,
                 _
             ) = event.kind {
                 return token == admittedToken &&
-                    workspaceId == focusedWorkspaceId &&
+                    workspaceId == laterWorkspaceId &&
                     pendingWorkspaceId == nil &&
                     contextFocusedWorkspaceId == focusedWorkspaceId &&
                     contextFocusedMonitorId == monitor.id &&
                     nativeSpaceMonitorId == monitor.id
+            }
+            return false
+        })
+    }
+
+    @Test @MainActor func focusedUntrackedStandardWindowAdmissionSynthesizesCreatePlacementContextWhenCGSCreateHasNotArrived() async {
+        let controller = makeAXEventTestController()
+        guard let monitor = controller.monitorForInteraction(),
+              let focusedWorkspaceId = controller.workspaceManager.workspaceId(for: "1", createIfMissing: false),
+              let activeWorkspaceId = controller.workspaceManager.workspaceId(for: "2", createIfMissing: false)
+        else {
+            Issue.record("Missing workspace fixture")
+            return
+        }
+
+        let focusedToken = controller.workspaceManager.addWindow(
+            AXWindowRef(element: AXUIElementCreateSystemWide(), windowId: 9_181),
+            pid: 9_181,
+            windowId: 9_181,
+            to: focusedWorkspaceId
+        )
+        let admittedPid: pid_t = 9_182
+        let admittedWindowId = 9_183
+        let admittedToken = WindowToken(pid: admittedPid, windowId: admittedWindowId)
+        let admittedInfo = makeAXEventWindowInfo(
+            id: UInt32(admittedWindowId),
+            pid: admittedPid,
+            title: "Focused admission before CGS create",
+            frame: CGRect(x: 120, y: 120, width: 900, height: 640)
+        )
+
+        controller.hasStartedServices = true
+        _ = controller.workspaceManager.setManagedFocus(
+            focusedToken,
+            in: focusedWorkspaceId,
+            onMonitor: monitor.id
+        )
+        #expect(controller.workspaceManager.setActiveWorkspace(activeWorkspaceId, on: monitor.id))
+        #expect(controller.interactionWorkspace()?.id == activeWorkspaceId)
+        #expect(controller.axEventHandler.pendingCreatePlacementContext(for: admittedWindowId) == nil)
+
+        controller.axEventHandler.windowInfoProvider = { windowId in
+            windowId == UInt32(admittedWindowId) ? admittedInfo : nil
+        }
+        controller.axEventHandler.focusedWindowRefProvider = { pid in
+            guard pid == admittedPid else { return nil }
+            return AXWindowRef(element: AXUIElementCreateSystemWide(), windowId: admittedWindowId)
+        }
+        controller.axEventHandler.windowFactsProvider = { axRef, _ in
+            guard axRef.windowId == admittedWindowId else {
+                return makeAXEventWindowRuleFacts()
+            }
+            return makeAXEventWindowRuleFacts(
+                bundleId: "com.example.activation-placement-synthesized",
+                title: "Focused admission before CGS create",
+                windowServer: admittedInfo
+            )
+        }
+        controller.axEventHandler.isFullscreenProvider = { _ in false }
+        defer {
+            controller.axEventHandler.resetDebugStateForTests()
+            controller.layoutRefreshController.resetDebugState()
+        }
+
+        controller.axEventHandler.handleAppActivation(
+            pid: admittedPid,
+            source: .workspaceDidActivateApplication
+        )
+        await controller.layoutRefreshController.waitForRefreshWorkForTests()
+
+        let trace = createFocusTraceEvents(on: controller)
+        #expect(controller.workspaceManager.entry(for: admittedToken)?.workspaceId == activeWorkspaceId)
+        #expect(controller.workspaceManager.confirmedManagedFocusToken == admittedToken)
+        #expect(controller.axEventHandler.pendingCreatePlacementContext(for: admittedWindowId) == nil)
+        #expect(trace.contains { event in
+            if case let .createPlacementResolved(
+                token,
+                workspaceId,
+                pendingWorkspaceId,
+                _,
+                contextFocusedWorkspaceId,
+                contextFocusedMonitorId,
+                nativeSpaceMonitorId,
+                _,
+                contextInteractionMonitorId,
+                _,
+                _,
+                _
+            ) = event.kind {
+                return token == admittedToken &&
+                    workspaceId == activeWorkspaceId &&
+                    pendingWorkspaceId == nil &&
+                    contextFocusedWorkspaceId == focusedWorkspaceId &&
+                    contextFocusedMonitorId == monitor.id &&
+                    nativeSpaceMonitorId == nil &&
+                    contextInteractionMonitorId == monitor.id
+            }
+            return false
+        })
+    }
+
+    @Test @MainActor func focusedUntrackedStandardWindowAdmissionUsesRecentSamePidWorkspaceWhenFocusWasCleared() async {
+        let controller = makeAXEventTestController()
+        guard let monitor = controller.monitorForInteraction(),
+              let bouncedWorkspaceId = controller.workspaceManager.workspaceId(for: "1", createIfMissing: false),
+              let recentWorkspaceId = controller.workspaceManager.workspaceId(for: "2", createIfMissing: false)
+        else {
+            Issue.record("Missing recent same-pid workspace fixture")
+            return
+        }
+
+        let appPid: pid_t = 9_184
+        let oldToken = controller.workspaceManager.addWindow(
+            AXWindowRef(element: AXUIElementCreateSystemWide(), windowId: 9_185),
+            pid: appPid,
+            windowId: 9_185,
+            to: recentWorkspaceId
+        )
+        let newWindowId = 9_186
+        let newToken = WindowToken(pid: appPid, windowId: newWindowId)
+        let newInfo = makeAXEventWindowInfo(
+            id: UInt32(newWindowId),
+            pid: appPid,
+            title: "Focused admission after app focus bounce",
+            frame: CGRect(x: 120, y: 120, width: 900, height: 640)
+        )
+
+        controller.hasStartedServices = true
+        #expect(controller.workspaceManager.setActiveWorkspace(recentWorkspaceId, on: monitor.id))
+        controller.axEventHandler.focusedWindowRefProvider = { pid in
+            guard pid == appPid else { return nil }
+            return AXWindowRef(element: AXUIElementCreateSystemWide(), windowId: oldToken.windowId)
+        }
+        controller.axEventHandler.isFullscreenProvider = { _ in false }
+        controller.axEventHandler.handleAppActivation(pid: appPid, source: .focusedWindowChanged)
+        #expect(controller.workspaceManager.confirmedManagedFocusToken == oldToken)
+
+        _ = controller.workspaceManager.removeWindow(pid: appPid, windowId: oldToken.windowId)
+        _ = controller.workspaceManager.enterNonManagedFocus(appFullscreen: false)
+        #expect(controller.workspaceManager.setActiveWorkspace(bouncedWorkspaceId, on: monitor.id))
+        #expect(controller.workspaceManager.confirmedManagedFocusToken == nil)
+        #expect(controller.workspaceManager.isNonManagedFocusActive)
+
+        controller.axEventHandler.windowInfoProvider = { windowId in
+            windowId == UInt32(newWindowId) ? newInfo : nil
+        }
+        controller.axEventHandler.focusedWindowRefProvider = { pid in
+            guard pid == appPid else { return nil }
+            return AXWindowRef(element: AXUIElementCreateSystemWide(), windowId: newWindowId)
+        }
+        controller.axEventHandler.windowFactsProvider = { axRef, _ in
+            guard axRef.windowId == newWindowId else {
+                return makeAXEventWindowRuleFacts()
+            }
+            return makeAXEventWindowRuleFacts(
+                bundleId: "com.example.activation-placement-recent-pid",
+                title: "Focused admission after app focus bounce",
+                windowServer: newInfo
+            )
+        }
+        defer {
+            controller.axEventHandler.resetDebugStateForTests()
+            controller.layoutRefreshController.resetDebugState()
+        }
+
+        controller.axEventHandler.handleAppActivation(pid: appPid, source: .focusedWindowChanged)
+        await controller.layoutRefreshController.waitForRefreshWorkForTests()
+
+        let trace = createFocusTraceEvents(on: controller)
+        #expect(controller.workspaceManager.entry(for: newToken)?.workspaceId == bouncedWorkspaceId)
+        #expect(controller.workspaceManager.confirmedManagedFocusToken == newToken)
+        #expect(trace.contains { event in
+            if case let .createPlacementResolved(
+                token,
+                workspaceId,
+                _,
+                _,
+                contextFocusedWorkspaceId,
+                contextFocusedMonitorId,
+                _,
+                _,
+                _,
+                _,
+                _,
+                _
+            ) = event.kind {
+                return token == newToken &&
+                    workspaceId == bouncedWorkspaceId &&
+                    contextFocusedWorkspaceId == recentWorkspaceId &&
+                    contextFocusedMonitorId == monitor.id
             }
             return false
         })

--- a/Tests/NehirTests/RefreshRoutingTests.swift
+++ b/Tests/NehirTests/RefreshRoutingTests.swift
@@ -170,6 +170,20 @@ private func waitForRefreshWork(on controller: WMController) async {
 }
 
 @MainActor
+private func waitUntilRefreshTest(
+    iterations: Int = 500,
+    condition: () -> Bool
+) async {
+    for _ in 0 ..< iterations where !condition() {
+        try? await Task.sleep(for: .milliseconds(1))
+    }
+
+    if !condition() {
+        Issue.record("Timed out waiting for refresh test condition")
+    }
+}
+
+@MainActor
 private func waitForSettledRefreshWork(on controller: WMController) async {
     await controller.layoutRefreshController.waitForSettledRefreshWorkForTests()
     await controller.waitForWorkspaceBarRefreshForTests()
@@ -657,6 +671,7 @@ private func syncNiriWorkspaceStatesForRefreshTests(
                 6_202: "Launch Restore B",
                 6_203: "Launch Restore C"
             ]
+            var expectedRestoredColumnSpecs: [ProportionalSize] = []
 
             do {
                 let initialSettings = SettingsStore(defaults: defaults)
@@ -724,6 +739,7 @@ private func syncNiriWorkspaceStatesForRefreshTests(
                     affectedWorkspaceIds: [workspaceId]
                 )
                 await waitForSettledRefreshWork(on: initialController)
+                expectedRestoredColumnSpecs = engine.columns(in: workspaceId).map(\.width)
 
                 let persistedEntries = initialController.workspaceManager.persistedWindowRestoreCatalogForTests()
                     .entries
@@ -787,10 +803,11 @@ private func syncNiriWorkspaceStatesForRefreshTests(
             ])
 
             let restoredColumns = engine.columns(in: restoredWorkspaceId)
-            #expect(restoredColumns.count == 2)
-            if restoredColumns.count == 2 {
-                #expect(abs(restoredColumns[0].cachedWidth - 480) < 0.5)
-                #expect(abs(restoredColumns[1].cachedWidth - 720) < 0.5)
+            #expect(restoredColumns.count == expectedRestoredColumnSpecs.count)
+            if restoredColumns.count == expectedRestoredColumnSpecs.count {
+                for (restoredColumn, expectedWidthSpec) in zip(restoredColumns, expectedRestoredColumnSpecs) {
+                    #expect(restoredColumn.width == expectedWidthSpec)
+                }
             }
         }
     }
@@ -1680,6 +1697,9 @@ private func syncNiriWorkspaceStatesForRefreshTests(
             pid: targetPid,
             source: .workspaceDidActivateApplication
         )
+        await waitUntilRefreshTest {
+            controller.workspaceManager.confirmedManagedFocusToken == targetToken
+        }
         await waitForRefreshWork(on: controller)
 
         #expect(controller.interactionWorkspace()?.id == workspaceTwo)
@@ -1744,6 +1764,9 @@ private func syncNiriWorkspaceStatesForRefreshTests(
             pid: targetPid,
             source: .workspaceDidActivateApplication
         )
+        await waitUntilRefreshTest {
+            controller.workspaceManager.confirmedManagedFocusToken == targetToken
+        }
         await waitForRefreshWork(on: controller)
 
         #expect(controller.interactionWorkspace()?.id == workspaceTwo)

--- a/Tests/NehirTests/ServiceLifecycleManagerTests.swift
+++ b/Tests/NehirTests/ServiceLifecycleManagerTests.swift
@@ -394,6 +394,7 @@ private func waitUntilServiceLifecycleTest(
             guard incomingPid == survivingPid else { return nil }
             return AXWindowRef(element: AXUIElementCreateSystemWide(), windowId: survivingToken.windowId)
         }
+        #expect(controller.workspaceManager.setActiveWorkspace(ws1, on: monitor.id))
 
         controller.axEventHandler.handleAppActivation(
             pid: survivingPid,

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -302,14 +302,15 @@ struct AXWindowRef: Hashable, @unchecked Sendable {
 From creation to destruction, a window passes through these stages:
 
 **Creation:**
-1. `CGSEventObserver` receives `.created(windowId, spaceId)` from SkyLight
-2. `AXEventHandler` queries window attributes via accessibility APIs (role, subrole, title, size, buttons)
+1. `CGSEventObserver` receives `.created(windowId, spaceId)` from SkyLight and captures a `WindowCreatePlacementContext` when possible (native-space monitor, active focus request, confirmed focus, interaction monitor, and source metadata).
+2. `AXEventHandler` queries window attributes via accessibility APIs (role, subrole, title, size, buttons). AX can occasionally report focused-window state before the SkyLight create event has drained; in that AX-first path, `AXEventHandler` synthesizes the same placement context before admission.
 3. `WindowRuleEngine.evaluate()` produces a `WindowDecision`:
    - `.managed` — tiled in the layout engine
    - `.floating` — tracked but positioned independently
    - `.unmanaged` — ignored entirely (e.g., system UI, panels)
-4. If tracked: `WindowModel` creates an `Entry`, layout engine inserts a node
-5. `LayoutRefreshController` schedules a refresh to compute and apply frames
+4. `WMController.resolveWorkspaceForNewWindow(...)` chooses the workspace from placement inputs. Current frame/interaction monitor evidence beats stale confirmed focus; recent same-pid workspace is only a fallback for focus-cleared AX-first admission.
+5. If tracked: `WindowModel` creates an `Entry`, layout engine inserts a node.
+6. `LayoutRefreshController` schedules a refresh to compute and apply frames.
 
 **Destruction:**
 1. `CGSEventObserver` receives `.destroyed(windowId, spaceId)`
@@ -318,7 +319,7 @@ From creation to destruction, a window passes through these stages:
 4. `LayoutRefreshController` schedules a `windowRemoval` refresh
 5. Focus recovery runs if the destroyed window was focused
 
-Nehir also guards the native activation race around close/collapse. macOS may focus another window from the same application before Nehir receives the destroy/miniaturize event; if that sibling window lives on an inactive workspace, Nehir suppresses the unrelated same-PID activation instead of following macOS to the other workspace. For unmanaged quick-terminal surfaces, same-PID fallback is suppressed even on the current workspace so closing/collapsing the quick terminal does not scroll to that app's managed column. Explicit Nehir focus requests still bypass this guard.
+Nehir also guards the native activation race around close/collapse. macOS may focus another window before Nehir receives the destroy, hide, or AX focus-loss signal for the disappearing surface. `AXEventHandler` arms a short `windowCloseFocusRecovery` lease from tracked destroys, untracked auxiliary same-pid destroys, focused-window loss, and the confirmed managed window becoming hidden. While the lease is active, unrelated native activations away from the recovery workspace are suppressed; duplicate confirmations of the already-focused token preserve the active viewport instead of revealing parked columns. If an inactive-workspace `workspaceDidActivateApplication` arrives just before the close signal, Nehir briefly defers and retries it so recovery can arm first; if no recovery appears, the retry is allowed as a real native activation. Explicit Nehir focus requests still bypass this guard.
 
 **Managed Replacement:**
 Some apps (browsers, terminals) destroy and recreate windows during internal operations. `AXEventHandler` detects these patterns via `ManagedReplacementMetadata` correlation — matching a destroy+create pair within a 150ms grace period to preserve the window's workspace assignment and position.
@@ -357,6 +358,8 @@ RefreshReason              → Route              → Scheduling
 ```
 
 **Coalescing:** If a refresh is already in progress, incoming requests are merged into a `pendingRefresh`. When the active refresh completes, the pending refresh fires. This prevents redundant layout calculations during bursts of events.
+
+**Activation boundary:** Relayout may rediscover or sync windows that already existed before the current refresh. Those windows are inserted into the layout state, but automatic focus activation is only emitted for a newly synced window when its workspace is active on its monitor and that monitor is the current interaction monitor. Refreshing an inactive workspace must never steal focus or scroll the user away.
 
 **DisplayLink Integration:** When animations are active (spring-based viewport scrolling, workspace switch effects), a `CADisplayLink` per display fires at the native refresh rate, driving per-frame layout recalculation.
 
@@ -594,7 +597,16 @@ The `FocusBridgeCoordinator` manages the request/confirmation part of this model
 
 **Focus serialization:** `focusWindow(_:performFocus:onDeferredFocus:)` serializes focus operations. If a focus request arrives while one is in-flight, it queues as the active focus request successor and fires after the current request completes or times out.
 
-**Close/collapse focus guard:** When the focused window closes, collapses, or otherwise disappears, the OS can immediately report a different same-app window as focused. For terminals and apps with quick-terminal surfaces, that replacement focus often points at another workspace. Nehir treats unrelated same-PID activation on an inactive workspace as a native fallback, not as user workspace navigation, and ignores it unless it matches an explicit `ManagedFocusRequest`. If the disappearing focus target is unmanaged (for example a quick terminal), same-PID fallback is also ignored on the current workspace to avoid scrolling to that app's managed column. This keeps the active workspace stable after closing a Niri-managed window, a managed floating window, or an unmanaged quick-terminal surface. The tradeoff is intentional: native same-app window switching should go through Nehir commands if it must be guaranteed.
+**Close/hide focus recovery:** When the focused window closes, hides, collapses, or otherwise loses AX focus, the OS can immediately report a different managed window as focused. For terminals and apps with dropdown/quick-terminal surfaces, that replacement focus often points at another workspace or parked column. Nehir treats this as a native fallback, not as user navigation, unless it matches an explicit `ManagedFocusRequest`.
+
+Recovery is deliberately short-lived and signal-driven:
+
+- tracked focused-window destroy;
+- untracked auxiliary same-pid destroy (common for dropdown helper AX elements);
+- focused-window loss from `AXFocusedWindowChanged window=nil`;
+- the confirmed managed window becoming hidden while its workspace is active.
+
+During the `windowCloseFocusRecovery` lease, unrelated activations off the recovery workspace are suppressed. Same-workspace activations for a different token are also suppressed when they are native fallbacks rather than requests. Because macOS can report the successor `workspaceDidActivateApplication` before the close signal, Nehir briefly defers ambiguous inactive-workspace native activations and retries them; if recovery armed in the meantime they are suppressed, otherwise the retry proceeds.
 
 ### 4.6 Input Handling
 
@@ -763,7 +775,7 @@ A lightweight `NSWindow` overlay that draws a rounded rectangle around the focus
 | **Overview** | `Core/Overview/OverviewController.swift` | Bird's-eye view of all workspaces with window thumbnails (ScreenCaptureKit), search, drag-to-reorganize |
 | **Command Palette** | `UI/CommandPalette/CommandPaletteController.swift` | Fuzzy-search interface for windows, commands, and menu items |
 | **Menu Anywhere** | `UI/MenuAnywhere/MenuAnywhereController.swift` | UI controller that uses the Core menu extraction layer to display any app's menu at cursor position |
-| **Workspace Bar** | `UI/WorkspaceBar/WorkspaceBarManager.swift` | Visual workspace indicators with window icons per workspace |
+| **Workspace Bar** | `UI/WorkspaceBar/WorkspaceBarManager.swift` | Visual workspace indicators with window icons per workspace. Clicks route by `WorkspaceDescriptor.ID` rather than display label so UI labels can change without changing activation identity. |
 | **Scratchpad** | `Core/Workspace/WorkspaceManager.swift` | Tracks the transient scratchpad window via `scratchpadToken()`. Show/hide and focus recovery are coordinated by `WMController`. |
 | **Status Bar** | `UI/StatusBar/StatusBarController.swift` | Menu bar icon with settings access and workspace summary |
 

--- a/docs/plans/completed/20260615-new-window-placement-investigation.md
+++ b/docs/plans/completed/20260615-new-window-placement-investigation.md
@@ -15,51 +15,88 @@ All file references should be re-verified before implementing; line numbers drif
 
 ## TL;DR
 
-> **Updated after step 1 landed** (2026-06-15, second capture set). The new
-> `## Niri create focus trace` section wrote `create_placement_resolved` to
-> the dump and **refuted both original hypotheses**. See
-> [Step 1 confirmed — root cause revised](#step-1-confirmed--root-cause-revised-2026-06-15).
+> **Latest update (2026-06-15, 21:02 capture):** direct interaction-monitor
+> write tracing refutes the nil-writer theory. The `interaction_monitor=nil`
+> fields in `create_placement_resolved` are best explained by **missing create
+> placement context**, because AX focus/activation can admit a new window before
+> the CGS `.created` event runs `captureCreatePlacementContext`.
 
-- **Root cause (H4, confirmed by tracing):** for every new Ghostty window
-  captured with the new tracing, **all** snapshotted placement inputs are
-  `nil` (`pending_workspace`, `pending_monitor`, `focused_workspace`,
-  `focused_monitor`, `native_monitor`, `interaction_monitor`; only
-  `frame_monitor` is occasionally non-nil). With the snapshot empty,
-  `createPlacementTarget` falls straight through every priority branch to its
-  final fallback, `fallbackWorkspaceId` (`WMController.swift:1271`), which is
-  the **live** `interactionWorkspace()?.id` (`WMController.swift:2953`).
-  `interactionWorkspace()` → `monitorForInteraction()` (`WMController.swift:922`)
-  returns `monitors.first` — i.e. the **main** display, because
-  `Monitor.current()` is built from `NSScreen.screens` whose index 0 is the
-  main screen (`Monitor.swift:19`) — whenever `interactionMonitorId` **and**
-  `confirmedManagedFocusToken` are both nil. That is exactly the transient
-  state left behind by the app-switch / non-managed-focus churn. So a
-  brand-new window is placed on the **main monitor regardless of where the
-  user actually is.**
-- `monitorForInteraction()` consults `interactionMonitorId`, then the focused
-  token's monitor, then `monitors.first` — it **never** consults
-  `previousInteractionMonitorId` (`WorkspaceManager.swift:166`), which exists
-  precisely to remember the monitor across such a transient clear. That gap is
-  the bug.
-- The earlier reasoning (H1 favored) was a best-effort read of a dump that
-  lacked `create_placement_resolved`; the `native_app_switch` lease observed in
-  the first capture was a *consequence* of where focus ended up, not the
-  *cause* of placement.
-- **⚠️ Fix direction revised again (third capture):** the obvious fix — make
-  `monitorForInteraction()` prefer `previousInteractionMonitorId` — is **on
-  hold pending Q4.** A third capture showed `previousInteractionMonitorId=nil`
-  throughout a run where the nil definitely fired, which is inconsistent with
-  the nil flowing through `updateInteractionMonitor` (the one path that
-  populates `prev`). If the nil enters through a reconcile write site that
-  doesn't touch `prev`, that fix is a no-op. Pre-apply tracing was added to
-  answer Q4; see
-  [Third capture](#third-capture-2026-06-15-1833-utc--the-nil-is-transient-prevnil-throughout)
-  and [Fix direction (revised)](#fix-direction-revised-after-step-1).
+- The original hypotheses are still refuted: `pending_workspace=nil` /
+  `pending_monitor=nil` rules out pending focus, and `native_monitor=nil` rules
+  out native Space placement for the problematic windows.
+- Earlier captures showed every context-derived placement input nil. The latest
+  capture adds the decisive ordering: `create_placement_resolved …` appears
+  **before** `create_seen window=…` for Ghostty windows `6160`, `6164`, and
+  `6166`. That means the placement can run through
+  `admitFocusedWindowBeforeNonManagedFallback(... createPlacementContext:
+  createPlacementContextsByWindowId[windowId])` before the create context exists.
+- `## Interaction monitor writes` contains only `interaction=ID(displayId: 1)`
+  writes from `applyReconciledFocusSession`, never a write to nil. Therefore a
+  `previousInteractionMonitorId` fallback is not supported by the current
+  evidence and should not be shipped blindly.
+- Current fix direction: make AX-first admission synthesize/capture a
+  `WindowCreatePlacementContext` before calling `prepareCreateCandidate`, or
+  otherwise ensure placement uses create-time focus/interaction inputs even when
+  AX focus beats CGS create.
 
-The sections below this point are the **original step-2 investigation**,
-preserved for context. The section above and the
-[Step 1 confirmed](#step-1-confirmed--root-cause-revised-2026-06-15) section
-supersede the H1/H2/H3 hypotheses.
+The sections below preserve the full investigation history. The newest section,
+[Direct write tracing result](#direct-write-tracing-result-2026-06-15-2102-utc--q4-revised-again),
+supersedes the earlier nil-writer / `previousInteractionMonitorId` fix direction.
+
+## Resolution architecture (2026-06-16)
+
+The final placement fix is intentionally source-ordered and monitor-aware:
+
+1. **AX-first admissions synthesize placement context.** If an AX focus event
+   admits a standard window before the CGS create event has populated
+   `createPlacementContextsByWindowId`, `AXEventHandler` now constructs the same
+   `WindowCreatePlacementContext` on the AX path. The trace fields
+   `context_source`, `focused_workspace_source`, and `recent_pid_workspace`
+   make that decision visible.
+2. **Recent same-pid workspace is a fallback, not a global truth.** It helps when
+   focus was cleared before the AX-first admission, but it must not override a
+   current active workspace/monitor signal.
+3. **Frame/interaction monitor beats stale confirmed focus.**
+   `WMController.createPlacementTarget` now prefers the active workspace on the
+   frame/interaction monitor when confirmed focus points at another workspace or
+   monitor. This fixed the case where a quick terminal or old app focus kept
+   confirmed focus anchored to the previous workspace while the user had already
+   switched.
+4. **Relayout does not steal focus from inactive workspaces.** `NiriLayoutHandler`
+   only emits automatic activation for newly synced windows when the workspace is
+   active on its monitor and matches the current interaction monitor. Rediscovering
+   an old window during layout refresh can no longer teleport focus.
+5. **Workspace bar navigation uses identity.** Workspace-bar clicks now pass the
+   `WorkspaceDescriptor.ID` of the clicked item instead of re-resolving the
+   display label. This avoids ambiguous or stale label resolution when activating
+   later workspaces.
+
+### Validation evidence
+
+A later live validation run confirmed the user-visible behavior: new windows
+were created on the expected workspace after switching workspaces with the quick
+terminal open. Representative resolved placements in that run showed the target
+workspace following the active workspace/monitor rather than stale focus:
+
+```text
+create_placement_resolved token=WindowToken(pid: 897, windowId: 7619)
+  workspace=9B7FB1EB-9116-453B-8463-C09FC85F71D1
+  focused_workspace=9B7FB1EB-9116-453B-8463-C09FC85F71D1
+  frame_monitor=Optional(ID(displayId: 1)) interaction_monitor=Optional(ID(displayId: 1))
+  context_source=ax_focused_admission_synthesized
+  focused_workspace_source=confirmed_focus
+
+create_placement_resolved token=WindowToken(pid: 33418, windowId: 7650)
+  workspace=7FBFE458-6A8C-47E2-B88A-638130428B53
+  focused_workspace=E1041C23-1AA5-4681-8BD5-99B0F3086180
+  frame_monitor=Optional(ID(displayId: 1)) interaction_monitor=Optional(ID(displayId: 1))
+  context_source=ax_focused_admission_synthesized
+  focused_workspace_source=recent_pid
+```
+
+The second event is the important architecture check: the resolved workspace
+(`7FBFE...`) intentionally differs from the stale focused/recent workspace
+(`E104...`) because the active interaction/frame placement target took priority.
 
 ---
 
@@ -276,6 +313,81 @@ A fresh repro with this build will show the exact reconcile record that received
 nil-writer fired in the gap immediately before it. That brackets Q4 to a single
 event and identifies whether the nil flows through a `prev`-preserving path or
 not — deciding the fix shape.
+
+### Direct write tracing result (2026-06-15, 21:02 UTC) — Q4 revised again
+
+A later capture added `## Interaction monitor writes` and `## AX notification
+trace`. It changes the interpretation of the `interaction_monitor=nil` lines.
+The capture ran from `2026-06-15T21:02:29Z` to `21:02:44Z` on one built-in
+display.
+
+**Direct interaction-monitor writes never set the value to nil.** The write log
+contains only no-op/refresh writes from `applyReconciledFocusSession`, all with
+`interaction=ID(displayId: 1)` and `previous=nil`, for example:
+
+```
+2026-06-15T21:02:38Z interaction=ID(displayId: 1) reason=applyReconciledFocusSession
+2026-06-15T21:02:38Z previous=nil reason=applyReconciledFocusSession
+2026-06-15T21:02:39Z interaction=ID(displayId: 1) reason=applyReconciledFocusSession
+2026-06-15T21:02:39Z previous=nil reason=applyReconciledFocusSession
+2026-06-15T21:02:40Z interaction=ID(displayId: 1) reason=applyReconciledFocusSession
+2026-06-15T21:02:40Z previous=nil reason=applyReconciledFocusSession
+```
+
+There is no `interaction=ID(displayId: 1)→nil`, no `interaction=nil`, and no
+`previous=ID(displayId: 1)` record in the whole capture. So Q4's answer is:
+**the observed `interaction_monitor=nil` is not explained by a runtime write that
+clears `sessionState.interactionMonitorId` during the capture.** The
+`previousInteractionMonitorId` fallback would not help this capture.
+
+**The stronger signal is event ordering: placement resolves before
+`create_seen`.** For each Ghostty window below, `create_placement_resolved` is
+recorded before `create_seen window=…`:
+
+```
+activation_source_observed pid=897 source=workspaceDidActivateApplication
+create_placement_resolved token=WindowToken(pid: 897, windowId: 6160)
+  workspace=DBD47BBA-5B7F-4013-B64C-408E95674A06
+  pending_workspace=nil pending_monitor=nil
+  focused_workspace=nil focused_monitor=nil
+  native_monitor=nil frame_monitor=Optional(ID(displayId: 1)) interaction_monitor=nil
+candidate_tracked token=WindowToken(pid: 897, windowId: 6160) workspace=DBD47BBA…
+focus_confirmed token=WindowToken(pid: 897, windowId: 6160) workspace=DBD47BBA…
+create_seen window=6160
+
+activation_source_observed pid=897 source=focusedWindowChanged
+create_placement_resolved token=WindowToken(pid: 897, windowId: 6164)
+  workspace=F339DEEE-E6DE-4BE6-A474-9E44C4FD2466
+  pending_workspace=nil pending_monitor=nil
+  focused_workspace=nil focused_monitor=nil
+  native_monitor=nil frame_monitor=Optional(ID(displayId: 1)) interaction_monitor=nil
+candidate_tracked token=WindowToken(pid: 897, windowId: 6164) workspace=F339DEEE…
+create_seen window=6164
+
+activation_source_observed pid=897 source=focusedWindowChanged
+create_placement_resolved token=WindowToken(pid: 897, windowId: 6166)
+  workspace=F339DEEE-E6DE-4BE6-A474-9E44C4FD2466
+  pending_workspace=nil pending_monitor=nil
+  focused_workspace=nil focused_monitor=nil
+  native_monitor=nil frame_monitor=nil interaction_monitor=nil
+candidate_tracked token=WindowToken(pid: 897, windowId: 6166) workspace=F339DEEE…
+create_seen window=6166
+```
+
+This points to a different root cause than a nil-writer: the window can be
+admitted through the AX focus / activation path before the CGS `.created` event
+runs `captureCreatePlacementContext`. The relevant code path is
+`admitFocusedWindowBeforeNonManagedFallback(... createPlacementContext:
+createPlacementContextsByWindowId[windowId])`; when the CGS create has not yet
+arrived, that dictionary lookup is nil, so all context-derived fields in
+`create_placement_resolved` are nil. Only frame/current-live placement remains.
+
+**Current fix direction after this capture:** stop treating
+`interaction_monitor=nil` as proof that `interactionMonitorId` was cleared.
+Instead, make AX-first admission synthesize/capture a placement context before
+calling `prepareCreateCandidate`, or otherwise ensure create placement uses a
+create-time context even when AX focus beats CGS create. A
+`previousInteractionMonitorId` fallback is not supported by this evidence.
 
 ---
 
@@ -662,3 +774,143 @@ test, `:9703`) are the right neighbourhood to extend.
    that fix until Q4 is answered.** The pre-apply tracing added on 2026-06-15
    (see [Third capture](#third-capture-2026-06-15-1833-utc--the-nil-is-transient-prevnil-throughout))
    is the instrument to answer it.
+
+---
+
+## Latest regression evidence — recent same-pid fallback can be stale
+
+A later repro with the new placement-source fields showed the AX-first synthesis
+path working, but choosing the wrong fallback source for a quick-terminal spawn.
+The decisive event was self-contained in the runtime dump:
+
+```text
+create_placement_resolved token=WindowToken(pid: 897, windowId: 6708)
+workspace=741420DA-78FC-4051-9F6A-AD13033E062C
+pending_workspace=nil pending_monitor=nil
+focused_workspace=741420DA-78FC-4051-9F6A-AD13033E062C
+focused_monitor=Optional(ID(displayId: 1))
+native_monitor=nil frame_monitor=nil
+interaction_monitor=Optional(ID(displayId: 1))
+context_source=ax_focused_admission_synthesized
+focused_workspace_source=recent_pid
+recent_pid_workspace=741420DA-78FC-4051-9F6A-AD13033E062C
+```
+
+That means the synthesized context no longer lost all placement data; instead it
+selected workspace 1 specifically because `recentManagedWorkspaceByPid[897]`
+pointed at an older same-pid Ghostty window. This is a valid fallback only when
+there is no fresher app-event workspace. It is wrong for dropdown/quick-terminal
+flows where the app emits `AXFocusedWindowChanged window=nil` or an auxiliary
+`AXUIElementDestroyed window=101` on the currently active workspace before the
+real standard window is admitted.
+
+The follow-up fix keeps the recent-PID fallback, but makes it second-choice:
+
+1. Record a short-lived `recent_app_event` workspace for same-app focused-window
+   loss / auxiliary destroy events, anchored to the current app-event workspace.
+2. For AX-first standard-window admission, prefer `recent_app_event` over
+   `recent_pid`; retain `recent_pid` only as the fallback for cases where focus
+   was cleared without a fresh app event.
+3. Preserve the trace fields so the next capture can distinguish:
+   `focused_workspace_source=recent_app_event` vs `recent_pid` vs
+   `confirmed_focus`.
+
+Regression added:
+
+- `focusedUntrackedStandardWindowAdmissionPrefersRecentAppEventWorkspaceOverStaleSamePidWorkspace`
+
+
+### Still open: wrong column / stacking behavior
+
+The workspace fix deliberately does **not** change Niri insertion semantics. The
+current engine path is:
+
+```text
+NiriLayoutHandler.syncAndInsert
+→ NiriLayoutEngine.syncWindows
+→ NiriLayoutEngine.addWindow
+```
+
+`addWindow` always creates a new column for a new token and inserts it after, in
+priority order, an existing focused-token column, the selected-node column, or
+the last column. Because the latest repro also complained that terminal windows
+were inserted as new columns instead of the expected existing terminal column,
+a new diagnostics-only `## Niri insertion trace` section was added. Each line
+records:
+
+```text
+workspace=<uuid> token=<new token> beforeColumns=<n>
+selectedNodeBefore=<node> selectedTokenBefore=<token-or-nil> selectedColumnBefore=<idx-or-nil>
+focusedTokenBefore=<token-or-nil> focusedColumnBefore=<idx-or-nil>
+reference=<focused_token|selected_node|last_column|empty_workspace>
+referenceColumn=<idx-or-nil> landedColumn=<idx-or-nil> landedColumnTokens=<tokens>
+```
+
+Use the next capture to decide whether the wrong-column symptom is merely the
+current “new token ⇒ new column” policy, or whether the selected/focused
+reference is stale at insertion time.
+
+---
+
+## Revert note (2026-06-16) — recent-app-event fallback did not help, lease change regressed
+
+The `recent_app_event` workspace fallback and the `windowCloseFocusRecoveryDuration`
+bump to 4.0 s were reverted. Two fresh captures showed why:
+
+1. **Placement still wrong.** A capture with the active workspace = workspace 3
+   (empty, no managed windows) and all existing Ghostty windows on workspace 1
+   still placed the new Ghostty window on workspace 1. The decisive line:
+
+   ```text
+   create_placement_resolved token=WindowToken(pid: 897, windowId: 6906)
+     workspace=5A1CF56C-… focused_workspace=5A1CF56C-…
+     context_source=ax_focused_admission_synthesized
+     focused_workspace_source=recent_pid
+     recent_pid_workspace=5A1CF56C-…
+   ```
+
+   `recent_app_event` was never populated, and even if it had been, by the time
+   the new window was admitted, `focus_confirmed token=897:6712
+   workspace=5A1CF56C source=focusedWindowChanged` had already activated
+   workspace 1. The placement faithfully followed the (now wrong) active focus.
+
+2. **Scroll became common.** The 4.0 s lease plus arming on every
+   `AXFocusedWindowChanged window=nil` made the viewport reveal fire routinely.
+   The smoking gun is the focus-confirm reveal on the parked column:
+
+   ```text
+   reason=ax_focus_confirm_reveal_result token=WindowToken(pid: 897, windowId: 6712)
+     columnIndex=3 visibility=parked(maximum) didReveal=true
+     currentViewStart=0.0 targetViewStart=2932.6 animating=true
+   ```
+
+   Hiding the quick terminal lets macOS re-focus the existing Ghostty managed
+   window (`897:6712`), which is parked offscreen in column 3; the focus-confirm
+   reveal then scrolls the viewport to it. The longer/broader lease made that
+   re-focus reach the reveal path far more often.
+
+### True root cause (both symptoms share it)
+
+The quick terminal shares `pid 897` with the existing managed Ghostty windows on
+workspace 1. When the quick terminal shows/hides, macOS fires
+`AXFocusedWindowChanged pid=897`, and Nehir resolves it to the existing managed
+window `897:6712` on workspace 1 and confirms focus there — pulling the user to
+workspace 1 and scrolling to its column.
+
+The suppression guard
+`shouldSuppressSameAppInactiveWorkspaceActivationBeforeCloseRecovery`
+(`AXEventHandler.swift`) fails in this topology because the user is on an
+**empty** active workspace (workspace 3) with `confirmedManagedFocusToken == nil`,
+so its `guard let focusedToken = …` falls through and returns `false`. The
+guard was written assuming the user always has a confirmed managed focus on the
+active workspace to anchor against; that assumption breaks for empty
+workspaces.
+
+### Next direction (not yet implemented)
+
+- Suppress same-pid inactive-workspace activation anchored on the **active
+  workspace** (not the confirmed focus token) when the app event is
+  `focusedWindowChanged` and the resolved window lives on an inactive workspace.
+- Consider not revealing (preserving the viewport) for a focus-confirm that
+  arrives while a window-close/quick-terminal recovery context is active on the
+  same workspace.

--- a/docs/plans/completed/20260615-quick-terminal-close-switches-workspace.md
+++ b/docs/plans/completed/20260615-quick-terminal-close-switches-workspace.md
@@ -1,0 +1,502 @@
+# Quick-Terminal Close Switches Active Workspace — Discovery
+
+Reported issue: **closing the Ghostty "quick terminal" switches the active
+workspace to workspace 1, unexpectedly.** An existing fix in this fork is
+supposed to ignore macOS's same-app focus redirection on window close and keep
+the user on the same workspace with no viewport scrolling. That fix did not fire
+here. All evidence is inlined below; this document does not depend on any trace
+file surviving.
+
+All file references should be re-verified before implementing; line numbers drift.
+
+---
+
+## TL;DR
+
+- The existing "stay on workspace after close" guard is the
+  **`.windowCloseFocusRecovery`** focus-policy lease, begun in
+  `AXEventHandler.handleRemoved(token:)` (`AXEventHandler.swift:1163`–`1165`)
+  **only when** the removed window is genuinely destroyed **and** was the
+  confirmed focused window. It lasts 0.6 s (`windowCloseFocusRecoveryDuration`,
+  `:296`).
+- In the captured repro, the quick-terminal "close" produced **no window
+  removal at all**: the `LayoutRefreshController` `windowRemoval` counter is `8`
+  at both capture start and end, no `window_removed` reconcile event appears in
+  `## Tracing logs`, and
+  `lastAffectedWorkspaceIdsByReason[.windowDestroyed] = Set([])`. So
+  `handleRemoved` never ran, the lease was never begun, and the post-close
+  focus redirection was unsuppressed.
+- The unwanted switch is visible mid-capture: focus moved from a Ghostty window
+  on **workspace 2** (`189E7132`) back to Slack on **workspace 1**
+  (`5B8E9E2A`) via a `native_app_switch` /
+  `workspaceDidActivateApplication` lease.
+- **Root cause:** the recovery trigger is destroy-gated. A quick terminal that
+  **hides / orders-out** (the typical dropdown-terminal close behavior) is not a
+  destroy, so the suppression never arms. The fix should arm the recovery on
+  *focus leaving a managed window*, not only on destruction.
+- Secondary gap: even the in-capture switch was **cross-app** (Ghostty `pid 897`
+  → Slack `pid 84013`), but the same-app guard
+  (`shouldSuppressSameAppInactiveWorkspaceActivationBeforeCloseRecovery`,
+  `:1264`) only suppresses same-`pid` activations. So that particular jump would
+  not have been caught even with the lease active.
+
+---
+
+## Inlined trace findings (self-contained)
+
+> Source: runtime trace capture, nehir v0.5.0, build `vfb5ce3`,
+> startedAt `2026-06-15T19:52:40Z`, endedAt `2026-06-15T19:52:55Z`,
+> duration 15.108 s. Single monitor.
+
+### Topology & workspace mapping
+
+```
+ID(displayId: 1) isMain=true hasNotch=true frame=(0.0, 0.0, 2056.0, 1329.0)
+    visibleFrame=(0.0, 0.0, 2056.0, 1290.0) name=Built-in Retina Display
+```
+
+- **workspace 1** = `5B8E9E2A-CF45-4DDE-90DB-F0ECB6F01C14` — visible at start/end
+- **workspace 2** = `189E7132-DBC3-4D92-A6B2-A75ED79ACFE6` — a Ghostty window
+  lands here mid-capture
+
+Managed windows of interest (Ghostty is `pid 897`, Slack is `pid 84013`):
+
+| token | app | workspace | notes |
+|---|---|---|---|
+| `84013:1025` | slack | `5B8E9E2A` (ws1) | confirmed focus at START |
+| `897:5632` | ghostty | `5B8E9E2A` (ws1) | admitted mid-capture; focused at END |
+| `897:5637` | ghostty | `189E7132` (ws2) | admitted mid-capture; briefly focused on ws2 |
+
+### Proof that no window was destroyed during the capture
+
+`LayoutRefreshController` counters (cumulative since app start), start vs end:
+
+```
+START  windowRemoval=8   relayout=14  immediateRelayout=388
+END    windowRemoval=8   relayout=16  immediateRelayout=393
+```
+
+`windowRemoval` is unchanged (8 → 8). `lastAffectedWorkspaceIdsByReason` at END:
+
+```
+Nehir.RefreshReason.windowDestroyed: Set([])
+```
+
+And `## Tracing logs` contains **no** `window_removed` record. The only
+`window_admitted` records are creates. Conclusion: the quick-terminal "close"
+the user performed is **not** a destroy in nehir's model — it is a hide / order
+out / focus loss. This is the central fact the fix must account for.
+
+### The unwanted workspace switch (mid-capture)
+
+Selected `## Tracing logs` records, in order (all carry
+`interaction=ID(displayId: 1)/prev=nil`):
+
+```
+#36 19:52:51 window_admitted token=897:5637 workspace=189E7132 (ws2) mode=tiling
+#37 19:52:51 managed_focus_confirmed token=897:5637 workspace=189E7132 (ws2)
+            monitor=Optional(ID(displayId: 1)) plan=focused=897:5637,pending=nil
+#38 19:52:51 focus_lease_changed owner=native_app_switch
+            reason=workspaceDidActivateApplication plan=…lease=native_app_switch
+…
+#55 19:52:51 focus_lease_changed owner=nil  focus_lease=cleared
+#56 19:52:51 focus_lease_changed owner=native_app_switch
+            reason=workspaceDidActivateApplication
+#57 19:52:51 managed_focus_confirmed token=84013:1025 (slack)
+            workspace=5B8E9E2A (ws1) monitor=Optional(ID(displayId: 1))
+            plan=focused=84013:1025,pending=nil,lease=native_app_switch
+```
+
+`#57` is the switch: confirmed focus leaves the Ghostty window on **workspace 2**
+and lands on Slack on **workspace 1**, under a `native_app_switch` lease. The
+viewport trace confirms the active workspace went 1 → 2 → 1 (workspace-2
+viewport records appear at `19:52:51`; workspace-1 records reappear at
+`19:52:52` with Slack `84013:1025` as `confirmedFocus`). The
+`LayoutRefreshController` executed `workspaceTransition: 4` times during the
+capture.
+
+The `## Niri create focus trace` corroborates the churn: many
+`activation_source_observed pid=897 source=focusedWindowChanged` and
+`non_managed_fallback_entered pid=897` records around this window, plus
+`pending_focus_started request=… token=897:5637 workspace=189E7132` followed by
+focus bouncing back to Slack `84013:1025` on `5B8E9E2A`.
+
+### State at END
+
+```
+focused=WindowToken(pid: 897, windowId: 5632)   ← ghostty, workspace 1
+interaction-monitor=ID(displayId: 1)
+workspace 1 visible, columns=5, activeColumnIndex=3, currentViewStart=4250.8
+workspace 2 NOT visible, 1 column (897:5637)
+```
+
+The quick-terminal window `897:5632` is still managed at END (not destroyed) —
+consistent with the "close = hide" finding.
+
+### Fresh capture with raw AX notifications (2026-06-15, 21:02 UTC)
+
+A later single-monitor capture added raw AX notification tracing and direct
+interaction-monitor write tracing. It reproduces the same workspace-2 →
+workspace-1 jump with more precise evidence.
+
+Workspace mapping in this capture:
+
+- **workspace 1** = `DBD47BBA-5B7F-4013-B64C-408E95674A06`
+- **workspace 2** = `F339DEEE-E6DE-4BE6-A474-9E44C4FD2466`
+
+At `21:02:40`, Ghostty window `897:6166` is focused on workspace 2:
+
+```
+#50 21:02:40 window_admitted token=897:6166 workspace=F339DEEE (ws2) mode=tiling
+#51 21:02:40 managed_focus_confirmed token=897:6166 workspace=F339DEEE (ws2)
+#56 21:02:40 managed_focus_requested token=897:6166 workspace=F339DEEE (ws2)
+#57 21:02:40 managed_focus_confirmed token=897:6166 workspace=F339DEEE (ws2)
+```
+
+At `21:02:41`, the jump starts. macOS/Nehir observe an activation of the
+workspace-1 app Zed (`16714:4929`) under a native app-switch lease, then hide the
+workspace-2 Ghostty windows:
+
+```
+#66 21:02:41 focus_lease_changed owner=native_app_switch
+              reason=workspaceDidActivateApplication
+              plan=focused=897:6166,pending=nil,lease=native_app_switch
+#67 21:02:41 managed_focus_confirmed token=16714:4929
+              workspace=DBD47BBA (ws1) monitor=Optional(ID(displayId: 1))
+              plan=focused=16714:4929,pending=nil,lease=native_app_switch
+#68 21:02:41 hidden_state_changed token=16714:4929 workspace=DBD47BBA hidden=false
+#69 21:02:41 hidden_state_changed token=897:6160 workspace=DBD47BBA hidden=false
+#70 21:02:41 hidden_state_changed token=897:6164 workspace=F339DEEE hidden=true
+#71 21:02:41 hidden_state_changed token=897:6166 workspace=F339DEEE hidden=true
+```
+
+The viewport trace for the same instant confirms this is an actual activation of
+workspace 1, not just focus bookkeeping:
+
+```
+workspace=1 id=DBD47BBA reason=ax_focus_confirm_before_activate
+  token=WindowToken(pid: 16714, windowId: 4929)
+  preserveActiveViewport=false confirmedFocus=WindowToken(pid: 16714, windowId: 4929)
+workspace=1 id=DBD47BBA reason=ax_focus_confirm_after_activate
+  token=WindowToken(pid: 16714, windowId: 4929)
+  preserveActiveViewport=false confirmedFocus=WindowToken(pid: 16714, windowId: 4929)
+workspace=1 id=DBD47BBA reason=ax_focus_confirm_skip_relayout
+  token=WindowToken(pid: 16714, windowId: 4929) isWorkspaceActive=false
+```
+
+Raw AX notifications around the same period are:
+
+```
+21:02:38 ax=AXFocusedWindowChanged pid=897 window=nil
+21:02:39 ax=AXFocusedWindowChanged pid=897 window=nil
+21:02:40 ax=AXFocusedWindowChanged pid=897 window=nil
+21:02:41 ax=AXUIElementDestroyed pid=897 window=101
+21:02:43 ax=AXFocusedWindowChanged pid=897 window=nil
+```
+
+Important interpretation: the raw `AXUIElementDestroyed` is for `window=101`,
+not for the managed Ghostty windows in the trace (`6160`, `6164`, `6166`). The
+managed window table at END still contains all three Ghostty windows, with
+`6164`/`6166` on workspace 2 and hidden because the workspace is inactive. So
+the existing destroy-gated close recovery still does not apply to the managed
+quick-terminal window that was focused.
+
+This capture therefore strengthens H1: the visible "close" path is a focus-loss
+/ hide / app-activation sequence, not a tracked managed-window removal. The
+specific bad transition is `workspaceDidActivateApplication` confirming an
+unrelated workspace-1 managed window while the focused Ghostty window on
+workspace 2 is disappearing or losing AX focus.
+
+---
+
+## The existing fix, cited
+
+The "ignore macOS same-app focus selection on close / stay on workspace" guard
+is a focus-policy lease:
+
+- **Lease owner:** `FocusPolicyLease.windowCloseFocusRecovery`
+  (`FocusPolicyEngine.swift:5`).
+- **Begun:** `AXEventHandler.beginWindowCloseFocusRecovery(in:)`
+  (`AXEventHandler.swift:1210`), which sets a 0.6 s context
+  (`windowCloseFocusRecoveryDuration`, `:296`) and calls
+  `focusPolicyEngine.beginLease(owner: .windowCloseFocusRecovery, …)`.
+- **Gated on destruction + confirmed focus.** The only call site is
+  `handleRemoved(token:)` (`:1163`–`1165`):
+
+  ```swift
+  let shouldRecoverFocus = token == controller.workspaceManager.confirmedManagedFocusToken
+  if shouldRecoverFocus, let workspaceId = affectedWorkspaceId {
+      beginWindowCloseFocusRecovery(in: workspaceId)
+  }
+  ```
+
+  `handleRemoved(token:)` is reached only from the destroy pipeline
+  (`processPreparedDestroy` → `handleRemoved`, `AXEventHandler.swift:2655`;
+  and `handleRemoved(pid:winId:)` → `handleWindowDestroyed`, `:1146`).
+
+- **What the lease suppresses:**
+  - `shouldSuppressObservedActivationDuringWindowCloseRecovery` (`:1249`)
+    drops observed activations on a workspace other than the recovery
+    workspace.
+  - `shouldSuppressSameAppInactiveWorkspaceActivationBeforeCloseRecovery`
+    (`:1264`) drops same-`pid` activations onto an inactive workspace (this is
+    the "ignore macOS selecting another window of the same app" guard).
+  - The `if activeWindowCloseFocusRecoveryWorkspaceId() != nil` early-return
+    at `:1538` returns early for `unrelatedNoRequest` activations during the
+    lease.
+
+### Why it did not fire here
+
+1. **No destroy.** The recovery is begun exclusively from `handleRemoved`, i.e.
+   on real window destruction. This capture proves the quick-terminal close was
+   not a destroy (`windowRemoval` unchanged, no `window_removed` event). So the
+   lease was never armed and every suppression above was a no-op.
+2. **Cross-app jump is out of the same-app guard's scope.** Even if the lease
+   had been active, the observed switch (`#57`) is Ghostty (`897`) → Slack
+   (`84013`) — different `pid`. The same-app guard
+   (`shouldSuppressSameAppInactiveWorkspaceActivationBeforeCloseRecovery`,
+   `:1264`) keys on `currentTarget.pid == observedEntry.pid` /
+   `focusedToken.pid == observedEntry.pid`, so it would not have suppressed a
+   cross-app activation. The `:1538` early-return *would* have caught an
+   `unrelatedNoRequest` activation — but only while the lease is active, which
+   requires (1).
+3. **0.6 s is fragile.** `windowCloseFocusRecoveryDuration` (`:296`) is 600 ms.
+  Even for a genuine destroy, a focus redirection that arrives after 600 ms
+  (common when an app takes time to re-activate) escapes the guard.
+
+---
+
+## Hypotheses
+
+### H1 — quick-terminal close is a hide/order-out, not a destroy (favored)
+
+Ghostty's quick terminal toggles visibility rather than destroying its window.
+macOS therefore delivers a **focus-changed** event (focus leaves the terminal)
+rather than a destroy. Because the recovery lease is destroy-gated, it never
+arms, and macOS's chosen successor window (here Slack on workspace 1, or another
+same-app window) takes focus unimpeded.
+
+Consistent with: `windowRemoval` unchanged across the capture; `897:5632` still
+managed at END; the `native_app_switch` / `focusedWindowChanged` activation
+churn in `## Niri create focus trace`.
+
+### H2 — the recovery armed but expired before the redirection
+
+The lease lasts 0.6 s. If the close *were* a destroy but macOS redirected focus
+>600 ms later, the guard would have expired. Less likely than H1 here (no
+destroy evidence at all), but the 0.6 s window is independently fragile and
+worth addressing.
+
+### H3 — the quick terminal is classified as an unmanaged overlay
+
+The recent commit `d2827df` ("Implement focus-follows-mouse suppression for
+unmanaged overlay") suggests dropdown/overlay windows may be unmanaged. If the
+quick terminal is unmanaged, it never becomes `confirmedManagedFocusToken`, so
+`shouldRecoverFocus` (`token == confirmedManagedFocusToken`) is false even on
+destroy. Verify by checking the quick terminal's disposition
+(`WindowDecisionEvaluation.decision.disposition`) and whether it ever appears as
+`confirmedManagedFocusToken`. In this capture `897:5632` *is* managed
+(`mode=tiling`, admitted via `window_admitted`), so H3 is unlikely for this
+window — but the classification is worth confirming for the real close path.
+
+---
+
+## Reproduction steps (for a fresh capture)
+
+1. Single monitor. Workspace 1 with Slack (or any app) focused.
+2. Open a Ghostty quick terminal (toggle hotkey). Confirm it is admitted to a
+   workspace (watch `## Tracing logs` for `window_admitted token=897:…`).
+3. Switch to workspace 2 (so the active workspace is not workspace 1).
+4. Toggle the quick terminal closed. Start runtime trace capture just before.
+5. Stop capture. Check:
+   - Did `windowRemoval` increment? (Establishes destroy vs hide.)
+   - Is there a `focus_lease owner=.windowCloseFocusRecovery` /
+     `window_close_focus_recovery` in the reconcile trace? (Establishes whether
+     the recovery armed.)
+   - Which `managed_focus_confirmed` / `focus_lease_changed owner=native_app_switch`
+     record follows the close, and does its `workspace=` differ from the
+     pre-close active workspace?
+
+---
+
+## Fix direction
+
+### Primary (H1): arm recovery on focus loss, not only on destroy
+
+The trigger must cover "managed window lost focus / was ordered out without
+being destroyed". Options:
+
+- **A. Focus-out driven recovery.** When a managed window that is the
+  `confirmedManagedFocusToken` loses keyboard focus to a non-managed successor
+  (or is ordered out), begin a short `.windowCloseFocusRecovery`-style lease on
+  its workspace, mirroring `beginWindowCloseFocusRecovery` (`:1210`) but keyed
+  off the AX focus-out / `focusedWindowChanged` signal rather than
+  `handleRemoved`. This requires a reliable "focus left this managed window"
+  signal — the same `activation_source_observed pid=… source=focusedWindowChanged`
+  stream already visible in `## Niri create focus trace`.
+- **B. Broaden the existing suppression's scope.** Decouple
+  `shouldSuppressObservedActivationDuringWindowCloseRecovery` (`:1249`) and the
+  `:1538` early-return from destruction: also arm them when a managed window
+  transitions to hidden (`hidden_state_changed … phase=hidden`) while it was the
+  confirmed focus. This reuses the existing reconcile events and avoids a new
+  signal source.
+
+Prefer B first (reuses existing plumbing); fall back to A if the hide signal is
+unreliable.
+
+### Secondary: cover cross-app redirection
+
+Even with the lease armed via (A)/(B), the same-app guard
+(`shouldSuppressSameAppInactiveWorkspaceActivationBeforeCloseRecovery`, `:1264`)
+won't catch a Ghostty → Slack jump. The `:1538` `unrelatedNoRequest` early-return
+*will* catch it while the lease is active — so the primary fix mostly subsumes
+this — but verify that the post-close activation is classified
+`unrelatedNoRequest` (not `matchesActiveRequest`). If an app-switch leaves a
+*pending* managed request, `:1543` continues it and the early-return is bypassed.
+
+### Tertiary: revisit the 0.6 s duration
+
+`windowCloseFocusRecoveryDuration` (`:296`) is tight. Either lengthen it for the
+hide-driven case (app re-activation can lag) or make the hide-driven lease
+end only when focus settles on a managed window on the recovery workspace,
+rather than on a fixed timer.
+
+### Regression test
+
+Add a test in `Tests/NehirTests/AXEventHandlerTests.swift` (near the
+`windowCloseFocusRecovery` coverage): a managed window that is the confirmed
+focus is **hidden** (not destroyed) while the active workspace is workspace 2;
+assert that the subsequent cross-app / same-app activation does not move
+confirmed focus off workspace 2 and does not trigger a workspace transition.
+This would fail today and pass after (A)/(B).
+
+---
+
+## Later regression evidence — recovery armed but expired before successor activation
+
+A later close repro showed that the recovery lease can arm correctly but still
+miss the real native successor activation because the activation arrives several
+seconds later. The relevant timeline was:
+
+```text
+21:59:56 event=focus_lease_changed owner=window_close_focus_recovery
+         plan=focus=focused=WindowToken(pid: 897, windowId: 6691),pending=nil,lease=window_close_focus_recovery
+21:59:56 event=window_removed token=WindowToken(pid: 897, windowId: 6691)
+         workspace=A7A0D5D7-BE3A-4B65-8613-04D1B5F040A0
+         plan=phase=destroyed focus=focused=nil,pending=nil,lease=window_close_focus_recovery
+21:59:59 event=managed_focus_requested token=WindowToken(pid: 897, windowId: 6493)
+         workspace=741420DA-78FC-4051-9F6A-AD13033E062C
+         plan=focus=focused=nil,pending=WindowToken(pid: 897, windowId: 6493)
+21:59:59 event=managed_focus_confirmed token=WindowToken(pid: 897, windowId: 6493)
+         workspace=741420DA-78FC-4051-9F6A-AD13033E062C
+```
+
+The active workspace at close time was `A7A0D5D7-BE3A-4B65-8613-04D1B5F040A0`;
+the successor activation was on `741420DA-78FC-4051-9F6A-AD13033E062C`. The old
+lease duration was 0.6 s, so by the time the 3 s delayed activation arrived,
+`shouldSuppressObservedActivationDuringWindowCloseRecovery` had no active
+recovery context to consult.
+
+Follow-up fix:
+
+- Extend `windowCloseFocusRecoveryDuration` from 0.6 s to 4.0 s.
+- Record the same fresh app-event workspace on focused-window loss and
+  untracked auxiliary destroy so quick-terminal hides/auxiliary destroys have a
+  workspace anchor even when no tracked managed window is destroyed.
+
+Existing and new regression coverage:
+
+- `focusedWindowLossSuppressesUnrelatedInactiveWorkspaceActivation`
+- `untrackedSamePidDestroySuppressesUnrelatedInactiveWorkspaceActivation`
+- `focusedUntrackedStandardWindowAdmissionPrefersRecentAppEventWorkspaceOverStaleSamePidWorkspace`
+
+
+---
+
+## Revert note (2026-06-16) — long lease made the scroll common, not rare
+
+The `windowCloseFocusRecoveryDuration` change from 0.6 s to 4.0 s, plus arming
+the recovery lease on every `AXFocusedWindowChanged window=nil`, was reverted.
+A fresh capture of a quick-terminal **hide** showed the viewport scrolling to
+the existing Ghostty column far more often than before:
+
+```text
+managed_focus_confirmed token=WindowToken(pid: 897, windowId: 6712)
+  workspace=5A1CF56C-…
+reason=ax_focus_confirm_reveal_result token=WindowToken(pid: 897, windowId: 6712)
+  columnIndex=3 visibility=parked(Nehir.AxisHideEdge.maximum) didReveal=true
+  currentViewStart=0.0 → targetViewStart=2932.6 animating=true
+```
+
+When the quick terminal hides, macOS re-focuses the existing managed Ghostty
+window `897:6712`, which is parked offscreen (column 3). The focus-confirm
+reveal then animates the viewport to it. The 4.0 s / broad-arming change made
+that re-focus reach the reveal path routinely.
+
+The 0.6 s lease and the original confirmed-same-pid-only arming are restored.
+The remaining open issue is that focus-confirm on a parked offscreen column
+still reveals/scrolls; the candidate fix is to preserve the active viewport for
+a focus-confirm that lands while a recovery context is active, or to not reveal
+a `parked` column on a non-user-initiated focus change.
+
+---
+
+## Resolution architecture (2026-06-16)
+
+The final fix treats quick-terminal close/hide as an **ordering problem** rather
+than as a Ghostty-specific behavior. The observable close signal can arrive via
+several channels and not always before macOS chooses a successor focus target:
+
+1. tracked managed-window destroy;
+2. untracked same-pid auxiliary destroy, such as an AX element with `window=101`;
+3. the currently confirmed managed window becoming hidden because its workspace
+   is inactive;
+4. `AXFocusedWindowChanged window=nil` for the app that owned the confirmed
+   managed focus.
+
+The robust architecture is:
+
+- **Keep the short close-recovery lease.** `windowCloseFocusRecoveryDuration`
+  remains 0.6 s. A previous 4.0 s lease made ordinary app-internal refocuses
+  much more likely to scroll to parked columns.
+- **Arm recovery from multiple close-shaped signals.** Recovery can begin from a
+  tracked destroy, an auxiliary same-pid destroy, focused-window loss, or the
+  confirmed managed window becoming hidden while its workspace is active.
+- **Suppress only while the recovery context is active.**
+  `shouldSuppressObservedActivationDuringWindowCloseRecovery` drops unrelated
+  activations away from the recovery workspace, including unrelated same-workspace
+  native activations for a different token than the current focus.
+- **Preserve the viewport on duplicate focus confirmation.** If AX confirms an
+  already-confirmed token, `handleManagedAppActivation` marks the activation as
+  `preserveActiveViewport`, so repeated `focusedWindowChanged` events do not
+  reveal parked columns.
+- **Defer ambiguous inactive native activations before recovery.** In the last
+  failing capture, macOS reported `workspaceDidActivateApplication` for an older
+  managed window on an inactive workspace before the quick-terminal destroy/hide
+  signal arrived. `shouldDeferInactiveNativeActivationBeforeCloseRecovery`
+  postpones exactly that shape briefly. If a close signal arms recovery during
+  the delay, the retry is suppressed by the normal recovery path. If no recovery
+  signal arrives, the retry is allowed so genuine native app switches still work.
+
+This keeps the policy generic: no bundle ID, app name, or Ghostty-specific rule
+is involved. Ghostty only supplied the repro because dropdown terminals commonly
+hide, destroy helper AX elements, or lose focused AX state before the managed
+window itself is removed.
+
+### Validation evidence
+
+A later live validation run repeatedly opened new windows and closed the quick
+terminal without reproducing the workspace jump. The relevant trace facts are
+self-contained:
+
+```text
+07:16:51 event=focus_lease_changed owner=window_close_focus_recovery
+         reason=window_close_focus_recovery
+         plan=focus=focused=WindowToken(pid: 897, windowId: 7585),pending=nil,lease=window_close_focus_recovery
+07:16:51 event=window_removed token=WindowToken(pid: 897, windowId: 7585)
+         workspace=7FBFE458-6A8C-47E2-B88A-638130428B53
+         plan=phase=destroyed focus=focused=nil,pending=nil,lease=window_close_focus_recovery
+```
+
+User-visible result from that run: no quick-terminal close jump reproduced, and
+new windows were created on the expected workspace.


### PR DESCRIPTION
## Summary

- place new windows using AX-first placement context and active interaction monitor
- prevent layout refresh from auto-activating inactive-workspace windows
- stabilize quick-terminal close/hide focus recovery
- make workspace bar clicks target workspace IDs
- add tracing/docs for placement and focus-recovery decisions

## Release notes

Choose one:

- [x] Added a `.changeset/*.md` for user-visible changes (`mise run changeset -- patch "..."`).
- [ ] No user-visible change; apply the `no release note` label to make CI skip intentional.

## Validation

<!-- Commands run, screenshots, or manual checks. -->

- [ ] Ran relevant tests/checks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * New windows now consistently open on the currently active workspace, even during rapid focus changes
  * Fixed unexpected workspace switches when closing quick-terminal dropdown windows
  * Improved reliability of workspace bar navigation and selection
  * Enhanced focus recovery to prevent unrelated window activations from switching workspaces
  * Refined layout refresh behavior to avoid auto-activating windows on inactive workspaces

<!-- end of auto-generated comment: release notes by coderabbit.ai -->