### PR TITLE
Suppress frame-change relayout after a recent frame-write failure (P4)

### DIFF
--- a/.changeset/20260619034853-stop-re-layout-thrash-after-a-window-rejects-a-f.md
+++ b/.changeset/20260619034853-stop-re-layout-thrash-after-a-window-rejects-a-f.md
@@ -1,0 +1,6 @@
+---
+"nehir": patch
+
+---
+
+Stop re-layout thrash after a window rejects a frame write, so apps that snap back to a minimum size no longer drive a relayout loop.

--- a/Sources/Nehir/Core/Ax/AXManager.swift
+++ b/Sources/Nehir/Core/Ax/AXManager.swift
@@ -166,6 +166,9 @@ final class AXManager {
         if pendingFrameWrites[windowId] != nil {
             return true
         }
+        if recentFrameWriteFailures[windowId] != nil {
+            return true
+        }
         guard let observedFrame,
               let lastAppliedFrame = lastAppliedFrames[windowId]
         else {

--- a/Tests/NehirTests/AXManagerTests.swift
+++ b/Tests/NehirTests/AXManagerTests.swift
@@ -157,6 +157,158 @@ private func axManagerTestWriteResult(
         #expect(controller.axManager.recentFrameWriteFailure(for: token.windowId) == .verificationMismatch)
     }
 
+    @Test @MainActor func shouldSuppressFrameChangeRelayoutAfterRecentFrameWriteFailure() async {
+        let controller = makeLayoutPlanTestController()
+        guard let monitor = controller.workspaceManager.monitors.first,
+              let workspaceId = controller.workspaceManager.activeWorkspaceOrFirst(on: monitor.id)?.id
+        else {
+            Issue.record("Missing monitor or active workspace for P4 suppression test")
+            return
+        }
+
+        let token = addLayoutPlanTestWindow(on: controller, workspaceId: workspaceId, windowId: 913)
+        let targetFrame = CGRect(x: 200, y: 120, width: 840, height: 540)
+
+        var attemptCount = 0
+        var observerResults: [AXFrameApplyResult] = []
+        controller.axManager.frameApplyOverrideForTests = { requests in
+            attemptCount += 1
+            return requests.map { request in
+                let failureReason: AXFrameWriteFailureReason = if attemptCount == 1 {
+                    .cacheMiss
+                } else {
+                    .verificationMismatch
+                }
+                return AXFrameApplyResult(
+                    requestId: request.requestId,
+                    pid: request.pid,
+                    windowId: request.windowId,
+                    targetFrame: request.frame,
+                    currentFrameHint: request.currentFrameHint,
+                    writeResult: axManagerTestWriteResult(
+                        targetFrame: request.frame,
+                        currentFrameHint: request.currentFrameHint,
+                        observedFrame: request.currentFrameHint,
+                        failureReason: failureReason
+                    )
+                )
+            }
+        }
+
+        controller.axManager.applyFramesParallel(
+            [(token.pid, token.windowId, targetFrame)],
+            terminalObserver: { observerResults.append($0) }
+        )
+
+        let observedTerminalResult = await waitForConditionForTests {
+            observerResults.count == 1
+        }
+
+        #expect(observedTerminalResult)
+        #expect(observerResults.first?.writeResult.failureReason == .verificationMismatch)
+
+        // Post-failure state: no pending write, no confirmed last-applied frame, failure recorded.
+        #expect(controller.axManager.pendingFrameWrite(for: token.windowId) == nil)
+        #expect(controller.axManager.lastAppliedFrame(for: token.windowId) == nil)
+        #expect(controller.axManager.recentFrameWriteFailure(for: token.windowId) == .verificationMismatch)
+
+        // The app's snap-back notification must be suppressed for any observed frame (or none),
+        // breaking the snap-back -> relayout -> re-enqueue loop.
+        let unrelatedObservedFrame = CGRect(x: 10, y: 10, width: 10, height: 10)
+        #expect(controller.axManager.shouldSuppressFrameChangeRelayout(for: token.windowId, observedFrame: unrelatedObservedFrame))
+        #expect(controller.axManager.shouldSuppressFrameChangeRelayout(for: token.windowId, observedFrame: nil))
+    }
+
+    @Test @MainActor func frameChangeRelayoutSuppressionEndsAfterEnqueueClearsFailure() async {
+        let controller = makeLayoutPlanTestController()
+        guard let monitor = controller.workspaceManager.monitors.first,
+              let workspaceId = controller.workspaceManager.activeWorkspaceOrFirst(on: monitor.id)?.id
+        else {
+            Issue.record("Missing monitor or active workspace for P4 bounded-clearing test")
+            return
+        }
+
+        let token = addLayoutPlanTestWindow(on: controller, workspaceId: workspaceId, windowId: 914)
+        let failedTargetFrame = CGRect(x: 200, y: 120, width: 840, height: 540)
+
+        var attemptCount = 0
+        var observerResults: [AXFrameApplyResult] = []
+        controller.axManager.frameApplyOverrideForTests = { requests in
+            attemptCount += 1
+            return requests.map { request in
+                let failureReason: AXFrameWriteFailureReason = if attemptCount == 1 {
+                    .cacheMiss
+                } else {
+                    .verificationMismatch
+                }
+                return AXFrameApplyResult(
+                    requestId: request.requestId,
+                    pid: request.pid,
+                    windowId: request.windowId,
+                    targetFrame: request.frame,
+                    currentFrameHint: request.currentFrameHint,
+                    writeResult: axManagerTestWriteResult(
+                        targetFrame: request.frame,
+                        currentFrameHint: request.currentFrameHint,
+                        observedFrame: request.currentFrameHint,
+                        failureReason: failureReason
+                    )
+                )
+            }
+        }
+
+        controller.axManager.applyFramesParallel(
+            [(token.pid, token.windowId, failedTargetFrame)],
+            terminalObserver: { observerResults.append($0) }
+        )
+
+        let observedTerminalResult = await waitForConditionForTests {
+            observerResults.count == 1
+        }
+        #expect(observedTerminalResult)
+        #expect(controller.axManager.recentFrameWriteFailure(for: token.windowId) == .verificationMismatch)
+
+        // Swap to a success override and enqueue a fresh target. The enqueue path clears the
+        // failure flag, bounding the suppression window to the failed-write period.
+        controller.axManager.frameApplyOverrideForTests = { requests in
+            requests.map { request in
+                AXFrameApplyResult(
+                    requestId: request.requestId,
+                    pid: request.pid,
+                    windowId: request.windowId,
+                    targetFrame: request.frame,
+                    currentFrameHint: request.currentFrameHint,
+                    writeResult: axManagerTestWriteResult(
+                        targetFrame: request.frame,
+                        currentFrameHint: request.currentFrameHint,
+                        observedFrame: request.frame,
+                        failureReason: nil
+                    )
+                )
+            }
+        }
+
+        var secondObserverResults: [AXFrameApplyResult] = []
+        let freshTargetFrame = CGRect(x: 300, y: 200, width: 1000, height: 700)
+        controller.axManager.applyFramesParallel(
+            [(token.pid, token.windowId, freshTargetFrame)],
+            terminalObserver: { secondObserverResults.append($0) }
+        )
+
+        let observedSecondResult = await waitForConditionForTests {
+            secondObserverResults.count == 1
+        }
+        #expect(observedSecondResult)
+
+        // The failure flag is cleared on enqueue and the fresh write confirmed.
+        #expect(controller.axManager.recentFrameWriteFailure(for: token.windowId) == nil)
+        #expect(controller.axManager.lastAppliedFrame(for: token.windowId) == freshTargetFrame)
+
+        // Suppression no longer applies to an unrelated observed frame.
+        let unrelatedObservedFrame = CGRect(x: 10, y: 10, width: 10, height: 10)
+        #expect(controller.axManager.shouldSuppressFrameChangeRelayout(for: token.windowId, observedFrame: unrelatedObservedFrame) == false)
+    }
+
     @Test @MainActor func terminalObserverCompletesImmediatelyWhenTargetFrameAlreadyCached() {
         let controller = makeLayoutPlanTestController()
         guard let monitor = controller.workspaceManager.monitors.first,


### PR DESCRIPTION
## Summary

shouldSuppressFrameChangeRelayout now also returns true while recentFrameWriteFailures[windowId] is set, breaking the app snap-back -> relayout -> re-enqueue loop. Suppression is bounded: every enqueue clears the
flag. Trigger-side fix; root cause (sub-minimum target) tracked separately.

## Release notes

Choose one:

- [x] Added a `.changeset/*.md` for user-visible changes (`mise run changeset -- patch "..."`).
- [ ] No user-visible change; apply the `no release note` label to make CI skip intentional.

## Validation

<!-- Commands run, screenshots, or manual checks. -->

- [ ] Ran relevant tests/checks.
