### PR TITLE
Reveal moved windows in target workspace viewports

### DIFF
--- a/.changeset/20260619110312-reveal-moved-windows-in-target-workspace-viewpor.md
+++ b/.changeset/20260619110312-reveal-moved-windows-in-target-workspace-viewpor.md
@@ -1,0 +1,6 @@
+---
+"nehir": patch
+
+---
+
+Reveal moved windows in target workspace viewports

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,68 @@
+# AGENTS.md
+
+Instructions for AI agents working in this repository.
+
+## Plans branch instructions
+
+When working with planning documents in the dedicated plans-only worktree/branch,
+read that worktree's `AGENTS.md` first and follow it. The plans branch has its
+own document layout and stricter durable-doc rules (for example, no local
+machine-specific paths in discovery/planning docs).
+
+## Tests: wait for user-confirmed fix before editing
+
+When debugging a runtime bug, **do not add, modify, or rewrite tests until the
+user has confirmed the fix works in their real repro**. Runtime traces and the
+user's validation are the acceptance signal. Touching tests before that
+confirmation wastes tokens and creates churn. After the user confirms the fix,
+then add or update regression tests if requested or clearly useful.
+
+## Changesets
+
+For user-visible changes, create a Changesets release-note fragment with:
+
+```bash
+mise run changeset <patch|minor|major|none> "User-facing summary"
+```
+
+Use `patch` for bug fixes, `minor` for new user-facing features, `major` for
+breaking changes, and `none` for release-note-only changes. Add contributors
+when needed with `--contributors handle1,handle2`. Issue reporters count as
+contributors; include their GitHub handle when a change fixes a reported issue.
+Mention the ticket/issue number in the changeset summary when one was involved.
+
+## Commit messages
+
+Do not use Conventional Commits formatting (`fix:`, `feat:`, `chore:`, etc.).
+Use concise plain-English commit subjects instead.
+
+## Discovery documents: do not reference trace log filenames
+
+When writing discovery / investigation documents (under `docs/plans/discovery/`,
+or anywhere that records a runtime bug), **do not reference trace log filenames**
+(e.g. `runtime-trace-1781525802769-1781525820832.log`, line numbers inside a
+log, "trace 1 / trace 2", or relative paths into `~/.local/state/nehir/traces/`).
+
+**Why:** trace logs are machine-local and ephemeral. They will not exist later,
+on another machine, or in CI — so any finding that depends on re-opening one
+becomes unverifiable and effectively useless.
+
+**Do instead — inline the evidence into the document itself.** A discovery must
+be self-contained. Copy the specific values, events, or fields that prove the
+finding directly into the prose:
+
+- Relevant log lines / events, quoted as text (not as a file reference).
+- The concrete numeric state that demonstrates the bug — e.g.
+  `currentViewStart=3186.1 → targetViewStart=1259.5`,
+  `isWorkspaceActive=false`, `interactionMonitor=display 2`, `didReveal=true`.
+- Window tokens, pids, workspace/monitor identifiers needed to follow the
+  reasoning, restated where they matter (not "see the log").
+- The topology/initial state required to reproduce (which app on which monitor,
+  which workspace was focused, etc.).
+
+The goal is that the document can be read and acted on with no access to any
+captured log. If a detail is worth citing from a trace, it is worth copying into
+the document.
+
+Code citations (file + line, e.g. `AXEventHandler.swift:1790`) are fine and
+encouraged — they point at durable source, not ephemeral runtime output.

--- a/Sources/Nehir/Core/Controller/WorkspaceNavigationHandler.swift
+++ b/Sources/Nehir/Core/Controller/WorkspaceNavigationHandler.swift
@@ -90,6 +90,43 @@ final class WorkspaceNavigationHandler {
         return ids
     }
 
+    private func prepareMovedWindowTargetViewport(
+        token: WindowToken,
+        workspaceId: WorkspaceDescriptor.ID,
+        reveal: Bool = true
+    ) {
+        guard let controller else { return }
+
+        var targetState = controller.workspaceManager.niriViewportState(for: workspaceId)
+        if let engine = controller.niriEngine,
+           let movedNode = engine.findNode(for: token),
+           engine.findColumn(containing: movedNode, in: workspaceId) != nil
+        {
+            targetState.selectedNodeId = movedNode.id
+
+            if reveal,
+               let monitor = controller.workspaceManager.monitor(for: workspaceId)
+            {
+                let gap = controller.gapSize(for: monitor)
+                let workingFrame = controller.insetWorkingFrame(for: monitor)
+                engine.ensureSelectionVisible(
+                    node: movedNode,
+                    in: workspaceId,
+                    motion: controller.motionPolicy.snapshot(),
+                    state: &targetState,
+                    workingFrame: workingFrame,
+                    gaps: gap
+                )
+            }
+        }
+
+        applySessionPatch(
+            workspaceId: workspaceId,
+            viewportState: targetState,
+            rememberedFocusToken: token
+        )
+    }
+
     private struct WorkspaceTransitionFocusHandoff {
         let focusToken: WindowToken?
         let shouldClearManagedFocus: Bool
@@ -610,7 +647,7 @@ final class WorkspaceNavigationHandler {
         guard transferResult.succeeded else { return }
 
         controller.reassignManagedWindow(token, to: targetWorkspace.id)
-        applySessionPatch(workspaceId: targetWorkspace.id, rememberedFocusToken: token)
+        prepareMovedWindowTargetViewport(token: token, workspaceId: targetWorkspace.id)
 
         let actualSourceWsId = transferResult.sourceWorkspaceId ?? wsId
         let sourceState = controller.workspaceManager.niriViewportState(for: actualSourceWsId)
@@ -798,28 +835,7 @@ final class WorkspaceNavigationHandler {
             {
                 controller.layoutRefreshController.stopScrollAnimation(for: sourceMonitor.displayId)
             }
-            var targetState = controller.workspaceManager.niriViewportState(for: target.id)
-            if let engine = controller.niriEngine,
-               let movedNode = engine.findNode(for: token),
-               let monitor = controller.workspaceManager.monitor(for: target.id)
-            {
-                targetState.selectedNodeId = movedNode.id
-                let gap = controller.gapSize(for: monitor)
-                let workingFrame = controller.insetWorkingFrame(for: monitor)
-                engine.ensureSelectionVisible(
-                    node: movedNode,
-                    in: target.id,
-                    motion: controller.motionPolicy.snapshot(),
-                    state: &targetState,
-                    workingFrame: workingFrame,
-                    gaps: gap
-                )
-            }
-            applySessionPatch(
-                workspaceId: target.id,
-                viewportState: targetState,
-                rememberedFocusToken: token
-            )
+            prepareMovedWindowTargetViewport(token: token, workspaceId: target.id)
             controller.layoutRefreshController.commitWorkspaceTransition(
                 affectedWorkspaces: affectedWorkspaceIds(
                     sourceWorkspaceId: actualSourceWsId,
@@ -844,6 +860,7 @@ final class WorkspaceNavigationHandler {
             {
                 controller.layoutRefreshController.stopScrollAnimation(for: sourceMonitor.displayId)
             }
+            prepareMovedWindowTargetViewport(token: token, workspaceId: target.id)
             controller.layoutRefreshController.commitWorkspaceTransition(
                 affectedWorkspaces: affectedWorkspaceIds(
                     sourceWorkspaceId: actualSourceWsId,
@@ -872,7 +889,7 @@ final class WorkspaceNavigationHandler {
         guard transferResult.succeeded else { return false }
 
         controller.reassignManagedWindow(token, to: targetWsId)
-        applySessionPatch(workspaceId: targetWsId, rememberedFocusToken: token)
+        prepareMovedWindowTargetViewport(token: token, workspaceId: targetWsId)
 
         let actualSourceWsId = transferResult.sourceWorkspaceId ?? currentWorkspaceId
         if let actualSourceWsId {
@@ -932,29 +949,7 @@ final class WorkspaceNavigationHandler {
                 _ = controller.workspaceManager.setActiveWorkspace(targetWsId, on: monitor.id)
             }
 
-            var targetState = controller.workspaceManager.niriViewportState(for: targetWsId)
-            if let engine = controller.niriEngine,
-               let movedNode = engine.findNode(for: token),
-               let monitor = controller.workspaceManager.monitor(for: targetWsId)
-            {
-                targetState.selectedNodeId = movedNode.id
-
-                let gap = controller.gapSize(for: monitor)
-                let workingFrame = controller.insetWorkingFrame(for: monitor)
-                engine.ensureSelectionVisible(
-                    node: movedNode,
-                    in: targetWsId,
-                    motion: controller.motionPolicy.snapshot(),
-                    state: &targetState,
-                    workingFrame: workingFrame,
-                    gaps: gap
-                )
-            }
-            applySessionPatch(
-                workspaceId: targetWsId,
-                viewportState: targetState,
-                rememberedFocusToken: token
-            )
+            prepareMovedWindowTargetViewport(token: token, workspaceId: targetWsId)
 
             controller.layoutRefreshController.commitWorkspaceTransition(
                 affectedWorkspaces: affectedWorkspaceIds(
@@ -970,6 +965,7 @@ final class WorkspaceNavigationHandler {
             controller.recoverSourceFocusAfterMove(in: actualSourceWsId, preferredNodeId: sourceState.selectedNodeId)
             let focusToken = controller.resolveAndSetWorkspaceFocusToken(for: actualSourceWsId)
 
+            prepareMovedWindowTargetViewport(token: token, workspaceId: targetWsId)
             controller.layoutRefreshController.commitWorkspaceTransition(
                 affectedWorkspaces: affectedWorkspaceIds(
                     sourceWorkspaceId: actualSourceWsId,

--- a/Tests/NehirTests/WorkspaceNavigationHandlerTests.swift
+++ b/Tests/NehirTests/WorkspaceNavigationHandlerTests.swift
@@ -1,0 +1,152 @@
+import ApplicationServices
+import CoreGraphics
+import Foundation
+@testable import Nehir
+import Testing
+
+private func makeWorkspaceNavigationTestDefaults() -> UserDefaults {
+    let suiteName = "dev.guria.nehir.workspace-navigation.test.\(UUID().uuidString)"
+    return UserDefaults(suiteName: suiteName)!
+}
+
+@MainActor
+private func makeWorkspaceNavigationTestController(
+    monitors: [Monitor] = [makeLayoutPlanTestMonitor()],
+    workspaceConfigurations: [WorkspaceConfiguration] = [
+        WorkspaceConfiguration(name: "1", monitorAssignment: .main),
+        WorkspaceConfiguration(name: "2", monitorAssignment: .main)
+    ]
+) -> WMController {
+    resetSharedControllerStateForTests()
+    let settings = SettingsStore(defaults: makeWorkspaceNavigationTestDefaults())
+    settings.workspaceConfigurations = workspaceConfigurations
+    let controller = WMController(
+        settings: settings,
+        windowFocusOperations: WindowFocusOperations(
+            activateApp: { _ in },
+            focusSpecificWindow: { _, _, _ in },
+            raiseWindow: { _ in }
+        )
+    )
+    installSynchronousFrameApplySuccessOverride(on: controller)
+    controller.workspaceManager.applyMonitorConfigurationChange(monitors)
+    return controller
+}
+
+@MainActor
+private func addWorkspaceNavigationTestWindow(
+    on controller: WMController,
+    workspaceId: WorkspaceDescriptor.ID,
+    windowId: Int
+) -> WindowHandle {
+    let token = controller.workspaceManager.addWindow(
+        makeLayoutPlanTestWindow(windowId: windowId),
+        pid: getpid(),
+        windowId: windowId,
+        to: workspaceId
+    )
+    guard let handle = controller.workspaceManager.handle(for: token) else {
+        fatalError("Expected bridge handle for workspace navigation test window")
+    }
+    return handle
+}
+
+@MainActor
+private func syncNiriWorkspaceStateForWorkspaceNavigationTests(
+    on controller: WMController,
+    workspaceIds: Set<WorkspaceDescriptor.ID>
+) {
+    guard let engine = controller.niriEngine else { return }
+
+    for workspaceId in workspaceIds {
+        let handles = controller.workspaceManager.entries(in: workspaceId).map(\.handle)
+        let selectedNodeId = controller.workspaceManager.niriViewportState(for: workspaceId).selectedNodeId
+        let focusedHandle = controller.workspaceManager.lastFocusedHandle(in: workspaceId)
+        _ = engine.syncWindows(
+            handles,
+            in: workspaceId,
+            selectedNodeId: selectedNodeId,
+            focusedHandle: focusedHandle
+        )
+
+        let resolvedSelection = focusedHandle.flatMap { engine.findNode(for: $0)?.id }
+            ?? engine.validateSelection(selectedNodeId, in: workspaceId)
+        controller.workspaceManager.withNiriViewportState(for: workspaceId) { state in
+            state.selectedNodeId = resolvedSelection
+            state.activeColumnIndex = min(state.activeColumnIndex, max(0, engine.columns(in: workspaceId).count - 1))
+        }
+    }
+}
+
+@MainActor
+private func assertMovedWindowRevealedInTargetViewport(
+    controller: WMController,
+    workspaceId: WorkspaceDescriptor.ID,
+    token: WindowToken,
+    sourceLocation: SourceLocation = #_sourceLocation
+) {
+    guard let engine = controller.niriEngine else {
+        Issue.record("Missing Niri engine", sourceLocation: sourceLocation)
+        return
+    }
+    guard let movedNode = engine.findNode(for: token),
+          let movedColumn = engine.column(of: movedNode),
+          let movedColumnIndex = engine.columnIndex(of: movedColumn, in: workspaceId)
+    else {
+        Issue.record("Moved node was not present in the target workspace", sourceLocation: sourceLocation)
+        return
+    }
+
+    let targetState = controller.workspaceManager.niriViewportState(for: workspaceId)
+    #expect(movedColumnIndex > 0, sourceLocation: sourceLocation)
+    #expect(targetState.selectedNodeId == movedNode.id, sourceLocation: sourceLocation)
+    #expect(targetState.activeColumnIndex == movedColumnIndex, sourceLocation: sourceLocation)
+    #expect(controller.workspaceManager.rememberedTiledFocusToken(in: workspaceId) == token, sourceLocation: sourceLocation)
+}
+
+@Suite(.serialized) struct WorkspaceNavigationHandlerTests {
+    @Test @MainActor func moveFocusedWindowWithoutFollowRevealsInactiveTargetViewport() async throws {
+        let controller = makeWorkspaceNavigationTestController()
+        controller.settings.focusFollowsWindowToMonitor = false
+
+        guard let monitor = controller.workspaceManager.monitors.first,
+              let targetWorkspaceId = controller.workspaceManager.workspaceId(for: "1", createIfMissing: false),
+              let sourceWorkspaceId = controller.workspaceManager.workspaceId(for: "2", createIfMissing: false)
+        else {
+            Issue.record("Missing single-monitor workspace fixture")
+            return
+        }
+
+        controller.enableNiriLayout()
+        await waitForLayoutPlanRefreshWork(on: controller)
+        controller.syncMonitorsToNiriEngine()
+
+        let targetFirst = addWorkspaceNavigationTestWindow(on: controller, workspaceId: targetWorkspaceId, windowId: 10_101)
+        _ = addWorkspaceNavigationTestWindow(on: controller, workspaceId: targetWorkspaceId, windowId: 10_102)
+        _ = addWorkspaceNavigationTestWindow(on: controller, workspaceId: targetWorkspaceId, windowId: 10_103)
+        let movedHandle = addWorkspaceNavigationTestWindow(on: controller, workspaceId: sourceWorkspaceId, windowId: 10_104)
+
+        _ = controller.workspaceManager.rememberFocus(targetFirst, in: targetWorkspaceId)
+        _ = controller.workspaceManager.setManagedFocus(movedHandle, in: sourceWorkspaceId, onMonitor: monitor.id)
+        syncNiriWorkspaceStateForWorkspaceNavigationTests(
+            on: controller,
+            workspaceIds: [targetWorkspaceId, sourceWorkspaceId]
+        )
+        controller.workspaceManager.withNiriViewportState(for: targetWorkspaceId) { state in
+            state.activeColumnIndex = 0
+            state.viewOffsetPixels = .static(0)
+        }
+        _ = controller.workspaceManager.setActiveWorkspace(sourceWorkspaceId, on: monitor.id)
+        _ = controller.workspaceManager.setInteractionMonitor(monitor.id)
+
+        controller.workspaceNavigationHandler.moveFocusedWindow(toWorkspaceIndex: 0)
+        await waitForLayoutPlanRefreshWork(on: controller)
+
+        assertMovedWindowRevealedInTargetViewport(
+            controller: controller,
+            workspaceId: targetWorkspaceId,
+            token: movedHandle.id
+        )
+        #expect(controller.interactionWorkspace()?.id == sourceWorkspaceId)
+    }
+}


### PR DESCRIPTION
## Summary

<!-- What changed and why? -->

## Release notes

Choose one:

- [x] Added a `.changeset/*.md` for user-visible changes (`mise run changeset -- patch "..."`).
- [ ] No user-visible change; apply the `no release note` label to make CI skip intentional.

## Validation

<!-- Commands run, screenshots, or manual checks. -->

- [ ] Ran relevant tests/checks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Windows moved between workspaces are now properly revealed in the target workspace viewport, ensuring moved windows are immediately visible.

* **Tests**
  * Added new workspace navigation tests to verify moved-window reveal/selection behavior, including the “without follow” scenario.

* **Documentation**
  * Updated repository agent/process guidelines to standardize how user-visible changesets and investigation docs are created.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->