### PR TITLE
Monitor-identity-agnostic restore (issue #65)

### DIFF
--- a/.changeset/20260619002634-add-monitor-independent-restore.md
+++ b/.changeset/20260619002634-add-monitor-independent-restore.md
@@ -1,0 +1,6 @@
+---
+"nehir": minor
+contributors: [syepes]
+---
+
+Add an opt-in monitor-independent restore mode so apps, workspaces, and per-monitor settings can follow layout position when moving between different monitor sets.

--- a/Sources/Nehir/Core/Config/CanonicalTOMLConfig.swift
+++ b/Sources/Nehir/Core/Config/CanonicalTOMLConfig.swift
@@ -33,10 +33,11 @@ struct CanonicalTOMLConfig: Codable, Equatable {
         var preventSleepEnabled: Bool
         var ipcEnabled: Bool
         var developerModeEnabled: Bool
+        var ignoreMonitorIdentity: Bool
         var unknownFields: [String: SettingsTOMLUnknownValue] = [:]
 
         enum CodingKeys: String, CodingKey, CaseIterable {
-            case hotkeysEnabled, preventSleepEnabled, ipcEnabled, developerModeEnabled
+            case hotkeysEnabled, preventSleepEnabled, ipcEnabled, developerModeEnabled, ignoreMonitorIdentity
         }
     }
 
@@ -229,6 +230,7 @@ extension CanonicalTOMLConfig {
             preventSleepEnabled: export.preventSleepEnabled,
             ipcEnabled: export.ipcEnabled,
             developerModeEnabled: export.developerModeEnabled,
+            ignoreMonitorIdentity: export.ignoreMonitorIdentity,
             unknownFields: unknown["general"] ?? [:]
         )
         focus = Focus(
@@ -403,6 +405,7 @@ extension CanonicalTOMLConfig {
             statusBarUseWorkspaceId: statusBar.useWorkspaceId,
             appearanceMode: appearance.mode,
             developerModeEnabled: general.developerModeEnabled,
+            ignoreMonitorIdentity: general.ignoreMonitorIdentity,
             settingsTOMLUnknownFields: unknown
         )
     }
@@ -449,6 +452,7 @@ extension CanonicalTOMLConfig.General {
         preventSleepEnabled = try container.decodeWithDefault(Bool.self, forKey: .preventSleepEnabled, default: d.preventSleepEnabled)
         ipcEnabled = try container.decodeWithDefault(Bool.self, forKey: .ipcEnabled, default: d.ipcEnabled)
         developerModeEnabled = try container.decodeWithDefault(Bool.self, forKey: .developerModeEnabled, default: d.developerModeEnabled)
+        ignoreMonitorIdentity = try container.decodeWithDefault(Bool.self, forKey: .ignoreMonitorIdentity, default: d.ignoreMonitorIdentity)
         unknownFields = try SettingsTOMLUnknownValue.decodeUnknownFields(from: decoder, excluding: CodingKeys.self)
     }
 
@@ -458,6 +462,7 @@ extension CanonicalTOMLConfig.General {
         try container.encode(preventSleepEnabled, forKey: "preventSleepEnabled")
         try container.encode(ipcEnabled, forKey: "ipcEnabled")
         try container.encode(developerModeEnabled, forKey: "developerModeEnabled")
+        try container.encode(ignoreMonitorIdentity, forKey: "ignoreMonitorIdentity")
         try container.encodeUnknownFields(unknownFields)
     }
 }

--- a/Sources/Nehir/Core/Config/MonitorBarSettings.swift
+++ b/Sources/Nehir/Core/Config/MonitorBarSettings.swift
@@ -5,6 +5,7 @@ struct MonitorBarSettings: MonitorSettingsType {
     let id: UUID
     var monitorName: String
     var monitorDisplayId: CGDirectDisplayID?
+    var monitorAnchorPoint: CGPoint?
 
     var enabled: Bool?
     var showLabels: Bool?
@@ -25,6 +26,7 @@ struct MonitorBarSettings: MonitorSettingsType {
         id: UUID = UUID(),
         monitorName: String,
         monitorDisplayId: CGDirectDisplayID? = nil,
+        monitorAnchorPoint: CGPoint? = nil,
         enabled: Bool? = nil,
         showLabels: Bool? = nil,
         showFloatingWindows: Bool? = nil,
@@ -43,6 +45,7 @@ struct MonitorBarSettings: MonitorSettingsType {
         self.id = id
         self.monitorName = monitorName
         self.monitorDisplayId = monitorDisplayId
+        self.monitorAnchorPoint = monitorAnchorPoint
         self.enabled = enabled
         self.showLabels = showLabels
         self.showFloatingWindows = showFloatingWindows
@@ -60,7 +63,8 @@ struct MonitorBarSettings: MonitorSettingsType {
     }
 
     private enum CodingKeys: String, CodingKey {
-        case id, monitorName, monitorDisplayId, enabled, showLabels, showFloatingWindows, deduplicateAppIcons
+        case id, monitorName, monitorDisplayId, monitorAnchorPoint
+        case enabled, showLabels, showFloatingWindows, deduplicateAppIcons
         case hideEmptyWorkspaces, reserveLayoutSpace, notchAware, showTraceButton, position, windowLevel
         case height, backgroundOpacity, xOffset, yOffset
     }
@@ -70,6 +74,7 @@ struct MonitorBarSettings: MonitorSettingsType {
         id = try container.decode(UUID.self, forKey: .id)
         monitorName = try container.decode(String.self, forKey: .monitorName)
         monitorDisplayId = try container.decodeIfPresent(CGDirectDisplayID.self, forKey: .monitorDisplayId)
+        monitorAnchorPoint = try container.decodeIfPresent(CGPoint.self, forKey: .monitorAnchorPoint)
         enabled = try container.decodeIfPresent(Bool.self, forKey: .enabled)
         showLabels = try container.decodeIfPresent(Bool.self, forKey: .showLabels)
         showFloatingWindows = try container.decodeIfPresent(Bool.self, forKey: .showFloatingWindows)
@@ -93,6 +98,7 @@ struct MonitorBarSettings: MonitorSettingsType {
         try container.encode(id, forKey: .id)
         try container.encode(monitorName, forKey: .monitorName)
         try container.encodeIfPresent(monitorDisplayId, forKey: .monitorDisplayId)
+        try container.encodeIfPresent(monitorAnchorPoint, forKey: .monitorAnchorPoint)
         try container.encodeIfPresent(enabled, forKey: .enabled)
         try container.encodeIfPresent(showLabels, forKey: .showLabels)
         try container.encodeIfPresent(showFloatingWindows, forKey: .showFloatingWindows)

--- a/Sources/Nehir/Core/Config/MonitorGapSettings.swift
+++ b/Sources/Nehir/Core/Config/MonitorGapSettings.swift
@@ -5,6 +5,7 @@ struct MonitorGapSettings: MonitorSettingsType {
     let id: UUID
     var monitorName: String
     var monitorDisplayId: CGDirectDisplayID?
+    var monitorAnchorPoint: CGPoint?
 
     var gapSize: Double?
     var outerGapLeft: Double?
@@ -20,6 +21,7 @@ struct MonitorGapSettings: MonitorSettingsType {
         id: UUID = UUID(),
         monitorName: String,
         monitorDisplayId: CGDirectDisplayID? = nil,
+        monitorAnchorPoint: CGPoint? = nil,
         gapSize: Double? = nil,
         outerGapLeft: Double? = nil,
         outerGapRight: Double? = nil,
@@ -29,6 +31,7 @@ struct MonitorGapSettings: MonitorSettingsType {
         self.id = id
         self.monitorName = monitorName
         self.monitorDisplayId = monitorDisplayId
+        self.monitorAnchorPoint = monitorAnchorPoint
         self.gapSize = gapSize
         self.outerGapLeft = outerGapLeft
         self.outerGapRight = outerGapRight

--- a/Sources/Nehir/Core/Config/MonitorNiriSettings.swift
+++ b/Sources/Nehir/Core/Config/MonitorNiriSettings.swift
@@ -5,6 +5,7 @@ struct MonitorNiriSettings: MonitorSettingsType {
     let id: UUID
     var monitorName: String
     var monitorDisplayId: CGDirectDisplayID?
+    var monitorAnchorPoint: CGPoint?
 
     var balancedColumnCount: Int?
     var loneWindowPolicy: LoneWindowPolicy?
@@ -13,18 +14,20 @@ struct MonitorNiriSettings: MonitorSettingsType {
         id: UUID = UUID(),
         monitorName: String,
         monitorDisplayId: CGDirectDisplayID? = nil,
+        monitorAnchorPoint: CGPoint? = nil,
         balancedColumnCount: Int? = nil,
         loneWindowPolicy: LoneWindowPolicy? = nil
     ) {
         self.id = id
         self.monitorName = monitorName
         self.monitorDisplayId = monitorDisplayId
+        self.monitorAnchorPoint = monitorAnchorPoint
         self.balancedColumnCount = balancedColumnCount
         self.loneWindowPolicy = loneWindowPolicy
     }
 
     private enum CodingKeys: String, CodingKey {
-        case id, monitorName, monitorDisplayId, balancedColumnCount, loneWindowPolicy
+        case id, monitorName, monitorDisplayId, monitorAnchorPoint, balancedColumnCount, loneWindowPolicy
     }
 
     init(from decoder: Decoder) throws {
@@ -32,6 +35,7 @@ struct MonitorNiriSettings: MonitorSettingsType {
         id = try container.decode(UUID.self, forKey: .id)
         monitorName = try container.decode(String.self, forKey: .monitorName)
         monitorDisplayId = try container.decodeIfPresent(CGDirectDisplayID.self, forKey: .monitorDisplayId)
+        monitorAnchorPoint = try container.decodeIfPresent(CGPoint.self, forKey: .monitorAnchorPoint)
         balancedColumnCount = try container.decodeIfPresent(Int.self, forKey: .balancedColumnCount)
         loneWindowPolicy = try container.decodeIfPresent(LoneWindowPolicy.self, forKey: .loneWindowPolicy)
     }
@@ -41,6 +45,7 @@ struct MonitorNiriSettings: MonitorSettingsType {
         try container.encode(id, forKey: .id)
         try container.encode(monitorName, forKey: .monitorName)
         try container.encodeIfPresent(monitorDisplayId, forKey: .monitorDisplayId)
+        try container.encodeIfPresent(monitorAnchorPoint, forKey: .monitorAnchorPoint)
         try container.encodeIfPresent(balancedColumnCount, forKey: .balancedColumnCount)
         try container.encodeIfPresent(loneWindowPolicy, forKey: .loneWindowPolicy)
     }

--- a/Sources/Nehir/Core/Config/MonitorOrientationSettings.swift
+++ b/Sources/Nehir/Core/Config/MonitorOrientationSettings.swift
@@ -7,5 +7,6 @@ struct MonitorOrientationSettings: MonitorSettingsType {
 
     var monitorName: String
     var monitorDisplayId: CGDirectDisplayID? = nil
+    var monitorAnchorPoint: CGPoint? = nil
     var orientation: Monitor.Orientation?
 }

--- a/Sources/Nehir/Core/Config/MonitorOverrideFileStore.swift
+++ b/Sources/Nehir/Core/Config/MonitorOverrideFileStore.swift
@@ -82,6 +82,10 @@ enum MonitorOverrideFileStore {
         lines.append("[match]")
         lines.append("name = \(quoted(key.name))")
         if let displayId = key.displayId { lines.append("displayId = \(displayId)") }
+        if let anchor = matchAnchorPoint(for: document) {
+            lines.append("anchorX = \(formatNumber(anchor.x))")
+            lines.append("anchorY = \(formatNumber(anchor.y))")
+        }
 
         if let gaps = document.gaps, gaps.hasOverrides {
             lines.append("")
@@ -153,12 +157,14 @@ enum MonitorOverrideFileStore {
 
         guard let match = fields["match"], let name = extractString(match["name"]) else { return nil }
         let displayId = match["displayId"].flatMap { CGDirectDisplayID($0.trimmingCharacters(in: .whitespaces)) }
+        let anchorPoint = extractAnchorPoint(x: match["anchorX"], y: match["anchorY"])
         var document = MonitorDocument()
 
         if let gaps = fields["gaps"] {
             document.gaps = MonitorGapSettings(
                 monitorName: name,
                 monitorDisplayId: displayId,
+                monitorAnchorPoint: anchorPoint,
                 gapSize: gaps["size"].flatMap(extractDouble),
                 outerGapLeft: gaps["outerLeft"].flatMap(extractDouble),
                 outerGapRight: gaps["outerRight"].flatMap(extractDouble),
@@ -182,6 +188,7 @@ enum MonitorOverrideFileStore {
             document.niri = MonitorNiriSettings(
                 monitorName: name,
                 monitorDisplayId: displayId,
+                monitorAnchorPoint: anchorPoint,
                 balancedColumnCount: niri["balancedColumnCount"].flatMap { Int($0.trimmingCharacters(in: .whitespaces)) },
                 loneWindowPolicy: loneWindowPolicy
             )
@@ -191,6 +198,7 @@ enum MonitorOverrideFileStore {
             document.bar = MonitorBarSettings(
                 monitorName: name,
                 monitorDisplayId: displayId,
+                monitorAnchorPoint: anchorPoint,
                 enabled: bar["enabled"].flatMap(extractBool),
                 showLabels: bar["showLabels"].flatMap(extractBool),
                 showFloatingWindows: bar["showFloatingWindows"].flatMap(extractBool),
@@ -211,6 +219,7 @@ enum MonitorOverrideFileStore {
             document.orientation = MonitorOrientationSettings(
                 monitorName: name,
                 monitorDisplayId: displayId,
+                monitorAnchorPoint: anchorPoint,
                 orientation: orientation["orientation"].flatMap(extractString).flatMap(Monitor.Orientation.init(rawValue:))
             )
         }
@@ -263,5 +272,19 @@ enum MonitorOverrideFileStore {
 
     private static func extractDouble(_ raw: String) -> Double? {
         Double(raw.trimmingCharacters(in: .whitespaces))
+    }
+
+    private static func matchAnchorPoint(for document: MonitorDocument) -> CGPoint? {
+        document.bar?.monitorAnchorPoint
+            ?? document.gaps?.monitorAnchorPoint
+            ?? document.orientation?.monitorAnchorPoint
+            ?? document.niri?.monitorAnchorPoint
+    }
+
+    private static func extractAnchorPoint(x: String?, y: String?) -> CGPoint? {
+        guard let anchorX = x.flatMap(extractDouble), let anchorY = y.flatMap(extractDouble) else {
+            return nil
+        }
+        return CGPoint(x: anchorX, y: anchorY)
     }
 }

--- a/Sources/Nehir/Core/Config/MonitorSettingsType.swift
+++ b/Sources/Nehir/Core/Config/MonitorSettingsType.swift
@@ -12,25 +12,10 @@ protocol MonitorSettingsType: Codable, Identifiable, Equatable {
 enum MonitorSettingsStore {
     static func get<T: MonitorSettingsType>(
         for monitor: Monitor,
-        in settings: [T],
-        ignoreIdentity: Bool = false
+        in settings: [T]
     ) -> T? {
         if let exact = settings.first(where: { $0.monitorDisplayId == monitor.displayId }) {
             return exact
-        }
-
-        // When ignoring monitor identity, pick the override whose saved position is closest to
-        // this monitor so per-monitor settings follow layout position rather than model/name.
-        if ignoreIdentity {
-            let nearest = settings
-                .compactMap { setting -> (setting: T, distance: CGFloat)? in
-                    guard let anchor = setting.monitorAnchorPoint else { return nil }
-                    return (setting, anchor.distanceSquared(to: monitor.workspaceAnchorPoint))
-                }
-                .min { $0.distance < $1.distance }
-            if let nearest {
-                return nearest.setting
-            }
         }
 
         return settings.first {
@@ -83,10 +68,3 @@ enum MonitorSettingsStore {
     }
 }
 
-private extension CGPoint {
-    func distanceSquared(to point: CGPoint) -> CGFloat {
-        let dx = x - point.x
-        let dy = y - point.y
-        return dx * dx + dy * dy
-    }
-}

--- a/Sources/Nehir/Core/Config/MonitorSettingsType.swift
+++ b/Sources/Nehir/Core/Config/MonitorSettingsType.swift
@@ -4,13 +4,35 @@ import Foundation
 protocol MonitorSettingsType: Codable, Identifiable, Equatable {
     var monitorName: String { get set }
     var monitorDisplayId: CGDirectDisplayID? { get set }
+    /// Top-left anchor of the monitor when the override was saved. Used as a position fallback
+    /// when matching ignores monitor identity. Optional for backward compatibility.
+    var monitorAnchorPoint: CGPoint? { get set }
 }
 
 enum MonitorSettingsStore {
-    static func get<T: MonitorSettingsType>(for monitor: Monitor, in settings: [T]) -> T? {
+    static func get<T: MonitorSettingsType>(
+        for monitor: Monitor,
+        in settings: [T],
+        ignoreIdentity: Bool = false
+    ) -> T? {
         if let exact = settings.first(where: { $0.monitorDisplayId == monitor.displayId }) {
             return exact
         }
+
+        // When ignoring monitor identity, pick the override whose saved position is closest to
+        // this monitor so per-monitor settings follow layout position rather than model/name.
+        if ignoreIdentity {
+            let nearest = settings
+                .compactMap { setting -> (setting: T, distance: CGFloat)? in
+                    guard let anchor = setting.monitorAnchorPoint else { return nil }
+                    return (setting, anchor.distanceSquared(to: monitor.workspaceAnchorPoint))
+                }
+                .min { $0.distance < $1.distance }
+            if let nearest {
+                return nearest.setting
+            }
+        }
+
         return settings.first {
             $0.monitorDisplayId == nil && $0.monitorName == monitor.name
         }
@@ -58,5 +80,13 @@ enum MonitorSettingsStore {
 
     static func remove<T: MonitorSettingsType>(for monitorName: String, from settings: inout [T]) {
         settings.removeAll { $0.monitorName == monitorName }
+    }
+}
+
+private extension CGPoint {
+    func distanceSquared(to point: CGPoint) -> CGFloat {
+        let dx = x - point.x
+        let dy = y - point.y
+        return dx * dx + dy * dy
     }
 }

--- a/Sources/Nehir/Core/Config/SettingsExport.swift
+++ b/Sources/Nehir/Core/Config/SettingsExport.swift
@@ -82,6 +82,12 @@ struct SettingsExport: Equatable, Sendable {
 
     var developerModeEnabled: Bool
 
+    /// When enabled, monitor matching during restore ignores the monitor model/name and
+    /// resolves displays by layout position (anchor-point geometry) instead, so apps,
+    /// workspaces, and per-monitor settings stay on the same monitor across reconnects of
+    /// different monitor sets (e.g. home vs office).
+    var ignoreMonitorIdentity: Bool
+
     var capabilityOverrides: [WindowCapabilityProfileTOMLOverride] = []
 
     /// Unknown keys decoded from settings.toml under known schema tables, grouped by table path.
@@ -156,6 +162,7 @@ extension SettingsExport {
             statusBarUseWorkspaceId: false,
             appearanceMode: AppearanceMode.dark.rawValue,
             developerModeEnabled: false,
+            ignoreMonitorIdentity: false,
             capabilityOverrides: []
         )
     }

--- a/Sources/Nehir/Core/Config/SettingsStore.swift
+++ b/Sources/Nehir/Core/Config/SettingsStore.swift
@@ -487,7 +487,8 @@ final class SettingsStore {
 
         workspaceConfigurations = SettingsStore.normalizedWorkspaceConfigurations(
             export.workspaceConfigurations,
-            monitors: monitors
+            monitors: monitors,
+            ignoreIdentity: export.ignoreMonitorIdentity
         )
 
         bordersEnabled = export.bordersEnabled
@@ -515,15 +516,28 @@ final class SettingsStore {
         workspaceBarYOffset = export.workspaceBarYOffset
         workspaceBarAccentColor = export.workspaceBarAccentColor
         workspaceBarTextColor = export.workspaceBarTextColor
-        monitorBarSettings = SettingsStore.reboundMonitorSettings(export.monitorBarSettings, monitors: monitors)
+        monitorBarSettings = SettingsStore.reboundMonitorSettings(
+            export.monitorBarSettings,
+            monitors: monitors,
+            ignoreIdentity: export.ignoreMonitorIdentity
+        )
 
         appRules = export.appRules
-        monitorGapSettings = SettingsStore.reboundMonitorSettings(export.monitorGapSettings, monitors: monitors)
+        monitorGapSettings = SettingsStore.reboundMonitorSettings(
+            export.monitorGapSettings,
+            monitors: monitors,
+            ignoreIdentity: export.ignoreMonitorIdentity
+        )
         monitorOrientationSettings = SettingsStore.reboundMonitorSettings(
             export.monitorOrientationSettings,
-            monitors: monitors
+            monitors: monitors,
+            ignoreIdentity: export.ignoreMonitorIdentity
         )
-        monitorNiriSettings = SettingsStore.reboundMonitorSettings(export.monitorNiriSettings, monitors: monitors)
+        monitorNiriSettings = SettingsStore.reboundMonitorSettings(
+            export.monitorNiriSettings,
+            monitors: monitors,
+            ignoreIdentity: export.ignoreMonitorIdentity
+        )
 
         preventSleepEnabled = export.preventSleepEnabled
         ipcEnabled = export.ipcEnabled
@@ -627,12 +641,13 @@ final class SettingsStore {
 
     static func normalizedWorkspaceConfigurations(
         _ configs: [WorkspaceConfiguration],
-        monitors: [Monitor] = []
+        monitors: [Monitor] = [],
+        ignoreIdentity: Bool = false
     ) -> [WorkspaceConfiguration] {
         var seen: Set<String> = []
         let rebound = configs.map { config in
             guard case let .specificDisplay(output) = config.monitorAssignment,
-                  let resolvedMonitor = output.resolveMonitor(in: monitors)
+                  let resolvedMonitor = output.resolveMonitor(in: monitors, ignoreIdentity: ignoreIdentity)
             else {
                 return config
             }
@@ -656,25 +671,88 @@ final class SettingsStore {
 
     private static func reboundMonitorSettings<T: MonitorSettingsType>(
         _ settings: [T],
+        monitors: [Monitor],
+        ignoreIdentity: Bool = false
+    ) -> [T] {
+        if ignoreIdentity {
+            return reboundMonitorSettingsByPosition(settings, monitors: monitors)
+        }
+
+        return settings.map { setting in
+            var rebound = setting
+            let resolvedMonitor = reboundMonitor(
+                displayId: rebound.monitorDisplayId,
+                monitorName: rebound.monitorName,
+                anchorPoint: nil,
+                monitors: monitors,
+                ignoreIdentity: false
+            )
+            applyResolvedMonitor(resolvedMonitor, to: &rebound)
+            return rebound
+        }
+    }
+
+    private static func reboundMonitorSettingsByPosition<T: MonitorSettingsType>(
+        _ settings: [T],
         monitors: [Monitor]
     ) -> [T] {
-        settings.map { setting in
-            var rebound = setting
-            let resolvedDisplayId = reboundMonitorDisplayId(
-                rebound.monitorDisplayId,
-                monitorName: rebound.monitorName,
-                monitors: monitors
-            )
-            rebound.monitorDisplayId = resolvedDisplayId
-            // Refresh the saved anchor whenever the monitor is currently connected, so a later
-            // reconnect can match this override by layout position. When the monitor is absent,
-            // keep the previously stored anchor.
-            if let resolvedDisplayId,
-               let monitor = monitors.first(where: { $0.displayId == resolvedDisplayId })
-            {
-                rebound.monitorAnchorPoint = monitor.workspaceAnchorPoint
+        var rebound = settings
+        var resolvedMonitorByIndex: [Int: Monitor] = [:]
+        var usedMonitorIds = Set<Monitor.ID>()
+
+        for index in rebound.indices {
+            guard let displayId = rebound[index].monitorDisplayId,
+                  let exact = monitors.first(where: { $0.displayId == displayId }),
+                  usedMonitorIds.insert(exact.id).inserted
+            else { continue }
+            resolvedMonitorByIndex[index] = exact
+        }
+
+        let anchorMatches = rebound.indices.flatMap { index -> [(index: Int, monitor: Monitor, distance: CGFloat)] in
+            guard resolvedMonitorByIndex[index] == nil,
+                  let anchor = rebound[index].monitorAnchorPoint
+            else { return [] }
+            return monitors
+                .filter { !usedMonitorIds.contains($0.id) }
+                .map { (index: index, monitor: $0, distance: anchor.distanceSquared(to: $0.workspaceAnchorPoint)) }
+        }
+        .sorted { lhs, rhs in
+            if lhs.distance != rhs.distance { return lhs.distance < rhs.distance }
+            if lhs.index != rhs.index { return lhs.index < rhs.index }
+            return monitorSortKey(lhs.monitor) < monitorSortKey(rhs.monitor)
+        }
+
+        var usedSettingIndices = Set(resolvedMonitorByIndex.keys)
+        for match in anchorMatches {
+            guard !usedSettingIndices.contains(match.index),
+                  usedMonitorIds.insert(match.monitor.id).inserted
+            else { continue }
+            resolvedMonitorByIndex[match.index] = match.monitor
+            usedSettingIndices.insert(match.index)
+        }
+
+        for index in rebound.indices where resolvedMonitorByIndex[index] == nil {
+            let matches = monitors.filter {
+                !usedMonitorIds.contains($0.id) && $0.name.caseInsensitiveCompare(rebound[index].monitorName) == .orderedSame
             }
-            return rebound
+            guard matches.count == 1, let match = matches.first else { continue }
+            resolvedMonitorByIndex[index] = match
+            usedMonitorIds.insert(match.id)
+        }
+
+        for index in rebound.indices {
+            applyResolvedMonitor(resolvedMonitorByIndex[index], to: &rebound[index])
+        }
+        return rebound
+    }
+
+    private static func applyResolvedMonitor<T: MonitorSettingsType>(_ monitor: Monitor?, to setting: inout T) {
+        setting.monitorDisplayId = monitor?.displayId
+        // Refresh the saved anchor whenever the monitor is currently connected, so a later
+        // reconnect can match this override by layout position. When the monitor is absent,
+        // keep the previously stored anchor.
+        if let monitor {
+            setting.monitorAnchorPoint = monitor.workspaceAnchorPoint
         }
     }
 
@@ -683,19 +761,38 @@ final class SettingsStore {
         monitorName: String,
         monitors: [Monitor]
     ) -> CGDirectDisplayID? {
-        if let displayId,
-           monitors.contains(where: { $0.displayId == displayId })
-        {
-            return displayId
-        }
+        reboundMonitor(
+            displayId: displayId,
+            monitorName: monitorName,
+            anchorPoint: nil,
+            monitors: monitors,
+            ignoreIdentity: false
+        )?.displayId
+    }
 
+    private static func reboundMonitor(
+        displayId: CGDirectDisplayID?,
+        monitorName: String,
+        anchorPoint: CGPoint?,
+        monitors: [Monitor],
+        ignoreIdentity: Bool
+    ) -> Monitor? {
+        if let displayId, let exact = monitors.first(where: { $0.displayId == displayId }) {
+            return exact
+        }
+        if ignoreIdentity, let anchorPoint {
+            return monitors.min {
+                $0.workspaceAnchorPoint.distanceSquared(to: anchorPoint)
+                    < $1.workspaceAnchorPoint.distanceSquared(to: anchorPoint)
+            }
+        }
         let matches = monitors.filter { $0.name.caseInsensitiveCompare(monitorName) == .orderedSame }
         guard matches.count == 1 else { return nil }
-        return matches[0].displayId
+        return matches[0]
     }
 
     func barSettings(for monitor: Monitor) -> MonitorBarSettings? {
-        MonitorSettingsStore.get(for: monitor, in: monitorBarSettings, ignoreIdentity: ignoreMonitorIdentity)
+        MonitorSettingsStore.get(for: monitor, in: monitorBarSettings)
     }
 
     func barSettings(for monitorName: String) -> MonitorBarSettings? {
@@ -748,7 +845,7 @@ final class SettingsStore {
     }
 
     func gapSettings(for monitor: Monitor) -> MonitorGapSettings? {
-        MonitorSettingsStore.get(for: monitor, in: monitorGapSettings, ignoreIdentity: ignoreMonitorIdentity)
+        MonitorSettingsStore.get(for: monitor, in: monitorGapSettings)
     }
 
     func gapSettings(for monitorName: String) -> MonitorGapSettings? {
@@ -779,7 +876,7 @@ final class SettingsStore {
     }
 
     func orientationSettings(for monitor: Monitor) -> MonitorOrientationSettings? {
-        MonitorSettingsStore.get(for: monitor, in: monitorOrientationSettings, ignoreIdentity: ignoreMonitorIdentity)
+        MonitorSettingsStore.get(for: monitor, in: monitorOrientationSettings)
     }
 
     func orientationSettings(for monitorName: String) -> MonitorOrientationSettings? {
@@ -808,7 +905,7 @@ final class SettingsStore {
     }
 
     func niriSettings(for monitor: Monitor) -> MonitorNiriSettings? {
-        MonitorSettingsStore.get(for: monitor, in: monitorNiriSettings, ignoreIdentity: ignoreMonitorIdentity)
+        MonitorSettingsStore.get(for: monitor, in: monitorNiriSettings)
     }
 
     func niriSettings(for monitorName: String) -> MonitorNiriSettings? {
@@ -880,5 +977,17 @@ final class SettingsStore {
     static func validatedLoneWindowMaxWidth(_ width: Double?) -> Double? {
         guard let width else { return nil }
         return min(1.0, max(0.10, width))
+    }
+
+    private static func monitorSortKey(_ monitor: Monitor) -> (CGFloat, CGFloat, UInt32) {
+        (monitor.frame.minX, -monitor.frame.maxY, monitor.displayId)
+    }
+}
+
+private extension CGPoint {
+    func distanceSquared(to point: CGPoint) -> CGFloat {
+        let dx = x - point.x
+        let dy = y - point.y
+        return dx * dx + dy * dy
     }
 }

--- a/Sources/Nehir/Core/Config/SettingsStore.swift
+++ b/Sources/Nehir/Core/Config/SettingsStore.swift
@@ -259,6 +259,10 @@ final class SettingsStore {
         didSet { scheduleSave() }
     }
 
+    var ignoreMonitorIdentity = SettingsStore.defaultExport.ignoreMonitorIdentity {
+        didSet { scheduleSave() }
+    }
+
     var scrollGestureEnabled = SettingsStore.defaultExport.scrollGestureEnabled {
         didSet { scheduleSave() }
     }
@@ -448,6 +452,7 @@ final class SettingsStore {
             statusBarUseWorkspaceId: statusBarUseWorkspaceId,
             appearanceMode: appearanceMode.rawValue,
             developerModeEnabled: developerModeEnabled,
+            ignoreMonitorIdentity: ignoreMonitorIdentity,
             capabilityOverrides: [],
             settingsTOMLUnknownFields: settingsTOMLUnknownFields
         )
@@ -534,6 +539,7 @@ final class SettingsStore {
 
         appearanceMode = AppearanceMode(rawValue: export.appearanceMode) ?? .dark
         developerModeEnabled = export.developerModeEnabled
+        ignoreMonitorIdentity = export.ignoreMonitorIdentity
         settingsTOMLUnknownFields = export.settingsTOMLUnknownFields
     }
 
@@ -654,11 +660,20 @@ final class SettingsStore {
     ) -> [T] {
         settings.map { setting in
             var rebound = setting
-            rebound.monitorDisplayId = reboundMonitorDisplayId(
+            let resolvedDisplayId = reboundMonitorDisplayId(
                 rebound.monitorDisplayId,
                 monitorName: rebound.monitorName,
                 monitors: monitors
             )
+            rebound.monitorDisplayId = resolvedDisplayId
+            // Refresh the saved anchor whenever the monitor is currently connected, so a later
+            // reconnect can match this override by layout position. When the monitor is absent,
+            // keep the previously stored anchor.
+            if let resolvedDisplayId,
+               let monitor = monitors.first(where: { $0.displayId == resolvedDisplayId })
+            {
+                rebound.monitorAnchorPoint = monitor.workspaceAnchorPoint
+            }
             return rebound
         }
     }
@@ -680,7 +695,7 @@ final class SettingsStore {
     }
 
     func barSettings(for monitor: Monitor) -> MonitorBarSettings? {
-        MonitorSettingsStore.get(for: monitor, in: monitorBarSettings)
+        MonitorSettingsStore.get(for: monitor, in: monitorBarSettings, ignoreIdentity: ignoreMonitorIdentity)
     }
 
     func barSettings(for monitorName: String) -> MonitorBarSettings? {
@@ -733,7 +748,7 @@ final class SettingsStore {
     }
 
     func gapSettings(for monitor: Monitor) -> MonitorGapSettings? {
-        MonitorSettingsStore.get(for: monitor, in: monitorGapSettings)
+        MonitorSettingsStore.get(for: monitor, in: monitorGapSettings, ignoreIdentity: ignoreMonitorIdentity)
     }
 
     func gapSettings(for monitorName: String) -> MonitorGapSettings? {
@@ -764,7 +779,7 @@ final class SettingsStore {
     }
 
     func orientationSettings(for monitor: Monitor) -> MonitorOrientationSettings? {
-        MonitorSettingsStore.get(for: monitor, in: monitorOrientationSettings)
+        MonitorSettingsStore.get(for: monitor, in: monitorOrientationSettings, ignoreIdentity: ignoreMonitorIdentity)
     }
 
     func orientationSettings(for monitorName: String) -> MonitorOrientationSettings? {
@@ -793,7 +808,7 @@ final class SettingsStore {
     }
 
     func niriSettings(for monitor: Monitor) -> MonitorNiriSettings? {
-        MonitorSettingsStore.get(for: monitor, in: monitorNiriSettings)
+        MonitorSettingsStore.get(for: monitor, in: monitorNiriSettings, ignoreIdentity: ignoreMonitorIdentity)
     }
 
     func niriSettings(for monitorName: String) -> MonitorNiriSettings? {

--- a/Sources/Nehir/Core/Config/WorkspacesTOMLCodec.swift
+++ b/Sources/Nehir/Core/Config/WorkspacesTOMLCodec.swift
@@ -1,3 +1,4 @@
+import CoreGraphics
 import Foundation
 import NehirIPC
 
@@ -33,6 +34,10 @@ enum WorkspacesTOMLCodec {
                 lines.append("monitor = \"specific\"")
                 lines.append("monitorName = \(quoted(output.name))")
                 lines.append("monitorDisplayId = \(output.displayId)")
+                if let anchor = output.anchorPoint {
+                    lines.append("monitorAnchorX = \(anchor.x)")
+                    lines.append("monitorAnchorY = \(anchor.y)")
+                }
             }
         }
         return Data((lines.joined(separator: "\n") + "\n").utf8)
@@ -57,7 +62,13 @@ enum WorkspacesTOMLCodec {
                       let displayIdRaw = row.values["monitorDisplayId"],
                       let displayId = UInt32(displayIdRaw.trimmingCharacters(in: .whitespaces))
                 else { assignment = .main; break }
-                assignment = .specificDisplay(OutputId(displayId: displayId, name: monitorName))
+                let anchorPoint = parseAnchorPoint(
+                    x: row.values["monitorAnchorX"],
+                    y: row.values["monitorAnchorY"]
+                )
+                assignment = .specificDisplay(
+                    OutputId(displayId: displayId, name: monitorName, anchorPoint: anchorPoint)
+                )
             default:
                 assignment = .main
             }
@@ -191,6 +202,14 @@ enum WorkspacesTOMLCodec {
             }
         }
         return line
+    }
+
+    private static func parseAnchorPoint(x: String?, y: String?) -> CGPoint? {
+        guard let x, let y,
+              let anchorX = Double(x.trimmingCharacters(in: .whitespaces)),
+              let anchorY = Double(y.trimmingCharacters(in: .whitespaces))
+        else { return nil }
+        return CGPoint(x: anchorX, y: anchorY)
     }
 
     private static func extractString(_ raw: String?) -> String? {

--- a/Sources/Nehir/Core/Monitor/MonitorDescription.swift
+++ b/Sources/Nehir/Core/Monitor/MonitorDescription.swift
@@ -5,7 +5,7 @@ enum MonitorDescription: Equatable {
     case secondary
     case output(OutputId)
 
-    func resolveMonitor(sortedMonitors: [Monitor]) -> Monitor? {
+    func resolveMonitor(sortedMonitors: [Monitor], ignoreIdentity: Bool = false) -> Monitor? {
         switch self {
         case .main:
             return sortedMonitors.first(where: { $0.isMain }) ?? sortedMonitors.first
@@ -18,7 +18,7 @@ enum MonitorDescription: Equatable {
             }
             return sortedMonitors.dropFirst().first
         case let .output(output):
-            return output.resolveMonitor(in: sortedMonitors)
+            return output.resolveMonitor(in: sortedMonitors, ignoreIdentity: ignoreIdentity)
         }
     }
 }

--- a/Sources/Nehir/Core/Monitor/MonitorRestoreAssignments.swift
+++ b/Sources/Nehir/Core/Monitor/MonitorRestoreAssignments.swift
@@ -57,13 +57,15 @@ func resolveWorkspaceRestoreAssignments(
     var usedMonitorIds: Set<Monitor.ID> = []
     var assignedWorkspaceIds: Set<WorkspaceDescriptor.ID> = []
 
-    for snapshot in filteredSnapshots {
-        guard let exactMonitor = sortedMonitors.first(where: { $0.displayId == snapshot.monitor.displayId }) else {
-            continue
+    if !ignoreIdentity {
+        for snapshot in filteredSnapshots {
+            guard let exactMonitor = sortedMonitors.first(where: { $0.displayId == snapshot.monitor.displayId }) else {
+                continue
+            }
+            guard usedMonitorIds.insert(exactMonitor.id).inserted else { continue }
+            assignments[exactMonitor.id] = snapshot.workspaceId
+            assignedWorkspaceIds.insert(snapshot.workspaceId)
         }
-        guard usedMonitorIds.insert(exactMonitor.id).inserted else { continue }
-        assignments[exactMonitor.id] = snapshot.workspaceId
-        assignedWorkspaceIds.insert(snapshot.workspaceId)
     }
 
     let remainingSnapshots = filteredSnapshots.filter { !assignedWorkspaceIds.contains($0.workspaceId) }

--- a/Sources/Nehir/Core/Monitor/MonitorRestoreAssignments.swift
+++ b/Sources/Nehir/Core/Monitor/MonitorRestoreAssignments.swift
@@ -30,6 +30,7 @@ private struct RestoreMatchingResult {
 func resolveWorkspaceRestoreAssignments(
     snapshots: [WorkspaceRestoreSnapshot],
     monitors: [Monitor],
+    ignoreIdentity: Bool = false,
     workspaceExists: (WorkspaceDescriptor.ID) -> Bool
 ) -> [Monitor.ID: WorkspaceDescriptor.ID] {
     guard !snapshots.isEmpty, !monitors.isEmpty else { return [:] }
@@ -69,7 +70,8 @@ func resolveWorkspaceRestoreAssignments(
     let remainingMonitors = sortedMonitors.filter { !usedMonitorIds.contains($0.id) }
     let remainingAssignments = resolveBestRestoreMatches(
         snapshots: remainingSnapshots,
-        monitors: remainingMonitors
+        monitors: remainingMonitors,
+        ignoreIdentity: ignoreIdentity
     )
     for (snapshotIndex, monitorId) in remainingAssignments {
         assignments[monitorId] = remainingSnapshots[snapshotIndex].workspaceId
@@ -80,7 +82,8 @@ func resolveWorkspaceRestoreAssignments(
 
 private func resolveBestRestoreMatches(
     snapshots: [WorkspaceRestoreSnapshot],
-    monitors: [Monitor]
+    monitors: [Monitor],
+    ignoreIdentity: Bool
 ) -> [Int: Monitor.ID] {
     guard !snapshots.isEmpty, !monitors.isEmpty else { return [:] }
 
@@ -139,7 +142,11 @@ private func resolveBestRestoreMatches(
             var nextMonitors = availableMonitors
             nextMonitors.remove(at: monitorIndex)
 
-            let score = restoreMatchScore(snapshot: currentSnapshot.monitor, monitor: monitor)
+            let score = restoreMatchScore(
+                snapshot: currentSnapshot.monitor,
+                monitor: monitor,
+                ignoreIdentity: ignoreIdentity
+            )
             var candidate = search(
                 snapshotIndex: snapshotIndex + 1,
                 availableMonitors: nextMonitors
@@ -162,9 +169,14 @@ private func resolveBestRestoreMatches(
 
 private func restoreMatchScore(
     snapshot: MonitorRestoreKey,
-    monitor: Monitor
+    monitor: Monitor,
+    ignoreIdentity: Bool
 ) -> (namePenalty: Int, geometryDelta: CGFloat) {
-    let namePenalty = snapshot.name.localizedCaseInsensitiveCompare(monitor.name) == .orderedSame ? 0 : 1
+    // When ignoring monitor identity, rank purely by layout position so the same workspace
+    // returns to the same physical monitor even if its model/name changed.
+    let namePenalty = ignoreIdentity
+        ? 0
+        : (snapshot.name.localizedCaseInsensitiveCompare(monitor.name) == .orderedSame ? 0 : 1)
     let anchorDistance = snapshot.anchorPoint.distanceSquared(to: monitor.workspaceAnchorPoint)
     let widthDelta = abs(snapshot.frameSize.width - monitor.frame.width)
     let heightDelta = abs(snapshot.frameSize.height - monitor.frame.height)

--- a/Sources/Nehir/Core/Monitor/OutputId.swift
+++ b/Sources/Nehir/Core/Monitor/OutputId.swift
@@ -1,28 +1,65 @@
 import CoreGraphics
 import Foundation
 
-struct OutputId: Hashable, Codable {
+struct OutputId: Codable {
     let displayId: CGDirectDisplayID
 
     let name: String
 
-    init(displayId: CGDirectDisplayID, name: String) {
+    /// Top-left anchor point of the monitor at the time the assignment was saved. Used as a
+    /// position fallback when matching ignores monitor identity. Optional for backward
+    /// compatibility with configs written before this field existed.
+    let anchorPoint: CGPoint?
+
+    init(displayId: CGDirectDisplayID, name: String, anchorPoint: CGPoint? = nil) {
         self.displayId = displayId
         self.name = name
+        self.anchorPoint = anchorPoint
     }
 
     init(from monitor: Monitor) {
         displayId = monitor.displayId
         name = monitor.name
+        anchorPoint = monitor.workspaceAnchorPoint
     }
 
-    func resolveMonitor(in monitors: [Monitor]) -> Monitor? {
+    func resolveMonitor(in monitors: [Monitor], ignoreIdentity: Bool = false) -> Monitor? {
         if let exact = monitors.first(where: { $0.displayId == displayId }) {
             return exact
+        }
+
+        // When ignoring monitor identity, resolve by layout position so a workspace pinned to a
+        // specific display reattaches to whatever monitor now occupies that position.
+        if ignoreIdentity, let anchorPoint {
+            return monitors.min {
+                $0.workspaceAnchorPoint.distanceSquared(to: anchorPoint)
+                    < $1.workspaceAnchorPoint.distanceSquared(to: anchorPoint)
+            }
         }
 
         let nameMatches = monitors.filter { $0.name.caseInsensitiveCompare(name) == .orderedSame }
         guard nameMatches.count == 1 else { return nil }
         return nameMatches[0]
+    }
+}
+
+extension OutputId: Hashable {
+    // Identity is the (displayId, name) pair; the anchor point is incidental restore metadata
+    // and must not affect equality so picker selections and stored assignments keep matching.
+    static func == (lhs: OutputId, rhs: OutputId) -> Bool {
+        lhs.displayId == rhs.displayId && lhs.name == rhs.name
+    }
+
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(displayId)
+        hasher.combine(name)
+    }
+}
+
+private extension CGPoint {
+    func distanceSquared(to point: CGPoint) -> CGFloat {
+        let dx = x - point.x
+        let dy = y - point.y
+        return dx * dx + dy * dy
     }
 }

--- a/Sources/Nehir/Core/Reconcile/RestorePlanner.swift
+++ b/Sources/Nehir/Core/Reconcile/RestorePlanner.swift
@@ -23,6 +23,7 @@ struct RestorePlanner {
         let disconnectedVisibleWorkspaceCache: [MonitorRestoreKey: WorkspaceDescriptor.ID]
         let interactionMonitorId: Monitor.ID?
         let previousInteractionMonitorId: Monitor.ID?
+        var ignoreMonitorIdentity: Bool = false
         let workspaceExists: (WorkspaceDescriptor.ID) -> Bool
         let homeMonitorId: (WorkspaceDescriptor.ID, [Monitor]) -> Monitor.ID?
         let effectiveMonitorId: (WorkspaceDescriptor.ID, [Monitor]) -> Monitor.ID?
@@ -45,6 +46,7 @@ struct RestorePlanner {
         let catalog: PersistedWindowRestoreCatalog
         let consumedEntries: Set<PersistedWindowRestoreConsumptionKey>
         let monitors: [Monitor]
+        var ignoreMonitorIdentity: Bool = false
         let workspaceIdForName: (String) -> WorkspaceDescriptor.ID?
     }
 
@@ -152,6 +154,7 @@ struct RestorePlanner {
         let restoredAssignments = resolveWorkspaceRestoreAssignments(
             snapshots: visibleSnapshots,
             monitors: input.newMonitors,
+            ignoreIdentity: input.ignoreMonitorIdentity,
             workspaceExists: input.workspaceExists
         )
 
@@ -270,7 +273,8 @@ struct RestorePlanner {
         let preferredMonitor = resolvePersistedPreferredMonitor(
             persistedEntry.restoreIntent.preferredMonitor,
             fallbackWorkspaceId: workspaceId,
-            monitors: input.monitors
+            monitors: input.monitors,
+            ignoreIdentity: input.ignoreMonitorIdentity
         )
 
         let targetMode: TrackedWindowMode = persistedEntry.restoreIntent.restoreToFloating ? .floating : input.metadata
@@ -351,7 +355,8 @@ struct RestorePlanner {
     private func resolvePersistedPreferredMonitor(
         _ preferredMonitor: DisplayFingerprint?,
         fallbackWorkspaceId _: WorkspaceDescriptor.ID,
-        monitors: [Monitor]
+        monitors: [Monitor],
+        ignoreIdentity: Bool
     ) -> Monitor? {
         guard let preferredMonitor else {
             return monitors.first
@@ -370,11 +375,13 @@ struct RestorePlanner {
         let bestFallback = monitors.min { lhs, rhs in
             let lhsScore = persistedMonitorMatchScore(
                 fingerprint: preferredMonitor,
-                monitor: lhs
+                monitor: lhs,
+                ignoreIdentity: ignoreIdentity
             )
             let rhsScore = persistedMonitorMatchScore(
                 fingerprint: preferredMonitor,
-                monitor: rhs
+                monitor: rhs,
+                ignoreIdentity: ignoreIdentity
             )
             if lhsScore.namePenalty != rhsScore.namePenalty {
                 return lhsScore.namePenalty < rhsScore.namePenalty
@@ -390,9 +397,14 @@ struct RestorePlanner {
 
     private func persistedMonitorMatchScore(
         fingerprint: DisplayFingerprint,
-        monitor: Monitor
+        monitor: Monitor,
+        ignoreIdentity: Bool
     ) -> (namePenalty: Int, geometryDelta: CGFloat) {
-        let namePenalty = fingerprint.name.localizedCaseInsensitiveCompare(monitor.name) == .orderedSame ? 0 : 1
+        // When ignoring monitor identity, rank purely by layout position so each window
+        // returns to the same physical monitor regardless of a changed model/name.
+        let namePenalty = ignoreIdentity
+            ? 0
+            : (fingerprint.name.localizedCaseInsensitiveCompare(monitor.name) == .orderedSame ? 0 : 1)
         let anchorDistance = fingerprint.anchorPoint.distanceSquared(to: monitor.workspaceAnchorPoint)
         let widthDelta = abs(fingerprint.frameSize.width - monitor.frame.width)
         let heightDelta = abs(fingerprint.frameSize.height - monitor.frame.height)

--- a/Sources/Nehir/Core/Workspace/WorkspaceManager.swift
+++ b/Sources/Nehir/Core/Workspace/WorkspaceManager.swift
@@ -535,6 +535,7 @@ final class WorkspaceManager {
                 disconnectedVisibleWorkspaceCache: disconnectedVisibleWorkspaceCache,
                 interactionMonitorId: sessionState.interactionMonitorId,
                 previousInteractionMonitorId: sessionState.previousInteractionMonitorId,
+                ignoreMonitorIdentity: settings.ignoreMonitorIdentity,
                 workspaceExists: { [weak self] workspaceId in
                     self?.descriptor(for: workspaceId) != nil
                 },
@@ -761,6 +762,7 @@ final class WorkspaceManager {
                       catalog: bootPersistedWindowRestoreCatalog,
                       consumedEntries: consumedBootPersistedWindowRestoreEntries,
                       monitors: monitors,
+                      ignoreMonitorIdentity: settings.ignoreMonitorIdentity,
                       workspaceIdForName: { [weak self] workspaceName in
                           self?.workspaceId(for: workspaceName, createIfMissing: false)
                       }
@@ -3586,6 +3588,7 @@ final class WorkspaceManager {
         let assignments = resolveWorkspaceRestoreAssignments(
             snapshots: snapshots,
             monitors: monitors,
+            ignoreIdentity: settings.ignoreMonitorIdentity,
             workspaceExists: { descriptor(for: $0) != nil }
         )
         guard !assignments.isEmpty else { return }
@@ -3656,6 +3659,7 @@ final class WorkspaceManager {
         let restoredAssignments = resolveWorkspaceRestoreAssignments(
             snapshots: visibleSnapshots,
             monitors: monitors,
+            ignoreIdentity: settings.ignoreMonitorIdentity,
             workspaceExists: { descriptor(for: $0) != nil }
         )
 
@@ -3767,7 +3771,10 @@ final class WorkspaceManager {
     ) -> Monitor? {
         guard let workspace = descriptor(for: workspaceId) else { return nil }
         guard let description = configuredMonitorDescription(for: workspace.name, context: context) else { return nil }
-        return description.resolveMonitor(sortedMonitors: context.sortedMonitors)
+        return description.resolveMonitor(
+            sortedMonitors: context.sortedMonitors,
+            ignoreIdentity: settings.ignoreMonitorIdentity
+        )
     }
 
     private func homeMonitorId(for workspaceId: WorkspaceDescriptor.ID) -> Monitor.ID? {

--- a/Sources/Nehir/UI/MonitorSettingsTab.swift
+++ b/Sources/Nehir/UI/MonitorSettingsTab.swift
@@ -41,6 +41,18 @@ struct MonitorSettingsTab: View {
         SettingsPage(
             subtitle: "Configure mouse warp order and per-monitor orientation without changing macOS display arrangement."
         ) {
+            Section("Display Matching") {
+                Toggle("Keep apps on the same monitor across reconnects", isOn: $settings.ignoreMonitorIdentity)
+                    .onChange(of: settings.ignoreMonitorIdentity) { _, _ in
+                        controller.updateWorkspaceBarSettings()
+                        controller.updateMonitorGapSettings()
+                        controller.updateMonitorNiriSettings()
+                    }
+                SettingsCaption(
+                    "Match saved windows, workspaces, and per-monitor settings by screen position instead of monitor model — so apps return to the same monitor (Main or Secondary) when moving between different monitor sets, such as home and office."
+                )
+            }
+
             Section("Mouse Warp") {
                 SettingsCaption("Moves the cursor to the opposite monitor when it reaches a screen edge.")
 

--- a/Sources/Nehir/UI/MonitorSettingsTab.swift
+++ b/Sources/Nehir/UI/MonitorSettingsTab.swift
@@ -42,14 +42,17 @@ struct MonitorSettingsTab: View {
             subtitle: "Configure mouse warp order and per-monitor orientation without changing macOS display arrangement."
         ) {
             Section("Display Matching") {
-                Toggle("Keep apps on the same monitor across reconnects", isOn: $settings.ignoreMonitorIdentity)
+                Toggle("Keep apps on the same screen position", isOn: $settings.ignoreMonitorIdentity)
                     .onChange(of: settings.ignoreMonitorIdentity) { _, _ in
                         controller.updateWorkspaceBarSettings()
                         controller.updateMonitorGapSettings()
                         controller.updateMonitorNiriSettings()
                     }
                 SettingsCaption(
-                    "Match saved windows, workspaces, and per-monitor settings by screen position instead of monitor model — so apps return to the same monitor (Main or Secondary) when moving between different monitor sets, such as home and office."
+                    "Use when moving between desks with different monitor models. Nehir restores saved windows, workspace display assignments, and per-monitor settings by layout position instead of display name."
+                )
+                SettingsCaption(
+                    "Leave off when settings should stay tied to a specific physical monitor."
                 )
             }
 

--- a/Tests/NehirTests/Fixtures/canonical-settings.toml
+++ b/Tests/NehirTests/Fixtures/canonical-settings.toml
@@ -29,6 +29,7 @@ top = 0.0
 [general]
 developerModeEnabled = false
 hotkeysEnabled = true
+ignoreMonitorIdentity = false
 ipcEnabled = false
 preventSleepEnabled = false
 

--- a/Tests/NehirTests/MonitorIdentityMatchingTests.swift
+++ b/Tests/NehirTests/MonitorIdentityMatchingTests.swift
@@ -1,0 +1,117 @@
+import CoreGraphics
+import Foundation
+@testable import Nehir
+import Testing
+
+private func makeIdentityTestMonitor(
+    displayId: CGDirectDisplayID,
+    name: String,
+    x: CGFloat,
+    y: CGFloat = 0,
+    width: CGFloat = 1920,
+    height: CGFloat = 1080
+) -> Monitor {
+    let frame = CGRect(x: x, y: y, width: width, height: height)
+    return Monitor(
+        id: Monitor.ID(displayId: displayId),
+        displayId: displayId,
+        frame: frame,
+        visibleFrame: frame,
+        hasNotch: false,
+        name: name
+    )
+}
+
+@Suite struct MonitorIdentityMatchingTests {
+    // MARK: - OutputId
+
+    @Test func outputIdEqualityIgnoresAnchorPoint() {
+        let withAnchor = OutputId(displayId: 1, name: "Display", anchorPoint: CGPoint(x: 10, y: 20))
+        let withoutAnchor = OutputId(displayId: 1, name: "Display")
+        #expect(withAnchor == withoutAnchor)
+        #expect(withAnchor.hashValue == withoutAnchor.hashValue)
+    }
+
+    @Test func outputIdResolvesByNameWhenIdentityKept() {
+        let saved = OutputId(from: makeIdentityTestMonitor(displayId: 100, name: "Shared", x: 1920))
+        let leftSameName = makeIdentityTestMonitor(displayId: 1, name: "Shared", x: 0)
+        let rightDifferentName = makeIdentityTestMonitor(displayId: 200, name: "Office", x: 1920)
+
+        let resolved = saved.resolveMonitor(in: [leftSameName, rightDifferentName])
+        #expect(resolved?.id == leftSameName.id)
+    }
+
+    @Test func outputIdResolvesByPositionWhenIdentityIgnored() {
+        let saved = OutputId(from: makeIdentityTestMonitor(displayId: 100, name: "Shared", x: 1920))
+        let leftSameName = makeIdentityTestMonitor(displayId: 1, name: "Shared", x: 0)
+        let rightDifferentName = makeIdentityTestMonitor(displayId: 200, name: "Office", x: 1920)
+
+        let resolved = saved.resolveMonitor(in: [leftSameName, rightDifferentName], ignoreIdentity: true)
+        #expect(resolved?.id == rightDifferentName.id)
+    }
+
+    @Test func outputIdStillPrefersExactDisplayIdWhenIgnoringIdentity() {
+        let exact = makeIdentityTestMonitor(displayId: 100, name: "Renamed", x: 0)
+        let saved = OutputId(displayId: 100, name: "Original", anchorPoint: CGPoint(x: 5000, y: 5000))
+        let resolved = saved.resolveMonitor(in: [exact], ignoreIdentity: true)
+        #expect(resolved?.id == exact.id)
+    }
+
+    // MARK: - MonitorSettingsStore
+
+    @Test func monitorSettingsResolveByPositionWhenIdentityIgnored() {
+        let leftSetting = MonitorBarSettings(
+            monitorName: "Left",
+            monitorAnchorPoint: CGPoint(x: 0, y: 1080),
+            enabled: true
+        )
+        let rightSetting = MonitorBarSettings(
+            monitorName: "Right",
+            monitorAnchorPoint: CGPoint(x: 1920, y: 1080),
+            enabled: false
+        )
+        let settings = [leftSetting, rightSetting]
+
+        let rightMonitor = makeIdentityTestMonitor(displayId: 900, name: "BrandNew", x: 1920)
+        let leftMonitor = makeIdentityTestMonitor(displayId: 901, name: "AlsoNew", x: 0)
+
+        #expect(MonitorSettingsStore.get(for: rightMonitor, in: settings, ignoreIdentity: true)?.id == rightSetting.id)
+        #expect(MonitorSettingsStore.get(for: leftMonitor, in: settings, ignoreIdentity: true)?.id == leftSetting.id)
+        // Without ignoring identity, an unrelated name/displayId does not match.
+        #expect(MonitorSettingsStore.get(for: rightMonitor, in: settings) == nil)
+    }
+
+    // MARK: - WorkspacesTOMLCodec anchor persistence
+
+    @Test func workspaceAssignmentAnchorRoundTrips() {
+        let output = OutputId(displayId: 42, name: "HP E27m G4", anchorPoint: CGPoint(x: 1920, y: 1080))
+        let config = WorkspaceConfiguration(name: "1", monitorAssignment: .specificDisplay(output))
+
+        let data = WorkspacesTOMLCodec.encode([config])
+        let decoded = WorkspacesTOMLCodec.decode(data, defaults: [])
+
+        guard case let .specificDisplay(decodedOutput) = decoded.first?.monitorAssignment else {
+            Issue.record("Expected a specificDisplay assignment")
+            return
+        }
+        #expect(decodedOutput.displayId == 42)
+        #expect(decodedOutput.anchorPoint == CGPoint(x: 1920, y: 1080))
+    }
+
+    @Test func workspaceAssignmentWithoutAnchorDecodesAsNil() {
+        let toml = """
+        [1]
+        monitor = "specific"
+        monitorName = "Legacy"
+        monitorDisplayId = 7
+        """
+        let decoded = WorkspacesTOMLCodec.decode(string: toml)
+
+        guard case let .specificDisplay(output) = decoded.first?.monitorAssignment else {
+            Issue.record("Expected a specificDisplay assignment")
+            return
+        }
+        #expect(output.displayId == 7)
+        #expect(output.anchorPoint == nil)
+    }
+}

--- a/Tests/NehirTests/MonitorIdentityMatchingTests.swift
+++ b/Tests/NehirTests/MonitorIdentityMatchingTests.swift
@@ -57,28 +57,43 @@ private func makeIdentityTestMonitor(
         #expect(resolved?.id == exact.id)
     }
 
+    @Test @MainActor func workspaceConfigurationsRebindByPositionWhenIdentityIgnored() {
+        let savedOutput = OutputId(from: makeIdentityTestMonitor(displayId: 100, name: "Shared", x: 1920))
+        let config = WorkspaceConfiguration(name: "1", monitorAssignment: .specificDisplay(savedOutput))
+        let leftSameName = makeIdentityTestMonitor(displayId: 1, name: "Shared", x: 0)
+        let rightDifferentName = makeIdentityTestMonitor(displayId: 200, name: "Office", x: 1920)
+
+        let rebound = SettingsStore.normalizedWorkspaceConfigurations(
+            [config],
+            monitors: [leftSameName, rightDifferentName],
+            ignoreIdentity: true
+        )
+
+        guard case let .specificDisplay(output) = rebound.first?.monitorAssignment else {
+            Issue.record("Expected a specificDisplay assignment")
+            return
+        }
+        #expect(output.displayId == rightDifferentName.displayId)
+    }
+
     // MARK: - MonitorSettingsStore
 
-    @Test func monitorSettingsResolveByPositionWhenIdentityIgnored() {
-        let leftSetting = MonitorBarSettings(
-            monitorName: "Left",
-            monitorAnchorPoint: CGPoint(x: 0, y: 1080),
-            enabled: true
-        )
-        let rightSetting = MonitorBarSettings(
+    @Test func monitorSettingsStoreUsesReboundDisplayIdentityOnly() {
+        let setting = MonitorBarSettings(
             monitorName: "Right",
             monitorAnchorPoint: CGPoint(x: 1920, y: 1080),
             enabled: false
         )
-        let settings = [leftSetting, rightSetting]
-
         let rightMonitor = makeIdentityTestMonitor(displayId: 900, name: "BrandNew", x: 1920)
-        let leftMonitor = makeIdentityTestMonitor(displayId: 901, name: "AlsoNew", x: 0)
+        let rebound = MonitorBarSettings(
+            monitorName: setting.monitorName,
+            monitorDisplayId: rightMonitor.displayId,
+            monitorAnchorPoint: setting.monitorAnchorPoint,
+            enabled: setting.enabled
+        )
 
-        #expect(MonitorSettingsStore.get(for: rightMonitor, in: settings, ignoreIdentity: true)?.id == rightSetting.id)
-        #expect(MonitorSettingsStore.get(for: leftMonitor, in: settings, ignoreIdentity: true)?.id == leftSetting.id)
-        // Without ignoring identity, an unrelated name/displayId does not match.
-        #expect(MonitorSettingsStore.get(for: rightMonitor, in: settings) == nil)
+        #expect(MonitorSettingsStore.get(for: rightMonitor, in: [setting]) == nil)
+        #expect(MonitorSettingsStore.get(for: rightMonitor, in: [rebound])?.id == rebound.id)
     }
 
     // MARK: - WorkspacesTOMLCodec anchor persistence

--- a/Tests/NehirTests/MonitorRestoreAssignmentsTests.swift
+++ b/Tests/NehirTests/MonitorRestoreAssignmentsTests.swift
@@ -95,6 +95,23 @@ private func makeMonitor(
         #expect(assignments[newRight.id] == wsRight)
     }
 
+    @Test func ignoringMonitorIdentitySkipsDisplayIdShortCircuit() {
+        let oldRight = makeMonitor(displayId: 20, name: "HomeRight", x: 1920, y: 0)
+        let newLeftWithOldId = makeMonitor(displayId: 20, name: "OfficeLeft", x: 0, y: 0)
+        let newRight = makeMonitor(displayId: 40, name: "OfficeRight", x: 1920, y: 0)
+        let workspaceId = WorkspaceDescriptor.ID()
+
+        let assignments = resolveWorkspaceRestoreAssignments(
+            snapshots: [WorkspaceRestoreSnapshot(monitor: .init(monitor: oldRight), workspaceId: workspaceId)],
+            monitors: [newLeftWithOldId, newRight],
+            ignoreIdentity: true,
+            workspaceExists: { _ in true }
+        )
+
+        #expect(assignments[newRight.id] == workspaceId)
+        #expect(assignments[newLeftWithOldId.id] == nil)
+    }
+
     @Test func filtersUnknownWorkspacesAndDuplicateWorkspaceSnapshots() {
         let left = makeMonitor(displayId: 500, name: "Left", x: 0, y: 0)
         let right = makeMonitor(displayId: 600, name: "Right", x: 1920, y: 0)

--- a/Tests/NehirTests/MonitorRestoreAssignmentsTests.swift
+++ b/Tests/NehirTests/MonitorRestoreAssignmentsTests.swift
@@ -69,6 +69,32 @@ private func makeMonitor(
         #expect(assignments[newRight.id] == wsRight)
     }
 
+    @Test func ignoringMonitorIdentityRestoresWorkspacesByPosition() {
+        // Old setup: workspace pinned to the right monitor "HomeRight".
+        let oldLeft = makeMonitor(displayId: 10, name: "HomeLeft", x: 0, y: 0)
+        let oldRight = makeMonitor(displayId: 20, name: "HomeRight", x: 1920, y: 0)
+        // New (office) setup: completely different names + displayIds, same positions.
+        let newLeft = makeMonitor(displayId: 30, name: "OfficeLeft", x: 0, y: 0)
+        let newRight = makeMonitor(displayId: 40, name: "OfficeRight", x: 1920, y: 0)
+
+        let wsLeft = WorkspaceDescriptor.ID()
+        let wsRight = WorkspaceDescriptor.ID()
+        let snapshots = [
+            WorkspaceRestoreSnapshot(monitor: .init(monitor: oldLeft), workspaceId: wsLeft),
+            WorkspaceRestoreSnapshot(monitor: .init(monitor: oldRight), workspaceId: wsRight)
+        ]
+
+        let assignments = resolveWorkspaceRestoreAssignments(
+            snapshots: snapshots,
+            monitors: [newLeft, newRight],
+            ignoreIdentity: true,
+            workspaceExists: { _ in true }
+        )
+
+        #expect(assignments[newLeft.id] == wsLeft)
+        #expect(assignments[newRight.id] == wsRight)
+    }
+
     @Test func filtersUnknownWorkspacesAndDuplicateWorkspaceSnapshots() {
         let left = makeMonitor(displayId: 500, name: "Left", x: 0, y: 0)
         let right = makeMonitor(displayId: 600, name: "Right", x: 1920, y: 0)

--- a/Tests/NehirTests/RestorePlannerTests.swift
+++ b/Tests/NehirTests/RestorePlannerTests.swift
@@ -163,6 +163,49 @@ struct RestorePlannerTests {
         #expect(plan.consumedEntry == PersistedWindowRestoreConsumptionKey(entry: secondEntry))
     }
 
+    @Test func ignoringMonitorIdentityRestoresWindowByPositionNotName() throws {
+        let planner = RestorePlanner()
+        // Saved on the right-hand monitor named "Shared".
+        let savedMonitor = makeLayoutPlanTestMonitor(displayId: 100, name: "Shared", x: 1920, y: 0)
+        // A different monitor now occupies the saved name on the LEFT, while the RIGHT position
+        // is held by a differently-named display — the window must follow the position.
+        let leftSameName = makeLayoutPlanTestMonitor(displayId: 1, name: "Shared", x: 0, y: 0)
+        let rightDifferentName = makeLayoutPlanTestMonitor(displayId: 200, name: "Office", x: 1920, y: 0)
+        let currentMonitors = [leftSameName, rightDifferentName]
+
+        let workspaceId = WorkspaceDescriptor.ID()
+        let token = WindowToken(pid: 900, windowId: 90)
+        let metadata = makeRestorePlannerMetadata(workspaceId: workspaceId, title: "Doc")
+        let entry = makeRestorePlannerCatalogEntry(
+            token: token,
+            metadata: metadata,
+            workspaceName: "1",
+            monitor: savedMonitor
+        )
+
+        func planMonitor(ignoreIdentity: Bool) throws -> Monitor.ID? {
+            let plan = try #require(
+                planner.planPersistedHydration(
+                    .init(
+                        token: token,
+                        metadata: metadata,
+                        catalog: PersistedWindowRestoreCatalog(entries: [entry]),
+                        consumedEntries: [],
+                        monitors: currentMonitors,
+                        ignoreMonitorIdentity: ignoreIdentity,
+                        workspaceIdForName: { _ in workspaceId }
+                    )
+                )
+            )
+            return plan.preferredMonitorId
+        }
+
+        // Identity on: name match wins, sending the window to the wrong (left) monitor.
+        #expect(try planMonitor(ignoreIdentity: false) == leftSameName.id)
+        // Identity ignored: layout position wins, keeping the window on the right monitor.
+        #expect(try planMonitor(ignoreIdentity: true) == rightDifferentName.id)
+    }
+
     @Test func semanticHydrationReturnsNilWhenFallbackIsAmbiguous() {
         let planner = RestorePlanner()
         let monitor = makeLayoutPlanTestMonitor(displayId: 701, name: "Main")

--- a/Tests/NehirTests/SettingsStoreTests.swift
+++ b/Tests/NehirTests/SettingsStoreTests.swift
@@ -698,6 +698,44 @@ struct HotkeySurfaceTests {
         #expect(settings.barSettings(for: currentMonitor) == nil)
     }
 
+    @Test func tomlApplyRebindsMonitorSettingsByPositionWhenIdentityIgnored() {
+        let settings = SettingsStore(defaults: makeTestDefaults())
+        let leftMonitor = makeSettingsTestMonitor(displayId: 201, name: "Left Office", x: 0)
+        let rightMonitor = makeSettingsTestMonitor(displayId: 202, name: "Right Office", x: 1920)
+        var export = SettingsExport.defaults()
+        export.ignoreMonitorIdentity = true
+        export.monitorBarSettings = [
+            MonitorBarSettings(
+                monitorName: "Home",
+                monitorDisplayId: 101,
+                monitorAnchorPoint: CGPoint(x: 1910, y: 1080),
+                enabled: false
+            )
+        ]
+
+        settings.applyExport(export, monitors: [leftMonitor, rightMonitor])
+
+        #expect(settings.monitorBarSettings.first?.monitorDisplayId == rightMonitor.displayId)
+        #expect(settings.monitorBarSettings.first?.monitorAnchorPoint == rightMonitor.workspaceAnchorPoint)
+    }
+
+    @Test func tomlApplyRebindsMonitorSettingsByPositionOneToOne() {
+        let settings = SettingsStore(defaults: makeTestDefaults())
+        let leftMonitor = makeSettingsTestMonitor(displayId: 201, name: "Left Office", x: 0)
+        let rightMonitor = makeSettingsTestMonitor(displayId: 202, name: "Right Office", x: 1920)
+        var export = SettingsExport.defaults()
+        export.ignoreMonitorIdentity = true
+        export.monitorBarSettings = [
+            MonitorBarSettings(monitorName: "Home Left", monitorAnchorPoint: CGPoint(x: 0, y: 1080), enabled: true),
+            MonitorBarSettings(monitorName: "Home Right", monitorAnchorPoint: CGPoint(x: 1920, y: 1080), enabled: false)
+        ]
+
+        settings.applyExport(export, monitors: [leftMonitor, rightMonitor])
+
+        let displayIds = settings.monitorBarSettings.compactMap(\.monitorDisplayId)
+        #expect(Set(displayIds) == [leftMonitor.displayId, rightMonitor.displayId])
+    }
+
 }
 
 @Suite(.serialized) @MainActor struct SettingsStoreAppearanceApplyTests {

--- a/Tests/NehirTests/SettingsStoreTests.swift
+++ b/Tests/NehirTests/SettingsStoreTests.swift
@@ -668,6 +668,7 @@ struct HotkeySurfaceTests {
         settings.statusBarUseWorkspaceId = true
         settings.scrollGestureEnabled = true
         settings.scrollSensitivity = 33
+        settings.ignoreMonitorIdentity = true
         settings.flushNow()
 
         let reloaded = SettingsStore(defaults: defaults)
@@ -680,6 +681,7 @@ struct HotkeySurfaceTests {
         #expect(reloaded.statusBarUseWorkspaceId == true)
         #expect(reloaded.scrollGestureEnabled == true)
         #expect(reloaded.scrollSensitivity == 33)
+        #expect(reloaded.ignoreMonitorIdentity == true)
     }
 
     @Test func tomlApplyClearsStaleMonitorDisplayIdWhenNameCannotBeResolved() {

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -244,6 +244,20 @@ App rules in `apprules.d/` carry an `order` field to preserve specificity orderi
 
 Runtime state (window restore catalog, command palette last mode) is stored separately under `~/.local/state/nehir/` — never in the config directory. Migration postpone decisions also live in state, not config. Your config stays clean and diffable.
 
+### 9. Monitor-independent restore
+
+By default Nehir reattaches saved monitor bindings (workspace→display assignments, per-monitor overrides, and per-window restore) by **monitor identity** — the macOS display id plus the display name (e.g. `HP E27m G4`). When you move the same Mac between different monitor sets — for example a dual-monitor desk at home and a different dual-monitor desk at the office — both the display id and the name change, so the saved bindings no longer match and apps land on the wrong monitor.
+
+Enable **Settings → Monitors → "Keep apps on the same monitor across reconnects"** (`[general] ignoreMonitorIdentity = true`) to match displays by **layout position** instead of model/name. Apps, workspaces, and per-monitor settings then return to the same monitor — Main or Secondary — regardless of which physical display now occupies that position.
+
+```toml
+# settings.toml
+[general]
+ignoreMonitorIdentity = true
+```
+
+Position matching uses each saved monitor's top-left anchor point, which Nehir records alongside the identity. `workspaces.toml` gains optional `monitorAnchorX` / `monitorAnchorY` keys for `specific` assignments, and `monitors.d/*.toml` `[match]` sections gain optional `anchorX` / `anchorY`. These are written automatically while the monitor is connected; configs without them keep the previous identity-only behavior, so the change is fully backward compatible. An exact display-id match always wins first, so reconnecting the *same* monitor behaves as before.
+
 ## File Reference
 
 | File | Required | Description |

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -246,15 +246,21 @@ Runtime state (window restore catalog, command palette last mode) is stored sepa
 
 ### 9. Monitor-independent restore
 
-By default Nehir reattaches saved monitor bindings (workspace→display assignments, per-monitor overrides, and per-window restore) by **monitor identity** — the macOS display id plus the display name (e.g. `HP E27m G4`). When you move the same Mac between different monitor sets — for example a dual-monitor desk at home and a different dual-monitor desk at the office — both the display id and the name change, so the saved bindings no longer match and apps land on the wrong monitor.
+By default Nehir reattaches saved monitor bindings (workspace→display assignments, per-monitor overrides, and per-window restore) by **monitor identity** — the macOS display id plus the display name (e.g. `HP E27m G4`). This is safest for existing setups because per-monitor gaps, orientation, bar, and niri overrides often describe the physical display itself.
 
-Enable **Settings → Monitors → "Keep apps on the same monitor across reconnects"** (`[general] ignoreMonitorIdentity = true`) to match displays by **layout position** instead of model/name. Apps, workspaces, and per-monitor settings then return to the same monitor — Main or Secondary — regardless of which physical display now occupies that position.
+When you move the same Mac between different monitor sets — for example a dual-monitor desk at home and a different dual-monitor desk at the office — both the display id and the name change, so identity matching may no longer find the intended display and apps can land on the wrong monitor. Enable **Settings → Monitors → "Keep apps on the same screen position"** (`[general] ignoreMonitorIdentity = true`) to match displays by **layout position** instead of model/name. Apps, workspaces, and per-monitor settings then return to the same monitor slot — Main or Secondary — regardless of which physical display now occupies that position.
 
 ```toml
 # settings.toml
 [general]
 ignoreMonitorIdentity = true
 ```
+
+Use this mode when you want Nehir state to follow monitor slots across similar layouts, such as home ↔ office dual-monitor desks or swapped monitor models.
+
+Leave it off when settings should follow a specific physical monitor, when you often rearrange display positions, or when temporary displays/projectors should not inherit external-monitor overrides.
+
+App rules do not store monitor identity directly. If an app rule assigns a window to a workspace, this setting can still affect the result indirectly through that workspace's monitor assignment.
 
 Position matching uses each saved monitor's top-left anchor point, which Nehir records alongside the identity. `workspaces.toml` gains optional `monitorAnchorX` / `monitorAnchorY` keys for `specific` assignments, and `monitors.d/*.toml` `[match]` sections gain optional `anchorX` / `anchorY`. These are written automatically while the monitor is connected; configs without them keep the previous identity-only behavior, so the change is fully backward compatible. An exact display-id match always wins first, so reconnecting the *same* monitor behaves as before.
 

--- a/docs/plans/completed/20260618-monitor-identity-agnostic-restore.md
+++ b/docs/plans/completed/20260618-monitor-identity-agnostic-restore.md
@@ -1,0 +1,175 @@
+# Monitor-identity-agnostic restore (issue #65)
+
+## Context
+
+Nehir ties every per-monitor binding to a monitor's **identity** — its `displayId` and
+`localizedName` (e.g. `"HP E27m G4"`). When the same laptop moves between different physical
+monitor sets (home dual-monitor ↔ office dual-monitor), *both* the `displayId` and `name`
+differ, so on reconnect Nehir cannot recognise "the same monitor" and:
+
+- **windows/apps land on the wrong monitor** — the runtime restore matchers rank candidate
+  monitors by **name match first**, so when no name matches the result is effectively
+  arbitrary instead of position-stable;
+- workspaces pinned to a specific display fall back to the main monitor;
+- per-monitor bar/gap/orientation/niri overrides are lost.
+
+**Primary goal (user requirement):** after a monitor disconnect → reconnect, *every app stays
+on the same monitor it was on before* — whether that monitor is now Main or Secondary —
+matched by **layout position (topology)** rather than monitor model/name.
+
+GitHub issue #65 asks for the same thing as a setting. Add a global toggle
+`ignoreMonitorIdentity` (default `false`). When enabled, all monitor-resolution paths ignore
+the monitor name/model and resolve by **position / anchor-point geometry** (which already
+encodes Main vs Secondary). (Note: App Rules in `AppRule.swift` don't bind to monitors, so the
+issue title's "App rules" is moot.)
+
+## Resolution paths to change
+
+These all currently let monitor **name** dominate. Position (anchorPoint, frameSize, `isMain`)
+already distinguishes Main vs Secondary; the fix is to stop letting name override it.
+
+**Runtime restore (the user's core requirement — windows/workspaces returning to position).
+These already persist geometry, so they need ONLY toggle-gating, no schema change:**
+
+1. **`MonitorRestoreAssignments.restoreMatchScore`** —
+   `Sources/Nehir/Core/Monitor/MonitorRestoreAssignments.swift:163` (via
+   `resolveWorkspaceRestoreAssignments:30`). Visible-workspace → monitor restore on topology
+   change. `namePenalty` is currently the first tiebreaker after `assignedCount`.
+2. **`RestorePlanner.persistedMonitorMatchScore` + `resolvePersistedPreferredMonitor`** —
+   `Sources/Nehir/Core/Reconcile/RestorePlanner.swift:351,391`. Per-window preferred-monitor
+   restore (`PersistedRestoreIntent.preferredMonitor`, a `DisplayFingerprint` that already
+   carries `anchorPoint` + `frameSize`, `ReconcileSnapshot.swift:78`). `namePenalty` ranks
+   first. **This is the path that decides which monitor each app's window returns to.**
+   - Workspace home/`effectiveMonitor` fallback (`WorkspaceManager.swift:3803`) is already
+     anchor-distance based; `.main`/`.secondary` descriptors (`MonitorDescription.swift`)
+     already resolve positionally — no change needed, just confirm they're in the path.
+
+**Persisted config (breaks across machines; needs an anchor persisted because the on-disk
+types store only name + displayId):**
+
+3. **`OutputId.resolveMonitor(in:)`** — `Sources/Nehir/Core/Monitor/OutputId.swift:19`.
+   Workspace→display pins (`.specificDisplay`). Today: exact `displayId`, else unique `name`.
+4. **`MonitorSettingsStore.get(for:in:)`** — `Sources/Nehir/Core/Config/MonitorSettingsType.swift:10`.
+   Per-monitor bar/gap/orientation/niri overrides. Today: `displayId`, else `name`.
+
+## Matching strategy
+
+When `ignoreMonitorIdentity` is on:
+- Keep the exact `displayId` short-circuit (correct + harmless when the *same* physical
+  monitor reconnects with a stable id).
+- **Drop the name penalty** so ranking falls to anchor-point distance + frame-size delta
+  (= position = Main/Secondary). Reuse the existing squared-distance helpers
+  (`MonitorRestoreAssignments.swift:183`, `RestorePlanner.swift:493`).
+- For paths #3/#4, the on-disk types lack geometry, so persist a **top-left anchor point**
+  (`Monitor.workspaceAnchorPoint`, `Monitor.swift:78`) and pick the nearest-anchor monitor;
+  fall back to today's name logic when the anchor is absent (old configs) or the toggle is
+  off — fully backward compatible.
+
+## Implementation
+
+### A. Thread the flag
+
+`SettingsStore` owns the new flag. Carry it into the planners and resolvers:
+- Add `ignoreMonitorIdentity: Bool` to `RestorePlanner.TopologyInput` (`:18`) and
+  `PersistedHydrationInput` (`:42`); populate from `settings.ignoreMonitorIdentity` at the
+  build sites in `WorkspaceManager` (`:529` topology, `:757` hydration).
+- Add an `ignoreIdentity` parameter to `resolveWorkspaceRestoreAssignments` /
+  `restoreMatchScore`, to `OutputId.resolveMonitor`, and to `MonitorSettingsStore.get`.
+- `SettingsStore` resolver methods (`barSettings(for:)` etc. `:682`+, and
+  `normalizedWorkspaceConfigurations` `:622`) read `self.ignoreMonitorIdentity` directly.
+
+### B. Gate name penalty in runtime matchers (paths #1, #2)
+
+- `restoreMatchScore`: `let namePenalty = ignoreIdentity ? 0 : (…existing…)`.
+- `persistedMonitorMatchScore`: same. In `resolvePersistedPreferredMonitor`, when
+  `ignoreIdentity` keep the exact-displayId short-circuit but skip the exact-fingerprint
+  short-circuit (it embeds the name) and rely on the name-free `min` ranking.
+- Confirm `planMonitorConfigurationChange` (`:152`,`:202`-`224`) and `planEvent` propagate the
+  flag where they call into these.
+
+### C. Persist anchor for on-disk references (paths #3, #4)
+
+- **`OutputId.swift`**: add `let anchorPoint: CGPoint?` (`Codable`/`Hashable`); populate in
+  `init(from monitor:)` with `monitor.workspaceAnchorPoint`.
+- **`WorkspacesTOMLCodec.swift`** (`encode:32`, `decode:55`): write/read `monitorAnchorX` /
+  `monitorAnchorY` for `.specificDisplay`; missing → `nil`.
+- **`MonitorSettingsType` protocol** (`:4`): add `var monitorAnchorPoint: CGPoint? { get set }`
+  (store as flat optional `anchorX`/`anchorY`). Add the property, init param, and `Codable`
+  keys (`decodeIfPresent`/`encodeIfPresent`, mirroring `monitorDisplayId`) to the 4 conformers:
+  `MonitorBarSettings`, `MonitorGapSettings`, `MonitorOrientationSettings`, `MonitorNiriSettings`.
+- **`MonitorOverrideFileStore.swift`**: write/read `anchorX`/`anchorY` in the `[match]`
+  section (`encode:82`, `decode:154`).
+- Populate the anchor on save by extending `SettingsStore.reboundMonitorSettings` /
+  `normalizedWorkspaceConfigurations` (`SettingsStore.swift:651,622`), which already rebind
+  `displayId` against current monitors.
+
+### D. Anchor-proximity resolution (paths #3, #4)
+
+- `OutputId.resolveMonitor(in:ignoreIdentity:)`: exact `displayId` first; then if
+  `ignoreIdentity` and `anchorPoint != nil`, return the monitor with nearest
+  `workspaceAnchorPoint`; else the current unique-name fallback.
+- `MonitorSettingsStore.get(for:in:ignoreIdentity:)`: `displayId`/name matches first; when
+  `ignoreIdentity`, among entries with an anchor pick the nearest to
+  `monitor.workspaceAnchorPoint`.
+- *Refinement:* prefer matching the built-in display to the built-in (via `Monitor.isMain`
+  / notch) before anchor proximity, so laptop-internal settings don't migrate onto an external.
+
+### E. Settings pipeline (mirror `developerModeEnabled` end-to-end)
+
+- **`SettingsExport.swift`**: add `var ignoreMonitorIdentity: Bool` + `false` in `defaults()`.
+- **`CanonicalTOMLConfig.swift`** `General` struct: add field + `CodingKeys`; `decodeWithDefault`
+  (~`:451`) and `encode` (~`:460`); `init(export:)` mapping (~`:227`) and reverse mapping into
+  `SettingsExport` (~`:393`).
+- **`SettingsStore.swift`**: published
+  `var ignoreMonitorIdentity = SettingsStore.defaultExport.ignoreMonitorIdentity { didSet { scheduleSave() } }`
+  (near `:258`); include in the export builder (~`:438`) and `apply(export:)` (~`:523`).
+
+### F. UI toggle — Monitor Settings tab
+
+In `MonitorSettingsTab.swift`, add a `Section` ("Display Matching") with:
+```swift
+Toggle("Keep apps on the same monitor across reconnects", isOn: $settings.ignoreMonitorIdentity)
+    .onChange(of: settings.ignoreMonitorIdentity) { _, _ in controller.refreshLayout() }
+SettingsCaption("Match saved windows, workspaces, and per-monitor settings by screen position instead of monitor model — so apps return to the same monitor (Main or Secondary) when moving between different monitor sets (e.g. home and office).")
+```
+Use existing helpers (`SettingsPage`, `SettingsCaption`); confirm the exact refresh entry
+point on `WMController` (the tab already holds `controller`).
+
+### G. Docs
+
+- `docs/CONFIGURATION.md`: document `[general] ignoreMonitorIdentity` and the new optional
+  `monitorAnchorX/Y` fields in `workspaces.toml` and `monitors.d/*.toml`.
+- `docs/SETTINGS_MIGRATIONS.md`: note the additive, backward-compatible fields (no migration —
+  all new keys optional).
+
+## Critical files
+
+- `Sources/Nehir/Core/Reconcile/RestorePlanner.swift` (per-window + topology restore)
+- `Sources/Nehir/Core/Monitor/MonitorRestoreAssignments.swift`
+- `Sources/Nehir/Core/Monitor/OutputId.swift`, `Sources/Nehir/Core/Monitor/MonitorDescription.swift`
+- `Sources/Nehir/Core/Config/MonitorSettingsType.swift`
+- `Sources/Nehir/Core/Config/{MonitorBarSettings,MonitorGapSettings,MonitorOrientationSettings,MonitorNiriSettings}.swift`
+- `Sources/Nehir/Core/Config/{WorkspacesTOMLCodec,MonitorOverrideFileStore}.swift`
+- `Sources/Nehir/Core/Config/{SettingsExport,CanonicalTOMLConfig,SettingsStore}.swift`
+- `Sources/Nehir/Core/Workspace/WorkspaceManager.swift` (planner build sites `:529`,`:757`)
+- `Sources/Nehir/UI/MonitorSettingsTab.swift`
+- `docs/CONFIGURATION.md`, `docs/SETTINGS_MIGRATIONS.md`
+
+## Verification
+
+1. **Unit tests** (extend existing suites):
+   - `Tests/NehirTests/RestorePlannerTests.swift` — per-window restore: with `ignoreIdentity:true`
+     and differing names/displayIds but matching position, windows resolve to the same Main /
+     Secondary monitor; with the flag off, legacy name-first behavior is unchanged.
+   - `Tests/NehirTests/MonitorRestoreAssignmentsTests.swift` — workspace restore ignores name
+     when flagged.
+   - New `OutputId.resolveMonitor` / `MonitorSettingsStore.get` cases (different name + displayId,
+     same anchor → match when flagged; no match when off / anchor absent).
+   - `Tests/NehirTests/SettingsStoreTests.swift` — round-trip the `ignoreMonitorIdentity` flag and
+     the persisted anchor fields (TOML encode/decode, backward compat when keys absent).
+   - Run: `swift test` (or `mise run test` if defined).
+2. **Build**: `swift build` / `mise run package:release`.
+3. **Manual (the real scenario):** with the toggle on, place apps across Main + Secondary,
+   disconnect a monitor, reconnect a *different model* in the same position, and confirm every
+   app returns to its original Main/Secondary monitor and per-monitor overrides reattach.
+   Repeat with the toggle off to confirm legacy identity-only behavior is unchanged.


### PR DESCRIPTION
## Summary

Monitor-identity-agnostic restore (issue #65)

<img width="963" height="775" alt="CleanShot-2026-06-18-000343" src="https://github.com/user-attachments/assets/6d5e6daf-e444-43c9-b2d3-fed09af43fdf" />


## Release notes

Choose one:

- [ ] Added a `.changeset/*.md` for user-visible changes (`mise run changeset -- patch "..."`).
- [ ] No user-visible change; apply the `no release note` label to make CI skip intentional.

## Validation

manual verification

- [ ] Ran relevant tests/checks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features

* Added "Keep apps on the same screen position" setting in Monitor Settings. When enabled, saved window and workspace positions are restored based on screen layout geometry rather than monitor identity, improving portability across different monitor configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->