### PR TITLE
Fix settings number field editing

### DIFF
--- a/.changeset/20260618232952-fix-centered-width-settings-fields-so-typing-no-.md
+++ b/.changeset/20260618232952-fix-centered-width-settings-fields-so-typing-no-.md
@@ -1,0 +1,6 @@
+---
+"nehir": patch
+contributors: [stefanpinterBE]
+---
+
+Fix numeric settings fields so typing no longer auto-corrects mid-entry, including centered width percentages and workspace bar offset steppers; centered width now preserves 100% values.

--- a/Sources/Nehir/Core/Config/SettingsStore.swift
+++ b/Sources/Nehir/Core/Config/SettingsStore.swift
@@ -864,6 +864,6 @@ final class SettingsStore {
 
     static func validatedLoneWindowMaxWidth(_ width: Double?) -> Double? {
         guard let width else { return nil }
-        return min(0.95, max(0.10, width))
+        return min(1.0, max(0.10, width))
     }
 }

--- a/Sources/Nehir/UI/OverridableControls.swift
+++ b/Sources/Nehir/UI/OverridableControls.swift
@@ -101,6 +101,69 @@ struct SettingsSliderRow: View {
     }
 }
 
+private struct DraftNumberTextField: View {
+    let label: String
+    let value: Double
+    let range: ClosedRange<Double>
+    let width: CGFloat
+    let onCommit: (Double) -> Void
+
+    @State private var draft = ""
+    @FocusState private var isFocused: Bool
+
+    private var clampedValue: Double {
+        min(max(value, range.lowerBound), range.upperBound)
+    }
+
+    var body: some View {
+        TextField(label, text: $draft)
+            .labelsHidden()
+            .textFieldStyle(.roundedBorder)
+            .frame(width: width)
+            .multilineTextAlignment(.trailing)
+            .focused($isFocused)
+            .onSubmit(commitDraft)
+            .onAppear { restoreDraftFromValue() }
+            .onChange(of: value) { _, _ in
+                if !isFocused { restoreDraftFromValue() }
+            }
+            .onChange(of: isFocused) { _, focused in
+                if focused {
+                    restoreDraftFromValue()
+                } else {
+                    commitDraft()
+                }
+            }
+            .accessibilityLabel(label)
+    }
+
+    private func restoreDraftFromValue() {
+        draft = formatted(clampedValue)
+    }
+
+    private func commitDraft() {
+        let trimmed = draft.trimmingCharacters(in: .whitespacesAndNewlines)
+        let parsed = numberFormatter.number(from: trimmed)?.doubleValue ?? clampedValue
+        let committed = min(max(parsed, range.lowerBound), range.upperBound)
+        draft = formatted(committed)
+        onCommit(committed)
+    }
+
+    private func formatted(_ value: Double) -> String {
+        numberFormatter.string(from: NSNumber(value: value)) ?? ""
+    }
+
+    private var numberFormatter: NumberFormatter {
+        let formatter = NumberFormatter()
+        formatter.locale = .current
+        formatter.numberStyle = .decimal
+        formatter.usesGroupingSeparator = false
+        formatter.minimumFractionDigits = 0
+        formatter.maximumFractionDigits = 6
+        return formatter
+    }
+}
+
 struct SettingsNumberStepperRow: View {
     let label: String
     @Binding var value: Double
@@ -118,21 +181,15 @@ struct SettingsNumberStepperRow: View {
                 .accessibilityLabel(label)
                 .accessibilityValue(valueText)
 
-                TextField(label, value: boundedValue, format: .number)
-                    .labelsHidden()
-                    .textFieldStyle(.roundedBorder)
-                    .frame(width: 64)
-                    .multilineTextAlignment(.trailing)
-                    .accessibilityLabel(label)
+                DraftNumberTextField(
+                    label: label,
+                    value: value,
+                    range: range,
+                    width: 64,
+                    onCommit: { value = $0 }
+                )
             }
         }
-    }
-
-    private var boundedValue: Binding<Double> {
-        Binding(
-            get: { value },
-            set: { value = min(max($0, range.lowerBound), range.upperBound) }
-        )
     }
 }
 
@@ -404,23 +461,17 @@ struct OverridableStepper: View {
                 .accessibilityLabel(label)
                 .accessibilityValue(displayValue)
 
-                TextField(label, value: boundedValue, format: .number)
-                    .labelsHidden()
-                    .textFieldStyle(.roundedBorder)
-                    .frame(width: 64)
-                    .multilineTextAlignment(.trailing)
-                    .accessibilityLabel(label)
+                DraftNumberTextField(
+                    label: label,
+                    value: effectiveValue,
+                    range: range,
+                    width: 64,
+                    onCommit: { onChange($0) }
+                )
 
                 overrideStatus
             }
         }
-    }
-
-    private var boundedValue: Binding<Double> {
-        Binding(
-            get: { effectiveValue },
-            set: { onChange(min(max($0, range.lowerBound), range.upperBound)) }
-        )
     }
 
     private var overrideStatus: some View {

--- a/Sources/Nehir/UI/SettingsView.swift
+++ b/Sources/Nehir/UI/SettingsView.swift
@@ -309,6 +309,54 @@ private struct StableSettingsControlRow<Content: View>: View {
     }
 }
 
+private struct PercentTextField: View {
+    let title: String
+    let value: Int
+    let range: ClosedRange<Int>
+    let onCommit: (Int) -> Void
+
+    @State private var draft = ""
+    @FocusState private var isFocused: Bool
+
+    private var clampedValue: Int { value.clamped(to: range) }
+
+    var body: some View {
+        HStack {
+            TextField(title, text: $draft)
+                .labelsHidden()
+                .textFieldStyle(.roundedBorder)
+                .frame(width: 48)
+                .multilineTextAlignment(.trailing)
+                .focused($isFocused)
+                .onSubmit(commitDraft)
+                .onAppear { restoreDraftFromValue() }
+                .onChange(of: value) { _, _ in
+                    if !isFocused { restoreDraftFromValue() }
+                }
+                .onChange(of: isFocused) { _, focused in
+                    if focused {
+                        restoreDraftFromValue()
+                    } else {
+                        commitDraft()
+                    }
+                }
+            Text("%")
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    private func restoreDraftFromValue() {
+        draft = String(clampedValue)
+    }
+
+    private func commitDraft() {
+        let parsed = Int(draft.trimmingCharacters(in: .whitespacesAndNewlines)) ?? clampedValue
+        let committed = parsed.clamped(to: range)
+        draft = String(committed)
+        onCommit(committed)
+    }
+}
+
 struct GlobalNiriSettingsSection: View {
     @Bindable var settings: SettingsStore
     @Bindable var controller: WMController
@@ -345,7 +393,7 @@ struct GlobalNiriSettingsSection: View {
         let loneWindowMaxWidthPercent = Binding(
             get: { Int((settings.niriLoneWindowMaxWidth ?? 0.6) * 100) },
             set: { newPercent in
-                settings.niriLoneWindowMaxWidth = Double(min(95, max(10, newPercent))) / 100.0
+                settings.niriLoneWindowMaxWidth = Double(newPercent.clamped(to: 10 ... 100)) / 100.0
                 controller.updateNiriConfig(loneWindowPolicy: settings.loneWindowPolicy)
             }
         )
@@ -368,15 +416,12 @@ struct GlobalNiriSettingsSection: View {
                 }
             } else {
                 StableSettingsControlRow("Width") {
-                    HStack {
-                        TextField("Width", value: defaultColumnWidthPercent, format: .number)
-                            .labelsHidden()
-                            .textFieldStyle(.roundedBorder)
-                            .frame(width: 48)
-                            .multilineTextAlignment(.trailing)
-                        Text("%")
-                            .foregroundStyle(.secondary)
-                    }
+                    PercentTextField(
+                        title: "Width",
+                        value: defaultColumnWidthPercent.wrappedValue,
+                        range: 5 ... 100,
+                        onCommit: { defaultColumnWidthPercent.wrappedValue = $0 }
+                    )
                 }
             }
 
@@ -396,15 +441,12 @@ struct GlobalNiriSettingsSection: View {
 
             if settings.niriLoneWindowMaxWidth != nil {
                 StableSettingsControlRow("Centered Width") {
-                    HStack {
-                        TextField("Centered Width", value: loneWindowMaxWidthPercent, format: .number)
-                            .labelsHidden()
-                            .textFieldStyle(.roundedBorder)
-                            .frame(width: 48)
-                            .multilineTextAlignment(.trailing)
-                        Text("%")
-                            .foregroundStyle(.secondary)
-                    }
+                    PercentTextField(
+                        title: "Centered Width",
+                        value: loneWindowMaxWidthPercent.wrappedValue,
+                        range: 10 ... 100,
+                        onCommit: { loneWindowMaxWidthPercent.wrappedValue = $0 }
+                    )
                 }
             }
 
@@ -415,22 +457,18 @@ struct GlobalNiriSettingsSection: View {
             ForEach(presets.indices, id: \.self) { index in
                 LabeledContent("Preset \(index + 1)") {
                     HStack {
-                        TextField("Preset \(index + 1)", value: Binding(
-                            get: { Int(presets[index] * 100) },
-                            set: { newPercent in
+                        PercentTextField(
+                            title: "Preset \(index + 1)",
+                            value: Int(presets[index] * 100),
+                            range: 5 ... 100,
+                            onCommit: { newPercent in
                                 var current = settings.niriColumnWidthPresets
-                                current[index] = Double(min(100, max(5, newPercent))) / 100.0
+                                current[index] = Double(newPercent) / 100.0
                                 settings.niriColumnWidthPresets = current
                                 controller.updateNiriConfig(columnWidthPresets: settings.niriColumnWidthPresets)
                             }
-                        ), format: .number)
-                            .labelsHidden()
-                            .textFieldStyle(.roundedBorder)
-                            .frame(width: 48)
-                            .multilineTextAlignment(.trailing)
-                            .accessibilityLabel("Preset \(index + 1) width")
-                        Text("%")
-                            .foregroundStyle(.secondary)
+                        )
+                        .accessibilityLabel("Preset \(index + 1) width")
                         Button(role: .destructive) {
                             var presets = settings.niriColumnWidthPresets
                             presets.remove(at: index)
@@ -532,7 +570,7 @@ struct MonitorNiriSettingsSection: View {
             },
             set: { newPercent in
                 updateSetting {
-                    $0.loneWindowPolicy = .centered(maxWidthFraction: Double(min(95, max(10, newPercent))) / 100.0)
+                    $0.loneWindowPolicy = .centered(maxWidthFraction: Double(newPercent.clamped(to: 10 ... 100)) / 100.0)
                 }
             }
         )
@@ -573,15 +611,12 @@ struct MonitorNiriSettingsSection: View {
 
             if case .centered = ms.loneWindowPolicy {
                 StableSettingsControlRow("Centered Width") {
-                    HStack {
-                        TextField("Centered Width", value: loneWindowMaxWidthPercent, format: .number)
-                            .labelsHidden()
-                            .textFieldStyle(.roundedBorder)
-                            .frame(width: 48)
-                            .multilineTextAlignment(.trailing)
-                        Text("%")
-                            .foregroundStyle(.secondary)
-                    }
+                    PercentTextField(
+                        title: "Centered Width",
+                        value: loneWindowMaxWidthPercent.wrappedValue,
+                        range: 10 ... 100,
+                        onCommit: { loneWindowMaxWidthPercent.wrappedValue = $0 }
+                    )
                 }
             }
 


### PR DESCRIPTION
## Summary

<!-- What changed and why? -->

## Release notes

Choose one:

- [x] Added a `.changeset/*.md` for user-visible changes (`mise run changeset -- patch "..."`).
- [ ] No user-visible change; apply the `no release note` label to make CI skip intentional.

## Validation

<!-- Commands run, screenshots, or manual checks. -->

- [ ] Ran relevant tests/checks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes
* Fixed numeric settings fields to prevent auto-correction while typing, so mid-entry values remain stable until commit
* Updated percentage-based controls (including centered width and related offset/stepper inputs) to allow values up to **100%** instead of capping at **95%**
* Centered width percentage now preserves **100%** correctly, with improved clamping and validation when inputs are submitted or focus changes
<!-- end of auto-generated comment: release notes by coderabbit.ai -->