### PR TITLE
Detect separate Spaces and clarify monitor guidance

### DIFF
--- a/.changeset/20260619152015-detect-macos-displays-have-separate-spaces-and-a.md
+++ b/.changeset/20260619152015-detect-macos-displays-have-separate-spaces-and-a.md
@@ -1,0 +1,6 @@
+---
+"nehir": minor
+
+---
+
+Detect macOS Displays have separate Spaces, clarify supported vertical/diagonal display arrangements, and add a Mouse Warp enable toggle with disabled-state guidance.

--- a/Sources/Nehir/Core/Config/CanonicalTOMLConfig.swift
+++ b/Sources/Nehir/Core/Config/CanonicalTOMLConfig.swift
@@ -54,13 +54,14 @@ struct CanonicalTOMLConfig: Codable, Equatable {
 
     struct MouseWarp: Codable, Equatable {
         // monitorOrder is a flat string array for now; future revision may use a typed OutputId.
+        var enabled: Bool
         var monitorOrder: [String]
         var axis: String?
         var margin: Int
         var unknownFields: [String: SettingsTOMLUnknownValue] = [:]
 
         enum CodingKeys: String, CodingKey, CaseIterable {
-            case monitorOrder, axis, margin
+            case enabled, monitorOrder, axis, margin
         }
     }
 
@@ -240,6 +241,7 @@ extension CanonicalTOMLConfig {
             unknownFields: unknown["focus"] ?? [:]
         )
         mouseWarp = MouseWarp(
+            enabled: export.mouseWarpEnabled,
             monitorOrder: export.mouseWarpMonitorOrder,
             axis: export.mouseWarpAxis,
             margin: export.mouseWarpMargin,
@@ -348,6 +350,7 @@ extension CanonicalTOMLConfig {
             focusFollowsMouse: focus.followsMouse,
             moveMouseToFocusedWindow: focus.moveMouseToFocusedWindow,
             focusFollowsWindowToMonitor: focus.followsWindowToMonitor,
+            mouseWarpEnabled: mouseWarp.enabled,
             mouseWarpMonitorOrder: mouseWarp.monitorOrder,
             mouseWarpAxis: mouseWarp.axis,
             mouseWarpMargin: mouseWarp.margin,
@@ -490,6 +493,7 @@ extension CanonicalTOMLConfig.MouseWarp {
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         let d = CanonicalTOMLConfig.defaults().mouseWarp
+        enabled = try container.decodeWithDefault(Bool.self, forKey: .enabled, default: d.enabled)
         monitorOrder = try container.decodeWithDefault([String].self, forKey: .monitorOrder, default: d.monitorOrder)
         axis = try container.decodeIfPresent(String.self, forKey: .axis)
         margin = try container.decodeWithDefault(Int.self, forKey: .margin, default: d.margin)
@@ -498,6 +502,7 @@ extension CanonicalTOMLConfig.MouseWarp {
 
     func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: SettingsTOMLDynamicKey.self)
+        try container.encode(enabled, forKey: "enabled")
         try container.encode(monitorOrder, forKey: "monitorOrder")
         try container.encodeIfPresent(axis, forKey: "axis")
         try container.encode(margin, forKey: "margin")

--- a/Sources/Nehir/Core/Config/SettingsExport.swift
+++ b/Sources/Nehir/Core/Config/SettingsExport.swift
@@ -15,6 +15,7 @@ struct SettingsExport: Equatable, Sendable {
     var focusFollowsMouse: Bool
     var moveMouseToFocusedWindow: Bool
     var focusFollowsWindowToMonitor: Bool
+    var mouseWarpEnabled: Bool
     var mouseWarpMonitorOrder: [String]
     var mouseWarpAxis: String?
     var mouseWarpMargin: Int
@@ -105,6 +106,7 @@ extension SettingsExport {
             focusFollowsMouse: false,
             moveMouseToFocusedWindow: false,
             focusFollowsWindowToMonitor: false,
+            mouseWarpEnabled: true,
             mouseWarpMonitorOrder: [],
             mouseWarpAxis: MouseWarpAxis.horizontal.rawValue,
             mouseWarpMargin: 1,

--- a/Sources/Nehir/Core/Config/SettingsStore.swift
+++ b/Sources/Nehir/Core/Config/SettingsStore.swift
@@ -33,6 +33,10 @@ final class SettingsStore {
         didSet { scheduleSave() }
     }
 
+    var mouseWarpEnabled = SettingsStore.defaultExport.mouseWarpEnabled {
+        didSet { scheduleSave() }
+    }
+
     var mouseWarpMonitorOrder = SettingsStore.defaultExport.mouseWarpMonitorOrder {
         didSet { scheduleSave() }
     }
@@ -395,6 +399,7 @@ final class SettingsStore {
             focusFollowsMouse: focusFollowsMouse,
             moveMouseToFocusedWindow: moveMouseToFocusedWindow,
             focusFollowsWindowToMonitor: focusFollowsWindowToMonitor,
+            mouseWarpEnabled: mouseWarpEnabled,
             mouseWarpMonitorOrder: mouseWarpMonitorOrder,
             mouseWarpAxis: mouseWarpAxis.rawValue,
             mouseWarpMargin: mouseWarpMargin,
@@ -467,6 +472,7 @@ final class SettingsStore {
         focusFollowsMouse = export.focusFollowsMouse
         moveMouseToFocusedWindow = export.moveMouseToFocusedWindow
         focusFollowsWindowToMonitor = export.focusFollowsWindowToMonitor
+        mouseWarpEnabled = export.mouseWarpEnabled
         mouseWarpMonitorOrder = export.mouseWarpMonitorOrder
         mouseWarpAxis = MouseWarpAxis(rawValue: export.mouseWarpAxis ?? baseline.mouseWarpAxis ?? "") ?? .horizontal
         mouseWarpMargin = export.mouseWarpMargin

--- a/Sources/Nehir/Core/Controller/WMController.swift
+++ b/Sources/Nehir/Core/Controller/WMController.swift
@@ -720,6 +720,7 @@ final class WMController {
     }
 
     func shouldUseMouseWarp(for monitors: [Monitor]? = nil) -> Bool {
+        guard settings.mouseWarpEnabled else { return false }
         let effectiveMonitors = monitors ?? workspaceManager.monitors
         return effectiveMonitors.count > 1
     }
@@ -2781,7 +2782,8 @@ final class WMController {
             "WMController runtime state",
             "enabled=\(isEnabled) desiredEnabled=\(desiredEnabled) hotkeysEnabled=\(hotkeysEnabled) desiredHotkeysEnabled=\(desiredHotkeysEnabled)",
             "accessibilityGranted=\(accessibilityPermissionGranted) lockScreenActive=\(isLockScreenActive) overviewOpen=\(isOverviewOpen()) startedServices=\(hasStartedServices)",
-            "focusFollowsMouse=\(focusFollowsMouseEnabled) moveMouseToFocusedWindow=\(moveMouseToFocusedWindowEnabled) mouseWarpPolicyEnabled=\(isMouseWarpPolicyEnabled)",
+            "focusFollowsMouse=\(focusFollowsMouseEnabled) moveMouseToFocusedWindow=\(moveMouseToFocusedWindowEnabled) mouseWarpEnabled=\(settings.mouseWarpEnabled) mouseWarpPolicyEnabled=\(isMouseWarpPolicyEnabled)",
+            "displaySpacesMode=\(SkyLight.shared.displaySpacesMode().rawValue)",
             "isTransferringWindow=\(isTransferringWindow) hiddenAppPIDs=\(hiddenAppPIDs.count) workspaceBarHiddenMonitors=\(hiddenWorkspaceBarMonitorIds.count)",
             "runtimeTraceCaptureActive=\(traceCaptureStatus.isActive) runtimeTraceStartedAt=\(traceCaptureStatus.startedAt?.ISO8601Format() ?? "nil") viewportTraceRecords=\(runtimeViewportTraceRecords.count) resizeTraceRecords=\(runtimeResizeTraceRecords.count) insertionTraceRecords=\(runtimeInsertionTraceRecords.count) mouseTraceRecords=\(runtimeMouseTraceRecords.count)",
             "workspaceBarRefreshDebugState requestCount=\(workspaceBarRefreshDebugState.requestCount) scheduledCount=\(workspaceBarRefreshDebugState.scheduledCount) executionCount=\(workspaceBarRefreshDebugState.executionCount) isQueued=\(workspaceBarRefreshDebugState.isQueued)",

--- a/Sources/Nehir/Core/Monitor/DisplayEnvironmentDiagnostics.swift
+++ b/Sources/Nehir/Core/Monitor/DisplayEnvironmentDiagnostics.swift
@@ -34,7 +34,7 @@ struct DisplayEnvironmentDiagnostics: Equatable {
             case let .fixedDock(_, monitorName, _, _):
                 "Fixed Dock detected on \(monitorName)"
             case .horizontalDisplayArrangement:
-                "Side-by-side display arrangement detected"
+                "Unsupported vertical display overlap detected"
             }
         }
 
@@ -52,7 +52,7 @@ struct DisplayEnvironmentDiagnostics: Equatable {
             case .fixedDock:
                 "Enable Dock auto-hide in System Settings > Desktop & Dock, or move the fixed Dock away from the edge used for hidden-window parking."
             case .horizontalDisplayArrangement:
-                "Arrange displays vertically in System Settings > Displays > Arrange so horizontal parking edges do not touch another display."
+                "Arrange displays vertically or diagonally in System Settings > Displays > Arrange so display frames do not overlap vertically."
             }
         }
     }
@@ -81,7 +81,11 @@ struct DisplayEnvironmentDiagnostics: Equatable {
         evaluate(monitors: Monitor.current())
     }
 
-    static func evaluate(monitors: [Monitor]) -> DisplayEnvironmentDiagnostics {
+    /// Evaluates the currently supported display environment. As of now Nehir supports
+    /// fixed-Dock-free setups and display arrangements with no vertical overlap
+    /// (vertical/diagonal layouts). Separate Spaces detection is shown as state in the
+    /// UI, but it does not change or suppress the support recommendation.
+    static func evaluate(monitors: [Monitor], spacesMode _: DisplaySpacesMode = .unavailable) -> DisplayEnvironmentDiagnostics {
         var issues: [Issue] = []
         issues.append(contentsOf: fixedDockIssues(monitors: monitors))
         issues.append(contentsOf: horizontalArrangementIssues(monitors: monitors))

--- a/Sources/Nehir/Core/SkyLight/DisplaySpacesMode.swift
+++ b/Sources/Nehir/Core/SkyLight/DisplaySpacesMode.swift
@@ -1,0 +1,36 @@
+import Foundation
+
+/// Whether macOS "Displays have separate Spaces" is enabled, as observed by Nehir.
+///
+/// Stage 1 (M4) uses this only for diagnostics: with Separate Spaces **ON**, each
+/// display's surfaces are isolated, so the side-by-side parked-window bleed that
+/// motivates Nehir's vertical-arrangement recommendation does not occur, and an
+/// experimental-support notice is surfaced instead. Mode detection lives on
+/// `SkyLight.displaySpacesMode(monitors:)`; see
+/// `discovery/20260618-displays-separate-spaces-mode-detection.md`.
+public enum DisplaySpacesMode: String, Sendable, Equatable {
+    /// "Displays have separate Spaces" is ON: each display has its own set of Spaces.
+    case enabled
+    /// Separate Spaces is OFF: displays share a single space set (the default macOS mode).
+    case disabled
+    /// The mode could not be determined (private symbol missing, single display,
+    /// or indeterminate managed-display-spaces shape). Callers should keep their
+    /// current conservative behavior.
+    case unavailable
+
+    var displayName: String {
+        switch self {
+        case .enabled: "Enabled"
+        case .disabled: "Disabled"
+        case .unavailable: "Unavailable"
+        }
+    }
+
+    var systemImage: String {
+        switch self {
+        case .enabled: "rectangle.connected.to.line.below"
+        case .disabled: "rectangle.on.rectangle"
+        case .unavailable: "questionmark.circle"
+        }
+    }
+}

--- a/Sources/Nehir/Core/SkyLight/SkyLight.swift
+++ b/Sources/Nehir/Core/SkyLight/SkyLight.swift
@@ -58,6 +58,10 @@ final class SkyLight {
     private typealias TransactionSetWindowLevelFunc = @convention(c) (CFTypeRef, UInt32, Int32) -> CGError
     private typealias CopyManagedDisplaySpacesFunc = @convention(c) (Int32) -> CFArray?
     private typealias DisplayCreateUUIDFromDisplayIDFunc = @convention(c) (CGDirectDisplayID) -> Unmanaged<CFUUID>?
+    // SLSGetSpaceManagementMode returns non-zero when "Displays have separate Spaces"
+    // is enabled, zero when disabled. Optional: may be missing/renamed on some macOS
+    // versions; `displaySpacesMode` falls back to the managed-display-spaces shape.
+    private typealias SpaceManagementModeFunc = @convention(c) (Int32) -> Int32
 
     typealias ConnectionNotifyCallback = @convention(c) (
         UInt32,
@@ -138,8 +142,13 @@ final class SkyLight {
     private let newRegionWithRect: NewRegionWithRectFunc?
     private let transactionSetWindowLevel: TransactionSetWindowLevelFunc?
     private let copyManagedDisplaySpaces: CopyManagedDisplaySpacesFunc?
+    private let getSpaceManagementMode: SpaceManagementModeFunc?
 
     @MainActor static var orderedStateProviderForTests: ((UInt32) -> Bool?)?
+    /// Test injection hook for `displaySpacesMode`. When non-nil it fully replaces
+    /// the runtime detection. Restore to `nil` in a `defer`. Mirrors
+    /// `orderedStateProviderForTests`.
+    @MainActor static var displaySpacesModeOverrideForTests: (() -> DisplaySpacesMode)?
     private static let displayCreateUUIDFromDisplayID: DisplayCreateUUIDFromDisplayIDFunc? = {
         let handle = dlopen("/System/Library/Frameworks/ApplicationServices.framework/ApplicationServices", RTLD_LAZY)
             ?? dlopen("/System/Library/Frameworks/CoreGraphics.framework/CoreGraphics", RTLD_LAZY)
@@ -278,6 +287,58 @@ final class SkyLight {
             as: CopyManagedDisplaySpacesFunc.self
         )
             ?? resolveOptional("CGSCopyManagedDisplaySpaces", as: CopyManagedDisplaySpacesFunc.self)
+        // Optional — must NOT gate startup. Fallback in `displaySpacesMode`.
+        getSpaceManagementMode = resolveOptional(
+            "SLSGetSpaceManagementMode",
+            as: SpaceManagementModeFunc.self
+        )
+    }
+
+    /// Whether macOS "Displays have separate Spaces" is enabled. Primary signal is
+    /// `SLSGetSpaceManagementMode` (non-zero = enabled). When that private symbol is
+    /// unavailable, fall back to inferring the mode from the managed-display-spaces
+    /// structure (one shared "Main" entry with multiple displays = OFF/disabled;
+    /// one entry per display = ON/enabled; indeterminate = unavailable). Monitors
+    /// are only consulted on the fallback path.
+    func displaySpacesMode(monitors: [Monitor]? = nil) -> DisplaySpacesMode {
+        if let override = Self.displaySpacesModeOverrideForTests {
+            return override()
+        }
+        if let getSpaceManagementMode {
+            let cid = getMainConnectionID()
+            if cid != 0 {
+                return getSpaceManagementMode(cid) != 0 ? .enabled : .disabled
+            }
+        }
+        return displaySpacesModeFromManagedDisplaySpaces(monitors: monitors ?? Monitor.current())
+    }
+
+    private func displaySpacesModeFromManagedDisplaySpaces(monitors: [Monitor]) -> DisplaySpacesMode {
+        guard let copyManagedDisplaySpaces else { return .unavailable }
+        // Single display is structurally indistinguishable between the two modes —
+        // do not claim a mode we cannot verify.
+        guard monitors.count > 1 else { return .unavailable }
+        let cid = getMainConnectionID()
+        guard cid != 0, let spacesRef = copyManagedDisplaySpaces(cid) else { return .unavailable }
+        defer { cfRelease(spacesRef) }
+        guard let displaySpaces = spacesRef as? [[String: Any]] else { return .unavailable }
+
+        let displayEntries = displaySpaces.compactMap { $0["Display Identifier"] as? String }.filter { !$0.isEmpty }
+        // Separate Spaces OFF: all displays share one space set under a single "Main" entry.
+        if displayEntries == ["Main"] {
+            return .disabled
+        }
+
+        let displayIdByIdentifier = Self.managedDisplayIdentifierMap(for: monitors)
+        let matchedDisplayIds = Set(displayEntries.compactMap { displayIdByIdentifier[$0] })
+        let allMonitorDisplayIds = Set(monitors.map(\.displayId))
+        // Separate Spaces ON: each attached display owns its own managed-display-spaces entry.
+        if !allMonitorDisplayIds.isEmpty,
+           matchedDisplayIds.isSuperset(of: allMonitorDisplayIds)
+        {
+            return .enabled
+        }
+        return .unavailable
     }
 
     func getMainConnectionID() -> Int32 {
@@ -368,16 +429,7 @@ final class SkyLight {
         defer { cfRelease(spacesRef) }
         guard let displaySpaces = spacesRef as? [[String: Any]] else { return nil }
 
-        var displayIdByIdentifier: [String: CGDirectDisplayID] = [:]
-        for monitor in monitors {
-            displayIdByIdentifier[String(monitor.displayId)] = monitor.displayId
-            if let identifier = Self.managedDisplayIdentifier(for: monitor.displayId) {
-                displayIdByIdentifier[identifier] = monitor.displayId
-            }
-        }
-        if let main = monitors.first(where: \.isMain) ?? monitors.first {
-            displayIdByIdentifier["Main"] = main.displayId
-        }
+        let displayIdByIdentifier = Self.managedDisplayIdentifierMap(for: monitors)
 
         for display in displaySpaces {
             guard Self.displaySpaces(display, contains: spaceId),
@@ -390,6 +442,20 @@ final class SkyLight {
         }
 
         return nil
+    }
+
+    private static func managedDisplayIdentifierMap(for monitors: [Monitor]) -> [String: CGDirectDisplayID] {
+        var displayIdByIdentifier: [String: CGDirectDisplayID] = [:]
+        for monitor in monitors {
+            displayIdByIdentifier[String(monitor.displayId)] = monitor.displayId
+            if let identifier = managedDisplayIdentifier(for: monitor.displayId) {
+                displayIdByIdentifier[identifier] = monitor.displayId
+            }
+        }
+        if let main = monitors.first(where: \.isMain) ?? monitors.first {
+            displayIdByIdentifier["Main"] = main.displayId
+        }
+        return displayIdByIdentifier
     }
 
     private static func managedDisplayIdentifier(for displayId: CGDirectDisplayID) -> String? {

--- a/Sources/Nehir/UI/DisplayDiagnosticsSettingsTab.swift
+++ b/Sources/Nehir/UI/DisplayDiagnosticsSettingsTab.swift
@@ -7,6 +7,7 @@ struct DisplayDiagnosticsSettingsTab: View {
     @Bindable var navigation: SettingsNavigationModel
 
     @State private var diagnostics = DisplayEnvironmentDiagnostics.current()
+    @State private var displaySpacesMode: DisplaySpacesMode = .unavailable
     @State private var monitors = Monitor.current()
     @State private var axGranted = AccessibilityPermissionMonitor.shared.isGranted
     @State private var applicableSettingsIssues: [SettingsDiagnosticsIssue] = []
@@ -133,10 +134,13 @@ struct DisplayDiagnosticsSettingsTab: View {
             }
 
             Section("Display and Dock Recommendations") {
-                SettingsCaption("For the best Niri scrolling experience, use an auto-hide Dock and arrange displays vertically in macOS System Settings.")
+                SettingsCaption("Nehir currently supports an auto-hide Dock and display arrangements with no vertical overlap: vertical or diagonal layouts in macOS System Settings. A diagonal arrangement is recommended when you want to avoid macOS' native cross-display edge warp and rely only on Nehir's configured Mouse Warp.")
+                Label("Displays have separate Spaces: \(displaySpacesMode.displayName)", systemImage: displaySpacesMode.systemImage)
+                    .foregroundStyle(.secondary)
+                SettingsCaption("Separate Spaces is detected for visibility only; Nehir does not enforce it or change display-arrangement recommendations based on it yet.")
 
                 if diagnostics.issues.isEmpty {
-                    Label("No fixed Dock or side-by-side display arrangement detected.", systemImage: "checkmark.circle")
+                    Label("No fixed Dock or unsupported vertical display overlap detected.", systemImage: "checkmark.circle")
                         .foregroundStyle(.green)
                 } else {
                     ForEach(diagnostics.issues) { issue in
@@ -449,7 +453,8 @@ struct DisplayDiagnosticsSettingsTab: View {
 
     private func refresh() {
         monitors = Monitor.current()
-        diagnostics = DisplayEnvironmentDiagnostics.evaluate(monitors: monitors)
+        displaySpacesMode = SkyLight.shared.displaySpacesMode(monitors: monitors)
+        diagnostics = DisplayEnvironmentDiagnostics.evaluate(monitors: monitors, spacesMode: displaySpacesMode)
         axGranted = AccessibilityPermissionMonitor.shared.isGranted
         refreshSettingsIssues()
         traceCaptureStatus = controller.runtimeTraceCaptureStatus

--- a/Sources/Nehir/UI/MonitorSettingsTab.swift
+++ b/Sources/Nehir/UI/MonitorSettingsTab.swift
@@ -37,6 +37,12 @@ struct MonitorSettingsTab: View {
         return sortedMonitors.first(where: { $0.id == monitorID })
     }
 
+    private var shouldWarnDisabledMouseWarpHasNoFullVerticalSideOverlap: Bool {
+        !settings.mouseWarpEnabled
+            && connectedMonitors.count > 1
+            && !MonitorSettingsTabModel.hasFullVerticalSideOverlap(connectedMonitors)
+    }
+
     var body: some View {
         SettingsPage(
             subtitle: "Configure mouse warp order and per-monitor orientation without changing macOS display arrangement."
@@ -57,33 +63,52 @@ struct MonitorSettingsTab: View {
             }
 
             Section("Mouse Warp") {
-                SettingsCaption("Moves the cursor to the opposite monitor when it reaches a screen edge.")
+                Toggle("Enable Mouse Warp", isOn: $settings.mouseWarpEnabled)
+                    .onChange(of: settings.mouseWarpEnabled) { _, _ in
+                        controller.syncMouseWarpPolicy()
+                    }
+                SettingsCaption("When enabled, moves the cursor to the opposite monitor when it reaches a screen edge. Use a diagonal macOS display arrangement to avoid native edge warping and rely only on Nehir's configured warp. Turn this off to rely only on macOS cursor movement.")
 
-                LabeledContent("Axis") {
-                    Picker("Warp Axis", selection: Binding(
-                        get: { settings.mouseWarpAxis },
-                        set: { settings.mouseWarpAxis = $0 }
-                    )) {
-                        ForEach(MouseWarpAxis.allCases, id: \.self) { axis in
-                            Text(axis.displayName).tag(axis)
+                if settings.mouseWarpEnabled {
+                    LabeledContent("Axis") {
+                        Picker("Warp Axis", selection: Binding(
+                            get: { settings.mouseWarpAxis },
+                            set: { settings.mouseWarpAxis = $0 }
+                        )) {
+                            ForEach(MouseWarpAxis.allCases, id: \.self) { axis in
+                                Text(axis.displayName).tag(axis)
+                            }
+                        }
+                        .labelsHidden()
+                        .pickerStyle(.segmented)
+                        .frame(maxWidth: 260)
+                    }
+
+                    LabeledContent("Trigger Margin") {
+                        Stepper(value: Binding(
+                            get: { settings.mouseWarpMargin },
+                            set: { settings.mouseWarpMargin = $0 }
+                        ), in: 1 ... 10) {
+                            Text("\(settings.mouseWarpMargin) px")
+                                .foregroundStyle(.secondary)
+                                .monospacedDigit()
                         }
                     }
-                    .labelsHidden()
-                    .pickerStyle(.segmented)
-                    .frame(maxWidth: 260)
-                }
-
-                LabeledContent("Trigger Margin") {
-                    Stepper(value: Binding(
-                        get: { settings.mouseWarpMargin },
-                        set: { settings.mouseWarpMargin = $0 }
-                    ), in: 1 ... 10) {
-                        Text("\(settings.mouseWarpMargin) px")
-                            .foregroundStyle(.secondary)
-                            .monospacedDigit()
+                    SettingsCaption("How close to the edge (in pixels) before the cursor jumps to the next monitor.")
+                } else {
+                    SettingsCaption("Axis and trigger margin settings are hidden while Mouse Warp is disabled; existing values are preserved.")
+                    if shouldWarnDisabledMouseWarpHasNoFullVerticalSideOverlap {
+                        HStack(alignment: .top, spacing: 6) {
+                            Image(systemName: "exclamationmark.triangle.fill")
+                                .foregroundStyle(.yellow)
+                                .accessibilityHidden(true)
+                            Text("Some displays do not share a full vertical edge overlap. With Mouse Warp disabled, macOS native cursor movement may only work through the overlapping edge segment, or may not cross between diagonally arranged displays at all.")
+                                .foregroundStyle(.secondary)
+                        }
+                        .font(.caption)
+                        .accessibilityElement(children: .combine)
                     }
                 }
-                SettingsCaption("How close to the edge (in pixels) before the cursor jumps to the next monitor.")
             }
 
             Section("Warp Order") {
@@ -496,6 +521,31 @@ enum MonitorSettingsTabModel {
         var reorderedEntries = entries
         reorderedEntries.swapAt(currentIndex, targetIndex)
         return reorderedEntries.map(\.name)
+    }
+
+    static func hasFullVerticalSideOverlap(_ monitors: [Monitor]) -> Bool {
+        guard monitors.count > 1 else { return true }
+
+        for firstIndex in monitors.indices {
+            for secondIndex in monitors.indices where secondIndex > firstIndex {
+                let firstFrame = monitors[firstIndex].frame
+                let secondFrame = monitors[secondIndex].frame
+                let horizontalOverlap = overlap(firstFrame.minX ... firstFrame.maxX, secondFrame.minX ... secondFrame.maxX)
+                guard horizontalOverlap < 1 else { continue }
+
+                let verticalOverlap = overlap(firstFrame.minY ... firstFrame.maxY, secondFrame.minY ... secondFrame.maxY)
+                let shorterHeight = min(firstFrame.height, secondFrame.height)
+                if verticalOverlap >= max(1, shorterHeight - 1) {
+                    return true
+                }
+            }
+        }
+
+        return false
+    }
+
+    private static func overlap(_ lhs: ClosedRange<CGFloat>, _ rhs: ClosedRange<CGFloat>) -> CGFloat {
+        max(0, min(lhs.upperBound, rhs.upperBound) - max(lhs.lowerBound, rhs.lowerBound))
     }
 }
 

--- a/Tests/NehirTests/DisplaySpacesModeTests.swift
+++ b/Tests/NehirTests/DisplaySpacesModeTests.swift
@@ -1,0 +1,85 @@
+import CoreGraphics
+import Foundation
+import Testing
+@testable import Nehir
+
+/// Stage 1 (M4) characterization tests for Displays-have-separate-Spaces mode
+/// detection and display diagnostics. The runtime detection path depends on
+/// private macOS symbols that cannot be exercised in CI, so these tests inject
+/// `displaySpacesModeOverrideForTests` for deterministic coverage.
+@MainActor
+@Suite
+struct DisplaySpacesModeTests {
+    private func makeMonitor(name: String, displayId: CGDirectDisplayID, frame: CGRect) -> Monitor {
+        Monitor(
+            id: Monitor.ID(displayId: displayId),
+            displayId: displayId,
+            frame: frame,
+            visibleFrame: frame,
+            hasNotch: false,
+            name: name
+        )
+    }
+
+    private func sideBySideMonitors() -> [Monitor] {
+        [
+            makeMonitor(name: "Primary", displayId: 101, frame: CGRect(x: 0, y: 0, width: 1440, height: 900)),
+            makeMonitor(name: "Secondary", displayId: 202, frame: CGRect(x: 1440, y: 100, width: 1440, height: 900))
+        ]
+    }
+
+    @Test func displaySpacesModeOverrideForTestsRoundTrips() {
+        let resolved = SkyLight.shared.displaySpacesMode()
+        #expect([.enabled, .disabled, .unavailable].contains(resolved))
+
+        SkyLight.displaySpacesModeOverrideForTests = { .enabled }
+        defer { SkyLight.displaySpacesModeOverrideForTests = nil }
+        #expect(SkyLight.shared.displaySpacesMode() == .enabled)
+
+        SkyLight.displaySpacesModeOverrideForTests = { .disabled }
+        #expect(SkyLight.shared.displaySpacesMode() == .disabled)
+
+        SkyLight.displaySpacesModeOverrideForTests = { .unavailable }
+        #expect(SkyLight.shared.displaySpacesMode() == .unavailable)
+
+        SkyLight.displaySpacesModeOverrideForTests = nil
+        let afterClear = SkyLight.shared.displaySpacesMode()
+        #expect([.enabled, .disabled, .unavailable].contains(afterClear))
+    }
+
+    @Test func separateSpacesModeDoesNotSuppressSupportedArrangementWarning() {
+        let monitors = sideBySideMonitors()
+        let enabled = DisplayEnvironmentDiagnostics.evaluate(monitors: monitors, spacesMode: .enabled)
+        let disabled = DisplayEnvironmentDiagnostics.evaluate(monitors: monitors, spacesMode: .disabled)
+        let unavailable = DisplayEnvironmentDiagnostics.evaluate(monitors: monitors, spacesMode: .unavailable)
+
+        #expect(enabled.issues.map(\.id) == disabled.issues.map(\.id))
+        #expect(unavailable.issues.map(\.id) == disabled.issues.map(\.id))
+        #expect(enabled.issues.contains { issue in
+            if case .horizontalDisplayArrangement = issue.kind { return true }
+            return false
+        })
+    }
+
+    @Test func singleMonitorHasNoArrangementWarningInAnyMode() {
+        let single = [makeMonitor(name: "Only", displayId: 303, frame: CGRect(x: 0, y: 0, width: 1440, height: 900))]
+
+        #expect(!DisplayEnvironmentDiagnostics.evaluate(monitors: single, spacesMode: .enabled).hasWarnings)
+        #expect(!DisplayEnvironmentDiagnostics.evaluate(monitors: single, spacesMode: .disabled).hasWarnings)
+        #expect(!DisplayEnvironmentDiagnostics.evaluate(monitors: single, spacesMode: .unavailable).hasWarnings)
+    }
+
+    @Test func evaluateWithoutSpacesModeIsHistoricalBehavior() {
+        let monitors = sideBySideMonitors()
+        let legacy = DisplayEnvironmentDiagnostics.evaluate(monitors: monitors)
+        let explicit = DisplayEnvironmentDiagnostics.evaluate(monitors: monitors, spacesMode: .enabled)
+
+        #expect(legacy.issues.map(\.id) == explicit.issues.map(\.id))
+    }
+
+    @Test func displayModeLabelsAreUserReadable() {
+        #expect(DisplaySpacesMode.enabled.displayName == "Enabled")
+        #expect(DisplaySpacesMode.disabled.displayName == "Disabled")
+        #expect(DisplaySpacesMode.unavailable.displayName == "Unavailable")
+    }
+}

--- a/Tests/NehirTests/Fixtures/canonical-settings.toml
+++ b/Tests/NehirTests/Fixtures/canonical-settings.toml
@@ -43,6 +43,7 @@ scrollSensitivity = 5.0
 
 [mouseWarp]
 axis = "horizontal"
+enabled = true
 margin = 1
 monitorOrder = []
 


### PR DESCRIPTION
## Summary

<!-- What changed and why? -->

## Release notes

Choose one:

- [x] Added a `.changeset/*.md` for user-visible changes (`mise run changeset -- patch "..."`).
- [ ] No user-visible change; apply the `no release note` label to make CI skip intentional.

## Validation

<!-- Commands run, screenshots, or manual checks. -->

- [ ] Ran relevant tests/checks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Mouse Warp enable/disable toggle, persisted in settings and reflected in runtime diagnostics.
  * Added detection and display of macOS “Displays have separate Spaces” status.
  * Updated display-arrangement guidance and warnings, including clearer vertical/diagonal overlap messaging.
* **Bug Fixes**
  * Improved Spaces-mode-aware diagnostics so issue detection remains consistent while refining guidance.
* **Tests**
  * Added a dedicated test suite covering Spaces mode detection and diagnostics behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->