### PR TITLE
Fix settings slider drag lag by committing on drag end

### DIFF
--- a/.changeset/20260617000142-settings-sliders-no-longer-lag-while-dragging.md
+++ b/.changeset/20260617000142-settings-sliders-no-longer-lag-while-dragging.md
@@ -1,0 +1,10 @@
+---
+"nehir": patch
+
+---
+
+Settings sliders no longer lag while dragging.
+
+- Dragging the Scroll Sensitivity slider (and other settings sliders such as Border Width, Workspace Bar Height/Opacity, and global gaps) used to trigger a synchronous settings save plus controller side-effects on every drag tick. The save's debounce was a single task yield, so it effectively fired once per frame, blocking the main actor with a TOML encode and disk write on each pixel of motion.
+- `SettingsSliderRow` now buffers the value in a local draft while dragging and commits it exactly once when the drag ends, so the `didSet` save and any `.onChange` controller work run a single time at release. The numeric value next to the slider still updates live while dragging.
+

--- a/Sources/Nehir/UI/BehaviorSettingsTab.swift
+++ b/Sources/Nehir/UI/BehaviorSettingsTab.swift
@@ -59,7 +59,7 @@ struct BehaviorSettingsTab: View {
                     value: $settings.scrollSensitivity,
                     range: 0.5 ... 20.0,
                     step: 0.5,
-                    valueText: String(format: "%.1f", settings.scrollSensitivity) + "x"
+                    formatter: { String(format: "%.1f", $0) + "x" }
                 )
                 .disabled(!settings.scrollGestureEnabled)
 

--- a/Sources/Nehir/UI/BorderSettingsTab.swift
+++ b/Sources/Nehir/UI/BorderSettingsTab.swift
@@ -27,7 +27,7 @@ struct BorderSettingsTab: View {
                         value: $settings.borderWidth,
                         range: 1 ... 12,
                         step: 0.5,
-                        valueText: String(format: "%.1f px", settings.borderWidth),
+                        formatter: { String(format: "%.1f px", $0) },
                         valueWidth: 56
                     )
                     .onChange(of: settings.borderWidth) { _, _ in

--- a/Sources/Nehir/UI/LayoutSettingsTab.swift
+++ b/Sources/Nehir/UI/LayoutSettingsTab.swift
@@ -74,7 +74,7 @@ struct LayoutSettingsTab: View {
                 ),
                 range: 0 ... 32,
                 step: 1,
-                valueText: "\(Int(effectiveGapSize)) px",
+                formatter: { "\(Int($0)) px" },
                 valueWidth: 64,
                 onEditingChanged: { editing in
                     if !editing { commitGapSizeDraft() }
@@ -94,7 +94,7 @@ struct LayoutSettingsTab: View {
                 ),
                 range: 0 ... 64,
                 step: 1,
-                valueText: "\(Int(effectiveOuterGapLeft)) px",
+                formatter: { "\(Int($0)) px" },
                 valueWidth: 64,
                 onEditingChanged: { editing in
                     if !editing { commitOuterGapDrafts() }
@@ -111,7 +111,7 @@ struct LayoutSettingsTab: View {
                 ),
                 range: 0 ... 64,
                 step: 1,
-                valueText: "\(Int(effectiveOuterGapRight)) px",
+                formatter: { "\(Int($0)) px" },
                 valueWidth: 64,
                 onEditingChanged: { editing in
                     if !editing { commitOuterGapDrafts() }
@@ -128,7 +128,7 @@ struct LayoutSettingsTab: View {
                 ),
                 range: 0 ... 64,
                 step: 1,
-                valueText: "\(Int(effectiveOuterGapTop)) px",
+                formatter: { "\(Int($0)) px" },
                 valueWidth: 64,
                 onEditingChanged: { editing in
                     if !editing { commitOuterGapDrafts() }
@@ -145,7 +145,7 @@ struct LayoutSettingsTab: View {
                 ),
                 range: 0 ... 64,
                 step: 1,
-                valueText: "\(Int(effectiveOuterGapBottom)) px",
+                formatter: { "\(Int($0)) px" },
                 valueWidth: 64,
                 onEditingChanged: { editing in
                     if !editing { commitOuterGapDrafts() }

--- a/Sources/Nehir/UI/OverridableControls.swift
+++ b/Sources/Nehir/UI/OverridableControls.swift
@@ -58,23 +58,44 @@ struct SettingsSliderRow: View {
     @Binding var value: Double
     let range: ClosedRange<Double>
     let step: Double
-    let valueText: String
+    let formatter: (Double) -> String
     var valueWidth: CGFloat = 56
+    /// Fired when an edit begins/ends. The row commits its own draft on drag end
+    /// regardless, so this is purely for optional side effects.
     var onEditingChanged: ((Bool) -> Void)? = nil
+
+    /// Buffered while dragging so each tick does not write through to `value`
+    /// (which would trigger per-tick `didSet` saves and side effects on the main
+    /// actor). Committed exactly once when the drag ends.
+    @State private var draftValue: Double?
+
+    private var effectiveValue: Double {
+        draftValue ?? value
+    }
 
     var body: some View {
         LabeledContent(label) {
             HStack {
-                Slider(value: $value, in: range, step: step, onEditingChanged: { editing in
+                let displayText = formatter(effectiveValue)
+                Slider(value: Binding(
+                    get: { effectiveValue },
+                    set: { newValue in
+                        draftValue = newValue
+                    }
+                ), in: range, step: step, onEditingChanged: { editing in
+                    if !editing, let draft = draftValue {
+                        value = draft
+                        draftValue = nil
+                    }
                     onEditingChanged?(editing)
                 }) {
                     Text(label)
                 }
                 .labelsHidden()
                 .accessibilityLabel(label)
-                .accessibilityValue(valueText)
+                .accessibilityValue(displayText)
 
-                SettingsValueText(text: valueText, width: valueWidth)
+                SettingsValueText(text: displayText, width: valueWidth)
             }
         }
     }

--- a/Sources/Nehir/UI/WorkspaceBarSettingsTab.swift
+++ b/Sources/Nehir/UI/WorkspaceBarSettingsTab.swift
@@ -156,7 +156,7 @@ private struct GlobalBarSettingsSection: View {
                     value: $settings.workspaceBarHeight,
                     range: 20 ... 40,
                     step: 2,
-                    valueText: "\(Int(settings.workspaceBarHeight)) px"
+                    formatter: { "\(Int($0)) px" }
                 )
                 .onChange(of: settings.workspaceBarHeight) { _, _ in
                     controller.updateWorkspaceBarSettings()
@@ -167,7 +167,7 @@ private struct GlobalBarSettingsSection: View {
                     value: $settings.workspaceBarBackgroundOpacity,
                     range: 0 ... 0.5,
                     step: 0.05,
-                    valueText: "\(Int(settings.workspaceBarBackgroundOpacity * 100))%"
+                    formatter: { "\(Int($0 * 100))%" }
                 )
                 .onChange(of: settings.workspaceBarBackgroundOpacity) { _, _ in
                     controller.updateWorkspaceBarSettings()


### PR DESCRIPTION
## Summary

SettingsSliderRow bound directly to the persisted property, whose didSet triggers scheduleSave(). The save debounce was only a single Task.yield(), so every drag tick did a synchronous TOML encode + disk write on the main actor, plus any .onChange controller side-effects. Buffer the slider value in a local draft while dragging and commit it once when the drag ends. The displayed value still updates live via a formatter closure.

Fixes Scroll Sensitivity and the same latent lag on Border Width, Workspace Bar Height/Opacity, and global gap sliders.

## Release notes

Choose one:

- [x] Added a `.changeset/*.md` for user-visible changes (`mise run changeset -- patch "..."`).
- [ ] No user-visible change; apply the `no release note` label to make CI skip intentional.

## Validation

<!-- Commands run, screenshots, or manual checks. -->

- [ ] Ran relevant tests/checks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Settings sliders no longer lag while dragging. Slider adjustments are now staged locally and committed only when you release the slider, improving responsiveness and reducing unnecessary saves.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->