### PR TITLE
Reset lone-window viewport after column removal

### DIFF
--- a/.changeset/20260617003015-reset-lone-window-viewport-after-column-removal.md
+++ b/.changeset/20260617003015-reset-lone-window-viewport-after-column-removal.md
@@ -1,0 +1,11 @@
+---
+"nehir": patch
+contributors: [dagrlx]
+---
+
+Reset the Niri viewport when closing back to a single fill-width window.
+
+- Closing the right column of a proportional pair could leave the surviving lone window with the old two-column viewport target (for example `targetViewStart=-516` after a `50% + 50%` pair collapsed to one full-width Ghostty window). A later focus/click relayout then applied that stale viewport and shifted the window hundreds of pixels off its fill position.
+- Lone-window viewport preparation now runs on window-removal relayouts even when the removal created an in-flight scroll/column animation, so the surviving fill-width window settles back to the fill viewport immediately.
+
+Fixes #56.

--- a/Sources/Nehir/Core/Controller/NiriLayoutHandler.swift
+++ b/Sources/Nehir/Core/Controller/NiriLayoutHandler.swift
@@ -583,7 +583,9 @@ enum NiriWindowMoveResult {
 
         let usesCenteredLoneWindow = pass.engine.singleWindowLayoutContext(in: pass.wsId) != nil
         let isGestureOrAnimation = state.viewOffsetPixels.isGesture || state.viewOffsetPixels.isAnimating
-        if usesCenteredLoneWindow, !isGestureOrAnimation {
+        let didRemoveWindow = !removal.removalResult.removedTokens.isEmpty
+        let shouldResolveLoneWindowViewport = !isGestureOrAnimation || didRemoveWindow
+        if usesCenteredLoneWindow, shouldResolveLoneWindowViewport {
             // Capture the lone window's previously resolved width before re-preparing so we
             // can detect a policy/size/monitor change (not just an initial setup).
             let previousSingleWindowWidth = pass.engine.singleWindowLayoutContext(in: pass.wsId)?.container.cachedWidth ?? 0

--- a/Tests/NehirTests/NiriLayoutEngineTests.swift
+++ b/Tests/NehirTests/NiriLayoutEngineTests.swift
@@ -1607,6 +1607,71 @@ private func makeCenteredCrossMonitorFixture(
         #expect(abs(secondFrame.minX - 1_036) < 0.6)
     }
 
+    @Test @MainActor func removingSecondWindowResetsFillLoneViewportDuringRemovalAnimation() async throws {
+        let monitor = makeLayoutPlanTestMonitor(width: 2_056, height: 1_290)
+        let controller = makeLayoutPlanTestController(monitors: [monitor])
+        guard let workspaceId = controller.workspaceManager.activeWorkspaceOrFirst(on: monitor.id)?.id else {
+            Issue.record("Missing active workspace for lone-window removal viewport regression test")
+            return
+        }
+
+        controller.enableNiriLayout()
+        await waitForLayoutPlanRefreshWork(on: controller)
+        controller.syncMonitorsToNiriEngine()
+        controller.niriEngine?.presetColumnWidths = [.proportion(0.5), .proportion(0.5)]
+        controller.niriEngine?.defaultColumnWidth = 0.5
+
+        let survivingToken = addLayoutPlanTestWindow(on: controller, workspaceId: workspaceId, windowId: 1_641)
+        let removedToken = addLayoutPlanTestWindow(on: controller, workspaceId: workspaceId, windowId: 1_642)
+        _ = controller.workspaceManager.setManagedFocus(removedToken, in: workspaceId, onMonitor: monitor.id)
+
+        let initialPlans = try await controller.niriLayoutHandler.layoutWithNiriEngine(
+            activeWorkspaces: [workspaceId]
+        )
+        controller.layoutRefreshController.executeLayoutPlans(initialPlans)
+
+        guard let engine = controller.niriEngine,
+              let removedNode = engine.findNode(for: removedToken),
+              let survivingNode = engine.findNode(for: survivingToken)
+        else {
+            Issue.record("Expected Niri nodes for lone-window removal viewport regression test")
+            return
+        }
+
+        let gap = controller.gapSize(for: monitor)
+        let rightColumnX = controller.workspaceManager.niriViewportState(for: workspaceId).columnX(
+            at: 1,
+            columns: engine.columns(in: workspaceId),
+            gap: gap
+        )
+        controller.workspaceManager.withNiriViewportState(for: workspaceId) { state in
+            state.selectedNodeId = removedNode.id
+            state.activeColumnIndex = 1
+            state.viewOffsetPixels = .static(-gap - rightColumnX)
+        }
+
+        _ = controller.workspaceManager.removeWindow(pid: removedToken.pid, windowId: removedToken.windowId)
+
+        let removalPlans = try await controller.niriLayoutHandler.layoutWithNiriEngine(
+            activeWorkspaces: [workspaceId]
+        )
+        guard let plan = removalPlans.first,
+              let viewportState = plan.sessionPatch.viewportState
+        else {
+            Issue.record("Expected Niri removal plan with viewport patch")
+            return
+        }
+
+        #expect(viewportState.selectedNodeId == survivingNode.id)
+        #expect(viewportState.activeColumnIndex == 0)
+        #expect(abs(viewportState.viewOffsetPixels.target()) < 0.6)
+        #expect(plan.diff.frameChanges.contains { change in
+            change.token == survivingToken
+                && abs(change.frame.minX - monitor.visibleFrame.minX) < 0.6
+                && abs(change.frame.width - monitor.visibleFrame.width) < 0.6
+        })
+    }
+
     @Test func additionalWindowUsesExplicitDefaultWidthWhenCreatingNewColumn() {
         let engine = NiriLayoutEngine(balancedColumnCount: 3)
         engine.presetColumnWidths = [.proportion(0.85), .proportion(1.0), .proportion(0.5)]


### PR DESCRIPTION
## Summary

Closing the right column of a proportional pair left the surviving lone window with the stale two-column viewport target (e.g. targetViewStart=-516 after a 50%+50% pair collapsed to one fill-width window). A later focus/click relayout then applied that offset and shifted the window off its fill position.

Lone-window viewport preparation now runs on window-removal relayouts even when the removal created an in-flight scroll/column animation, so the surviving fill-width window settles back to the fill viewport immediately.

Fixes #56.

## Release notes

Choose one:

- [x] Added a `.changeset/*.md` for user-visible changes (`mise run changeset -- patch "..."`).
- [ ] No user-visible change; apply the `no release note` label to make CI skip intentional.

## Validation

<!-- Commands run, screenshots, or manual checks. -->

- [ ] Ran relevant tests/checks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where closing a window in a two-column layout could leave the remaining window with incorrect viewport positioning. The viewport now properly resets to the correct fill position when returning to a single fill-width window, even during layout animations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->