### PR TITLE
Avoid popup what's new for patch releases

### DIFF
--- a/.changeset/20260618221451-show-what-s-new-only-once-per-major-minor-releas.md
+++ b/.changeset/20260618221451-show-what-s-new-only-once-per-major-minor-releas.md
@@ -1,0 +1,6 @@
+---
+"nehir": patch
+
+---
+
+Show What's New only once per major/minor release

--- a/Sources/Nehir/App/AppDelegate.swift
+++ b/Sources/Nehir/App/AppDelegate.swift
@@ -147,16 +147,17 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 OnboardingWindowController.shared.show(settings: settings, onboardingStore: onboardingStore)
             }
         } else {
-            // Auto-show What's New once per release. The running build must be a release
-            // version (dev's `0.0.0` placeholder and prereleases like `0.5.0-rc.1` stay
-            // silent), newer than the version the user last acknowledged, and there must
-            // be content to show. No hardcoded version constant to keep in sync — the
-            // comparison is against the running build's own version.
+            // Auto-show What's New once per major/minor release. The running build must
+            // be a release version (dev's `0.0.0` placeholder and prereleases like
+            // `0.5.0-rc.1` stay silent), newer in major/minor than the version the user
+            // last acknowledged, and there must be content to show. Patch releases reuse
+            // current content but do not auto-show it again.
             if let appVersion = Bundle.main.appVersion,
-               Self.isReleaseVersion(appVersion),
-               !WhatsNewContent.isEmpty,
-               let lastSeen = onboardingStore.lastSeenVersion,
-               Self.isVersion(appVersion, newerThan: lastSeen) {
+               Self.shouldAutoShowWhatsNew(
+                   appVersion: appVersion,
+                   lastSeenVersion: onboardingStore.lastSeenVersion,
+                   hasContent: !WhatsNewContent.isEmpty
+               ) {
                 DispatchQueue.main.async {
                     OnboardingWindowController.shared.showWhatsNew(
                         version: appVersion,
@@ -189,18 +190,32 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         return parts.count == 3 && parts != [0, 0, 0]
     }
 
-    /// Numeric `MAJOR.MINOR.PATCH` ordering, ignoring any prerelease suffix. Unparseable
-    /// components sort as `-1` so junk recorded on disk can never block an upgrade showing.
-    private static func isVersion(_ a: String, newerThan b: String) -> Bool {
-        func tuple(_ v: String) -> (Int, Int, Int) {
-            let core = v.split(separator: "-").first.map(String.init) ?? v
-            let parts = core.split(separator: ".").compactMap { Int($0) }
-            return parts.count == 3 ? (parts[0], parts[1], parts[2]) : (-1, -1, -1)
+    static func shouldAutoShowWhatsNew(
+        appVersion: String,
+        lastSeenVersion: String?,
+        hasContent: Bool
+    ) -> Bool {
+        guard isReleaseVersion(appVersion),
+              hasContent,
+              let lastSeenVersion
+        else {
+            return false
         }
-        let (x, y) = (tuple(a), tuple(b))
-        if x.0 != y.0 { return x.0 > y.0 }
-        if x.1 != y.1 { return x.1 > y.1 }
-        return x.2 > y.2
+        return isMajorMinorVersion(appVersion, newerThan: lastSeenVersion)
+    }
+
+    /// Numeric `MAJOR.MINOR` ordering. Patch releases reuse the current What's New
+    /// content but do not auto-show it again for users who already acknowledged the
+    /// same major/minor release.
+    private static func isMajorMinorVersion(_ currentVersion: String, newerThan previousVersion: String) -> Bool {
+        func tuple(_ versionString: String) -> (Int, Int) {
+            let core = versionString.split(separator: "-").first.map(String.init) ?? versionString
+            let parts = core.split(separator: ".").compactMap { Int($0) }
+            return parts.count == 3 ? (parts[0], parts[1]) : (-1, -1)
+        }
+        let (current, previous) = (tuple(currentVersion), tuple(previousVersion))
+        if current.0 != previous.0 { return current.0 > previous.0 }
+        return current.1 > previous.1
     }
 
     func startIPCServer(controller: WMController) throws {

--- a/Sources/Nehir/UI/Onboarding/WhatsNewContent.swift
+++ b/Sources/Nehir/UI/Onboarding/WhatsNewContent.swift
@@ -8,8 +8,9 @@ import Foundation
 ///
 /// Which release these describe is inferred from the running app version — there is no
 /// hardcoded version constant to keep in sync. Auto-show fires once when the running build
-/// is a release version newer than the one the user last acknowledged (see
-/// `AppDelegate.continueBootstrap`); dev builds (`0.0.0`) and prereleases never auto-show.
+/// is a release version with a newer major/minor than the one the user last acknowledged
+/// (see `AppDelegate.continueBootstrap`); dev builds (`0.0.0`), prereleases, and patch-only
+/// upgrades within an already-seen major/minor never auto-show.
 /// Keep `sections` current as part of release prep — empty `sections` disables the screen
 /// (auto-show is skipped and the on-demand entries no-op).
 enum WhatsNewContent {

--- a/Tests/NehirTests/WhatsNewAutoShowTests.swift
+++ b/Tests/NehirTests/WhatsNewAutoShowTests.swift
@@ -1,0 +1,75 @@
+@testable import Nehir
+import Testing
+
+@Suite @MainActor struct WhatsNewAutoShowTests {
+    @Test func patchUpgradeWithinSeenMajorMinorDoesNotAutoShow() {
+        #expect(!AppDelegate.shouldAutoShowWhatsNew(
+            appVersion: "0.5.1",
+            lastSeenVersion: "0.5.0",
+            hasContent: true
+        ))
+    }
+
+    @Test func majorMinorUpgradeAutoShowsEvenToPatchRelease() {
+        #expect(AppDelegate.shouldAutoShowWhatsNew(
+            appVersion: "0.5.1",
+            lastSeenVersion: "0.4.9",
+            hasContent: true
+        ))
+    }
+
+    @Test func majorVersionUpgradeAutoShows() {
+        #expect(AppDelegate.shouldAutoShowWhatsNew(
+            appVersion: "1.0.0",
+            lastSeenVersion: "0.9.9",
+            hasContent: true
+        ))
+    }
+
+    @Test func equalVersionsDoNotAutoShow() {
+        #expect(!AppDelegate.shouldAutoShowWhatsNew(
+            appVersion: "0.5.0",
+            lastSeenVersion: "0.5.0",
+            hasContent: true
+        ))
+    }
+
+    @Test func downgradeDoesNotAutoShow() {
+        #expect(!AppDelegate.shouldAutoShowWhatsNew(
+            appVersion: "0.4.0",
+            lastSeenVersion: "0.5.0",
+            hasContent: true
+        ))
+    }
+
+    @Test func malformedVersionDoesNotAutoShow() {
+        #expect(!AppDelegate.shouldAutoShowWhatsNew(
+            appVersion: "not-a-version",
+            lastSeenVersion: "0.4.9",
+            hasContent: true
+        ))
+    }
+
+    @Test func prereleaseDevMissingStateAndEmptyContentDoNotAutoShow() {
+        #expect(!AppDelegate.shouldAutoShowWhatsNew(
+            appVersion: "0.5.1-rc.1",
+            lastSeenVersion: "0.4.9",
+            hasContent: true
+        ))
+        #expect(!AppDelegate.shouldAutoShowWhatsNew(
+            appVersion: "0.0.0",
+            lastSeenVersion: "0.4.9",
+            hasContent: true
+        ))
+        #expect(!AppDelegate.shouldAutoShowWhatsNew(
+            appVersion: "0.5.0",
+            lastSeenVersion: nil,
+            hasContent: true
+        ))
+        #expect(!AppDelegate.shouldAutoShowWhatsNew(
+            appVersion: "0.5.0",
+            lastSeenVersion: "0.4.9",
+            hasContent: false
+        ))
+    }
+}


### PR DESCRIPTION
## Summary

<!-- What changed and why? -->

## Release notes

Choose one:

- [X] Added a `.changeset/*.md` for user-visible changes (`mise run changeset -- patch "..."`).
- [ ] No user-visible change; apply the `no release note` label to make CI skip intentional.

## Validation

<!-- Commands run, screenshots, or manual checks. -->

- [ ] Ran relevant tests/checks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes
* Updated “What’s New” auto-display behavior to trigger only once per major/minor release, avoiding repeated prompts on patch updates.
* Improved version gating to handle prereleases, invalid versions, missing last-seen state, and empty “What’s New” content—preventing unintended auto-shows.

## Documentation
* Clarified “auto-show” rules to specify major/minor upgrade requirements and exclusions.

## Tests
* Expanded automated coverage for “What’s New” auto-show scenarios, including equal versions and downgrades.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->