### PR TITLE
Coalesce same-kind refreshes instead of cancelling the active one (P2)

### DIFF
--- a/.changeset/20260619035535-coalesce-back-to-back-same-kind-refreshes-instea.md
+++ b/.changeset/20260619035535-coalesce-back-to-back-same-kind-refreshes-instea.md
@@ -1,0 +1,6 @@
+---
+"nehir": patch
+
+---
+
+Coalesce back-to-back same-kind refreshes instead of cancelling the in-flight one, so bursty relayouts no longer thrash or starve.

--- a/Sources/Nehir/Core/Controller/LayoutRefreshController.swift
+++ b/Sources/Nehir/Core/Controller/LayoutRefreshController.swift
@@ -1635,7 +1635,6 @@ import QuartzCore
             layoutState.activeRefreshTask?.cancel()
         case (.immediateRelayout, .immediateRelayout):
             mergePendingRefresh(refresh)
-            layoutState.activeRefreshTask?.cancel()
         case (.immediateRelayout, .relayout):
             mergePendingRefresh(refresh)
         case (.immediateRelayout, .visibilityRefresh):
@@ -1643,9 +1642,10 @@ import QuartzCore
         case (.immediateRelayout, .windowRemoval):
             mergePendingRefresh(refresh)
             layoutState.activeRefreshTask?.cancel()
+        case (.relayout, .relayout):
+            mergePendingRefresh(refresh)
         case (.relayout, .fullRescan),
              (.relayout, .immediateRelayout),
-             (.relayout, .relayout),
              (.relayout, .windowRemoval):
             mergePendingRefresh(refresh)
             layoutState.activeRefreshTask?.cancel()

--- a/Tests/NehirTests/RefreshRoutingTests.swift
+++ b/Tests/NehirTests/RefreshRoutingTests.swift
@@ -3777,7 +3777,14 @@ private func syncNiriWorkspaceStatesForRefreshTests(
         )
         await waitForRefreshWork(on: controller)
 
-        #expect(affectedWorkspaceSnapshots.last == [])
+        // P2 coalescing: same-kind refreshes no longer cancel the active task, so
+        // the active GLOBAL relayout runs to completion and the later scoped
+        // relayout runs as a follow-up. The invariant this test guards — a
+        // pending global relayout is not narrowed away by a scoped one — still
+        // holds: a global-scope pass (empty affected set) is executed, followed
+        // by the scoped catch-up pass.
+        #expect(affectedWorkspaceSnapshots.contains([]))
+        #expect(affectedWorkspaceSnapshots.contains([workspaceId]))
     }
 
     @Test @MainActor func appLifecycleUsesFullRescan() async {
@@ -4112,6 +4119,103 @@ private func syncNiriWorkspaceStatesForRefreshTests(
 
         #expect(relayoutEvents.map(\.0) == [.workspaceTransition, .gapsChanged])
         #expect(relayoutEvents.map(\.1) == [.immediateRelayout, .relayout])
+    }
+
+    // MARK: - P2: same-kind refreshes coalesce without cancelling the active task
+
+    @Test @MainActor func immediateRelayoutCoalescesWithActiveImmediateRelayoutWithoutCancelling() async {
+        let controller = makeRefreshTestController()
+        let gate = AsyncGate()
+        var relayoutEvents: [(RefreshReason, LayoutRefreshController.RefreshRoute)] = []
+        var sampledCancellation = false
+        var activeWasCancelled: Bool?
+
+        controller.layoutRefreshController.resetDebugState()
+        controller.layoutRefreshController.debugHooks.onRelayout = { reason, route in
+            relayoutEvents.append((reason, route))
+            if route == .immediateRelayout {
+                await gate.wait()
+                // Sample only on the active (first) traversal; the coalesced
+                // pending is a fresh task whose isCancelled would mask a regression.
+                if !sampledCancellation {
+                    sampledCancellation = true
+                    activeWasCancelled = Task.isCancelled
+                }
+            }
+            return true
+        }
+
+        controller.layoutRefreshController.requestImmediateRelayout(reason: .workspaceTransition)
+        await waitUntil { relayoutEvents.count == 1 }
+        // Same-kind arrival while the active task is parked: must merge, not cancel.
+        controller.layoutRefreshController.requestImmediateRelayout(reason: .appActivationTransition)
+
+        gate.open()
+        await waitForRefreshWork(on: controller)
+
+        #expect(activeWasCancelled == false)
+        #expect(relayoutEvents.map(\.1) == [.immediateRelayout, .immediateRelayout])
+    }
+
+    @Test @MainActor func relayoutCoalescesWithActiveRelayoutWithoutCancelling() async {
+        let controller = makeRefreshTestController()
+        let gate = AsyncGate()
+        var relayoutEvents: [(RefreshReason, LayoutRefreshController.RefreshRoute)] = []
+        var sampledCancellation = false
+        var activeWasCancelled: Bool?
+
+        controller.layoutRefreshController.resetDebugState()
+        controller.layoutRefreshController.debugHooks.onRelayout = { reason, route in
+            relayoutEvents.append((reason, route))
+            if route == .relayout {
+                await gate.wait()
+                if !sampledCancellation {
+                    sampledCancellation = true
+                    activeWasCancelled = Task.isCancelled
+                }
+            }
+            return true
+        }
+
+        // Both reasons route as .relayout with .plain scheduling (zero debounce),
+        // so neither side sleeps before the gated hook.
+        controller.layoutRefreshController.requestRelayout(reason: .gapsChanged)
+        await waitUntil { relayoutEvents.count == 1 }
+        controller.layoutRefreshController.requestRelayout(reason: .windowRuleReevaluation)
+
+        gate.open()
+        await waitForRefreshWork(on: controller)
+
+        #expect(activeWasCancelled == false)
+        #expect(relayoutEvents.map(\.0) == [.gapsChanged, .windowRuleReevaluation])
+        #expect(relayoutEvents.map(\.1) == [.relayout, .relayout])
+    }
+
+    @Test @MainActor func activeRelayoutIsStillCancelledByIncomingFullRescan() async {
+        let controller = makeRefreshTestController()
+        let gate = AsyncGate()
+        var relayoutEvents: [(RefreshReason, LayoutRefreshController.RefreshRoute)] = []
+        var activeWasCancelled: Bool?
+
+        controller.layoutRefreshController.resetDebugState()
+        controller.layoutRefreshController.debugHooks.onRelayout = { reason, route in
+            relayoutEvents.append((reason, route))
+            if route == .relayout {
+                await gate.wait()
+                activeWasCancelled = Task.isCancelled
+            }
+            return true
+        }
+
+        controller.layoutRefreshController.requestRelayout(reason: .gapsChanged)
+        await waitUntil { relayoutEvents.count == 1 }
+        // Escalation: an incoming full rescan must still cancel the active relayout.
+        controller.layoutRefreshController.requestFullRescan(reason: .startup)
+
+        gate.open()
+        await waitForRefreshWork(on: controller)
+
+        #expect(activeWasCancelled == true)
     }
 
     @Test @MainActor func visibilityRefreshCoalescesWhilePending() async {


### PR DESCRIPTION
## Summary

handleRefresh no longer cancels the active task for (.immediateRelayout, .immediateRelayout) and (.relayout, .relayout); both now merge into pending and let the active finish. Escalation cancels (relayout -> fullRescan / immediateRelayout / windowRemoval) are preserved.

Adds three RefreshRoutingTests (verified to fail without the source change). Updates scopedRelayoutDoesNotNarrowPendingGlobalRelayout to assert the preserved invariant — a global-scope pass still runs — instead of the old cancel-based .last == [] ordering: under coalescing the active global completes, then the scoped follow-up runs. The global is not lost, just one idempotent catch-up pass (the trade-off the P2 discovery accepted).

## Release notes

Choose one:

- [x] Added a `.changeset/*.md` for user-visible changes (`mise run changeset -- patch "..."`).
- [ ] No user-visible change; apply the `no release note` label to make CI skip intentional.

## Validation

<!-- Commands run, screenshots, or manual checks. -->

- [ ] Ran relevant tests/checks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved refresh handling so back-to-back refresh requests of the same kind are coalesced instead of causing in-flight cancellations, reducing thrashing during bursty relayouts.
  * Prevents starvation/performance degradation when rapid consecutive layout refreshes occur.
* **Tests**
  * Updated refresh routing assertions and added coverage for same-kind relayout coalescing and cancellation behavior during concurrent refresh scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->