### PR TITLE
Suppress cursor warp for FFM AX confirmations

### DIFF
--- a/.changeset/20260619144126-stop-focus-follows-mouse-from-warping-the-cursor.md
+++ b/.changeset/20260619144126-stop-focus-follows-mouse-from-warping-the-cursor.md
@@ -1,0 +1,6 @@
+---
+"nehir": patch
+
+---
+
+Prevent focus-follows-mouse-tagged AX focus confirmations from falling through to cursor warp when the generic pointer suppression is unavailable or expires.

--- a/Sources/Nehir/Core/Controller/AXEventHandler.swift
+++ b/Sources/Nehir/Core/Controller/AXEventHandler.swift
@@ -2185,6 +2185,9 @@ final class AXEventHandler: CGSEventDelegate {
 
         let target = controller.keyboardFocusTarget(for: entry.token, axRef: entry.axRef)
         var preferredMouseFrame: CGRect?
+        // M3: whether this confirmation is focus-follows-mouse driven. Hoisted out of
+        // the engine block so the cursor-warp gate below can suppress warp on hover.
+        var confirmationIsFFM = false
         if let engine = controller.niriEngine,
            let node = engine.findNode(for: entry.handle),
            let _ = controller.workspaceManager.monitor(for: wsId)
@@ -2201,6 +2204,7 @@ final class AXEventHandler: CGSEventDelegate {
             let recentFFMIsFresh = recentFFMDate.map { now.timeIntervalSince($0) <= 1.0 } ?? false
             let isFFM = pendingFFMToken == entry.token && pendingFFMIsFresh
                 || (recentFFMToken == entry.token && recentFFMIsFresh)
+            confirmationIsFFM = isFFM
             if pendingFFMToken == entry.token, pendingFFMIsFresh {
                 state.pendingFFMFocusToken = nil
                 state.pendingFFMFocusTimestamp = nil
@@ -2368,7 +2372,8 @@ final class AXEventHandler: CGSEventDelegate {
            controller.moveMouseToFocusedWindowEnabled,
            controller.workspaceManager.confirmedManagedFocusToken == entry.token,
            !controller.workspaceManager.isNonManagedFocusActive,
-           !controller.shouldSuppressMouseMoveToFocusedWindow(for: entry.token)
+           !controller.shouldSuppressMouseMoveToFocusedWindow(for: entry.token),
+           !confirmationIsFFM
         {
             controller.moveMouseToWindow(entry.token, preferredFrame: preferredMouseFrame, reason: "axFocusConfirmed")
         }

--- a/Tests/NehirTests/AXEventHandlerTests.swift
+++ b/Tests/NehirTests/AXEventHandlerTests.swift
@@ -1584,6 +1584,67 @@ private func waitUntilAXEventTest(
         #expect(updatedState.selectedNodeId == focusedNode.id)
     }
 
+    // MARK: - M3: FFM confirmations must not warp the cursor to the focused window
+
+    @Test @MainActor func ffmFocusConfirmationDoesNotWarpCursorWhenMoveMouseToFocusedWindowEnabled() async {
+        let controller = makeAXEventTestController()
+        guard let monitor = controller.workspaceManager.monitors.first,
+              let workspaceId = controller.workspaceManager.activeWorkspaceOrFirst(on: monitor.id)?.id
+        else {
+            Issue.record("Missing workspace for FFM-warp test")
+            return
+        }
+
+        controller.enableNiriLayout()
+        controller.updateNiriConfig(balancedColumnCount: 1)
+        await controller.layoutRefreshController.waitForRefreshWorkForTests()
+        controller.syncMonitorsToNiriEngine()
+        guard let engine = controller.niriEngine else {
+            Issue.record("Missing Niri engine")
+            return
+        }
+
+        let appPid: pid_t = 9_810
+        let targetToken = controller.workspaceManager.addWindow(
+            AXWindowRef(element: AXUIElementCreateSystemWide(), windowId: 9811),
+            pid: appPid,
+            windowId: 9811,
+            to: workspaceId
+        )
+        let targetNode = engine.addWindow(token: targetToken, to: workspaceId, afterSelection: nil, focusedToken: targetToken)
+        for column in engine.columns(in: workspaceId) {
+            column.cachedWidth = 900
+            column.cachedHeight = 800
+        }
+        _ = targetNode
+        guard let entry = controller.workspaceManager.entry(for: targetToken) else {
+            Issue.record("Missing entry for FFM-warp test")
+            return
+        }
+
+        _ = controller.workspaceManager.setManagedFocus(targetToken, in: workspaceId, onMonitor: monitor.id)
+        controller.setMoveMouseToFocusedWindow(true)
+
+        var warpPoints: [CGPoint] = []
+        controller.warpMouseCursorPosition = { warpPoints.append($0) }
+
+        // Mark this confirmation as focus-follows-mouse driven, as MouseEventHandler would.
+        controller.workspaceManager.withNiriViewportState(for: workspaceId) { state in
+            state.pendingFFMFocusToken = targetToken
+            state.pendingFFMFocusTimestamp = Date()
+        }
+
+        controller.axEventHandler.handleManagedAppActivation(
+            entry: entry,
+            isWorkspaceActive: true,
+            appFullscreen: false,
+            source: .focusedWindowChanged
+        )
+
+        #expect(controller.workspaceManager.confirmedManagedFocusToken == targetToken)
+        #expect(warpPoints.isEmpty)
+    }
+
     @Test @MainActor func workspaceActivationForPendingManagedRequestDoesNotStartNativeAppSwitchLease() {
         let controller = makeAXEventTestController()
         controller.hasStartedServices = true


### PR DESCRIPTION
## Summary

<!-- What changed and why? -->

## Release notes

Choose one:

- [x] Added a `.changeset/*.md` for user-visible changes (`mise run changeset -- patch "..."`).
- [ ] No user-visible change; apply the `no release note` label to make CI skip intentional.

## Validation

<!-- Commands run, screenshots, or manual checks. -->

- [ ] Ran relevant tests/checks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed an issue where the focus-follows-mouse feature was causing unwanted cursor warping when "move mouse to focused window" was enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->