### PR TITLE
Narrow WMController layout/focus surface behind coordinator protocols

### DIFF
--- a/.changeset/20260619212945-internal-narrow-wmcontroller-s-layout-and-focus-.md
+++ b/.changeset/20260619212945-internal-narrow-wmcontroller-s-layout-and-focus-.md
@@ -1,0 +1,6 @@
+---
+"nehir": none
+
+---
+
+Internal: narrow WMController's layout and focus surface behind LayoutCoordinator and FocusCoordinator protocols, funnel engine writes through setNiriEngine(_:), so command and event handlers no longer reach into the live niriEngine or the concrete NiriLayoutHandler.

--- a/Sources/Nehir/Core/Border/FocusBorderController.swift
+++ b/Sources/Nehir/Core/Border/FocusBorderController.swift
@@ -412,10 +412,6 @@ final class FocusBorderController {
     private func isManagedWindowFullscreen(_ token: WindowToken) -> Bool {
         guard let controller else { return false }
 
-        if controller.niriEngine?.findNode(for: token)?.isFullscreen == true {
-            return true
-        }
-
-        return false
+        return controller.focusCoordinator.isFocusedWindowFullscreen(token)
     }
 }

--- a/Sources/Nehir/Core/Controller/CommandHandler.swift
+++ b/Sources/Nehir/Core/Controller/CommandHandler.swift
@@ -47,27 +47,27 @@ final class CommandHandler {
 
         switch command {
         case let .focus(direction):
-            controller.niriLayoutHandler.focusNeighbor(direction: direction)
+            controller.layoutCoordinator.focusNeighbor(direction: direction)
         case .focusPrevious:
-            focusPreviousInNiri()
+            controller.layoutCoordinator.focusPrevious()
         case let .move(direction):
-            moveWindow(direction: direction)
+            controller.layoutCoordinator.moveWindow(direction: direction)
         case .moveWindowDown:
-            controller.niriLayoutHandler.moveWindow(direction: .down)
+            controller.layoutCoordinator.moveWindow(direction: .down)
         case .moveWindowUp:
-            controller.niriLayoutHandler.moveWindow(direction: .up)
+            controller.layoutCoordinator.moveWindow(direction: .up)
         case .moveWindowDownOrToWorkspaceDown:
-            controller.niriLayoutHandler.moveWindowOrToAdjacentWorkspace(direction: .down)
+            controller.layoutCoordinator.moveWindowOrToAdjacentWorkspace(direction: .down)
         case .moveWindowUpOrToWorkspaceUp:
-            controller.niriLayoutHandler.moveWindowOrToAdjacentWorkspace(direction: .up)
+            controller.layoutCoordinator.moveWindowOrToAdjacentWorkspace(direction: .up)
         case .consumeOrExpelWindowLeft:
-            controller.niriLayoutHandler.consumeOrExpelWindow(direction: .left)
+            controller.layoutCoordinator.consumeOrExpelWindow(direction: .left)
         case .consumeOrExpelWindowRight:
-            controller.niriLayoutHandler.consumeOrExpelWindow(direction: .right)
+            controller.layoutCoordinator.consumeOrExpelWindow(direction: .right)
         case .consumeWindowIntoColumn:
-            controller.niriLayoutHandler.consumeWindowIntoColumn()
+            controller.layoutCoordinator.consumeWindowIntoColumn()
         case .expelWindowFromColumn:
-            controller.niriLayoutHandler.expelWindowFromColumn()
+            controller.layoutCoordinator.expelWindowFromColumn()
         case let .moveToWorkspace(index):
             controller.workspaceNavigationHandler.moveFocusedWindow(toWorkspaceIndex: index)
         case .moveWindowToWorkspaceUp:
@@ -93,75 +93,75 @@ final class CommandHandler {
         case .focusMonitorLast:
             controller.workspaceNavigationHandler.focusLastMonitor()
         case .toggleFullscreen:
-            toggleFullscreen()
+            controller.layoutCoordinator.toggleFullscreen()
         case .toggleNativeFullscreen:
             toggleNativeFullscreenForFocused()
         case let .moveColumn(direction):
-            moveColumnInNiri(direction: direction)
+            controller.layoutCoordinator.moveColumn(direction: direction)
         case .moveColumnToFirst:
-            moveColumnToFirstInNiri()
+            controller.layoutCoordinator.moveColumnToFirst()
         case .moveColumnToLast:
-            moveColumnToLastInNiri()
+            controller.layoutCoordinator.moveColumnToLast()
         case let .moveColumnToIndex(index):
-            moveColumnToIndexInNiri(index: index)
+            controller.layoutCoordinator.moveColumnToIndex(index: index)
         case .toggleColumnTabbed:
-            toggleColumnTabbedInNiri()
+            controller.layoutCoordinator.toggleColumnTabbed()
         case .focusDownOrLeft:
-            focusDownOrLeftInNiri()
+            controller.layoutCoordinator.focusDownOrLeft()
         case .focusUpOrRight:
-            focusUpOrRightInNiri()
+            controller.layoutCoordinator.focusUpOrRight()
         case let .focusWindowInColumn(index):
-            focusWindowInColumnInNiri(index: index)
+            controller.layoutCoordinator.focusWindowInColumn(index: index)
         case .focusWindowTop:
-            focusWindowTopInNiri()
+            controller.layoutCoordinator.focusWindowTop()
         case .focusWindowBottom:
-            focusWindowBottomInNiri()
+            controller.layoutCoordinator.focusWindowBottom()
         case .focusWindowDownOrTop:
-            focusWindowDownOrTopInNiri()
+            controller.layoutCoordinator.focusWindowDownOrTop()
         case .focusWindowUpOrBottom:
-            focusWindowUpOrBottomInNiri()
+            controller.layoutCoordinator.focusWindowUpOrBottom()
         case .focusWindowOrWorkspaceDown:
-            focusWindowOrWorkspaceInNiri(direction: .down)
+            controller.layoutCoordinator.focusWindowOrWorkspace(direction: .down)
         case .focusWindowOrWorkspaceUp:
-            focusWindowOrWorkspaceInNiri(direction: .up)
+            controller.layoutCoordinator.focusWindowOrWorkspace(direction: .up)
         case .focusColumnFirst:
-            focusColumnFirstInNiri()
+            controller.layoutCoordinator.focusColumnFirst()
         case .focusColumnLast:
-            focusColumnLastInNiri()
+            controller.layoutCoordinator.focusColumnLast()
         case let .focusColumn(index):
-            focusColumnInNiri(index: index)
+            controller.layoutCoordinator.focusColumn(index: index)
         case .scrollViewportLeft:
-            controller.niriLayoutHandler.scrollViewport(direction: .left)
+            controller.layoutCoordinator.scrollViewport(direction: .left)
         case .scrollViewportRight:
-            controller.niriLayoutHandler.scrollViewport(direction: .right)
+            controller.layoutCoordinator.scrollViewport(direction: .right)
         case .cycleColumnWidthForward:
-            controller.niriLayoutHandler.cycleSize(forward: true)
+            controller.layoutCoordinator.cycleSize(forward: true)
         case .cycleColumnWidthBackward:
-            controller.niriLayoutHandler.cycleSize(forward: false)
+            controller.layoutCoordinator.cycleSize(forward: false)
         case .cycleWindowWidthForward:
-            controller.niriLayoutHandler.cycleWindowWidth(forward: true)
+            controller.layoutCoordinator.cycleWindowWidth(forward: true)
         case .cycleWindowWidthBackward:
-            controller.niriLayoutHandler.cycleWindowWidth(forward: false)
+            controller.layoutCoordinator.cycleWindowWidth(forward: false)
         case .cycleWindowHeightForward:
-            controller.niriLayoutHandler.cycleWindowHeight(forward: true)
+            controller.layoutCoordinator.cycleWindowHeight(forward: true)
         case .cycleWindowHeightBackward:
-            controller.niriLayoutHandler.cycleWindowHeight(forward: false)
+            controller.layoutCoordinator.cycleWindowHeight(forward: false)
         case .toggleColumnFullWidth:
-            controller.niriLayoutHandler.toggleColumnFullWidth()
+            controller.layoutCoordinator.toggleColumnFullWidth()
         case .expandColumnToAvailableWidth:
-            controller.niriLayoutHandler.expandColumnToAvailableWidth()
+            controller.layoutCoordinator.expandColumnToAvailableWidth()
         case .resetWindowHeight:
-            controller.niriLayoutHandler.resetWindowHeight()
+            controller.layoutCoordinator.resetWindowHeight()
         case let .setColumnWidth(change):
-            controller.niriLayoutHandler.setColumnWidth(change)
+            controller.layoutCoordinator.setColumnWidth(change)
         case let .setWindowWidth(change):
-            controller.niriLayoutHandler.setWindowWidth(change)
+            controller.layoutCoordinator.setWindowWidth(change)
         case let .setWindowHeight(change):
-            controller.niriLayoutHandler.setWindowHeight(change)
+            controller.layoutCoordinator.setWindowHeight(change)
         case let .swapWorkspaceWithMonitor(direction):
             controller.workspaceNavigationHandler.swapCurrentWorkspaceWithMonitor(direction: direction)
         case .balanceSizes:
-            controller.niriLayoutHandler.balanceSizes()
+            controller.layoutCoordinator.balanceSizes()
         case .workspaceBackAndForth:
             controller.workspaceNavigationHandler.workspaceBackAndForth()
         case let .focusWorkspaceAnywhere(index):
@@ -233,265 +233,6 @@ final class CommandHandler {
             && command != .debugToggleTraceCapture
     }
 
-
-    private func focusPreviousInNiri() {
-        guard let controller else { return }
-        controller.niriLayoutHandler.withNiriWorkspaceContext { engine, wsId, motion, state, _, workingFrame, gaps in
-            if let currentId = state.selectedNodeId {
-                engine.updateFocusTimestamp(for: currentId)
-            }
-
-            if let currentId = state.selectedNodeId {
-                engine.activateWindow(currentId)
-            }
-
-            guard let previousWindow = engine.focusPrevious(
-                currentNodeId: state.selectedNodeId,
-                in: wsId,
-                motion: motion,
-                state: &state,
-                workingFrame: workingFrame,
-                gaps: gaps,
-                limitToWorkspace: true
-            ) else {
-                return
-            }
-
-            controller.niriLayoutHandler.activateNode(
-                previousWindow, in: wsId, state: &state,
-                options: .init(ensureVisible: false, updateTimestamp: false, startAnimation: false)
-            )
-
-            if state.viewOffsetPixels.isAnimating {
-                controller.layoutRefreshController.startScrollAnimation(for: wsId)
-            }
-        }
-    }
-
-    private func focusDownOrLeftInNiri() {
-        executeCombinedNavigation { engine, currentNode, wsId, motion, state, workingFrame, gaps in
-            engine.focusDownOrLeft(
-                currentSelection: currentNode,
-                in: wsId,
-                motion: motion,
-                state: &state,
-                workingFrame: workingFrame,
-                gaps: gaps
-            )
-        }
-    }
-
-    private func focusUpOrRightInNiri() {
-        executeCombinedNavigation { engine, currentNode, wsId, motion, state, workingFrame, gaps in
-            engine.focusUpOrRight(
-                currentSelection: currentNode,
-                in: wsId,
-                motion: motion,
-                state: &state,
-                workingFrame: workingFrame,
-                gaps: gaps
-            )
-        }
-    }
-
-    private func focusWindowInColumnInNiri(index: Int) {
-        executeCombinedNavigation { engine, currentNode, wsId, motion, state, workingFrame, gaps in
-            engine.focusWindowInColumn(
-                index,
-                currentSelection: currentNode,
-                in: wsId,
-                motion: motion,
-                state: &state,
-                workingFrame: workingFrame,
-                gaps: gaps
-            )
-        }
-    }
-
-    private func focusWindowTopInNiri() {
-        executeCombinedNavigation { engine, currentNode, wsId, motion, state, workingFrame, gaps in
-            engine.focusWindowTop(
-                currentSelection: currentNode,
-                in: wsId,
-                motion: motion,
-                state: &state,
-                workingFrame: workingFrame,
-                gaps: gaps
-            )
-        }
-    }
-
-    private func focusWindowBottomInNiri() {
-        executeCombinedNavigation { engine, currentNode, wsId, motion, state, workingFrame, gaps in
-            engine.focusWindowBottom(
-                currentSelection: currentNode,
-                in: wsId,
-                motion: motion,
-                state: &state,
-                workingFrame: workingFrame,
-                gaps: gaps
-            )
-        }
-    }
-
-    private func focusWindowDownOrTopInNiri() {
-        executeCombinedNavigation { engine, currentNode, wsId, motion, state, workingFrame, gaps in
-            engine.focusWindowDownOrTop(
-                currentSelection: currentNode,
-                in: wsId,
-                motion: motion,
-                state: &state,
-                workingFrame: workingFrame,
-                gaps: gaps
-            )
-        }
-    }
-
-    private func focusWindowUpOrBottomInNiri() {
-        executeCombinedNavigation { engine, currentNode, wsId, motion, state, workingFrame, gaps in
-            engine.focusWindowUpOrBottom(
-                currentSelection: currentNode,
-                in: wsId,
-                motion: motion,
-                state: &state,
-                workingFrame: workingFrame,
-                gaps: gaps
-            )
-        }
-    }
-
-    private func focusWindowOrWorkspaceInNiri(direction: Direction) {
-        guard direction == .down || direction == .up else { return }
-        executeCombinedNavigation(onNoTarget: { [weak self] in
-            self?.controller?.workspaceNavigationHandler.switchWorkspaceRelative(
-                isNext: direction == .down,
-                wrapAround: false
-            )
-        }) { engine, currentNode, wsId, motion, state, workingFrame, gaps in
-            engine.focusTarget(
-                direction: direction,
-                currentSelection: currentNode,
-                in: wsId,
-                motion: motion,
-                state: &state,
-                workingFrame: workingFrame,
-                gaps: gaps
-            )
-        }
-    }
-
-    private func focusColumnFirstInNiri() {
-        executeCombinedNavigation { engine, currentNode, wsId, motion, state, workingFrame, gaps in
-            engine.focusColumnFirst(
-                currentSelection: currentNode,
-                in: wsId,
-                motion: motion,
-                state: &state,
-                workingFrame: workingFrame,
-                gaps: gaps
-            )
-        }
-    }
-
-    private func focusColumnLastInNiri() {
-        executeCombinedNavigation { engine, currentNode, wsId, motion, state, workingFrame, gaps in
-            engine.focusColumnLast(
-                currentSelection: currentNode,
-                in: wsId,
-                motion: motion,
-                state: &state,
-                workingFrame: workingFrame,
-                gaps: gaps
-            )
-        }
-    }
-
-    private func focusColumnInNiri(index: Int) {
-        executeCombinedNavigation { engine, currentNode, wsId, motion, state, workingFrame, gaps in
-            engine.focusColumn(
-                index,
-                currentSelection: currentNode,
-                in: wsId,
-                motion: motion,
-                state: &state,
-                workingFrame: workingFrame,
-                gaps: gaps
-            )
-        }
-    }
-
-    private func executeCombinedNavigation(
-        onNoTarget: (() -> Void)? = nil,
-        _ navigationAction: (
-            NiriLayoutEngine,
-            NiriNode,
-            WorkspaceDescriptor.ID,
-            MotionSnapshot,
-            inout ViewportState,
-            CGRect,
-            CGFloat
-        )
-            -> NiriNode?
-    ) {
-        guard let controller else { return }
-        guard let engine = controller.niriEngine else { return }
-        guard let wsId = controller.interactionWorkspace()?.id else { return }
-        guard let monitor = controller.workspaceManager.monitor(for: wsId) else { return }
-
-        var state = controller.workspaceManager.niriViewportState(for: wsId)
-        let currentNode: NiriNode
-        if let currentId = state.selectedNodeId,
-           let node = engine.findNode(by: currentId)
-        {
-            currentNode = node
-        } else if let lastFocused = controller.workspaceManager.rememberedTiledFocusToken(in: wsId),
-                  let node = engine.findNode(for: lastFocused)
-        {
-            state.selectedNodeId = node.id
-            currentNode = node
-        } else if let selectedId = engine.validateSelection(state.selectedNodeId, in: wsId),
-                  let node = engine.findNode(by: selectedId)
-        {
-            state.selectedNodeId = selectedId
-            currentNode = node
-        } else {
-            onNoTarget?()
-            return
-        }
-
-        let gap = controller.gapSize(for: monitor)
-        let workingFrame = controller.insetWorkingFrame(for: monitor)
-        let motion = controller.motionPolicy.snapshot()
-        guard let newNode = navigationAction(engine, currentNode, wsId, motion, &state, workingFrame, gap) else {
-            onNoTarget?()
-            return
-        }
-
-        controller.niriLayoutHandler.activateNode(
-            newNode, in: wsId, state: &state,
-            options: .init(activateWindow: false, ensureVisible: false)
-        )
-        _ = controller.workspaceManager.applySessionPatch(
-            .init(
-                workspaceId: wsId,
-                viewportState: state,
-                rememberedFocusToken: nil
-            )
-        )
-    }
-
-    private func moveWindow(direction: Direction) {
-        moveWindowInNiri(direction: direction)
-    }
-
-    private func toggleFullscreen() {
-        controller?.niriLayoutHandler.toggleFullscreen()
-    }
-
-    private func moveWindowInNiri(direction: Direction) {
-        controller?.niriLayoutHandler.moveWindow(direction: direction)
-    }
-
     private func toggleNativeFullscreenForFocused() {
         guard let controller else { return }
         let setFullscreen = nativeFullscreenSetter ?? { axRef, fullscreen in
@@ -528,9 +269,21 @@ final class CommandHandler {
             return
         }
 
-        let frontmostPid = frontmostAppPidProvider?() ?? NSWorkspace.shared.frontmostApplication?.processIdentifier
-        let frontmostToken = frontmostFocusedWindowTokenProvider?()
-            ?? frontmostPid.flatMap { controller.axEventHandler.focusedWindowToken(for: $0) }
+        // Honor an injected provider's nil rather than falling through to live
+        // state; fall back to AppKit/AX only when no provider is wired in.
+        let frontmostPid: pid_t?
+        if let frontmostAppPidProvider {
+            frontmostPid = frontmostAppPidProvider()
+        } else {
+            frontmostPid = NSWorkspace.shared.frontmostApplication?.processIdentifier
+        }
+
+        let frontmostToken: WindowToken?
+        if let frontmostFocusedWindowTokenProvider {
+            frontmostToken = frontmostFocusedWindowTokenProvider()
+        } else {
+            frontmostToken = frontmostPid.flatMap { controller.axEventHandler.focusedWindowToken(for: $0) }
+        }
         guard let token = controller.workspaceManager.nativeFullscreenCommandTarget(frontmostToken: frontmostToken),
               let entry = controller.workspaceManager.entry(for: token)
         else {
@@ -543,95 +296,4 @@ final class CommandHandler {
             return
         }
     }
-
-    private func moveColumnInNiri(direction: Direction) {
-        guard let controller else { return }
-        controller.niriLayoutHandler.withNiriOperationContext { ctx, state in
-            guard let column = ctx.engine.findColumn(containing: ctx.windowNode, in: ctx.wsId) else { return false }
-            let oldFrames = ctx.engine.captureWindowFrames(in: ctx.wsId)
-            guard ctx.engine.moveColumn(
-                column, direction: direction, in: ctx.wsId,
-                motion: ctx.motion,
-                state: &state,
-                workingFrame: ctx.workingFrame,
-                gaps: ctx.gaps
-            ) else { return false }
-            return ctx.commitWithCapturedAnimation(state: state, oldFrames: oldFrames)
-        }
-    }
-
-    private func moveColumnToFirstInNiri() {
-        guard let controller else { return }
-        controller.niriLayoutHandler.withNiriOperationContext { ctx, state in
-            guard let column = ctx.engine.findColumn(containing: ctx.windowNode, in: ctx.wsId) else { return false }
-            let oldFrames = ctx.engine.captureWindowFrames(in: ctx.wsId)
-            guard ctx.engine.moveColumnToFirst(
-                column,
-                in: ctx.wsId,
-                motion: ctx.motion,
-                state: &state,
-                workingFrame: ctx.workingFrame,
-                gaps: ctx.gaps
-            ) else { return false }
-            return ctx.commitWithCapturedAnimation(state: state, oldFrames: oldFrames)
-        }
-    }
-
-    private func moveColumnToLastInNiri() {
-        guard let controller else { return }
-        controller.niriLayoutHandler.withNiriOperationContext { ctx, state in
-            guard let column = ctx.engine.findColumn(containing: ctx.windowNode, in: ctx.wsId) else { return false }
-            let oldFrames = ctx.engine.captureWindowFrames(in: ctx.wsId)
-            guard ctx.engine.moveColumnToLast(
-                column,
-                in: ctx.wsId,
-                motion: ctx.motion,
-                state: &state,
-                workingFrame: ctx.workingFrame,
-                gaps: ctx.gaps
-            ) else { return false }
-            return ctx.commitWithCapturedAnimation(state: state, oldFrames: oldFrames)
-        }
-    }
-
-    private func moveColumnToIndexInNiri(index: Int) {
-        guard let controller else { return }
-        controller.niriLayoutHandler.withNiriOperationContext { ctx, state in
-            guard let column = ctx.engine.findColumn(containing: ctx.windowNode, in: ctx.wsId) else { return false }
-            let oldFrames = ctx.engine.captureWindowFrames(in: ctx.wsId)
-            guard ctx.engine.moveColumnToIndex(
-                column,
-                index,
-                in: ctx.wsId,
-                motion: ctx.motion,
-                state: &state,
-                workingFrame: ctx.workingFrame,
-                gaps: ctx.gaps
-            ) else { return false }
-            return ctx.commitWithCapturedAnimation(state: state, oldFrames: oldFrames)
-        }
-    }
-
-    private func toggleColumnTabbedInNiri() {
-        guard let controller else { return }
-        controller.niriLayoutHandler.withNiriWorkspaceContext { engine, wsId, motion, state, monitor, workingFrame, gaps in
-            let orientation = engine.monitor(for: monitor.id)?.orientation
-                ?? controller.settings.effectiveOrientation(for: monitor)
-            if engine.toggleColumnTabbed(
-                in: wsId,
-                state: &state,
-                motion: motion,
-                workingFrame: workingFrame,
-                gaps: gaps,
-                orientation: orientation
-            ) {
-                controller.layoutRefreshController.requestRefresh(reason: .layoutCommand)
-                if engine.hasAnyWindowAnimationsRunning(in: wsId) {
-                    controller.layoutRefreshController.startScrollAnimation(for: wsId)
-                }
-            }
-        }
-    }
-
-
 }

--- a/Sources/Nehir/Core/Controller/FocusCoordinator.swift
+++ b/Sources/Nehir/Core/Controller/FocusCoordinator.swift
@@ -1,0 +1,50 @@
+import AppKit
+import Foundation
+
+/// The explicit seam for interactive-mode cancellation and focus-dependent
+/// read queries, so handlers do not reach into the live `niriEngine` directly.
+///
+/// This is the boundary a *new* interactive mode (a gesture-driven mode, or a
+/// non-Niri layout's focus model) would implement. Today the sole conformer is
+/// `WMController`, which forwards to `niriEngine`.
+///
+/// The member set is the interactive-cancel surface (the two ops
+/// `MouseEventHandler` pokes the engine with) plus the focus-fullscreen read
+/// consumed by focus-dependent UI (`FocusBorderController`). Broader engine
+/// reads — whole-layout snapshots, refresh-pipeline relayout, lifecycle /
+/// topology sync, rendered-frame lookups — are assessed in Phase 4 and
+/// deliberately stay off this protocol; they are infrastructure, not the
+/// interactive-mode boundary.
+@MainActor protocol FocusCoordinator: AnyObject {
+    /// Cancel an in-flight interactive move (mouse drag).
+    func interactiveMoveCancel()
+    /// Tear down any active interactive resize session.
+    func clearInteractiveResize()
+    /// Read-only focus query: the layout node backing a window token, if any.
+    func focusedNode(for token: WindowToken) -> NiriNode?
+    /// Whether the window backing `token` is currently laid out fullscreen.
+    func isFocusedWindowFullscreen(_ token: WindowToken) -> Bool
+}
+
+// Adaptor: `WMController` forwards to the live `niriEngine`. Reads stay
+// optional-safe — a missing engine reports no node / not-fullscreen, matching
+// the previous `controller.niriEngine?.` reach-through behavior exactly.
+extension WMController: FocusCoordinator {
+    func interactiveMoveCancel() {
+        niriEngine?.interactiveMoveCancel()
+    }
+
+    func clearInteractiveResize() {
+        niriEngine?.clearInteractiveResize()
+    }
+
+    // `NiriLayoutEngine.findNode(for:)` returns `NiriWindow?`; returning it as
+    // `NiriNode?` is a covariant upcast (`NiriWindow: NiriNode`).
+    func focusedNode(for token: WindowToken) -> NiriNode? {
+        niriEngine?.findNode(for: token)
+    }
+
+    func isFocusedWindowFullscreen(_ token: WindowToken) -> Bool {
+        niriEngine?.findNode(for: token)?.isFullscreen ?? false
+    }
+}

--- a/Sources/Nehir/Core/Controller/LayoutCoordinator.swift
+++ b/Sources/Nehir/Core/Controller/LayoutCoordinator.swift
@@ -1,0 +1,61 @@
+import AppKit
+import Foundation
+
+/// The narrow layout-command surface that command logic depends on, instead of
+/// reaching through the concrete `NiriLayoutHandler` or live `niriEngine`.
+///
+/// The member set is derived from command-level capabilities — nothing
+/// speculative. Layout-pipeline internals (`layoutWithNiriEngine`,
+/// `registerScrollAnimation`, `insertWindow`, `updateTabbedColumnOverlays`,
+/// `hasScrollAnimation`, …) and low-level engine-context escape hatches
+/// deliberately stay off this protocol: they are refresh-pipeline plumbing or
+/// Niri implementation details, not the layout command surface.
+@MainActor protocol LayoutCoordinator: AnyObject {
+    // Focus / movement
+    func focusNeighbor(direction: Direction)
+    func focusPrevious()
+    func focusDownOrLeft()
+    func focusUpOrRight()
+    func focusWindowInColumn(index: Int)
+    func focusWindowTop()
+    func focusWindowBottom()
+    func focusWindowDownOrTop()
+    func focusWindowUpOrBottom()
+    func focusWindowOrWorkspace(direction: Direction)
+    func focusColumnFirst()
+    func focusColumnLast()
+    func focusColumn(index: Int)
+
+    @discardableResult func moveWindow(direction: Direction) -> NiriWindowMoveResult
+    func moveWindowOrToAdjacentWorkspace(direction: Direction)
+    func moveColumn(direction: Direction)
+    func moveColumnToFirst()
+    func moveColumnToLast()
+    func moveColumnToIndex(index: Int)
+    func consumeOrExpelWindow(direction: Direction)
+    func consumeWindowIntoColumn()
+    func expelWindowFromColumn()
+    func toggleFullscreen()
+    func toggleColumnTabbed()
+
+    // Sizing
+    func cycleSize(forward: Bool)
+    func cycleWindowWidth(forward: Bool)
+    func cycleWindowHeight(forward: Bool)
+    func toggleColumnFullWidth()
+    func expandColumnToAvailableWidth()
+    func resetWindowHeight()
+    func setColumnWidth(_ change: NiriSizeChange)
+    func setWindowWidth(_ change: NiriSizeChange)
+    func setWindowHeight(_ change: NiriSizeChange)
+    func balanceSizes()
+
+    // Viewport
+    func scrollViewport(direction: Direction)
+
+}
+
+// Conformance is free: `NiriLayoutHandler` already implements every requirement
+// with matching signatures. If a future signature drifts, fix this protocol to
+// match the concrete method — never edit the concrete method to satisfy it.
+extension NiriLayoutHandler: LayoutCoordinator {}

--- a/Sources/Nehir/Core/Controller/MouseEventHandler.swift
+++ b/Sources/Nehir/Core/Controller/MouseEventHandler.swift
@@ -579,7 +579,7 @@ final class MouseEventHandler {
         guard let controller else { return }
 
         if state.isMoving {
-            controller.niriEngine?.interactiveMoveCancel()
+            controller.focusCoordinator.interactiveMoveCancel()
             state.dragGhostController?.endDrag()
             state.isMoving = false
             state.moveIsInsertMode = false
@@ -588,7 +588,7 @@ final class MouseEventHandler {
         }
 
         if state.isResizing {
-            controller.niriEngine?.clearInteractiveResize()
+            controller.focusCoordinator.clearInteractiveResize()
             state.isResizing = false
             state.activeInteractionButton = nil
             state.activeInteractionWorkspaceId = nil

--- a/Sources/Nehir/Core/Controller/NiriLayoutHandler.swift
+++ b/Sources/Nehir/Core/Controller/NiriLayoutHandler.swift
@@ -1281,6 +1281,255 @@ enum NiriWindowMoveResult {
         )
     }
 
+    func focusPrevious() {
+        guard let controller else { return }
+        withNiriWorkspaceContext { engine, wsId, motion, state, _, workingFrame, gaps in
+            if let currentId = state.selectedNodeId {
+                engine.updateFocusTimestamp(for: currentId)
+            }
+
+            if let currentId = state.selectedNodeId {
+                engine.activateWindow(currentId)
+            }
+
+            guard let previousWindow = engine.focusPrevious(
+                currentNodeId: state.selectedNodeId,
+                in: wsId,
+                motion: motion,
+                state: &state,
+                workingFrame: workingFrame,
+                gaps: gaps,
+                limitToWorkspace: true
+            ) else {
+                return
+            }
+
+            activateNode(
+                previousWindow, in: wsId, state: &state,
+                options: .init(ensureVisible: false, updateTimestamp: false, startAnimation: false)
+            )
+
+            if state.viewOffsetPixels.isAnimating {
+                controller.layoutRefreshController.startScrollAnimation(for: wsId)
+            }
+        }
+    }
+
+    func focusDownOrLeft() {
+        executeCombinedNavigation { engine, currentNode, wsId, motion, state, workingFrame, gaps in
+            engine.focusDownOrLeft(
+                currentSelection: currentNode,
+                in: wsId,
+                motion: motion,
+                state: &state,
+                workingFrame: workingFrame,
+                gaps: gaps
+            )
+        }
+    }
+
+    func focusUpOrRight() {
+        executeCombinedNavigation { engine, currentNode, wsId, motion, state, workingFrame, gaps in
+            engine.focusUpOrRight(
+                currentSelection: currentNode,
+                in: wsId,
+                motion: motion,
+                state: &state,
+                workingFrame: workingFrame,
+                gaps: gaps
+            )
+        }
+    }
+
+    func focusWindowInColumn(index: Int) {
+        executeCombinedNavigation { engine, currentNode, wsId, motion, state, workingFrame, gaps in
+            engine.focusWindowInColumn(
+                index,
+                currentSelection: currentNode,
+                in: wsId,
+                motion: motion,
+                state: &state,
+                workingFrame: workingFrame,
+                gaps: gaps
+            )
+        }
+    }
+
+    func focusWindowTop() {
+        executeCombinedNavigation { engine, currentNode, wsId, motion, state, workingFrame, gaps in
+            engine.focusWindowTop(
+                currentSelection: currentNode,
+                in: wsId,
+                motion: motion,
+                state: &state,
+                workingFrame: workingFrame,
+                gaps: gaps
+            )
+        }
+    }
+
+    func focusWindowBottom() {
+        executeCombinedNavigation { engine, currentNode, wsId, motion, state, workingFrame, gaps in
+            engine.focusWindowBottom(
+                currentSelection: currentNode,
+                in: wsId,
+                motion: motion,
+                state: &state,
+                workingFrame: workingFrame,
+                gaps: gaps
+            )
+        }
+    }
+
+    func focusWindowDownOrTop() {
+        executeCombinedNavigation { engine, currentNode, wsId, motion, state, workingFrame, gaps in
+            engine.focusWindowDownOrTop(
+                currentSelection: currentNode,
+                in: wsId,
+                motion: motion,
+                state: &state,
+                workingFrame: workingFrame,
+                gaps: gaps
+            )
+        }
+    }
+
+    func focusWindowUpOrBottom() {
+        executeCombinedNavigation { engine, currentNode, wsId, motion, state, workingFrame, gaps in
+            engine.focusWindowUpOrBottom(
+                currentSelection: currentNode,
+                in: wsId,
+                motion: motion,
+                state: &state,
+                workingFrame: workingFrame,
+                gaps: gaps
+            )
+        }
+    }
+
+    func focusWindowOrWorkspace(direction: Direction) {
+        guard direction == .down || direction == .up else { return }
+        executeCombinedNavigation(
+            onNoTarget: { [weak controller] in
+                controller?.workspaceNavigationHandler.switchWorkspaceRelative(
+                    isNext: direction == .down,
+                    wrapAround: false
+                )
+            },
+            { engine, currentNode, wsId, motion, state, workingFrame, gaps in
+                engine.focusTarget(
+                    direction: direction,
+                    currentSelection: currentNode,
+                    in: wsId,
+                    motion: motion,
+                    state: &state,
+                    workingFrame: workingFrame,
+                    gaps: gaps
+                )
+            }
+        )
+    }
+
+    func focusColumnFirst() {
+        executeCombinedNavigation { engine, currentNode, wsId, motion, state, workingFrame, gaps in
+            engine.focusColumnFirst(
+                currentSelection: currentNode,
+                in: wsId,
+                motion: motion,
+                state: &state,
+                workingFrame: workingFrame,
+                gaps: gaps
+            )
+        }
+    }
+
+    func focusColumnLast() {
+        executeCombinedNavigation { engine, currentNode, wsId, motion, state, workingFrame, gaps in
+            engine.focusColumnLast(
+                currentSelection: currentNode,
+                in: wsId,
+                motion: motion,
+                state: &state,
+                workingFrame: workingFrame,
+                gaps: gaps
+            )
+        }
+    }
+
+    func focusColumn(index: Int) {
+        executeCombinedNavigation { engine, currentNode, wsId, motion, state, workingFrame, gaps in
+            engine.focusColumn(
+                index,
+                currentSelection: currentNode,
+                in: wsId,
+                motion: motion,
+                state: &state,
+                workingFrame: workingFrame,
+                gaps: gaps
+            )
+        }
+    }
+
+    private func executeCombinedNavigation(
+        onNoTarget: (() -> Void)? = nil,
+        _ navigationAction: (
+            NiriLayoutEngine,
+            NiriNode,
+            WorkspaceDescriptor.ID,
+            MotionSnapshot,
+            inout ViewportState,
+            CGRect,
+            CGFloat
+        )
+            -> NiriNode?
+    ) {
+        guard let controller else { return }
+        guard let engine = controller.niriEngine else { return }
+        guard let wsId = controller.interactionWorkspace()?.id else { return }
+        guard let monitor = controller.workspaceManager.monitor(for: wsId) else { return }
+
+        var state = controller.workspaceManager.niriViewportState(for: wsId)
+        let currentNode: NiriNode
+        if let currentId = state.selectedNodeId,
+           let node = engine.findNode(by: currentId)
+        {
+            currentNode = node
+        } else if let lastFocused = controller.workspaceManager.rememberedTiledFocusToken(in: wsId),
+                  let node = engine.findNode(for: lastFocused)
+        {
+            state.selectedNodeId = node.id
+            currentNode = node
+        } else if let selectedId = engine.validateSelection(state.selectedNodeId, in: wsId),
+                  let node = engine.findNode(by: selectedId)
+        {
+            state.selectedNodeId = selectedId
+            currentNode = node
+        } else {
+            onNoTarget?()
+            return
+        }
+
+        let gap = controller.gapSize(for: monitor)
+        let workingFrame = controller.insetWorkingFrame(for: monitor)
+        let motion = controller.motionPolicy.snapshot()
+        guard let newNode = navigationAction(engine, currentNode, wsId, motion, &state, workingFrame, gap) else {
+            onNoTarget?()
+            return
+        }
+
+        activateNode(
+            newNode, in: wsId, state: &state,
+            options: .init(activateWindow: false, ensureVisible: false)
+        )
+        _ = controller.workspaceManager.applySessionPatch(
+            .init(
+                workspaceId: wsId,
+                viewportState: state,
+                rememberedFocusToken: nil
+            )
+        )
+    }
+
     func toggleFullscreen() {
         guard let controller else { return }
         withNiriWorkspaceContext { engine, wsId, motion, state, _, _, _ in
@@ -1376,6 +1625,25 @@ enum NiriWindowMoveResult {
             )
             controller.layoutRefreshController.requestRefresh(reason: .layoutCommand)
             startScrollAnimationIfNeeded(for: wsId, state: state, engine: engine)
+        }
+    }
+
+    func toggleColumnTabbed() {
+        guard let controller else { return }
+        withNiriWorkspaceContext { engine, wsId, motion, state, monitor, workingFrame, gaps in
+            let orientation = engine.monitor(for: monitor.id)?.orientation
+                ?? controller.settings.effectiveOrientation(for: monitor)
+            if engine.toggleColumnTabbed(
+                in: wsId,
+                state: &state,
+                motion: motion,
+                workingFrame: workingFrame,
+                gaps: gaps,
+                orientation: orientation
+            ) {
+                controller.layoutRefreshController.requestRefresh(reason: .layoutCommand)
+                startScrollAnimationIfNeeded(for: wsId, state: state, engine: engine)
+            }
         }
     }
 
@@ -1529,7 +1797,7 @@ enum NiriWindowMoveResult {
         engine.revealPartial = revealPartial
         engine.renderStyle.tabIndicatorWidth = TabbedColumnOverlayManager.tabIndicatorWidth
         engine.animationClock = controller.animationClock
-        controller.niriEngine = engine
+        controller.setNiriEngine(engine)
         controller.syncNiriResizeTraceSink()
 
         syncMonitorsToNiriEngine()
@@ -1821,6 +2089,70 @@ enum NiriWindowMoveResult {
         guard direction == .down || direction == .up else { return }
         guard moveWindow(direction: direction) == .atColumnEdge else { return }
         controller?.workspaceNavigationHandler.moveWindowToAdjacentWorkspace(direction: direction)
+    }
+
+    func moveColumn(direction: Direction) {
+        withNiriOperationContext { ctx, state in
+            guard let column = ctx.engine.findColumn(containing: ctx.windowNode, in: ctx.wsId) else { return false }
+            let oldFrames = ctx.engine.captureWindowFrames(in: ctx.wsId)
+            guard ctx.engine.moveColumn(
+                column, direction: direction, in: ctx.wsId,
+                motion: ctx.motion,
+                state: &state,
+                workingFrame: ctx.workingFrame,
+                gaps: ctx.gaps
+            ) else { return false }
+            return ctx.commitWithCapturedAnimation(state: state, oldFrames: oldFrames)
+        }
+    }
+
+    func moveColumnToFirst() {
+        withNiriOperationContext { ctx, state in
+            guard let column = ctx.engine.findColumn(containing: ctx.windowNode, in: ctx.wsId) else { return false }
+            let oldFrames = ctx.engine.captureWindowFrames(in: ctx.wsId)
+            guard ctx.engine.moveColumnToFirst(
+                column,
+                in: ctx.wsId,
+                motion: ctx.motion,
+                state: &state,
+                workingFrame: ctx.workingFrame,
+                gaps: ctx.gaps
+            ) else { return false }
+            return ctx.commitWithCapturedAnimation(state: state, oldFrames: oldFrames)
+        }
+    }
+
+    func moveColumnToLast() {
+        withNiriOperationContext { ctx, state in
+            guard let column = ctx.engine.findColumn(containing: ctx.windowNode, in: ctx.wsId) else { return false }
+            let oldFrames = ctx.engine.captureWindowFrames(in: ctx.wsId)
+            guard ctx.engine.moveColumnToLast(
+                column,
+                in: ctx.wsId,
+                motion: ctx.motion,
+                state: &state,
+                workingFrame: ctx.workingFrame,
+                gaps: ctx.gaps
+            ) else { return false }
+            return ctx.commitWithCapturedAnimation(state: state, oldFrames: oldFrames)
+        }
+    }
+
+    func moveColumnToIndex(index: Int) {
+        withNiriOperationContext { ctx, state in
+            guard let column = ctx.engine.findColumn(containing: ctx.windowNode, in: ctx.wsId) else { return false }
+            let oldFrames = ctx.engine.captureWindowFrames(in: ctx.wsId)
+            guard ctx.engine.moveColumnToIndex(
+                column,
+                index,
+                in: ctx.wsId,
+                motion: ctx.motion,
+                state: &state,
+                workingFrame: ctx.workingFrame,
+                gaps: ctx.gaps
+            ) else { return false }
+            return ctx.commitWithCapturedAnimation(state: state, oldFrames: oldFrames)
+        }
     }
 
     func consumeOrExpelWindow(direction: Direction) {

--- a/Sources/Nehir/Core/Controller/WMController.swift
+++ b/Sources/Nehir/Core/Controller/WMController.swift
@@ -113,7 +113,17 @@ final class WMController {
     private let restorePlanner = RestorePlanner()
     let windowRuleEngine = WindowRuleEngine()
 
-    var niriEngine: NiriLayoutEngine?
+    /// The live Niri layout engine. Reads remain module-internal; writes are
+    /// funneled through `setNiriEngine(_:)` so future ad-hoc assignments are a
+    /// compile error rather than a code-review hope.
+    private(set) var niriEngine: NiriLayoutEngine?
+
+    /// The only sanctioned way to install/replace the live Niri engine.
+    /// Reads remain module-internal; writes are funneled here so future
+    /// ad-hoc assignments are caught at compile time.
+    func setNiriEngine(_ engine: NiriLayoutEngine?) {
+        niriEngine = engine
+    }
 
     let tabbedOverlayManager = TabbedColumnOverlayManager()
     @ObservationIgnored
@@ -165,6 +175,16 @@ final class WMController {
     var niriLayoutHandler: NiriLayoutHandler {
         layoutRefreshController.niriHandler
     }
+
+    /// Narrow layout-command surface for command logic. Prefer this over the
+    /// 41-method concrete `niriLayoutHandler` so the command boundary is an
+    /// auditable type, not a code-review hope.
+    var layoutCoordinator: LayoutCoordinator { niriLayoutHandler }
+
+    /// Narrow seam for interactive-mode cancellation and focus-dependent reads,
+    /// so handlers depend on the protocol rather than reaching into `niriEngine`.
+    /// `WMController` itself conforms; see `FocusCoordinator.swift`.
+    var focusCoordinator: FocusCoordinator { self }
 
     @ObservationIgnored
     private(set) lazy var serviceLifecycleManager = ServiceLifecycleManager(controller: self)


### PR DESCRIPTION
## Summary

Introduce LayoutCoordinator and FocusCoordinator protocols so command and event handlers depend on narrow capability surfaces instead of the concrete NiriLayoutHandler or the live niriEngine. Fold the combined-navigation, focus-previous, column-movement, and tabbed-column command logic into NiriLayoutHandler behind those protocol methods, removing the low-level withNiri*/activateNode escape hatches from LayoutCoordinator.

Funnel engine writes through a private(set) niriEngine plus setNiriEngine(_:) so ad-hoc reassignment is a compile error. No behavior change; all 1251 tests pass.

## Release notes

Choose one:

- [x] Added a `.changeset/*.md` for user-visible changes (`mise run changeset -- patch "..."`).
- [ ] No user-visible change; apply the `no release note` label to make CI skip intentional.

## Validation

<!-- Commands run, screenshots, or manual checks. -->

- [ ] Ran relevant tests/checks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded focus navigation with “focus previous” plus additional directional and window/column focus options.
  * Added column controls: toggle tabbed mode and move columns to first/last or a specific position.
* **Bug Fixes**
  * Improved fullscreen state detection for the focused window.
  * Enhanced native fullscreen toggling behavior for smoother transitions and more reliable restore flow.
* **Refactor**
  * Streamlined focus and layout command handling behind clearer internal coordination interfaces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->