### PR TITLE
Preserve orientation overrides and report effective orientation over IPC

### DIFF
--- a/.changeset/20260619034852-preserve-manual-monitor-orientation-overrides-ac.md
+++ b/.changeset/20260619034852-preserve-manual-monitor-orientation-overrides-ac.md
@@ -1,0 +1,6 @@
+---
+"nehir": patch
+
+---
+
+Preserve manual monitor orientation overrides across display updates and report the effective orientation over IPC instead of the auto-detected value.

--- a/Sources/Nehir/Core/Layout/Niri/NiriMonitor.swift
+++ b/Sources/Nehir/Core/Layout/Niri/NiriMonitor.swift
@@ -47,7 +47,9 @@ final class NiriMonitor {
     func updateOutputSize(monitor: Monitor, orientation: Monitor.Orientation? = nil) {
         frame = monitor.frame
         visibleFrame = monitor.visibleFrame
-        self.orientation = orientation ?? monitor.autoOrientation
+        if let orientation {
+            self.orientation = orientation
+        }
 
         if let screen = NSScreen.screens.first(where: { $0.displayId == monitor.displayId }) {
             scale = screen.backingScaleFactor

--- a/Sources/Nehir/IPC/IPCQueryRouter.swift
+++ b/Sources/Nehir/IPC/IPCQueryRouter.swift
@@ -412,8 +412,9 @@ final class IPCQueryRouter {
             frame: include("frame", in: fields) ? rect(from: monitor.frame) : nil,
             visibleFrame: include("visible-frame", in: fields) ? rect(from: monitor.visibleFrame) : nil,
             hasNotch: include("has-notch", in: fields) ? monitor.hasNotch : nil,
-            orientation: include("orientation", in: fields) ? ipcDisplayOrientation(from: monitor.autoOrientation) :
-                nil,
+            orientation: include("orientation", in: fields)
+                ? ipcDisplayOrientation(from: controller.settings.effectiveOrientation(for: monitor))
+                : nil,
             activeWorkspace: include("active-workspace", in: fields) ? activeWorkspace.map(workspaceRef(from:)) : nil
         )
     }

--- a/Tests/NehirTests/IPCQueryRouterTests.swift
+++ b/Tests/NehirTests/IPCQueryRouterTests.swift
@@ -759,4 +759,51 @@ private func prepareIPCQueryRouterNiriState(
         #expect(ruleActionsPayload.ruleActions == capabilitiesPayload.ruleActions)
         #expect(queriesPayload.queries.map { $0.name } == capabilitiesPayload.queries.map { $0.name })
     }
+
+    @Test func displaysQueryReportsEffectiveOrientationOverride() {
+        // Portrait fixture: autoOrientation == .vertical, but a user override forces .horizontal.
+        // The IPC `orientation` field must reflect the override, not the auto value.
+        let portraitMonitor = makeLayoutPlanTestMonitor(
+            displayId: layoutPlanTestSyntheticDisplayId(77),
+            name: "Portrait",
+            width: 900,
+            height: 1600
+        )
+        let controller = makeLayoutPlanTestController(monitors: [portraitMonitor])
+        defer { resetSharedControllerStateForTests() }
+
+        controller.settings.updateOrientationSettings(
+            MonitorOrientationSettings(
+                monitorName: portraitMonitor.name,
+                monitorDisplayId: portraitMonitor.displayId,
+                orientation: .horizontal
+            )
+        )
+
+        let router = IPCQueryRouter(controller: controller, sessionToken: ipcQueryRouterSessionToken)
+        let result = router.displaysResult(IPCQueryRequest(name: .displays))
+
+        #expect(result.displays.count == 1)
+        #expect(result.displays.first?.id == "display:\(portraitMonitor.displayId)")
+        #expect(result.displays.first?.orientation == .horizontal)
+    }
+
+    @Test func displaysQueryReportsAutoOrientationWhenNoOverride() {
+        // Guards the effectiveOrientation fallback: with no override installed, the
+        // auto orientation flows through. Landscape fixture -> .horizontal.
+        let landscapeMonitor = makeLayoutPlanTestMonitor(
+            displayId: layoutPlanTestSyntheticDisplayId(78),
+            name: "Landscape",
+            width: 1920,
+            height: 1080
+        )
+        let controller = makeLayoutPlanTestController(monitors: [landscapeMonitor])
+        defer { resetSharedControllerStateForTests() }
+
+        let router = IPCQueryRouter(controller: controller, sessionToken: ipcQueryRouterSessionToken)
+        let result = router.displaysResult(IPCQueryRequest(name: .displays))
+
+        #expect(result.displays.count == 1)
+        #expect(result.displays.first?.orientation == .horizontal)
+    }
 }

--- a/Tests/NehirTests/NiriMonitorTests.swift
+++ b/Tests/NehirTests/NiriMonitorTests.swift
@@ -1,0 +1,69 @@
+import CoreGraphics
+import Foundation
+@testable import Nehir
+import Testing
+
+/// Tests for `NiriMonitor` orientation handling.
+///
+/// Covers the leaf hardening in `updateOutputSize` (preserve a stored override
+/// when no explicit orientation argument is supplied) and the `init` fallback
+/// regression guard. See P3 in the upstream-port patch track.
+@Suite struct NiriMonitorTests {
+    /// Portrait (900×1600) fixture: `autoOrientation == .vertical`.
+    private func portraitMonitor() -> Monitor {
+        makeLayoutPlanTestMonitor(
+            displayId: layoutPlanTestSyntheticDisplayId(42),
+            name: "Portrait",
+            width: 900,
+            height: 1600
+        )
+    }
+
+    /// Landscape (1920×1080) fixture: `autoOrientation == .horizontal`.
+    private func landscapeMonitor() -> Monitor {
+        makeLayoutPlanTestMonitor(
+            displayId: layoutPlanTestSyntheticDisplayId(43),
+            name: "Landscape",
+            width: 1920,
+            height: 1080
+        )
+    }
+
+    @Test func updateOutputSizePreservesExistingOrientationWhenCalledWithNil() {
+        let monitor = portraitMonitor()
+        let niri = NiriMonitor(monitor: monitor, orientation: .horizontal)
+        #expect(niri.orientation == .horizontal)
+
+        // Reconfigure with a new frame but no explicit orientation argument.
+        // The stored `.horizontal` override must survive; auto would be `.vertical`.
+        let refreshedMonitor = Monitor(
+            id: monitor.id,
+            displayId: monitor.displayId,
+            frame: CGRect(x: 0, y: 0, width: 901, height: 1601),
+            visibleFrame: CGRect(x: 0, y: 0, width: 901, height: 1601),
+            hasNotch: false,
+            name: monitor.name
+        )
+        niri.updateOutputSize(monitor: refreshedMonitor, orientation: nil)
+
+        #expect(niri.orientation == .horizontal)
+        #expect(niri.frame == refreshedMonitor.frame)
+        #expect(niri.visibleFrame == refreshedMonitor.visibleFrame)
+    }
+
+    @Test func updateOutputSizeAppliesExplicitOrientationOverride() {
+        let monitor = portraitMonitor()
+        // Construct with the auto orientation (no override).
+        let niri = NiriMonitor(monitor: monitor, orientation: nil)
+        #expect(niri.orientation == .vertical)
+
+        // Supplying an explicit orientation still wins.
+        niri.updateOutputSize(monitor: monitor, orientation: .horizontal)
+        #expect(niri.orientation == .horizontal)
+    }
+
+    @Test func initFallsBackToAutoOrientationWhenNoOverride() {
+        #expect(NiriMonitor(monitor: portraitMonitor(), orientation: nil).orientation == .vertical)
+        #expect(NiriMonitor(monitor: landscapeMonitor(), orientation: nil).orientation == .horizontal)
+    }
+}


### PR DESCRIPTION
## Summary

NiriMonitor.updateOutputSize no longer clobbers an existing orientation when called with nil. IPC display queries report
settings.effectiveOrientation(for:), so overrides are reflected to nehirctl/scripts.


## Release notes

Choose one:

- [x] Added a `.changeset/*.md` for user-visible changes (`mise run changeset -- patch "..."`).
- [ ] No user-visible change; apply the `no release note` label to make CI skip intentional.

## Validation

<!-- Commands run, screenshots, or manual checks. -->

- [ ] Ran relevant tests/checks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Manual monitor orientation overrides are now correctly preserved when displays are updated
  * System now reports effective orientation respecting user overrides instead of auto-detected values

* **Tests**
  * Added tests for orientation override preservation and display query behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->