### PR TITLE
Restore windows on graceful quit

### DIFF
--- a/.changeset/20260619005116-restore-parked-windows-on-graceful-quit-and-docu.md
+++ b/.changeset/20260619005116-restore-parked-windows-on-graceful-quit-and-docu.md
@@ -1,0 +1,6 @@
+---
+"nehir": patch
+contributors: [bhupesh-sf]
+---
+
+Restore parked and edge-clipped windows on graceful quit, and document macOS rescue shortcuts.

--- a/README.md
+++ b/README.md
@@ -74,6 +74,17 @@ nehirctl command switch-workspace 2
 nehirctl --help
 ```
 
+### Recover windows after a crash or force quit
+
+Nehir restores parked/offscreen windows during a normal graceful quit. A force quit, crash, or `kill -9` bypasses shutdown cleanup, so macOS may leave previously parked windows at the screen edge.
+
+If that happens, use macOS's built-in window shortcuts to bring the selected Mission Control window back onscreen:
+
+- **Fill** — `Control` + `Globe/Fn` + `F`
+- **Centre/Center** — `Control` + `Globe/Fn` + `C`
+
+You can also find these actions in the macOS **Window** menu. In Mission Control, selecting the stuck window and applying **Fill** or **Centre/Center** usually restores it to the visible desktop.
+
 ## Debugging & Tracing
 
 Trace capture and the other debug commands are gated behind **Developer Mode**. Enable it in the **Diagnostics** tab of Settings — this unlocks the `Debug: …` commands in the command palette and hotkey settings, enables the IPC debug endpoints, and reveals the **Runtime State** and **Recent Traces** panels in that same tab.

--- a/Sources/Nehir/App/AppDelegate.swift
+++ b/Sources/Nehir/App/AppDelegate.swift
@@ -29,6 +29,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     func applicationWillTerminate(_: Notification) {
         if let controller = AppDelegate.sharedBootstrap?.controller {
+            controller.restoreHiddenWindowsForGracefulTermination()
             controller.serviceLifecycleManager.stop()
             controller.workspaceManager.flushPersistedWindowRestoreCatalogNow()
         }

--- a/Sources/Nehir/Core/Controller/LayoutRefreshController.swift
+++ b/Sources/Nehir/Core/Controller/LayoutRefreshController.swift
@@ -2080,6 +2080,58 @@ import QuartzCore
         return frameUpdates.count
     }
 
+    @discardableResult
+    func restoreHiddenWindowsForGracefulTermination() -> Int {
+        guard let controller, !controller.isLockScreenActive else { return 0 }
+
+        var positionPlans: [WindowPositionPlan] = []
+        var frameEntries: [(pid: pid_t, windowId: Int)] = []
+        var tokensToClear: [WindowToken] = []
+
+        for entry in controller.workspaceManager.allEntries() {
+            guard entry.layoutReason != .nativeFullscreen else { continue }
+            let hiddenState = controller.workspaceManager.hiddenState(for: entry.token)
+            guard let monitor = terminationRestoreMonitor(for: entry, hiddenState: hiddenState) else { continue }
+
+            if let hiddenState {
+                frameEntries.append((entry.pid, entry.windowId))
+                tokensToClear.append(entry.token)
+                controller.axManager.markWindowActive(entry.windowId)
+
+                if let plan = makeGracefulTerminationRestorePositionPlan(
+                    for: entry,
+                    monitor: monitor,
+                    hiddenState: hiddenState
+                ) {
+                    positionPlans.append(plan)
+                }
+                continue
+            }
+
+            guard let plan = makeGracefulTerminationVisibleClampPositionPlan(
+                for: entry,
+                monitor: monitor
+            ) else {
+                continue
+            }
+            frameEntries.append((entry.pid, entry.windowId))
+            controller.axManager.markWindowActive(entry.windowId)
+            positionPlans.append(plan)
+        }
+
+        guard !frameEntries.isEmpty else { return 0 }
+
+        controller.axManager.cancelPendingFrameJobs(frameEntries)
+        controller.axManager.unsuppressFrameWrites(frameEntries)
+        applyPositionPlans(positionPlans)
+
+        for token in tokensToClear {
+            controller.workspaceManager.setHiddenState(nil, for: token)
+        }
+
+        return frameEntries.count
+    }
+
     private func workspaceInactiveFloatingRestoreFrame(
         for entry: WindowModel.Entry,
         monitor: Monitor
@@ -3061,6 +3113,108 @@ import QuartzCore
             frameSize: frame.size,
             displayId: monitor.displayId
         )
+    }
+
+    private func terminationRestoreMonitor(
+        for entry: WindowModel.Entry,
+        hiddenState: WindowModel.HiddenState?
+    ) -> Monitor? {
+        guard let controller else { return nil }
+        return controller.workspaceManager.monitor(for: entry.workspaceId)
+            ?? hiddenState?.referenceMonitorId.flatMap { controller.workspaceManager.monitor(byId: $0) }
+            ?? controller.monitorForInteraction()
+            ?? controller.workspaceManager.monitors.first
+    }
+
+    private func makeGracefulTerminationRestorePositionPlan(
+        for entry: WindowModel.Entry,
+        monitor: Monitor,
+        hiddenState: WindowModel.HiddenState
+    ) -> WindowPositionPlan? {
+        guard let controller else { return nil }
+        guard let frame = fastFrame(for: entry.token, axRef: entry.axRef)
+            ?? controller.axManager.lastAppliedFrame(for: entry.windowId)
+            ?? (try? AXWindowService.frame(entry.axRef))
+        else {
+            return nil
+        }
+
+        let fallbackMonitor = hiddenState.referenceMonitorId
+            .flatMap { controller.workspaceManager.monitor(byId: $0) }
+        let safeRestore = safeTerminationRestoreFrame(
+            monitor: monitor,
+            fallbackMonitor: fallbackMonitor
+        )
+        let topLeft = topLeftPoint(from: hiddenState.proportionalPosition, in: safeRestore.frame)
+        let restoredOrigin = clampedOrigin(forTopLeft: topLeft, windowSize: frame.size, in: safeRestore.frame)
+        let moveEpsilon: CGFloat = 0.01
+        if abs(frame.origin.x - restoredOrigin.x) < moveEpsilon,
+           abs(frame.origin.y - restoredOrigin.y) < moveEpsilon
+        {
+            return nil
+        }
+
+        return WindowPositionPlan(
+            entry: entry,
+            origin: restoredOrigin,
+            frameSize: frame.size,
+            displayId: safeRestore.sourceMonitor.displayId
+        )
+    }
+
+    private func makeGracefulTerminationVisibleClampPositionPlan(
+        for entry: WindowModel.Entry,
+        monitor: Monitor
+    ) -> WindowPositionPlan? {
+        guard let controller else { return nil }
+        guard let frame = fastFrame(for: entry.token, axRef: entry.axRef)
+            ?? controller.axManager.lastAppliedFrame(for: entry.windowId)
+            ?? (try? AXWindowService.frame(entry.axRef))
+        else {
+            return nil
+        }
+
+        let safeRestore = safeTerminationRestoreFrame(monitor: monitor, fallbackMonitor: nil)
+        let restoredOrigin = clampedOrigin(
+            forTopLeft: frame.topLeftCorner,
+            windowSize: frame.size,
+            in: safeRestore.frame
+        )
+        let moveEpsilon: CGFloat = 0.01
+        if abs(frame.origin.x - restoredOrigin.x) < moveEpsilon,
+           abs(frame.origin.y - restoredOrigin.y) < moveEpsilon
+        {
+            return nil
+        }
+
+        return WindowPositionPlan(
+            entry: entry,
+            origin: restoredOrigin,
+            frameSize: frame.size,
+            displayId: safeRestore.sourceMonitor.displayId
+        )
+    }
+
+    private func safeTerminationRestoreFrame(
+        monitor: Monitor,
+        fallbackMonitor: Monitor?
+    ) -> (frame: CGRect, sourceMonitor: Monitor) {
+        if monitor.visibleFrame.width > 1, monitor.visibleFrame.height > 1 {
+            return (monitor.visibleFrame, monitor)
+        }
+        if let fallbackMonitor,
+           fallbackMonitor.visibleFrame.width > 1,
+           fallbackMonitor.visibleFrame.height > 1
+        {
+            return (fallbackMonitor.visibleFrame, fallbackMonitor)
+        }
+        if monitor.frame.width > 1, monitor.frame.height > 1 {
+            return (monitor.frame, monitor)
+        }
+        // Preserve the original last-resort frame selection while tracking which
+        // monitor that frame came from, so the caller reports the correct displayId.
+        let fallbackFrame = fallbackMonitor?.frame ?? monitor.frame
+        return (fallbackFrame, fallbackMonitor ?? monitor)
     }
 
     private func topLeftPoint(from proportionalPosition: CGPoint, in frame: CGRect) -> CGPoint {

--- a/Sources/Nehir/Core/Controller/WMController.swift
+++ b/Sources/Nehir/Core/Controller/WMController.swift
@@ -3534,6 +3534,11 @@ final class WMController {
     }
 
     @discardableResult
+    func restoreHiddenWindowsForGracefulTermination() -> Int {
+        layoutRefreshController.restoreHiddenWindowsForGracefulTermination()
+    }
+
+    @discardableResult
     func rescueOffscreenWindows() -> Int {
         guard !isLockScreenActive else { return 0 }
 


### PR DESCRIPTION
## Summary

resolves #70 

## Release notes

Choose one:

- [x] Added a `.changeset/*.md` for user-visible changes (`mise run changeset -- patch "..."`).
- [ ] No user-visible change; apply the `no release note` label to make CI skip intentional.

## Validation

<!-- Commands run, screenshots, or manual checks. -->

- [ ] Ran relevant tests/checks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Parked or edge-clipped windows are now automatically restored after graceful app termination, preventing windows from getting stuck off-screen.

* **Documentation**
  * Expanded the recovery guide with a “Recover windows after a crash or force quit” section, including macOS Mission Control shortcut tips (Fill and Centre/Center) and menu-based instructions to bring a stuck window back.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->