### PR TITLE
PureLayout reducer

### DIFF
--- a/.changeset/20260620004757-share-pure-niri-layout-decisions-between-onboard.md
+++ b/.changeset/20260620004757-share-pure-niri-layout-decisions-between-onboard.md
@@ -1,0 +1,6 @@
+---
+"nehir": none
+
+---
+
+Share pure Niri layout decisions between the onboarding move demo and runtime layout engine. This extracts a platform-free `PureLayout` reducer, drives the interactive demo through it, routes production Niri focus and focused-window move decisions through the same reducer, and adds bridge assertions so runtime tree mutations stay aligned with the pure model.

--- a/Sources/Nehir/Core/Controller/NiriLayoutHandler.swift
+++ b/Sources/Nehir/Core/Controller/NiriLayoutHandler.swift
@@ -2036,6 +2036,8 @@ enum NiriWindowMoveResult {
             guard let monitor = controller.workspaceManager.monitor(for: wsId) else { return }
             let workingFrame = controller.insetWorkingFrame(for: monitor)
             let gaps = controller.gapSize(for: monitor)
+            let orientation = engine.monitor(for: monitor.id)?.orientation
+                ?? controller.settings.effectiveOrientation(for: monitor)
 
             let ctx = NiriOperationContext(
                 controller: controller,
@@ -2045,7 +2047,8 @@ enum NiriWindowMoveResult {
                 windowNode: windowNode,
                 monitor: monitor,
                 workingFrame: workingFrame,
-                gaps: gaps
+                gaps: gaps,
+                orientation: orientation
             )
 
             if operation(ctx, &state) {
@@ -2074,7 +2077,8 @@ enum NiriWindowMoveResult {
                 motion: ctx.motion,
                 state: &state,
                 workingFrame: ctx.workingFrame,
-                gaps: ctx.gaps
+                gaps: ctx.gaps,
+                orientation: ctx.orientation
             ) else {
                 result = edgeResult
                 return false
@@ -2171,7 +2175,8 @@ enum NiriWindowMoveResult {
                 state: &state,
                 workingFrame: ctx.workingFrame,
                 gaps: ctx.gaps,
-                allowEdgeWrap: false
+                allowEdgeWrap: false,
+                orientation: ctx.orientation
             ) else {
                 return false
             }
@@ -2345,6 +2350,7 @@ struct NodeActivationOptions {
     let monitor: Monitor
     let workingFrame: CGRect
     let gaps: CGFloat
+    let orientation: Monitor.Orientation
 
     private func hasPendingAnimationWork(state: ViewportState) -> Bool {
         hasPendingNiriAnimationWork(state: state, engine: engine, workspaceId: wsId)

--- a/Sources/Nehir/Core/Layout/Niri/NiriLayoutEngine+ColumnOps.swift
+++ b/Sources/Nehir/Core/Layout/Niri/NiriLayoutEngine+ColumnOps.swift
@@ -482,12 +482,30 @@ extension NiriLayoutEngine {
     ) -> Bool {
         guard direction == .left || direction == .right else { return false }
 
-        if let pureWouldChange = pureLayoutMoveWouldChange(
+        let purePlan = pureLayoutMovePlan(
             window,
             direction: direction,
             in: workspaceId,
             allowEdgeWrap: allowEdgeWrap
-        ), !pureWouldChange {
+        )
+
+        switch purePlan {
+        case .noChange:
+            return false
+        case .horizontalExpel:
+            return expelWindow(
+                window,
+                to: direction,
+                in: workspaceId,
+                motion: motion,
+                state: &state,
+                workingFrame: workingFrame,
+                gaps: gaps
+            )
+        case .horizontalConsume,
+             .unsupported:
+            break
+        case .verticalSwap:
             return false
         }
 
@@ -497,7 +515,7 @@ extension NiriLayoutEngine {
             return false
         }
 
-        if currentColumn.windowNodes.count > 1 {
+        if purePlan == .unsupported, currentColumn.windowNodes.count > 1 {
             return expelWindow(
                 window,
                 to: direction,
@@ -510,19 +528,29 @@ extension NiriLayoutEngine {
         }
 
         let cols = columns(in: workspaceId)
-        let step = (direction == .right) ? 1 : -1
         let neighborIdx: Int
-        if allowEdgeWrap {
-            guard let wrappedIdx = wrapIndex(currentIdx + step, total: cols.count, in: workspaceId) else {
-                return false
+        switch purePlan {
+        case let .horizontalConsume(targetColumnIndexBeforeMove):
+            guard cols.indices.contains(targetColumnIndexBeforeMove) else { return false }
+            neighborIdx = targetColumnIndexBeforeMove
+        case .unsupported:
+            let step = (direction == .right) ? 1 : -1
+            if allowEdgeWrap {
+                guard let wrappedIdx = wrapIndex(currentIdx + step, total: cols.count, in: workspaceId) else {
+                    return false
+                }
+                neighborIdx = wrappedIdx
+            } else {
+                let adjacentIdx = currentIdx + step
+                guard adjacentIdx >= 0, adjacentIdx < cols.count else {
+                    return false
+                }
+                neighborIdx = adjacentIdx
             }
-            neighborIdx = wrappedIdx
-        } else {
-            let adjacentIdx = currentIdx + step
-            guard adjacentIdx >= 0, adjacentIdx < cols.count else {
-                return false
-            }
-            neighborIdx = adjacentIdx
+        case .noChange,
+             .horizontalExpel,
+             .verticalSwap:
+            return false
         }
 
         if neighborIdx == currentIdx { return false }

--- a/Sources/Nehir/Core/Layout/Niri/NiriLayoutEngine+ColumnOps.swift
+++ b/Sources/Nehir/Core/Layout/Niri/NiriLayoutEngine+ColumnOps.swift
@@ -488,12 +488,15 @@ extension NiriLayoutEngine {
             in: workspaceId,
             allowEdgeWrap: allowEdgeWrap
         )
+        let pureExpected = purePlan == .unsupported
+            ? nil
+            : pureLayoutExpectedMoveSnapshot(window, direction: direction, in: workspaceId, allowEdgeWrap: allowEdgeWrap)
 
         switch purePlan {
         case .noChange:
             return false
         case .horizontalExpel:
-            return expelWindow(
+            let moved = expelWindow(
                 window,
                 to: direction,
                 in: workspaceId,
@@ -502,6 +505,10 @@ extension NiriLayoutEngine {
                 workingFrame: workingFrame,
                 gaps: gaps
             )
+            if moved {
+                assertPureLayoutSnapshotMatches(pureExpected, selectedWindow: window, in: workspaceId)
+            }
+            return moved
         case .horizontalConsume,
              .unsupported:
             break
@@ -626,6 +633,10 @@ extension NiriLayoutEngine {
             fromContainerIndex: previousActiveColumnIndex,
             previousActiveContainerPosition: previousActiveColumnPosition
         )
+
+        if case .horizontalConsume = purePlan {
+            assertPureLayoutSnapshotMatches(pureExpected, selectedWindow: window, in: workspaceId)
+        }
 
         return true
     }

--- a/Sources/Nehir/Core/Layout/Niri/NiriLayoutEngine+ColumnOps.swift
+++ b/Sources/Nehir/Core/Layout/Niri/NiriLayoutEngine+ColumnOps.swift
@@ -482,6 +482,15 @@ extension NiriLayoutEngine {
     ) -> Bool {
         guard direction == .left || direction == .right else { return false }
 
+        if let pureWouldChange = pureLayoutMoveWouldChange(
+            window,
+            direction: direction,
+            in: workspaceId,
+            allowEdgeWrap: allowEdgeWrap
+        ), !pureWouldChange {
+            return false
+        }
+
         guard let currentColumn = findColumn(containing: window, in: workspaceId),
               let currentIdx = columnIndex(of: currentColumn, in: workspaceId)
         else {

--- a/Sources/Nehir/Core/Layout/Niri/NiriLayoutEngine+ColumnOps.swift
+++ b/Sources/Nehir/Core/Layout/Niri/NiriLayoutEngine+ColumnOps.swift
@@ -482,15 +482,13 @@ extension NiriLayoutEngine {
     ) -> Bool {
         guard direction == .left || direction == .right else { return false }
 
-        let purePlan = pureLayoutMovePlan(
+        let pureDecision = pureLayoutMoveDecision(
             window,
             direction: direction,
             in: workspaceId,
             allowEdgeWrap: allowEdgeWrap
         )
-        let pureExpected = purePlan == .unsupported
-            ? nil
-            : pureLayoutExpectedMoveSnapshot(window, direction: direction, in: workspaceId, allowEdgeWrap: allowEdgeWrap)
+        let purePlan = pureDecision.plan
 
         switch purePlan {
         case .noChange:
@@ -506,7 +504,7 @@ extension NiriLayoutEngine {
                 gaps: gaps
             )
             if moved {
-                assertPureLayoutSnapshotMatches(pureExpected, selectedWindow: window, in: workspaceId)
+                assertPureLayoutSnapshotMatches(pureDecision.expectedSnapshot, selectedWindow: window, in: workspaceId)
             }
             return moved
         case .horizontalConsume,
@@ -635,7 +633,7 @@ extension NiriLayoutEngine {
         )
 
         if case .horizontalConsume = purePlan {
-            assertPureLayoutSnapshotMatches(pureExpected, selectedWindow: window, in: workspaceId)
+            assertPureLayoutSnapshotMatches(pureDecision.expectedSnapshot, selectedWindow: window, in: workspaceId)
         }
 
         return true

--- a/Sources/Nehir/Core/Layout/Niri/NiriLayoutEngine+ColumnOps.swift
+++ b/Sources/Nehir/Core/Layout/Niri/NiriLayoutEngine+ColumnOps.swift
@@ -478,15 +478,17 @@ extension NiriLayoutEngine {
         state: inout ViewportState,
         workingFrame: CGRect,
         gaps: CGFloat,
-        allowEdgeWrap: Bool = true
+        allowEdgeWrap: Bool = true,
+        orientation: Monitor.Orientation = .horizontal
     ) -> Bool {
-        guard direction == .left || direction == .right else { return false }
+        guard let step = direction.primaryStep(for: orientation) else { return false }
 
         let pureDecision = pureLayoutMoveDecision(
             window,
             direction: direction,
             in: workspaceId,
-            allowEdgeWrap: allowEdgeWrap
+            allowEdgeWrap: allowEdgeWrap,
+            orientation: orientation
         )
         let purePlan = pureDecision.plan
 
@@ -501,7 +503,8 @@ extension NiriLayoutEngine {
                 motion: motion,
                 state: &state,
                 workingFrame: workingFrame,
-                gaps: gaps
+                gaps: gaps,
+                orientation: orientation
             )
             if moved {
                 assertPureLayoutSnapshotMatches(pureDecision.expectedSnapshot, selectedWindow: window, in: workspaceId)
@@ -528,7 +531,8 @@ extension NiriLayoutEngine {
                 motion: motion,
                 state: &state,
                 workingFrame: workingFrame,
-                gaps: gaps
+                gaps: gaps,
+                orientation: orientation
             )
         }
 
@@ -539,7 +543,6 @@ extension NiriLayoutEngine {
             guard cols.indices.contains(targetColumnIndexBeforeMove) else { return false }
             neighborIdx = targetColumnIndexBeforeMove
         case .unsupported:
-            let step = (direction == .right) ? 1 : -1
             if allowEdgeWrap {
                 guard let wrappedIdx = wrapIndex(currentIdx + step, total: cols.count, in: workspaceId) else {
                     return false
@@ -628,6 +631,7 @@ extension NiriLayoutEngine {
             state: &state,
             workingFrame: workingFrame,
             gaps: gaps,
+            orientation: orientation,
             fromContainerIndex: previousActiveColumnIndex,
             previousActiveContainerPosition: previousActiveColumnPosition
         )
@@ -793,9 +797,10 @@ extension NiriLayoutEngine {
         motion: MotionSnapshot,
         state: inout ViewportState,
         workingFrame: CGRect,
-        gaps: CGFloat
+        gaps: CGFloat,
+        orientation: Monitor.Orientation = .horizontal
     ) -> Bool {
-        guard direction == .left || direction == .right else { return false }
+        guard let step = direction.primaryStep(for: orientation) else { return false }
 
         guard let currentColumn = findColumn(containing: window, in: workspaceId),
               let root = roots[workspaceId],
@@ -818,7 +823,7 @@ extension NiriLayoutEngine {
         let newColumn = NiriContainer()
         copyColumnWidthState(from: currentColumn, to: newColumn)
 
-        if direction == .right {
+        if step > 0 {
             root.insertAfter(newColumn, reference: currentColumn)
         } else {
             root.insertBefore(newColumn, reference: currentColumn)
@@ -874,7 +879,8 @@ extension NiriLayoutEngine {
             motion: motion,
             state: &state,
             workingFrame: workingFrame,
-            gaps: gaps
+            gaps: gaps,
+            orientation: orientation
         )
 
         return true

--- a/Sources/Nehir/Core/Layout/Niri/NiriLayoutEngine+PureLayoutBridge.swift
+++ b/Sources/Nehir/Core/Layout/Niri/NiriLayoutEngine+PureLayoutBridge.swift
@@ -58,27 +58,79 @@ extension NiriLayoutEngine {
         return .handled(target)
     }
 
-    /// Returns whether `PureLayoutReducer` says the focused window move should
-    /// change the logical layout. `nil` means the bridge cannot model the current
-    /// runtime tree safely, so callers should fall back to existing Niri logic.
-    func pureLayoutMoveWouldChange(
+    enum PureLayoutMovePlan: Equatable {
+        case noChange
+        case verticalSwap(targetToken: WindowToken)
+        case horizontalExpel
+        case horizontalConsume(targetColumnIndexBeforeMove: Int)
+        case unsupported
+    }
+
+    /// Uses `PureLayoutReducer` as the focused-window move decision engine and
+    /// returns the concrete runtime operation Niri should execute. Niri still
+    /// owns tree mutation, viewport state, and animation, but the choice of
+    /// no-op / vertical swap / horizontal expel / horizontal consume comes from
+    /// the shared pure model.
+    func pureLayoutMovePlan(
         _ window: NiriWindow,
         direction: Direction,
         in workspaceId: WorkspaceDescriptor.ID,
         allowEdgeWrap: Bool
-    ) -> Bool? {
+    ) -> PureLayoutMovePlan {
         guard let pureDirection = PureDirection(direction: direction, orientation: .horizontal),
               let before = pureLayoutWorld(
                   in: workspaceId,
                   selectedWindow: window,
                   infiniteLoop: allowEdgeWrap && effectiveInfiniteLoop(in: workspaceId)
-              )
+              ),
+              let beforeWorkspace = before.activeWorkspace,
+              let beforeActiveColumnIndex = beforeWorkspace.activeColumnIndex,
+              beforeWorkspace.columns.indices.contains(beforeActiveColumnIndex)
         else {
-            return nil
+            return .unsupported
         }
 
         let after = PureLayoutReducer.moveFocusedWindow(pureDirection, in: before)
-        return after != before
+        guard after != before else { return .noChange }
+        guard let afterWorkspace = after.activeWorkspace else {
+            return .unsupported
+        }
+
+        if pureDirection.horizontalStep == nil {
+            guard let afterActiveColumnIndex = afterWorkspace.activeColumnIndex,
+                  afterWorkspace.columns.indices.contains(afterActiveColumnIndex),
+                  afterActiveColumnIndex == beforeActiveColumnIndex
+            else {
+                return .unsupported
+            }
+
+            let beforeColumn = beforeWorkspace.columns[beforeActiveColumnIndex]
+            let afterActiveWindowIndex = afterWorkspace.columns[afterActiveColumnIndex].activeWindowIndex
+            guard beforeColumn.windows.indices.contains(afterActiveWindowIndex) else {
+                return .unsupported
+            }
+
+            let displacedToken = beforeColumn.windows[afterActiveWindowIndex].id
+            guard displacedToken != window.token else { return .unsupported }
+            return .verticalSwap(targetToken: displacedToken)
+        }
+
+        if afterWorkspace.columns.count == beforeWorkspace.columns.count + 1 {
+            return .horizontalExpel
+        }
+
+        if afterWorkspace.columns.count == beforeWorkspace.columns.count - 1,
+           let afterActiveColumnIndex = afterWorkspace.activeColumnIndex,
+           afterWorkspace.columns.indices.contains(afterActiveColumnIndex)
+        {
+            let targetColumnID = afterWorkspace.columns[afterActiveColumnIndex].id.rawValue
+            guard beforeWorkspace.columns.indices.contains(targetColumnID) else {
+                return .unsupported
+            }
+            return .horizontalConsume(targetColumnIndexBeforeMove: targetColumnID)
+        }
+
+        return .unsupported
     }
 
     private func pureLayoutWorld(

--- a/Sources/Nehir/Core/Layout/Niri/NiriLayoutEngine+PureLayoutBridge.swift
+++ b/Sources/Nehir/Core/Layout/Niri/NiriLayoutEngine+PureLayoutBridge.swift
@@ -2,6 +2,13 @@ import AppKit
 import Foundation
 
 extension NiriLayoutEngine {
+    struct PureLayoutSnapshot: Equatable {
+        var columns: [[WindowToken]]
+        var activeColumnIndex: Int?
+        var activeWindowIndices: [Int]
+        var focusedWindowID: WindowToken?
+    }
+
     enum PureLayoutFocusResult {
         case handled(NiriNode?)
         case unsupported
@@ -41,6 +48,12 @@ extension NiriLayoutEngine {
             return .handled(nil)
         }
 
+        assertPureLayoutSnapshotMatches(
+            Self.pureLayoutSnapshot(after),
+            selectedWindow: target,
+            in: workspaceId
+        )
+
         if direction.primaryStep(for: orientation) != nil {
             state.activatePrevColumnOnRemoval = nil
         }
@@ -64,6 +77,45 @@ extension NiriLayoutEngine {
         case horizontalExpel
         case horizontalConsume(targetColumnIndexBeforeMove: Int)
         case unsupported
+    }
+
+    func pureLayoutExpectedMoveSnapshot(
+        _ window: NiriWindow,
+        direction: Direction,
+        in workspaceId: WorkspaceDescriptor.ID,
+        allowEdgeWrap: Bool
+    ) -> PureLayoutSnapshot? {
+        guard let pureDirection = PureDirection(direction: direction, orientation: .horizontal),
+              let before = pureLayoutWorld(
+                  in: workspaceId,
+                  selectedWindow: window,
+                  infiniteLoop: allowEdgeWrap && effectiveInfiniteLoop(in: workspaceId)
+              )
+        else {
+            return nil
+        }
+
+        let after = PureLayoutReducer.moveFocusedWindow(pureDirection, in: before)
+        return Self.pureLayoutSnapshot(after)
+    }
+
+    func assertPureLayoutSnapshotMatches(
+        _ expected: PureLayoutSnapshot?,
+        selectedWindow: NiriWindow,
+        in workspaceId: WorkspaceDescriptor.ID
+    ) {
+        guard let expected else { return }
+        guard let actualWorld = pureLayoutWorld(
+            in: workspaceId,
+            selectedWindow: selectedWindow,
+            infiniteLoop: effectiveInfiniteLoop(in: workspaceId)
+        ) else {
+            assertionFailure("Niri runtime could not be snapshotted after pure layout operation")
+            return
+        }
+
+        let actual = Self.pureLayoutSnapshot(actualWorld)
+        assert(actual == expected, "Niri runtime diverged from PureLayoutReducer. expected=\(expected), actual=\(actual)")
     }
 
     /// Uses `PureLayoutReducer` as the focused-window move decision engine and
@@ -131,6 +183,21 @@ extension NiriLayoutEngine {
         }
 
         return .unsupported
+    }
+
+    private static func pureLayoutSnapshot(
+        _ world: CoreWorld<WorkspaceDescriptor.ID, WindowToken>
+    ) -> PureLayoutSnapshot {
+        guard let workspace = world.activeWorkspace else {
+            return PureLayoutSnapshot(columns: [], activeColumnIndex: nil, activeWindowIndices: [], focusedWindowID: nil)
+        }
+
+        return PureLayoutSnapshot(
+            columns: workspace.columns.map { $0.windows.map(\.id) },
+            activeColumnIndex: workspace.activeColumnIndex,
+            activeWindowIndices: workspace.columns.map(\.activeWindowIndex),
+            focusedWindowID: workspace.focusedWindowID
+        )
     }
 
     private func pureLayoutWorld(

--- a/Sources/Nehir/Core/Layout/Niri/NiriLayoutEngine+PureLayoutBridge.swift
+++ b/Sources/Nehir/Core/Layout/Niri/NiriLayoutEngine+PureLayoutBridge.swift
@@ -1,7 +1,10 @@
 import AppKit
 import Foundation
+import OSLog
 
 extension NiriLayoutEngine {
+    private static let pureLayoutBridgeLogger = Logger(subsystem: "com.nehir", category: "pure-layout-bridge")
+
     struct PureLayoutSnapshot: Equatable {
         var columns: [[WindowToken]]
         var activeColumnIndex: Int?
@@ -79,24 +82,9 @@ extension NiriLayoutEngine {
         case unsupported
     }
 
-    func pureLayoutExpectedMoveSnapshot(
-        _ window: NiriWindow,
-        direction: Direction,
-        in workspaceId: WorkspaceDescriptor.ID,
-        allowEdgeWrap: Bool
-    ) -> PureLayoutSnapshot? {
-        guard let pureDirection = PureDirection(direction: direction, orientation: .horizontal),
-              let before = pureLayoutWorld(
-                  in: workspaceId,
-                  selectedWindow: window,
-                  infiniteLoop: allowEdgeWrap && effectiveInfiniteLoop(in: workspaceId)
-              )
-        else {
-            return nil
-        }
-
-        let after = PureLayoutReducer.moveFocusedWindow(pureDirection, in: before)
-        return Self.pureLayoutSnapshot(after)
+    struct PureLayoutMoveDecision: Equatable {
+        var plan: PureLayoutMovePlan
+        var expectedSnapshot: PureLayoutSnapshot?
     }
 
     func assertPureLayoutSnapshotMatches(
@@ -110,12 +98,16 @@ extension NiriLayoutEngine {
             selectedWindow: selectedWindow,
             infiniteLoop: effectiveInfiniteLoop(in: workspaceId)
         ) else {
+            Self.pureLayoutBridgeLogger.error("Niri runtime could not be snapshotted after pure layout operation")
             assertionFailure("Niri runtime could not be snapshotted after pure layout operation")
             return
         }
 
         let actual = Self.pureLayoutSnapshot(actualWorld)
-        assert(actual == expected, "Niri runtime diverged from PureLayoutReducer. expected=\(expected), actual=\(actual)")
+        guard actual != expected else { return }
+
+        Self.pureLayoutBridgeLogger.error("Niri runtime diverged from PureLayoutReducer. expected=\(String(describing: expected), privacy: .public), actual=\(String(describing: actual), privacy: .public)")
+        assertionFailure("Niri runtime diverged from PureLayoutReducer. expected=\(expected), actual=\(actual)")
     }
 
     /// Uses `PureLayoutReducer` as the focused-window move decision engine and
@@ -123,12 +115,12 @@ extension NiriLayoutEngine {
     /// owns tree mutation, viewport state, and animation, but the choice of
     /// no-op / vertical swap / horizontal expel / horizontal consume comes from
     /// the shared pure model.
-    func pureLayoutMovePlan(
+    func pureLayoutMoveDecision(
         _ window: NiriWindow,
         direction: Direction,
         in workspaceId: WorkspaceDescriptor.ID,
         allowEdgeWrap: Bool
-    ) -> PureLayoutMovePlan {
+    ) -> PureLayoutMoveDecision {
         guard let pureDirection = PureDirection(direction: direction, orientation: .horizontal),
               let before = pureLayoutWorld(
                   in: workspaceId,
@@ -139,13 +131,17 @@ extension NiriLayoutEngine {
               let beforeActiveColumnIndex = beforeWorkspace.activeColumnIndex,
               beforeWorkspace.columns.indices.contains(beforeActiveColumnIndex)
         else {
-            return .unsupported
+            return PureLayoutMoveDecision(plan: .unsupported, expectedSnapshot: nil)
         }
 
         let after = PureLayoutReducer.moveFocusedWindow(pureDirection, in: before)
-        guard after != before else { return .noChange }
+        let expectedSnapshot = Self.pureLayoutSnapshot(after)
+        guard after != before else {
+            return PureLayoutMoveDecision(plan: .noChange, expectedSnapshot: expectedSnapshot)
+        }
         guard let afterWorkspace = after.activeWorkspace else {
-            return .unsupported
+            logUnsupportedPureLayoutMove(direction: direction, reason: "missing after workspace")
+            return PureLayoutMoveDecision(plan: .unsupported, expectedSnapshot: expectedSnapshot)
         }
 
         if pureDirection.horizontalStep == nil {
@@ -153,36 +149,48 @@ extension NiriLayoutEngine {
                   afterWorkspace.columns.indices.contains(afterActiveColumnIndex),
                   afterActiveColumnIndex == beforeActiveColumnIndex
             else {
-                return .unsupported
+                logUnsupportedPureLayoutMove(direction: direction, reason: "vertical move changed active column")
+                return PureLayoutMoveDecision(plan: .unsupported, expectedSnapshot: expectedSnapshot)
             }
 
             let beforeColumn = beforeWorkspace.columns[beforeActiveColumnIndex]
             let afterActiveWindowIndex = afterWorkspace.columns[afterActiveColumnIndex].activeWindowIndex
             guard beforeColumn.windows.indices.contains(afterActiveWindowIndex) else {
-                return .unsupported
+                logUnsupportedPureLayoutMove(direction: direction, reason: "vertical target index outside before column")
+                return PureLayoutMoveDecision(plan: .unsupported, expectedSnapshot: expectedSnapshot)
             }
 
             let displacedToken = beforeColumn.windows[afterActiveWindowIndex].id
-            guard displacedToken != window.token else { return .unsupported }
-            return .verticalSwap(targetToken: displacedToken)
-        }
-
-        if afterWorkspace.columns.count == beforeWorkspace.columns.count + 1 {
-            return .horizontalExpel
-        }
-
-        if afterWorkspace.columns.count == beforeWorkspace.columns.count - 1,
-           let afterActiveColumnIndex = afterWorkspace.activeColumnIndex,
-           afterWorkspace.columns.indices.contains(afterActiveColumnIndex)
-        {
-            let targetColumnID = afterWorkspace.columns[afterActiveColumnIndex].id.rawValue
-            guard beforeWorkspace.columns.indices.contains(targetColumnID) else {
-                return .unsupported
+            guard displacedToken != window.token else {
+                logUnsupportedPureLayoutMove(direction: direction, reason: "vertical move did not identify displaced window")
+                return PureLayoutMoveDecision(plan: .unsupported, expectedSnapshot: expectedSnapshot)
             }
-            return .horizontalConsume(targetColumnIndexBeforeMove: targetColumnID)
+            return PureLayoutMoveDecision(plan: .verticalSwap(targetToken: displacedToken), expectedSnapshot: expectedSnapshot)
         }
 
-        return .unsupported
+        let sourceColumn = beforeWorkspace.columns[beforeActiveColumnIndex]
+        if sourceColumn.windows.count > 1 {
+            return PureLayoutMoveDecision(plan: .horizontalExpel, expectedSnapshot: expectedSnapshot)
+        }
+
+        guard let afterActiveColumnIndex = afterWorkspace.activeColumnIndex,
+              afterWorkspace.columns.indices.contains(afterActiveColumnIndex)
+        else {
+            logUnsupportedPureLayoutMove(direction: direction, reason: "horizontal consume missing active target column")
+            return PureLayoutMoveDecision(plan: .unsupported, expectedSnapshot: expectedSnapshot)
+        }
+
+        let targetColumnID = afterWorkspace.columns[afterActiveColumnIndex].id.rawValue
+        guard beforeWorkspace.columns.indices.contains(targetColumnID) else {
+            logUnsupportedPureLayoutMove(direction: direction, reason: "horizontal consume target does not map to a before column")
+            return PureLayoutMoveDecision(plan: .unsupported, expectedSnapshot: expectedSnapshot)
+        }
+        return PureLayoutMoveDecision(plan: .horizontalConsume(targetColumnIndexBeforeMove: targetColumnID), expectedSnapshot: expectedSnapshot)
+    }
+
+    private func logUnsupportedPureLayoutMove(direction: Direction, reason: String) {
+        Self.pureLayoutBridgeLogger.error("Unsupported PureLayout move transform for direction=\(direction.rawValue, privacy: .public): \(reason, privacy: .public)")
+        assertionFailure("Unsupported PureLayout move transform for direction=\(direction): \(reason)")
     }
 
     private static func pureLayoutSnapshot(

--- a/Sources/Nehir/Core/Layout/Niri/NiriLayoutEngine+PureLayoutBridge.swift
+++ b/Sources/Nehir/Core/Layout/Niri/NiriLayoutEngine+PureLayoutBridge.swift
@@ -42,7 +42,6 @@ extension NiriLayoutEngine {
         }
 
         let after = PureLayoutReducer.focus(pureDirection, in: before)
-        applyPureLayoutActiveTileIndices(after, in: workspaceId)
 
         guard after != before,
               let focusedToken = after.activeWorkspace?.focusedWindowID,
@@ -51,6 +50,7 @@ extension NiriLayoutEngine {
             return .handled(nil)
         }
 
+        applyPureLayoutActiveTileIndices(after, in: workspaceId)
         assertPureLayoutSnapshotMatches(
             Self.pureLayoutSnapshot(after),
             selectedWindow: target,
@@ -93,17 +93,11 @@ extension NiriLayoutEngine {
         in workspaceId: WorkspaceDescriptor.ID
     ) {
         guard let expected else { return }
-        guard let actualWorld = pureLayoutWorld(
-            in: workspaceId,
-            selectedWindow: selectedWindow,
-            infiniteLoop: effectiveInfiniteLoop(in: workspaceId)
-        ) else {
+        guard let actual = livePureLayoutSnapshot(in: workspaceId, selectedWindow: selectedWindow) else {
             Self.pureLayoutBridgeLogger.error("Niri runtime could not be snapshotted after pure layout operation")
             assertionFailure("Niri runtime could not be snapshotted after pure layout operation")
             return
         }
-
-        let actual = Self.pureLayoutSnapshot(actualWorld)
         guard actual != expected else { return }
 
         Self.pureLayoutBridgeLogger.error("Niri runtime diverged from PureLayoutReducer. expected=\(String(describing: expected), privacy: .public), actual=\(String(describing: actual), privacy: .public)")
@@ -119,9 +113,10 @@ extension NiriLayoutEngine {
         _ window: NiriWindow,
         direction: Direction,
         in workspaceId: WorkspaceDescriptor.ID,
-        allowEdgeWrap: Bool
+        allowEdgeWrap: Bool,
+        orientation: Monitor.Orientation
     ) -> PureLayoutMoveDecision {
-        guard let pureDirection = PureDirection(direction: direction, orientation: .horizontal),
+        guard let pureDirection = PureDirection(direction: direction, orientation: orientation),
               let before = pureLayoutWorld(
                   in: workspaceId,
                   selectedWindow: window,
@@ -145,29 +140,63 @@ extension NiriLayoutEngine {
         }
 
         if pureDirection.horizontalStep == nil {
-            guard let afterActiveColumnIndex = afterWorkspace.activeColumnIndex,
-                  afterWorkspace.columns.indices.contains(afterActiveColumnIndex),
-                  afterActiveColumnIndex == beforeActiveColumnIndex
-            else {
-                logUnsupportedPureLayoutMove(direction: direction, reason: "vertical move changed active column")
-                return PureLayoutMoveDecision(plan: .unsupported, expectedSnapshot: expectedSnapshot)
-            }
-
-            let beforeColumn = beforeWorkspace.columns[beforeActiveColumnIndex]
-            let afterActiveWindowIndex = afterWorkspace.columns[afterActiveColumnIndex].activeWindowIndex
-            guard beforeColumn.windows.indices.contains(afterActiveWindowIndex) else {
-                logUnsupportedPureLayoutMove(direction: direction, reason: "vertical target index outside before column")
-                return PureLayoutMoveDecision(plan: .unsupported, expectedSnapshot: expectedSnapshot)
-            }
-
-            let displacedToken = beforeColumn.windows[afterActiveWindowIndex].id
-            guard displacedToken != window.token else {
-                logUnsupportedPureLayoutMove(direction: direction, reason: "vertical move did not identify displaced window")
-                return PureLayoutMoveDecision(plan: .unsupported, expectedSnapshot: expectedSnapshot)
-            }
-            return PureLayoutMoveDecision(plan: .verticalSwap(targetToken: displacedToken), expectedSnapshot: expectedSnapshot)
+            return classifyPureLayoutVerticalMove(
+                window: window,
+                direction: direction,
+                beforeWorkspace: beforeWorkspace,
+                beforeActiveColumnIndex: beforeActiveColumnIndex,
+                afterWorkspace: afterWorkspace,
+                expectedSnapshot: expectedSnapshot
+            )
         }
 
+        return classifyPureLayoutHorizontalMove(
+            direction: direction,
+            beforeWorkspace: beforeWorkspace,
+            beforeActiveColumnIndex: beforeActiveColumnIndex,
+            afterWorkspace: afterWorkspace,
+            expectedSnapshot: expectedSnapshot
+        )
+    }
+
+    private func classifyPureLayoutVerticalMove(
+        window: NiriWindow,
+        direction: Direction,
+        beforeWorkspace: CoreWorkspace<WorkspaceDescriptor.ID, WindowToken>,
+        beforeActiveColumnIndex: Int,
+        afterWorkspace: CoreWorkspace<WorkspaceDescriptor.ID, WindowToken>,
+        expectedSnapshot: PureLayoutSnapshot
+    ) -> PureLayoutMoveDecision {
+        guard let afterActiveColumnIndex = afterWorkspace.activeColumnIndex,
+              afterWorkspace.columns.indices.contains(afterActiveColumnIndex),
+              afterActiveColumnIndex == beforeActiveColumnIndex
+        else {
+            logUnsupportedPureLayoutMove(direction: direction, reason: "vertical move changed active column")
+            return PureLayoutMoveDecision(plan: .unsupported, expectedSnapshot: expectedSnapshot)
+        }
+
+        let beforeColumn = beforeWorkspace.columns[beforeActiveColumnIndex]
+        let afterActiveWindowIndex = afterWorkspace.columns[afterActiveColumnIndex].activeWindowIndex
+        guard beforeColumn.windows.indices.contains(afterActiveWindowIndex) else {
+            logUnsupportedPureLayoutMove(direction: direction, reason: "vertical target index outside before column")
+            return PureLayoutMoveDecision(plan: .unsupported, expectedSnapshot: expectedSnapshot)
+        }
+
+        let displacedToken = beforeColumn.windows[afterActiveWindowIndex].id
+        guard displacedToken != window.token else {
+            logUnsupportedPureLayoutMove(direction: direction, reason: "vertical move did not identify displaced window")
+            return PureLayoutMoveDecision(plan: .unsupported, expectedSnapshot: expectedSnapshot)
+        }
+        return PureLayoutMoveDecision(plan: .verticalSwap(targetToken: displacedToken), expectedSnapshot: expectedSnapshot)
+    }
+
+    private func classifyPureLayoutHorizontalMove(
+        direction: Direction,
+        beforeWorkspace: CoreWorkspace<WorkspaceDescriptor.ID, WindowToken>,
+        beforeActiveColumnIndex: Int,
+        afterWorkspace: CoreWorkspace<WorkspaceDescriptor.ID, WindowToken>,
+        expectedSnapshot: PureLayoutSnapshot
+    ) -> PureLayoutMoveDecision {
         let sourceColumn = beforeWorkspace.columns[beforeActiveColumnIndex]
         if sourceColumn.windows.count > 1 {
             return PureLayoutMoveDecision(plan: .horizontalExpel, expectedSnapshot: expectedSnapshot)
@@ -205,6 +234,46 @@ extension NiriLayoutEngine {
             activeColumnIndex: workspace.activeColumnIndex,
             activeWindowIndices: workspace.columns.map(\.activeWindowIndex),
             focusedWindowID: workspace.focusedWindowID
+        )
+    }
+
+    private func livePureLayoutSnapshot(
+        in workspaceId: WorkspaceDescriptor.ID,
+        selectedWindow: NiriWindow
+    ) -> PureLayoutSnapshot? {
+        let niriColumns = columns(in: workspaceId)
+        guard !niriColumns.isEmpty else { return nil }
+
+        var activeColumnIndex: Int?
+        var snapshotColumns: [[WindowToken]] = []
+        var activeWindowIndices: [Int] = []
+
+        for (columnIndex, column) in niriColumns.enumerated() {
+            let windows = column.windowNodes
+            guard !windows.isEmpty else { return nil }
+
+            if windows.contains(where: { $0 === selectedWindow }) {
+                activeColumnIndex = columnIndex
+            }
+
+            snapshotColumns.append(windows.map(\.token))
+            activeWindowIndices.append(min(max(column.activeTileIdx, 0), windows.count - 1))
+        }
+
+        let focusedWindowID = activeColumnIndex.flatMap { columnIndex -> WindowToken? in
+            guard snapshotColumns.indices.contains(columnIndex),
+                  activeWindowIndices.indices.contains(columnIndex)
+            else { return nil }
+            let activeWindowIndex = activeWindowIndices[columnIndex]
+            guard snapshotColumns[columnIndex].indices.contains(activeWindowIndex) else { return nil }
+            return snapshotColumns[columnIndex][activeWindowIndex]
+        }
+
+        return PureLayoutSnapshot(
+            columns: snapshotColumns,
+            activeColumnIndex: activeColumnIndex,
+            activeWindowIndices: activeWindowIndices,
+            focusedWindowID: focusedWindowID
         )
     }
 

--- a/Sources/Nehir/Core/Layout/Niri/NiriLayoutEngine+PureLayoutBridge.swift
+++ b/Sources/Nehir/Core/Layout/Niri/NiriLayoutEngine+PureLayoutBridge.swift
@@ -1,0 +1,173 @@
+import AppKit
+import Foundation
+
+extension NiriLayoutEngine {
+    enum PureLayoutFocusResult {
+        case handled(NiriNode?)
+        case unsupported
+    }
+
+    /// Uses the platform-free `PureLayoutReducer` as the focus decision engine,
+    /// then applies the resulting active-tile indices back onto the live Niri tree.
+    /// Geometry, viewport scrolling, and activation remain owned by Niri runtime code.
+    func pureLayoutFocusTarget(
+        direction: Direction,
+        currentSelection: NiriNode,
+        in workspaceId: WorkspaceDescriptor.ID,
+        motion: MotionSnapshot,
+        state: inout ViewportState,
+        workingFrame: CGRect,
+        gaps: CGFloat,
+        orientation: Monitor.Orientation
+    ) -> PureLayoutFocusResult {
+        guard let pureDirection = PureDirection(direction: direction, orientation: orientation),
+              let currentWindow = currentSelection as? NiriWindow,
+              let before = pureLayoutWorld(
+                  in: workspaceId,
+                  selectedWindow: currentWindow,
+                  infiniteLoop: effectiveInfiniteLoop(in: workspaceId)
+              )
+        else {
+            return .unsupported
+        }
+
+        let after = PureLayoutReducer.focus(pureDirection, in: before)
+        applyPureLayoutActiveTileIndices(after, in: workspaceId)
+
+        guard after != before,
+              let focusedToken = after.activeWorkspace?.focusedWindowID,
+              let target = findNode(for: focusedToken)
+        else {
+            return .handled(nil)
+        }
+
+        if direction.primaryStep(for: orientation) != nil {
+            state.activatePrevColumnOnRemoval = nil
+        }
+
+        ensureSelectionVisible(
+            node: target,
+            in: workspaceId,
+            motion: motion,
+            state: &state,
+            workingFrame: workingFrame,
+            gaps: gaps,
+            orientation: orientation
+        )
+
+        return .handled(target)
+    }
+
+    /// Returns whether `PureLayoutReducer` says the focused window move should
+    /// change the logical layout. `nil` means the bridge cannot model the current
+    /// runtime tree safely, so callers should fall back to existing Niri logic.
+    func pureLayoutMoveWouldChange(
+        _ window: NiriWindow,
+        direction: Direction,
+        in workspaceId: WorkspaceDescriptor.ID,
+        allowEdgeWrap: Bool
+    ) -> Bool? {
+        guard let pureDirection = PureDirection(direction: direction, orientation: .horizontal),
+              let before = pureLayoutWorld(
+                  in: workspaceId,
+                  selectedWindow: window,
+                  infiniteLoop: allowEdgeWrap && effectiveInfiniteLoop(in: workspaceId)
+              )
+        else {
+            return nil
+        }
+
+        let after = PureLayoutReducer.moveFocusedWindow(pureDirection, in: before)
+        return after != before
+    }
+
+    private func pureLayoutWorld(
+        in workspaceId: WorkspaceDescriptor.ID,
+        selectedWindow: NiriWindow,
+        infiniteLoop: Bool
+    ) -> CoreWorld<WorkspaceDescriptor.ID, WindowToken>? {
+        let niriColumns = columns(in: workspaceId)
+        guard !niriColumns.isEmpty else { return nil }
+
+        var activeColumnIndex: Int?
+        var coreColumns: [CoreColumn<WindowToken>] = []
+
+        for (columnIndex, column) in niriColumns.enumerated() {
+            let windows = column.windowNodes
+            guard !windows.isEmpty else { return nil }
+
+            let selectedIndex = windows.firstIndex { $0 === selectedWindow }
+            let clampedActiveIndex = min(max(column.activeTileIdx, 0), windows.count - 1)
+            let activeWindowIndex = selectedIndex ?? clampedActiveIndex
+
+            if selectedIndex != nil {
+                activeColumnIndex = columnIndex
+            }
+
+            coreColumns.append(
+                CoreColumn(
+                    id: CoreColumnID(rawValue: columnIndex),
+                    windows: windows.map { CoreWindow(id: $0.token) },
+                    activeWindowIndex: activeWindowIndex
+                )
+            )
+        }
+
+        guard let activeColumnIndex else { return nil }
+
+        return CoreWorld(
+            workspaces: [
+                CoreWorkspace(
+                    id: workspaceId,
+                    columns: coreColumns,
+                    activeColumnIndex: activeColumnIndex
+                )
+            ],
+            activeWorkspaceIndex: 0,
+            nextColumnID: coreColumns.count,
+            config: PureLayoutConfig(infiniteLoop: infiniteLoop)
+        )
+    }
+
+    private func applyPureLayoutActiveTileIndices(
+        _ world: CoreWorld<WorkspaceDescriptor.ID, WindowToken>,
+        in workspaceId: WorkspaceDescriptor.ID
+    ) {
+        guard let workspace = world.activeWorkspace else { return }
+        let niriColumns = columns(in: workspaceId)
+
+        for (index, pureColumn) in workspace.columns.enumerated() where niriColumns.indices.contains(index) {
+            let niriColumn = niriColumns[index]
+            guard !niriColumn.windowNodes.isEmpty else { continue }
+            let clampedActiveIndex = min(max(pureColumn.activeWindowIndex, 0), niriColumn.windowNodes.count - 1)
+            niriColumn.setActiveTileIdx(clampedActiveIndex)
+            updateTabbedColumnVisibility(column: niriColumn)
+        }
+    }
+}
+
+private extension PureDirection {
+    /// Maps display-space directions onto PureLayout's logical axes.
+    ///
+    /// PureLayout models columns on its horizontal axis and stack position on its
+    /// vertical axis. A vertical monitor rotates the user's display-space commands:
+    /// up/down move between columns, while left/right move within a stack.
+    init?(direction: Direction, orientation: Monitor.Orientation) {
+        switch orientation {
+        case .horizontal:
+            switch direction {
+            case .left: self = .left
+            case .right: self = .right
+            case .up: self = .up
+            case .down: self = .down
+            }
+        case .vertical:
+            switch direction {
+            case .up: self = .left
+            case .down: self = .right
+            case .right: self = .up
+            case .left: self = .down
+            }
+        }
+    }
+}

--- a/Sources/Nehir/Core/Layout/Niri/NiriLayoutEngine+WindowOps.swift
+++ b/Sources/Nehir/Core/Layout/Niri/NiriLayoutEngine+WindowOps.swift
@@ -14,11 +14,17 @@ extension NiriLayoutEngine {
         switch direction {
         case .down,
              .up:
-            switch pureLayoutMovePlan(node, direction: direction, in: workspaceId, allowEdgeWrap: true) {
+            let purePlan = pureLayoutMovePlan(node, direction: direction, in: workspaceId, allowEdgeWrap: true)
+            switch purePlan {
             case .noChange:
                 return false
             case let .verticalSwap(targetToken):
-                return moveWindowVertical(node, targetToken: targetToken)
+                let expected = pureLayoutExpectedMoveSnapshot(node, direction: direction, in: workspaceId, allowEdgeWrap: true)
+                let moved = moveWindowVertical(node, targetToken: targetToken)
+                if moved {
+                    assertPureLayoutSnapshotMatches(expected, selectedWindow: node, in: workspaceId)
+                }
+                return moved
             case .unsupported:
                 return moveWindowVertical(node, direction: direction)
             case .horizontalConsume,

--- a/Sources/Nehir/Core/Layout/Niri/NiriLayoutEngine+WindowOps.swift
+++ b/Sources/Nehir/Core/Layout/Niri/NiriLayoutEngine+WindowOps.swift
@@ -14,15 +14,17 @@ extension NiriLayoutEngine {
         switch direction {
         case .down,
              .up:
-            if let pureWouldChange = pureLayoutMoveWouldChange(
-                node,
-                direction: direction,
-                in: workspaceId,
-                allowEdgeWrap: true
-            ), !pureWouldChange {
+            switch pureLayoutMovePlan(node, direction: direction, in: workspaceId, allowEdgeWrap: true) {
+            case .noChange:
+                return false
+            case let .verticalSwap(targetToken):
+                return moveWindowVertical(node, targetToken: targetToken)
+            case .unsupported:
+                return moveWindowVertical(node, direction: direction)
+            case .horizontalConsume,
+                 .horizontalExpel:
                 return false
             }
-            return moveWindowVertical(node, direction: direction)
         case .left,
              .right:
             return consumeOrExpelWindow(
@@ -38,10 +40,6 @@ extension NiriLayoutEngine {
     }
 
     private func moveWindowVertical(_ node: NiriWindow, direction: Direction) -> Bool {
-        guard let column = node.parent as? NiriContainer else {
-            return false
-        }
-
         let sibling: NiriNode?
         switch direction {
         case .up:
@@ -52,14 +50,30 @@ extension NiriLayoutEngine {
             return false
         }
 
-        guard let targetSibling = sibling else {
+        guard let targetSibling = sibling as? NiriWindow else {
+            return false
+        }
+
+        return moveWindowVertical(node, targetWindow: targetSibling)
+    }
+
+    private func moveWindowVertical(_ node: NiriWindow, targetToken: WindowToken) -> Bool {
+        guard let targetWindow = findNode(for: targetToken) else { return false }
+        return moveWindowVertical(node, targetWindow: targetWindow)
+    }
+
+    private func moveWindowVertical(_ node: NiriWindow, targetWindow: NiriWindow) -> Bool {
+        guard let column = node.parent as? NiriContainer,
+              targetWindow.parent === column,
+              targetWindow !== node
+        else {
             return false
         }
 
         let nodeIdx = column.windowNodes.firstIndex { $0 === node }
-        let siblingIdx = column.windowNodes.firstIndex { $0 === targetSibling }
+        let siblingIdx = column.windowNodes.firstIndex { $0 === targetWindow }
 
-        node.swapWith(targetSibling)
+        node.swapWith(targetWindow)
 
         if column.displayMode == .tabbed, let nIdx = nodeIdx, let sIdx = siblingIdx {
             if nIdx == column.activeTileIdx {

--- a/Sources/Nehir/Core/Layout/Niri/NiriLayoutEngine+WindowOps.swift
+++ b/Sources/Nehir/Core/Layout/Niri/NiriLayoutEngine+WindowOps.swift
@@ -14,10 +14,18 @@ extension NiriLayoutEngine {
         switch direction {
         case .down,
              .up:
-            moveWindowVertical(node, direction: direction)
+            if let pureWouldChange = pureLayoutMoveWouldChange(
+                node,
+                direction: direction,
+                in: workspaceId,
+                allowEdgeWrap: true
+            ), !pureWouldChange {
+                return false
+            }
+            return moveWindowVertical(node, direction: direction)
         case .left,
              .right:
-            consumeOrExpelWindow(
+            return consumeOrExpelWindow(
                 node,
                 direction: direction,
                 in: workspaceId,

--- a/Sources/Nehir/Core/Layout/Niri/NiriLayoutEngine+WindowOps.swift
+++ b/Sources/Nehir/Core/Layout/Niri/NiriLayoutEngine+WindowOps.swift
@@ -14,15 +14,14 @@ extension NiriLayoutEngine {
         switch direction {
         case .down,
              .up:
-            let purePlan = pureLayoutMovePlan(node, direction: direction, in: workspaceId, allowEdgeWrap: true)
-            switch purePlan {
+            let pureDecision = pureLayoutMoveDecision(node, direction: direction, in: workspaceId, allowEdgeWrap: true)
+            switch pureDecision.plan {
             case .noChange:
                 return false
             case let .verticalSwap(targetToken):
-                let expected = pureLayoutExpectedMoveSnapshot(node, direction: direction, in: workspaceId, allowEdgeWrap: true)
                 let moved = moveWindowVertical(node, targetToken: targetToken)
                 if moved {
-                    assertPureLayoutSnapshotMatches(expected, selectedWindow: node, in: workspaceId)
+                    assertPureLayoutSnapshotMatches(pureDecision.expectedSnapshot, selectedWindow: node, in: workspaceId)
                 }
                 return moved
             case .unsupported:

--- a/Sources/Nehir/Core/Layout/Niri/NiriLayoutEngine+WindowOps.swift
+++ b/Sources/Nehir/Core/Layout/Niri/NiriLayoutEngine+WindowOps.swift
@@ -9,29 +9,10 @@ extension NiriLayoutEngine {
         motion: MotionSnapshot,
         state: inout ViewportState,
         workingFrame: CGRect,
-        gaps: CGFloat
+        gaps: CGFloat,
+        orientation: Monitor.Orientation = .horizontal
     ) -> Bool {
-        switch direction {
-        case .down,
-             .up:
-            let pureDecision = pureLayoutMoveDecision(node, direction: direction, in: workspaceId, allowEdgeWrap: true)
-            switch pureDecision.plan {
-            case .noChange:
-                return false
-            case let .verticalSwap(targetToken):
-                let moved = moveWindowVertical(node, targetToken: targetToken)
-                if moved {
-                    assertPureLayoutSnapshotMatches(pureDecision.expectedSnapshot, selectedWindow: node, in: workspaceId)
-                }
-                return moved
-            case .unsupported:
-                return moveWindowVertical(node, direction: direction)
-            case .horizontalConsume,
-                 .horizontalExpel:
-                return false
-            }
-        case .left,
-             .right:
+        if direction.primaryStep(for: orientation) != nil {
             return consumeOrExpelWindow(
                 node,
                 direction: direction,
@@ -39,26 +20,45 @@ extension NiriLayoutEngine {
                 motion: motion,
                 state: &state,
                 workingFrame: workingFrame,
-                gaps: gaps
+                gaps: gaps,
+                orientation: orientation
             )
+        }
+
+        guard direction.secondaryStep(for: orientation) != nil else { return false }
+
+        let pureDecision = pureLayoutMoveDecision(
+            node,
+            direction: direction,
+            in: workspaceId,
+            allowEdgeWrap: true,
+            orientation: orientation
+        )
+        switch pureDecision.plan {
+        case .noChange:
+            return false
+        case let .verticalSwap(targetToken):
+            let moved = moveWindowVertical(node, targetToken: targetToken)
+            if moved {
+                assertPureLayoutSnapshotMatches(pureDecision.expectedSnapshot, selectedWindow: node, in: workspaceId)
+            }
+            return moved
+        case .unsupported:
+            return moveWindowVertical(node, direction: direction, orientation: orientation)
+        case .horizontalConsume,
+             .horizontalExpel:
+            return false
         }
     }
 
-    private func moveWindowVertical(_ node: NiriWindow, direction: Direction) -> Bool {
-        let sibling: NiriNode?
-        switch direction {
-        case .up:
-            sibling = node.nextSibling()
-        case .down:
-            sibling = node.prevSibling()
-        default:
-            return false
-        }
-
-        guard let targetSibling = sibling as? NiriWindow else {
-            return false
-        }
-
+    private func moveWindowVertical(
+        _ node: NiriWindow,
+        direction: Direction,
+        orientation: Monitor.Orientation
+    ) -> Bool {
+        guard let step = direction.secondaryStep(for: orientation) else { return false }
+        let sibling = step > 0 ? node.nextSibling() : node.prevSibling()
+        guard let targetSibling = sibling as? NiriWindow else { return false }
         return moveWindowVertical(node, targetWindow: targetSibling)
     }
 
@@ -75,17 +75,13 @@ extension NiriLayoutEngine {
             return false
         }
 
-        let nodeIdx = column.windowNodes.firstIndex { $0 === node }
-        let siblingIdx = column.windowNodes.firstIndex { $0 === targetWindow }
-
         node.swapWith(targetWindow)
 
-        if column.displayMode == .tabbed, let nIdx = nodeIdx, let sIdx = siblingIdx {
-            if nIdx == column.activeTileIdx {
-                column.setActiveTileIdx(sIdx)
-            } else if sIdx == column.activeTileIdx {
-                column.setActiveTileIdx(nIdx)
-            }
+        if let movedIndex = column.windowNodes.firstIndex(where: { $0 === node }) {
+            column.setActiveTileIdx(movedIndex)
+        }
+        if column.displayMode == .tabbed {
+            updateTabbedColumnVisibility(column: column)
         }
 
         return true

--- a/Sources/Nehir/Core/Layout/Niri/NiriNavigation.swift
+++ b/Sources/Nehir/Core/Layout/Niri/NiriNavigation.swift
@@ -248,6 +248,22 @@ extension NiriLayoutEngine {
         gaps: CGFloat,
         orientation: Monitor.Orientation = .horizontal
     ) -> NiriNode? {
+        switch pureLayoutFocusTarget(
+            direction: direction,
+            currentSelection: currentSelection,
+            in: workspaceId,
+            motion: motion,
+            state: &state,
+            workingFrame: workingFrame,
+            gaps: gaps,
+            orientation: orientation
+        ) {
+        case let .handled(target):
+            return target
+        case .unsupported:
+            break
+        }
+
         if direction.primaryStep(for: orientation) != nil {
             return moveSelectionCrossContainer(
                 direction: direction,

--- a/Sources/Nehir/Core/PureLayout/PureDirection.swift
+++ b/Sources/Nehir/Core/PureLayout/PureDirection.swift
@@ -1,0 +1,26 @@
+import Foundation
+
+enum PureDirection: Equatable {
+    case left
+    case right
+    case up
+    case down
+
+    var horizontalStep: Int? {
+        switch self {
+        case .left: -1
+        case .right: 1
+        case .up, .down: nil
+        }
+    }
+
+    /// Storage-order step for vertical movement/focus.
+    /// Storage index 0 is visual bottom, so visual up is +1 and visual down is -1.
+    var verticalStorageStep: Int? {
+        switch self {
+        case .up: 1
+        case .down: -1
+        case .left, .right: nil
+        }
+    }
+}

--- a/Sources/Nehir/Core/PureLayout/PureLayoutInvariants.swift
+++ b/Sources/Nehir/Core/PureLayout/PureLayoutInvariants.swift
@@ -1,0 +1,60 @@
+import Foundation
+
+struct PureLayoutInvariantViolation: Equatable, CustomStringConvertible {
+    var message: String
+
+    var description: String { message }
+}
+
+enum PureLayoutInvariants {
+    static func validate<WSID: Hashable, ID: Hashable>(
+        _ world: CoreWorld<WSID, ID>
+    ) -> [PureLayoutInvariantViolation] {
+        var violations: [PureLayoutInvariantViolation] = []
+
+        if !world.workspaces.isEmpty, !world.workspaces.indices.contains(world.activeWorkspaceIndex) {
+            violations.append(.init(message: "activeWorkspaceIndex is out of bounds"))
+        }
+
+        var windowIDs = Set<ID>()
+        var maxColumnID = Int.min
+
+        for (workspaceIndex, workspace) in world.workspaces.enumerated() {
+            if workspace.columns.isEmpty {
+                if workspace.activeColumnIndex != nil {
+                    violations.append(.init(message: "empty workspace at index \(workspaceIndex) has activeColumnIndex"))
+                }
+            } else {
+                if workspace.activeColumnIndex == nil || !workspace.columns.indices.contains(workspace.activeColumnIndex!) {
+                    violations.append(.init(message: "workspace at index \(workspaceIndex) has invalid activeColumnIndex"))
+                }
+            }
+
+            var columnIDs = Set<CoreColumnID>()
+            for (columnIndex, column) in workspace.columns.enumerated() {
+                if !columnIDs.insert(column.id).inserted {
+                    violations.append(.init(message: "duplicate column id \(column.id.rawValue) in workspace index \(workspaceIndex)"))
+                }
+                maxColumnID = max(maxColumnID, column.id.rawValue)
+
+                if column.windows.isEmpty {
+                    violations.append(.init(message: "empty column at workspace index \(workspaceIndex), column index \(columnIndex)"))
+                } else if !column.windows.indices.contains(column.activeWindowIndex) {
+                    violations.append(.init(message: "column at workspace index \(workspaceIndex), column index \(columnIndex) has invalid activeWindowIndex"))
+                }
+
+                for window in column.windows {
+                    if !windowIDs.insert(window.id).inserted {
+                        violations.append(.init(message: "duplicate window id \(window.id)"))
+                    }
+                }
+            }
+        }
+
+        if maxColumnID != Int.min, world.nextColumnID <= maxColumnID {
+            violations.append(.init(message: "nextColumnID must be greater than existing column ids"))
+        }
+
+        return violations
+    }
+}

--- a/Sources/Nehir/Core/PureLayout/PureLayoutModels.swift
+++ b/Sources/Nehir/Core/PureLayout/PureLayoutModels.swift
@@ -1,0 +1,58 @@
+import Foundation
+
+struct PureLayoutConfig: Equatable {
+    var infiniteLoop: Bool = false
+}
+
+struct CoreColumnID: Hashable, Equatable {
+    var rawValue: Int
+}
+
+struct CoreWindow<ID: Hashable>: Equatable {
+    var id: ID
+}
+
+struct CoreColumn<ID: Hashable>: Equatable {
+    var id: CoreColumnID
+
+    /// Storage order, not visual order. Index 0 is visual bottom.
+    var windows: [CoreWindow<ID>]
+
+    /// Storage index of the active/focused tile within this column.
+    var activeWindowIndex: Int
+}
+
+struct CoreWorkspace<WSID: Hashable, ID: Hashable>: Equatable {
+    var id: WSID
+    var columns: [CoreColumn<ID>]
+
+    /// Nil only when the workspace has zero columns/windows.
+    var activeColumnIndex: Int?
+}
+
+struct CoreWorld<WSID: Hashable, ID: Hashable>: Equatable {
+    var workspaces: [CoreWorkspace<WSID, ID>]
+    var activeWorkspaceIndex: Int
+    var nextColumnID: Int
+    var config: PureLayoutConfig
+}
+
+extension CoreWorkspace {
+    var activeColumn: CoreColumn<ID>? {
+        guard let activeColumnIndex, columns.indices.contains(activeColumnIndex) else { return nil }
+        return columns[activeColumnIndex]
+    }
+
+    var focusedWindowID: ID? {
+        guard let activeColumn else { return nil }
+        guard activeColumn.windows.indices.contains(activeColumn.activeWindowIndex) else { return nil }
+        return activeColumn.windows[activeColumn.activeWindowIndex].id
+    }
+}
+
+extension CoreWorld {
+    var activeWorkspace: CoreWorkspace<WSID, ID>? {
+        guard workspaces.indices.contains(activeWorkspaceIndex) else { return nil }
+        return workspaces[activeWorkspaceIndex]
+    }
+}

--- a/Sources/Nehir/Core/PureLayout/PureLayoutReducer.swift
+++ b/Sources/Nehir/Core/PureLayout/PureLayoutReducer.swift
@@ -1,0 +1,215 @@
+import Foundation
+
+enum PureLayoutReducer {
+    static func focus<WSID: Hashable, ID: Hashable>(
+        _ direction: PureDirection,
+        in world: CoreWorld<WSID, ID>
+    ) -> CoreWorld<WSID, ID> {
+        guard let horizontalStep = direction.horizontalStep else {
+            return focusVertical(direction, in: world)
+        }
+
+        var result = world
+        guard let workspaceIndex = activeWorkspaceIndex(in: result),
+              let activeColumnIndex = result.workspaces[workspaceIndex].activeColumnIndex
+        else { return world }
+
+        let columns = result.workspaces[workspaceIndex].columns
+        guard let targetColumnIndex = resolvedIndex(
+            activeColumnIndex + horizontalStep,
+            count: columns.count,
+            wrapping: result.config.infiniteLoop
+        ) else { return world }
+
+        result.workspaces[workspaceIndex].columns[targetColumnIndex].clampActiveWindowIndex()
+        result.workspaces[workspaceIndex].activeColumnIndex = targetColumnIndex
+        return validated(result)
+    }
+
+    static func moveFocusedWindow<WSID: Hashable, ID: Hashable>(
+        _ direction: PureDirection,
+        in world: CoreWorld<WSID, ID>
+    ) -> CoreWorld<WSID, ID> {
+        if direction.horizontalStep != nil {
+            return moveFocusedWindowHorizontal(direction, in: world)
+        }
+        return moveFocusedWindowVertical(direction, in: world)
+    }
+
+    static func switchWorkspace<WSID: Hashable, ID: Hashable>(
+        by delta: Int,
+        in world: CoreWorld<WSID, ID>
+    ) -> CoreWorld<WSID, ID> {
+        guard delta != 0 else { return world }
+        let targetWorkspaceIndex = world.activeWorkspaceIndex + delta
+        guard world.workspaces.indices.contains(targetWorkspaceIndex) else { return world }
+
+        var result = world
+        result.activeWorkspaceIndex = targetWorkspaceIndex
+
+        if result.workspaces[targetWorkspaceIndex].columns.isEmpty {
+            result.workspaces[targetWorkspaceIndex].activeColumnIndex = nil
+        } else {
+            result.workspaces[targetWorkspaceIndex].activeColumnIndex = 0
+            let windowCount = result.workspaces[targetWorkspaceIndex].columns[0].windows.count
+            result.workspaces[targetWorkspaceIndex].columns[0].activeWindowIndex = max(0, windowCount - 1)
+        }
+
+        return validated(result)
+    }
+
+    static func focusWindow<WSID: Hashable, ID: Hashable>(
+        columnIndex: Int,
+        windowStorageIndex: Int,
+        in world: CoreWorld<WSID, ID>
+    ) -> CoreWorld<WSID, ID> {
+        var result = world
+        guard let workspaceIndex = activeWorkspaceIndex(in: result),
+              result.workspaces[workspaceIndex].columns.indices.contains(columnIndex),
+              result.workspaces[workspaceIndex].columns[columnIndex].windows.indices.contains(windowStorageIndex)
+        else { return world }
+
+        result.workspaces[workspaceIndex].activeColumnIndex = columnIndex
+        result.workspaces[workspaceIndex].columns[columnIndex].activeWindowIndex = windowStorageIndex
+        return validated(result)
+    }
+
+    private static func focusVertical<WSID: Hashable, ID: Hashable>(
+        _ direction: PureDirection,
+        in world: CoreWorld<WSID, ID>
+    ) -> CoreWorld<WSID, ID> {
+        guard let step = direction.verticalStorageStep else { return world }
+        var result = world
+        guard let workspaceIndex = activeWorkspaceIndex(in: result),
+              let activeColumnIndex = result.workspaces[workspaceIndex].activeColumnIndex,
+              result.workspaces[workspaceIndex].columns.indices.contains(activeColumnIndex)
+        else { return world }
+
+        let currentWindowIndex = result.workspaces[workspaceIndex].columns[activeColumnIndex].activeWindowIndex
+        let targetWindowIndex = currentWindowIndex + step
+        guard result.workspaces[workspaceIndex].columns[activeColumnIndex].windows.indices.contains(targetWindowIndex) else {
+            return world
+        }
+
+        result.workspaces[workspaceIndex].columns[activeColumnIndex].activeWindowIndex = targetWindowIndex
+        return validated(result)
+    }
+
+    private static func moveFocusedWindowHorizontal<WSID: Hashable, ID: Hashable>(
+        _ direction: PureDirection,
+        in world: CoreWorld<WSID, ID>
+    ) -> CoreWorld<WSID, ID> {
+        guard let step = direction.horizontalStep else { return world }
+        var result = world
+        guard let workspaceIndex = activeWorkspaceIndex(in: result),
+              let sourceColumnIndex = result.workspaces[workspaceIndex].activeColumnIndex,
+              result.workspaces[workspaceIndex].columns.indices.contains(sourceColumnIndex)
+        else { return world }
+
+        let sourceColumn = result.workspaces[workspaceIndex].columns[sourceColumnIndex]
+        guard sourceColumn.windows.indices.contains(sourceColumn.activeWindowIndex) else { return world }
+
+        if sourceColumn.windows.count > 1 {
+            return expelFocusedWindow(direction: direction, in: result, workspaceIndex: workspaceIndex, sourceColumnIndex: sourceColumnIndex)
+        }
+
+        let columns = result.workspaces[workspaceIndex].columns
+        guard let neighborIndex = resolvedIndex(
+            sourceColumnIndex + step,
+            count: columns.count,
+            wrapping: result.config.infiniteLoop
+        ), neighborIndex != sourceColumnIndex
+        else { return world }
+
+        let neighborID = columns[neighborIndex].id
+        let movedWindow = sourceColumn.windows[sourceColumn.activeWindowIndex]
+        result.workspaces[workspaceIndex].columns.remove(at: sourceColumnIndex)
+        guard let targetIndexAfterRemoval = result.workspaces[workspaceIndex].columns.firstIndex(where: { $0.id == neighborID }) else {
+            return world
+        }
+
+        result.workspaces[workspaceIndex].columns[targetIndexAfterRemoval].windows.insert(movedWindow, at: 0)
+        result.workspaces[workspaceIndex].columns[targetIndexAfterRemoval].activeWindowIndex = 0
+        result.workspaces[workspaceIndex].activeColumnIndex = targetIndexAfterRemoval
+        return validated(result)
+    }
+
+    private static func expelFocusedWindow<WSID: Hashable, ID: Hashable>(
+        direction: PureDirection,
+        in world: CoreWorld<WSID, ID>,
+        workspaceIndex: Int,
+        sourceColumnIndex: Int
+    ) -> CoreWorld<WSID, ID> {
+        var result = world
+        guard let step = direction.horizontalStep else { return world }
+        let activeWindowIndex = result.workspaces[workspaceIndex].columns[sourceColumnIndex].activeWindowIndex
+        let movedWindow = result.workspaces[workspaceIndex].columns[sourceColumnIndex].windows.remove(at: activeWindowIndex)
+        result.workspaces[workspaceIndex].columns[sourceColumnIndex].clampActiveWindowIndex()
+
+        let newColumn = CoreColumn(
+            id: CoreColumnID(rawValue: result.nextColumnID),
+            windows: [movedWindow],
+            activeWindowIndex: 0
+        )
+        result.nextColumnID += 1
+
+        let insertionIndex = step > 0 ? sourceColumnIndex + 1 : sourceColumnIndex
+        result.workspaces[workspaceIndex].columns.insert(newColumn, at: insertionIndex)
+        result.workspaces[workspaceIndex].activeColumnIndex = insertionIndex
+        return validated(result)
+    }
+
+    private static func moveFocusedWindowVertical<WSID: Hashable, ID: Hashable>(
+        _ direction: PureDirection,
+        in world: CoreWorld<WSID, ID>
+    ) -> CoreWorld<WSID, ID> {
+        guard let step = direction.verticalStorageStep else { return world }
+        var result = world
+        guard let workspaceIndex = activeWorkspaceIndex(in: result),
+              let activeColumnIndex = result.workspaces[workspaceIndex].activeColumnIndex,
+              result.workspaces[workspaceIndex].columns.indices.contains(activeColumnIndex)
+        else { return world }
+
+        let currentIndex = result.workspaces[workspaceIndex].columns[activeColumnIndex].activeWindowIndex
+        let targetIndex = currentIndex + step
+        guard result.workspaces[workspaceIndex].columns[activeColumnIndex].windows.indices.contains(targetIndex) else {
+            return world
+        }
+
+        result.workspaces[workspaceIndex].columns[activeColumnIndex].windows.swapAt(currentIndex, targetIndex)
+        result.workspaces[workspaceIndex].columns[activeColumnIndex].activeWindowIndex = targetIndex
+        return validated(result)
+    }
+
+    private static func activeWorkspaceIndex<WSID: Hashable, ID: Hashable>(
+        in world: CoreWorld<WSID, ID>
+    ) -> Int? {
+        guard world.workspaces.indices.contains(world.activeWorkspaceIndex) else { return nil }
+        return world.activeWorkspaceIndex
+    }
+
+    private static func resolvedIndex(_ index: Int, count: Int, wrapping: Bool) -> Int? {
+        guard count > 0 else { return nil }
+        if wrapping {
+            return ((index % count) + count) % count
+        }
+        return (0 ..< count).contains(index) ? index : nil
+    }
+
+    private static func validated<WSID: Hashable, ID: Hashable>(
+        _ world: CoreWorld<WSID, ID>
+    ) -> CoreWorld<WSID, ID> {
+        assert(PureLayoutInvariants.validate(world).isEmpty)
+        return world
+    }
+}
+
+private extension CoreColumn {
+    mutating func clampActiveWindowIndex() {
+        if windows.isEmpty {
+            activeWindowIndex = 0
+        } else {
+            activeWindowIndex = min(max(activeWindowIndex, 0), windows.count - 1)
+        }
+    }
+}

--- a/Sources/Nehir/UI/Onboarding/InteractiveMoveDemo.swift
+++ b/Sources/Nehir/UI/Onboarding/InteractiveMoveDemo.swift
@@ -16,6 +16,7 @@ final class MoveDemoModel: ObservableObject {
 
     struct Column: Identifiable, Equatable {
         let id: Int
+        /// Visual order, top-to-bottom, for SwiftUI rendering and hit-testing.
         var windows: [Window]
         var count: Int { windows.count }
     }
@@ -33,10 +34,7 @@ final class MoveDemoModel: ObservableObject {
         let action: String
     }
 
-    @Published private(set) var workspaces: [Workspace]
-    @Published private(set) var currentWorkspaceIndex: Int = 0
-    @Published private(set) var focusedColumnId: Int
-    @Published private(set) var focusedWindowId: Int
+    @Published private var world: CoreWorld<Int, Int>
 
     /// Horizontal scroll position (left-origin). `0` shows the leftmost columns; the track
     /// is offset by `-scrollX`.
@@ -49,7 +47,8 @@ final class MoveDemoModel: ObservableObject {
     @Published var paletteOpen = false
     @Published var paletteSelection = 0
 
-    private var columnIdSeed: Int
+    private var symbolsByWindowID: [Int: String]
+    private var workspaceLabelsByID: [Int: String]
 
     // Fixed geometry so scroll math is deterministic (never derived from measured layout).
     let viewportWidth: CGFloat = 150
@@ -95,27 +94,44 @@ final class MoveDemoModel: ObservableObject {
             let symbol = ws2Symbols[(i + 2) % ws2Symbols.count]
             return Column(id: 200 + i, windows: [Window(id: 200 + i, symbol: symbol)])
         }
-        workspaces = [
+        let seededWorkspaces = [
             Workspace(id: 0, label: "1", columns: ws0),
             Workspace(id: 1, label: "2", columns: ws1),
             Workspace(id: 2, label: "3", columns: ws2)
         ]
-        columnIdSeed = 1000
-        focusedColumnId = ws0.first?.id ?? 0
-        focusedWindowId = ws0.first?.windows.first?.id ?? 0
-    }
 
-    private func nextColumnId() -> Int {
-        columnIdSeed += 1
-        return columnIdSeed
+        symbolsByWindowID = Dictionary(
+            uniqueKeysWithValues: seededWorkspaces
+                .flatMap(\.columns)
+                .flatMap(\.windows)
+                .map { ($0.id, $0.symbol) }
+        )
+        workspaceLabelsByID = Dictionary(uniqueKeysWithValues: seededWorkspaces.map { ($0.id, $0.label) })
+        world = Self.makeWorld(fromVisualWorkspaces: seededWorkspaces, nextColumnID: 1001)
     }
 
     // MARK: Derived
 
+    var workspaces: [Workspace] { Self.makeVisualWorkspaces(from: world, symbolsByWindowID: symbolsByWindowID, labelsByWorkspaceID: workspaceLabelsByID) }
+
+    var currentWorkspaceIndex: Int { world.activeWorkspaceIndex }
+
+    var focusedColumnId: Int {
+        guard let workspace = world.activeWorkspace,
+              let activeColumnIndex = workspace.activeColumnIndex,
+              workspace.columns.indices.contains(activeColumnIndex)
+        else { return 0 }
+        return workspace.columns[activeColumnIndex].id.rawValue
+    }
+
+    var focusedWindowId: Int {
+        world.activeWorkspace?.focusedWindowID ?? 0
+    }
+
     var currentWorkspace: Workspace { workspaces[currentWorkspaceIndex] }
 
     private var focusedColumnIndex: Int? {
-        workspaces[currentWorkspaceIndex].columns.firstIndex { $0.id == focusedColumnId }
+        world.activeWorkspace?.activeColumnIndex
     }
 
     var contentWidth: CGFloat {
@@ -155,31 +171,102 @@ final class MoveDemoModel: ObservableObject {
         animateFocusIfNeeded { self.scrollX = target }
     }
 
+    private static func makeWorld(fromVisualWorkspaces workspaces: [Workspace], nextColumnID: Int) -> CoreWorld<Int, Int> {
+        CoreWorld(
+            workspaces: workspaces.map { workspace in
+                CoreWorkspace(
+                    id: workspace.id,
+                    columns: workspace.columns.map { column in
+                        let storageWindows = column.windows.reversed().map { CoreWindow(id: $0.id) }
+                        return CoreColumn(
+                            id: CoreColumnID(rawValue: column.id),
+                            windows: Array(storageWindows),
+                            activeWindowIndex: max(0, column.windows.count - 1)
+                        )
+                    },
+                    activeColumnIndex: workspace.columns.isEmpty ? nil : 0
+                )
+            },
+            activeWorkspaceIndex: 0,
+            nextColumnID: nextColumnID,
+            config: PureLayoutConfig(infiniteLoop: false)
+        )
+    }
+
+    private static func makeVisualWorkspaces(
+        from world: CoreWorld<Int, Int>,
+        symbolsByWindowID: [Int: String],
+        labelsByWorkspaceID: [Int: String]
+    ) -> [Workspace] {
+        world.workspaces.map { workspace in
+            Workspace(
+                id: workspace.id,
+                label: labelsByWorkspaceID[workspace.id] ?? "\(workspace.id)",
+                columns: workspace.columns.map { column in
+                    Column(
+                        id: column.id.rawValue,
+                        windows: column.windows.reversed().map { window in
+                            Window(id: window.id, symbol: symbolsByWindowID[window.id] ?? Self.symbols[abs(window.id) % Self.symbols.count])
+                        }
+                    )
+                }
+            )
+        }
+    }
+
+    private static func focusedColumnID(in world: CoreWorld<Int, Int>) -> Int? {
+        guard let workspace = world.activeWorkspace,
+              let activeColumnIndex = workspace.activeColumnIndex,
+              workspace.columns.indices.contains(activeColumnIndex)
+        else { return nil }
+        return workspace.columns[activeColumnIndex].id.rawValue
+    }
+
+    private func commitWorld(_ newWorld: CoreWorld<Int, Int>, resetScroll: Bool = false, scrollToFocusedColumn: Bool = true) {
+        guard newWorld != world || resetScroll else { return }
+        let visualWorkspaces = Self.makeVisualWorkspaces(from: newWorld, symbolsByWindowID: symbolsByWindowID, labelsByWorkspaceID: workspaceLabelsByID)
+        let targetColumnID = Self.focusedColumnID(in: newWorld) ?? focusedColumnId
+        let targetScroll = resetScroll ? CGFloat(0) : (scrollToFocusedColumn ? scrollCentering(columns: visualWorkspaces[newWorld.activeWorkspaceIndex].columns, columnId: targetColumnID) : scrollX)
+        animateFocusIfNeeded {
+            world = newWorld
+            scrollX = targetScroll
+        }
+    }
+
     // MARK: Focus
 
     func focusColumn(_ id: Int) {
-        guard let col = currentWorkspace.columns.first(where: { $0.id == id }) else { return }
-        let targetScroll = scrollCentering(columnId: id)
-        animateFocusIfNeeded {
-            focusedColumnId = id
-            focusedWindowId = col.windows.first?.id ?? focusedWindowId
-            scrollX = targetScroll
-        }
+        guard let workspace = world.activeWorkspace,
+              let columnIndex = workspace.columns.firstIndex(where: { $0.id.rawValue == id })
+        else { return }
+        let column = workspace.columns[columnIndex]
+        guard !column.windows.isEmpty else { return }
+        let newWorld = PureLayoutReducer.focusWindow(
+            columnIndex: columnIndex,
+            windowStorageIndex: column.windows.count - 1,
+            in: world
+        )
+        commitWorld(newWorld)
     }
 
-    /// Focuses a specific window within a column by stack index.
+    /// Focuses a specific window within a column by visual stack index.
     func focusWindow(columnId: Int, index: Int) {
-        guard let col = currentWorkspace.columns.first(where: { $0.id == columnId }) else { return }
-        let clamped = min(max(index, 0), col.windows.count - 1)
-        let targetScroll = scrollCentering(columnId: columnId)
-        animateFocusIfNeeded {
-            focusedColumnId = columnId
-            focusedWindowId = col.windows.indices.contains(clamped) ? col.windows[clamped].id : focusedWindowId
-            scrollX = targetScroll
-        }
+        guard let workspace = world.activeWorkspace,
+              let columnIndex = workspace.columns.firstIndex(where: { $0.id.rawValue == columnId })
+        else { return }
+        let column = workspace.columns[columnIndex]
+        guard !column.windows.isEmpty else { return }
+        let visualIndex = min(max(index, 0), column.windows.count - 1)
+        let storageIndex = column.windows.count - 1 - visualIndex
+        let newWorld = PureLayoutReducer.focusWindow(
+            columnIndex: columnIndex,
+            windowStorageIndex: storageIndex,
+            in: world
+        )
+        commitWorld(newWorld)
     }
 
-    /// Hit-tests the canvas at `screenX`. Returns the column id and the window stack index
+    /// Hit-tests the canvas at `screenX`. Returns the column id and the visual window stack index
     /// under the point (so clicking a stacked window focuses that specific window, not just
     /// the top of the stack). `canvasWidth` is the drawn width; `scrollX` is the current scroll.
     /// The first column's left edge sits at `(canvasWidth - viewportWidth)/2 - scrollX`.
@@ -202,7 +289,7 @@ final class MoveDemoModel: ObservableObject {
         guard let xy = resolveHit(screenX: screenX, canvasWidth: canvasWidth) else { return nil }
         let column = currentWorkspace.columns.first(where: { $0.id == xy.columnId }) ?? currentWorkspace.columns[0]
         guard column.windows.count > 1 else { return xy }
-        // Window tiles divide the column height; map y → stack index.
+        // Window tiles divide the column height; map y → visual stack index.
         let columnTop = (canvasHeight - columnHeight) / 2
         let relY = screenY - columnTop
         let available = columnHeight - 6 - CGFloat(column.windows.count - 1) * windowSpacing
@@ -213,75 +300,29 @@ final class MoveDemoModel: ObservableObject {
     }
 
     func focusLeft() {
-        guard let i = focusedColumnIndex, i > 0 else { return }
-        focusColumn(currentWorkspace.columns[i - 1].id)
+        commitWorld(PureLayoutReducer.focus(.left, in: world))
     }
 
     func focusRight() {
-        guard let i = focusedColumnIndex, i < currentWorkspace.columns.count - 1 else { return }
-        focusColumn(currentWorkspace.columns[i + 1].id)
+        commitWorld(PureLayoutReducer.focus(.right, in: world))
     }
 
     func focusUp() {
-        guard let col = currentWorkspace.columns.first(where: { $0.id == focusedColumnId }),
-              let i = col.windows.firstIndex(where: { $0.id == focusedWindowId }),
-              i > 0
-        else { return }
-        animateFocusIfNeeded { focusedWindowId = col.windows[i - 1].id }
+        commitWorld(PureLayoutReducer.focus(.up, in: world))
     }
 
     func focusDown() {
-        guard let col = currentWorkspace.columns.first(where: { $0.id == focusedColumnId }),
-              let i = col.windows.firstIndex(where: { $0.id == focusedWindowId }),
-              i < col.windows.count - 1
-        else { return }
-        animateFocusIfNeeded { focusedWindowId = col.windows[i + 1].id }
+        commitWorld(PureLayoutReducer.focus(.down, in: world))
     }
 
     // MARK: Move (consume-or-expel)
 
-    /// Niri move-left/right. A window that shares a column **expels** into its own new column
+    /// Niri move-left/right. A window that shares a column **expels** it into its own new column
     /// (placed on the moved-toward side); a solo window **collocates** into the neighbour
     /// column (stacking), and its now-empty source column collapses.
     func moveFocusedWindow(direction: Int) {
-        guard direction == -1 || direction == 1 else { return }
-        guard let i = focusedColumnIndex else { return }
-        var cols = currentWorkspace.columns
-        guard let winIndex = cols[i].windows.firstIndex(where: { $0.id == focusedWindowId }) else { return }
-
-        if cols[i].windows.count > 1 {
-            // EXPEL: pull the focused window into a new solo column on the direction side.
-            let window = cols[i].windows.remove(at: winIndex)
-            let newColumn = Column(id: nextColumnId(), windows: [window])
-            let insertIndex = direction == 1 ? i + 1 : i
-            let clamped = min(max(insertIndex, 0), cols.count)
-            cols.insert(newColumn, at: clamped)
-            commitMove(columns: cols, focusedColumnId: newColumn.id, focusedWindowId: window.id)
-        } else {
-            // CONSUME: collocate into the neighbour column on the direction side; source collapses.
-            let target = i + direction
-            guard cols.indices.contains(target) else { return }
-            let window = cols[i].windows[0]
-            cols.remove(at: i)
-            // After removing source at i, resolve the neighbour's new index:
-            //  - direction == 1  (neighbour was i+1) → shifts down to i
-            //  - direction == -1 (neighbour was i-1) → stays at i-1
-            let resolvedTarget = direction == 1 ? i : i - 1
-            cols[resolvedTarget].windows.append(window)
-            commitMove(columns: cols, focusedColumnId: cols[resolvedTarget].id, focusedWindowId: window.id)
-        }
-    }
-
-    /// Commits a move: structure change + focus + scroll all in one animation transaction so the
-    /// reflow, highlight, and viewport track stay in sync.
-    private func commitMove(columns: [Column], focusedColumnId: Int, focusedWindowId: Int) {
-        let targetScroll = scrollCentering(columns: columns, columnId: focusedColumnId)
-        animateFocusIfNeeded {
-            workspaces[currentWorkspaceIndex].columns = columns
-            self.focusedColumnId = focusedColumnId
-            self.focusedWindowId = focusedWindowId
-            scrollX = targetScroll
-        }
+        guard let pureDirection = horizontalDirection(for: direction) else { return }
+        commitWorld(PureLayoutReducer.moveFocusedWindow(pureDirection, in: world))
     }
 
     // MARK: ⌥-drag column reorder
@@ -305,8 +346,7 @@ final class MoveDemoModel: ObservableObject {
         let rawOffset = Int((dragTranslation / max(slotWidth, 1)).rounded())
         let to = min(max(from + rawOffset, 0), currentWorkspace.columns.count - 1)
         if to != from {
-            let col = workspaces[currentWorkspaceIndex].columns.remove(at: from)
-            workspaces[currentWorkspaceIndex].columns.insert(col, at: to)
+            reorderColumnInWorld(from: from, to: to)
         }
         cancelColumnDrag()
         ensureFocusedVisible()
@@ -322,22 +362,38 @@ final class MoveDemoModel: ObservableObject {
         guard let from = currentWorkspace.columns.firstIndex(where: { $0.id == columnId }) else { return }
         let to = min(max(from + delta, 0), currentWorkspace.columns.count - 1)
         guard to != from else { return }
-        let col = workspaces[currentWorkspaceIndex].columns.remove(at: from)
-        workspaces[currentWorkspaceIndex].columns.insert(col, at: to)
+        reorderColumnInWorld(from: from, to: to)
         ensureFocusedVisible()
+    }
+
+    private func reorderColumnInWorld(from: Int, to: Int) {
+        var newWorld = world
+        guard newWorld.workspaces.indices.contains(newWorld.activeWorkspaceIndex),
+              newWorld.workspaces[newWorld.activeWorkspaceIndex].columns.indices.contains(from),
+              newWorld.workspaces[newWorld.activeWorkspaceIndex].columns.indices.contains(to)
+        else { return }
+
+        let activeColumnID = newWorld.activeWorkspace.flatMap { workspace -> CoreColumnID? in
+            guard let activeColumnIndex = workspace.activeColumnIndex,
+                  workspace.columns.indices.contains(activeColumnIndex)
+            else { return nil }
+            return workspace.columns[activeColumnIndex].id
+        }
+
+        let col = newWorld.workspaces[newWorld.activeWorkspaceIndex].columns.remove(at: from)
+        newWorld.workspaces[newWorld.activeWorkspaceIndex].columns.insert(col, at: to)
+        if let activeColumnID,
+           let activeIndex = newWorld.workspaces[newWorld.activeWorkspaceIndex].columns.firstIndex(where: { $0.id == activeColumnID })
+        {
+            newWorld.workspaces[newWorld.activeWorkspaceIndex].activeColumnIndex = activeIndex
+        }
+        world = newWorld
     }
 
     // MARK: Workspace
 
     func switchWorkspace(by delta: Int) {
-        let next = currentWorkspaceIndex + delta
-        guard workspaces.indices.contains(next) else { return }
-        animateFocusIfNeeded {
-            currentWorkspaceIndex = next
-            scrollX = 0
-            focusedColumnId = workspaces[next].columns.first?.id ?? focusedColumnId
-            focusedWindowId = workspaces[next].columns.first?.windows.first?.id ?? focusedWindowId
-        }
+        commitWorld(PureLayoutReducer.switchWorkspace(by: delta, in: world), resetScroll: true)
     }
 
     // MARK: Palette
@@ -380,14 +436,24 @@ final class MoveDemoModel: ObservableObject {
 
     /// Moves the focused window up/down within its column stack (reorders the stack).
     func moveFocusedWindowVertical(direction: Int) {
-        guard direction == -1 || direction == 1 else { return }
-        guard let colIndex = focusedColumnIndex else { return }
-        var cols = currentWorkspace.columns
-        guard let winIndex = cols[colIndex].windows.firstIndex(where: { $0.id == focusedWindowId }) else { return }
-        let target = winIndex + direction
-        guard cols[colIndex].windows.indices.contains(target) else { return }
-        cols[colIndex].windows.swapAt(winIndex, target)
-        workspaces[currentWorkspaceIndex].columns = cols
+        guard let pureDirection = verticalDirection(for: direction) else { return }
+        commitWorld(PureLayoutReducer.moveFocusedWindow(pureDirection, in: world), scrollToFocusedColumn: false)
+    }
+
+    private func horizontalDirection(for direction: Int) -> PureDirection? {
+        switch direction {
+        case -1: .left
+        case 1: .right
+        default: nil
+        }
+    }
+
+    private func verticalDirection(for direction: Int) -> PureDirection? {
+        switch direction {
+        case -1: .up
+        case 1: .down
+        default: nil
+        }
     }
 }
 

--- a/Tests/NehirTests/InteractiveMoveDemoModelTests.swift
+++ b/Tests/NehirTests/InteractiveMoveDemoModelTests.swift
@@ -1,0 +1,60 @@
+import Testing
+@testable import Nehir
+
+@MainActor
+@Suite struct InteractiveMoveDemoModelTests {
+    @Test func initialDemoSnapshotPreservesVisibleColumnAndWindowOrder() {
+        let model = MoveDemoModel()
+
+        #expect(model.currentWorkspace.columns.map(\.id) == [0, 1, 2, 3, 4, 5, 6])
+        #expect(model.currentWorkspace.columns[1].windows.map(\.id) == [1, 2])
+        #expect(model.focusedColumnId == 0)
+        #expect(model.focusedWindowId == 0)
+    }
+
+    @Test func focusingStackedWindowUsesVisualIndexAtStorageBoundary() {
+        let model = MoveDemoModel()
+
+        model.focusWindow(columnId: 1, index: 0)
+        #expect(model.focusedWindowId == 1)
+
+        model.focusDown()
+        #expect(model.focusedWindowId == 2)
+    }
+
+    @Test func verticalMoveKeepsPreExtractionVisibleOrderBehavior() {
+        let model = MoveDemoModel()
+        model.focusWindow(columnId: 1, index: 0)
+
+        model.moveFocusedWindowVertical(direction: 1)
+        #expect(model.currentWorkspace.columns[1].windows.map(\.id) == [2, 1])
+        #expect(model.focusedWindowId == 1)
+
+        model.moveFocusedWindowVertical(direction: -1)
+        #expect(model.currentWorkspace.columns[1].windows.map(\.id) == [1, 2])
+        #expect(model.focusedWindowId == 1)
+    }
+
+    @Test func consumeIntoStackedNeighborPlacesConsumedWindowAtVisibleBottom() {
+        let model = MoveDemoModel()
+
+        model.moveFocusedWindow(direction: 1)
+
+        #expect(model.currentWorkspace.columns.map(\.id).prefix(1) == [1])
+        #expect(model.currentWorkspace.columns[0].windows.map(\.id) == [1, 2, 0])
+        #expect(model.focusedColumnId == 1)
+        #expect(model.focusedWindowId == 0)
+    }
+
+    @Test func workspaceSwitchResetsScrollAndSelectsFirstVisibleTile() {
+        let model = MoveDemoModel()
+        model.scrollX = 42
+
+        model.switchWorkspace(by: 1)
+
+        #expect(model.currentWorkspaceIndex == 1)
+        #expect(model.scrollX == 0)
+        #expect(model.focusedColumnId == 100)
+        #expect(model.focusedWindowId == 100)
+    }
+}

--- a/Tests/NehirTests/PureLayoutAgreementTests.swift
+++ b/Tests/NehirTests/PureLayoutAgreementTests.swift
@@ -140,11 +140,11 @@ import Testing
                 realColumn.appendChild(window)
                 engine.tokenToNode[token] = window
             }
-            let columnActiveIndex = columnIndex == activeColumnIndex ? activeWindowIndex : min(activeWindowIndex, max(tokens.count - 1, 0))
+            let columnActiveIndex = min(max(activeWindowIndex, 0), max(tokens.count - 1, 0))
             realColumn.setActiveTileIdx(columnActiveIndex)
 
-            if columnIndex == activeColumnIndex, tokens.indices.contains(activeWindowIndex) {
-                selectedToken = tokens[activeWindowIndex]
+            if columnIndex == activeColumnIndex, tokens.indices.contains(columnActiveIndex) {
+                selectedToken = tokens[columnActiveIndex]
             }
 
             coreColumns.append(
@@ -156,15 +156,17 @@ import Testing
             )
         }
 
+        let clampedActiveColumnIndex = min(max(activeColumnIndex, 0), max(coreColumns.count - 1, 0))
         let pure = CoreWorld(
-            workspaces: [CoreWorkspace(id: workspaceId, columns: coreColumns, activeColumnIndex: activeColumnIndex)],
+            workspaces: [CoreWorkspace(id: workspaceId, columns: coreColumns, activeColumnIndex: clampedActiveColumnIndex)],
             activeWorkspaceIndex: 0,
             nextColumnID: 100,
             config: PureLayoutConfig(infiniteLoop: infiniteLoop)
         )
         var state = ViewportState()
-        state.activeColumnIndex = activeColumnIndex
-        let selected = selectedToken ?? coreColumns[activeColumnIndex].windows[activeWindowIndex].id
+        state.activeColumnIndex = clampedActiveColumnIndex
+        let activeColumn = coreColumns[clampedActiveColumnIndex]
+        let selected = selectedToken ?? activeColumn.windows[activeColumn.activeWindowIndex].id
         state.selectedNodeId = engine.findNode(for: selected)?.id
 
         return Fixture(

--- a/Tests/NehirTests/PureLayoutAgreementTests.swift
+++ b/Tests/NehirTests/PureLayoutAgreementTests.swift
@@ -1,0 +1,210 @@
+import AppKit
+import Testing
+@testable import Nehir
+
+@Suite struct PureLayoutAgreementTests {
+    private struct AgreementSnapshot: Equatable {
+        var columns: [[WindowToken]]
+        var activeColumnIndex: Int?
+        var focusedWindowID: WindowToken?
+    }
+
+    private struct Fixture {
+        var pure: CoreWorld<UUID, WindowToken>
+        var engine: NiriLayoutEngine
+        var workspaceId: WorkspaceDescriptor.ID
+        var state: ViewportState
+        var selectedToken: WindowToken
+    }
+
+    @Test func focusLeftRightAgreesInThreeColumnWorld() {
+        var fixture = makeFixture(columns: [[1], [2], [3]], activeColumnIndex: 1, activeWindowIndex: 0)
+        assertAgreement(afterFocus: .right, fixture: &fixture)
+
+        fixture = makeFixture(columns: [[1], [2], [3]], activeColumnIndex: 1, activeWindowIndex: 0)
+        assertAgreement(afterFocus: .left, fixture: &fixture)
+    }
+
+    @Test func focusUpDownAgreesInStackedColumn() {
+        var fixture = makeFixture(columns: [[1, 2, 3]], activeColumnIndex: 0, activeWindowIndex: 1)
+        assertAgreement(afterFocus: .up, fixture: &fixture)
+
+        fixture = makeFixture(columns: [[1, 2, 3]], activeColumnIndex: 0, activeWindowIndex: 1)
+        assertAgreement(afterFocus: .down, fixture: &fixture)
+    }
+
+    @Test func moveUpDownAgreesInStackedColumn() {
+        var fixture = makeFixture(columns: [[1, 2, 3]], activeColumnIndex: 0, activeWindowIndex: 1)
+        assertAgreement(afterMove: .up, fixture: &fixture)
+
+        fixture = makeFixture(columns: [[1, 2, 3]], activeColumnIndex: 0, activeWindowIndex: 1)
+        assertAgreement(afterMove: .down, fixture: &fixture)
+    }
+
+    @Test func expelLeftRightFromStackedColumnAgrees() {
+        var fixture = makeFixture(columns: [[1, 2], [3]], activeColumnIndex: 0, activeWindowIndex: 1)
+        assertAgreement(afterMove: .right, fixture: &fixture)
+
+        fixture = makeFixture(columns: [[1], [2, 3]], activeColumnIndex: 1, activeWindowIndex: 0)
+        assertAgreement(afterMove: .left, fixture: &fixture)
+    }
+
+    @Test func consumeLeftRightFromSoloColumnAgrees() {
+        var fixture = makeFixture(columns: [[1], [2, 3]], activeColumnIndex: 0, activeWindowIndex: 0)
+        assertAgreement(afterMove: .right, fixture: &fixture)
+
+        fixture = makeFixture(columns: [[1, 2], [3]], activeColumnIndex: 1, activeWindowIndex: 0)
+        assertAgreement(afterMove: .left, fixture: &fixture)
+    }
+
+    @Test func noWrapEdgeConsumeAndFocusAgreeWhenInfiniteLoopDisabled() {
+        var fixture = makeFixture(columns: [[1], [2]], activeColumnIndex: 0, activeWindowIndex: 0, infiniteLoop: false)
+        assertAgreement(afterFocus: .left, fixture: &fixture)
+
+        fixture = makeFixture(columns: [[1], [2]], activeColumnIndex: 0, activeWindowIndex: 0, infiniteLoop: false)
+        assertAgreement(afterMove: .left, fixture: &fixture)
+    }
+
+    @Test func wrapEdgeConsumeAndFocusAgreeWhenInfiniteLoopEnabled() {
+        var fixture = makeFixture(columns: [[1], [2]], activeColumnIndex: 0, activeWindowIndex: 0, infiniteLoop: true)
+        assertAgreement(afterFocus: .left, fixture: &fixture)
+
+        fixture = makeFixture(columns: [[1], [2]], activeColumnIndex: 0, activeWindowIndex: 0, infiniteLoop: true)
+        assertAgreement(afterMove: .left, fixture: &fixture)
+    }
+
+    private func assertAgreement(afterFocus direction: PureDirection, fixture: inout Fixture) {
+        fixture.pure = PureLayoutReducer.focus(direction, in: fixture.pure)
+
+        let selected = fixture.engine.findNode(for: fixture.selectedToken)
+        if let selected,
+           let target = fixture.engine.focusTarget(
+               direction: niriDirection(for: direction),
+               currentSelection: selected,
+               in: fixture.workspaceId,
+               motion: .disabled,
+               state: &fixture.state,
+               workingFrame: workingFrame,
+               gaps: gap
+           ) as? NiriWindow
+        {
+            fixture.selectedToken = target.token
+            fixture.state.selectedNodeId = target.id
+        }
+
+        #expect(pureSnapshot(fixture.pure) == realSnapshot(fixture))
+    }
+
+    private func assertAgreement(afterMove direction: PureDirection, fixture: inout Fixture) {
+        fixture.pure = PureLayoutReducer.moveFocusedWindow(direction, in: fixture.pure)
+
+        if let selected = fixture.engine.findNode(for: fixture.selectedToken) {
+            let moved = fixture.engine.moveWindow(
+                selected,
+                direction: niriDirection(for: direction),
+                in: fixture.workspaceId,
+                motion: .disabled,
+                state: &fixture.state,
+                workingFrame: workingFrame,
+                gaps: gap
+            )
+            if moved {
+                fixture.selectedToken = selected.token
+                fixture.state.selectedNodeId = selected.id
+            }
+        }
+
+        #expect(pureSnapshot(fixture.pure) == realSnapshot(fixture))
+    }
+
+    private func makeFixture(
+        columns: [[Int]],
+        activeColumnIndex: Int,
+        activeWindowIndex: Int,
+        infiniteLoop: Bool = false
+    ) -> Fixture {
+        let workspaceId = UUID()
+        let engine = NiriLayoutEngine(infiniteLoop: infiniteLoop)
+        let root = engine.ensureRoot(for: workspaceId)
+        var coreColumns: [CoreColumn<WindowToken>] = []
+        var selectedToken: WindowToken?
+
+        for (columnIndex, windowIDs) in columns.enumerated() {
+            let realColumn = NiriContainer()
+            realColumn.cachedWidth = 240
+            root.appendChild(realColumn)
+
+            let tokens = windowIDs.map { WindowToken(pid: 900, windowId: $0) }
+            for token in tokens {
+                let window = NiriWindow(token: token)
+                realColumn.appendChild(window)
+                engine.tokenToNode[token] = window
+            }
+            let columnActiveIndex = columnIndex == activeColumnIndex ? activeWindowIndex : min(activeWindowIndex, max(tokens.count - 1, 0))
+            realColumn.setActiveTileIdx(columnActiveIndex)
+
+            if columnIndex == activeColumnIndex, tokens.indices.contains(activeWindowIndex) {
+                selectedToken = tokens[activeWindowIndex]
+            }
+
+            coreColumns.append(
+                CoreColumn(
+                    id: CoreColumnID(rawValue: columnIndex),
+                    windows: tokens.map { CoreWindow(id: $0) },
+                    activeWindowIndex: columnActiveIndex
+                )
+            )
+        }
+
+        let pure = CoreWorld(
+            workspaces: [CoreWorkspace(id: workspaceId, columns: coreColumns, activeColumnIndex: activeColumnIndex)],
+            activeWorkspaceIndex: 0,
+            nextColumnID: 100,
+            config: PureLayoutConfig(infiniteLoop: infiniteLoop)
+        )
+        var state = ViewportState()
+        state.activeColumnIndex = activeColumnIndex
+        let selected = selectedToken ?? coreColumns[activeColumnIndex].windows[activeWindowIndex].id
+        state.selectedNodeId = engine.findNode(for: selected)?.id
+
+        return Fixture(
+            pure: pure,
+            engine: engine,
+            workspaceId: workspaceId,
+            state: state,
+            selectedToken: selected
+        )
+    }
+
+    private func pureSnapshot(_ world: CoreWorld<UUID, WindowToken>) -> AgreementSnapshot {
+        guard let workspace = world.activeWorkspace else {
+            return AgreementSnapshot(columns: [], activeColumnIndex: nil, focusedWindowID: nil)
+        }
+        return AgreementSnapshot(
+            columns: workspace.columns.map { $0.windows.map(\.id) },
+            activeColumnIndex: workspace.activeColumnIndex,
+            focusedWindowID: workspace.focusedWindowID
+        )
+    }
+
+    private func realSnapshot(_ fixture: Fixture) -> AgreementSnapshot {
+        let columns = fixture.engine.columns(in: fixture.workspaceId)
+        return AgreementSnapshot(
+            columns: columns.map { $0.windowNodes.map(\.token) },
+            activeColumnIndex: columns.isEmpty ? nil : fixture.state.activeColumnIndex,
+            focusedWindowID: fixture.selectedToken
+        )
+    }
+
+    private func niriDirection(for direction: PureDirection) -> Direction {
+        switch direction {
+        case .left: .left
+        case .right: .right
+        case .up: .up
+        case .down: .down
+        }
+    }
+
+    private var workingFrame: CGRect { CGRect(x: 0, y: 0, width: 900, height: 600) }
+    private var gap: CGFloat { 10 }
+}

--- a/Tests/NehirTests/PureLayoutBoundaryTests.swift
+++ b/Tests/NehirTests/PureLayoutBoundaryTests.swift
@@ -1,0 +1,39 @@
+import Foundation
+import Testing
+
+@Suite struct PureLayoutBoundaryTests {
+    @Test func pureLayoutFilesDoNotReferenceRuntimeOrPlatformTypes() throws {
+        let root = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .appendingPathComponent("Sources/Nehir/Core/PureLayout")
+
+        let forbiddenTokens = [
+            "import AppKit",
+            "import ApplicationServices",
+            "AXUIElement",
+            "SkyLight",
+            "WindowToken",
+            "NiriNode",
+            "NiriLayoutEngine",
+            "ViewportState",
+            "WorkspaceDescriptor",
+            "Monitor.",
+            "Monitor("
+        ]
+
+        let files = try FileManager.default.contentsOfDirectory(
+            at: root,
+            includingPropertiesForKeys: nil
+        ).filter { $0.pathExtension == "swift" }
+
+        #expect(!files.isEmpty)
+        for file in files {
+            let content = try String(contentsOf: file, encoding: .utf8)
+            for token in forbiddenTokens {
+                #expect(!content.contains(token), "\(file.lastPathComponent) contains forbidden token \(token)")
+            }
+        }
+    }
+}

--- a/Tests/NehirTests/PureLayoutBoundaryTests.swift
+++ b/Tests/NehirTests/PureLayoutBoundaryTests.swift
@@ -23,10 +23,12 @@ import Testing
             "Monitor("
         ]
 
-        let files = try FileManager.default.contentsOfDirectory(
+        let files = FileManager.default.enumerator(
             at: root,
             includingPropertiesForKeys: nil
-        ).filter { $0.pathExtension == "swift" }
+        )?
+        .compactMap { $0 as? URL }
+        .filter { $0.pathExtension == "swift" } ?? []
 
         #expect(!files.isEmpty)
         for file in files {

--- a/Tests/NehirTests/PureLayoutReducerTests.swift
+++ b/Tests/NehirTests/PureLayoutReducerTests.swift
@@ -1,0 +1,166 @@
+import Testing
+@testable import Nehir
+
+@Suite struct PureLayoutReducerTests {
+    typealias World = CoreWorld<Int, String>
+
+    @Test func focusHorizontalMovesBetweenColumnsWithoutChangingStructure() {
+        let world = makeWorld(columns: [column(0, ["A"]), column(1, ["B1", "B2"], active: 1), column(2, ["C"])])
+        let moved = assertValid(PureLayoutReducer.focus(.right, in: world))
+
+        #expect(moved.workspaces[0].activeColumnIndex == 1)
+        #expect(moved.workspaces[0].focusedWindowID == "B2")
+        #expect(snapshot(moved) == [["A"], ["B1", "B2"], ["C"]])
+    }
+
+    @Test func focusHorizontalDoesNotWrapByDefaultAtEdges() {
+        let world = makeWorld(columns: [column(0, ["A"]), column(1, ["B"])])
+        let moved = assertValid(PureLayoutReducer.focus(.left, in: world))
+
+        #expect(moved == world)
+    }
+
+    @Test func focusHorizontalWrapsWhenInfiniteLoopEnabled() {
+        var world = makeWorld(columns: [column(0, ["A"]), column(1, ["B"])])
+        world.config.infiniteLoop = true
+
+        let moved = assertValid(PureLayoutReducer.focus(.left, in: world))
+
+        #expect(moved.workspaces[0].activeColumnIndex == 1)
+        #expect(moved.workspaces[0].focusedWindowID == "B")
+    }
+
+    @Test func focusVerticalUsesStorageBottomConvention() {
+        let world = makeWorld(columns: [column(0, ["bottom", "middle", "top"], active: 0)])
+
+        let up = assertValid(PureLayoutReducer.focus(.up, in: world))
+        let downFromUp = assertValid(PureLayoutReducer.focus(.down, in: up))
+        let downAtBottom = assertValid(PureLayoutReducer.focus(.down, in: world))
+
+        #expect(up.workspaces[0].focusedWindowID == "middle")
+        #expect(downFromUp.workspaces[0].focusedWindowID == "bottom")
+        #expect(downAtBottom == world)
+    }
+
+    @Test func moveVerticalSwapsWithStorageUpAndDown() {
+        let world = makeWorld(columns: [column(0, ["bottom", "middle", "top"], active: 1)])
+
+        let movedUp = assertValid(PureLayoutReducer.moveFocusedWindow(.up, in: world))
+        #expect(snapshot(movedUp) == [["bottom", "top", "middle"]])
+        #expect(movedUp.workspaces[0].focusedWindowID == "middle")
+        #expect(movedUp.workspaces[0].activeColumn?.activeWindowIndex == 2)
+
+        let movedDown = assertValid(PureLayoutReducer.moveFocusedWindow(.down, in: movedUp))
+        #expect(movedDown == world)
+    }
+
+    @Test func moveHorizontalExpelsStackedWindowIntoNewColumnOnDirectionSide() {
+        let world = makeWorld(columns: [column(0, ["A1", "A2"], active: 1), column(1, ["B"])], nextColumnID: 10)
+
+        let right = assertValid(PureLayoutReducer.moveFocusedWindow(.right, in: world))
+        #expect(snapshot(right) == [["A1"], ["A2"], ["B"]])
+        #expect(right.workspaces[0].columns.map(\.id.rawValue) == [0, 10, 1])
+        #expect(right.workspaces[0].activeColumnIndex == 1)
+        #expect(right.workspaces[0].focusedWindowID == "A2")
+        #expect(right.nextColumnID == 11)
+
+        let left = assertValid(PureLayoutReducer.moveFocusedWindow(.left, in: world))
+        #expect(snapshot(left) == [["A2"], ["A1"], ["B"]])
+        #expect(left.workspaces[0].columns.map(\.id.rawValue) == [10, 0, 1])
+        #expect(left.workspaces[0].activeColumnIndex == 0)
+    }
+
+    @Test func moveHorizontalConsumesSoloWindowIntoNeighborVisualBottom() {
+        let world = makeWorld(columns: [column(0, ["A"]), column(1, ["B-bottom", "B-top"], active: 1)])
+
+        let moved = assertValid(PureLayoutReducer.moveFocusedWindow(.right, in: world))
+
+        #expect(snapshot(moved) == [["A", "B-bottom", "B-top"]])
+        #expect(moved.workspaces[0].columns[0].id.rawValue == 1)
+        #expect(moved.workspaces[0].activeColumnIndex == 0)
+        #expect(moved.workspaces[0].columns[0].activeWindowIndex == 0)
+        #expect(moved.workspaces[0].focusedWindowID == "A")
+    }
+
+    @Test func moveHorizontalDoesNotConsumePastEdgeByDefault() {
+        let world = makeWorld(columns: [column(0, ["A"]), column(1, ["B"])])
+        let moved = assertValid(PureLayoutReducer.moveFocusedWindow(.left, in: world))
+
+        #expect(moved == world)
+    }
+
+    @Test func moveHorizontalWrapsAtEdgeWhenInfiniteLoopEnabled() {
+        var world = makeWorld(columns: [column(0, ["A"]), column(1, ["B1", "B2"], active: 1)])
+        world.config.infiniteLoop = true
+
+        let moved = assertValid(PureLayoutReducer.moveFocusedWindow(.left, in: world))
+
+        #expect(snapshot(moved) == [["A", "B1", "B2"]])
+        #expect(moved.workspaces[0].columns[0].id.rawValue == 1)
+        #expect(moved.workspaces[0].focusedWindowID == "A")
+    }
+
+    @Test func switchWorkspaceSelectsDestinationFirstVisibleTile() {
+        let workspace0 = CoreWorkspace(id: 0, columns: [column(0, ["A"])], activeColumnIndex: 0)
+        let workspace1 = CoreWorkspace(id: 1, columns: [column(10, ["B-bottom", "B-top"], active: 0)], activeColumnIndex: 0)
+        let world = World(workspaces: [workspace0, workspace1], activeWorkspaceIndex: 0, nextColumnID: 11, config: .init())
+
+        let moved = assertValid(PureLayoutReducer.switchWorkspace(by: 1, in: world))
+
+        #expect(moved.activeWorkspaceIndex == 1)
+        #expect(moved.workspaces[1].activeColumnIndex == 0)
+        #expect(moved.workspaces[1].focusedWindowID == "B-top")
+    }
+
+    @Test func invariantsRejectEmptyColumnsDuplicateWindowIDsAndInvalidFocus() {
+        let invalid = World(
+            workspaces: [
+                CoreWorkspace(
+                    id: 0,
+                    columns: [
+                        CoreColumn(id: .init(rawValue: 0), windows: [], activeWindowIndex: 0),
+                        CoreColumn(id: .init(rawValue: 0), windows: [CoreWindow(id: "dup")], activeWindowIndex: 3),
+                        CoreColumn(id: .init(rawValue: 2), windows: [CoreWindow(id: "dup")], activeWindowIndex: 0)
+                    ],
+                    activeColumnIndex: 9
+                )
+            ],
+            activeWorkspaceIndex: 3,
+            nextColumnID: 2,
+            config: .init()
+        )
+
+        let violations = PureLayoutInvariants.validate(invalid).map(\.message)
+
+        #expect(violations.contains { $0.contains("activeWorkspaceIndex") })
+        #expect(violations.contains { $0.contains("invalid activeColumnIndex") })
+        #expect(violations.contains { $0.contains("empty column") })
+        #expect(violations.contains { $0.contains("duplicate column id") })
+        #expect(violations.contains { $0.contains("invalid activeWindowIndex") })
+        #expect(violations.contains { $0.contains("duplicate window id") })
+        #expect(violations.contains { $0.contains("nextColumnID") })
+    }
+
+    private func column(_ id: Int, _ windows: [String], active: Int = 0) -> CoreColumn<String> {
+        CoreColumn(id: .init(rawValue: id), windows: windows.map { CoreWindow(id: $0) }, activeWindowIndex: active)
+    }
+
+    private func makeWorld(columns: [CoreColumn<String>], nextColumnID: Int = 100) -> World {
+        World(
+            workspaces: [CoreWorkspace(id: 0, columns: columns, activeColumnIndex: columns.isEmpty ? nil : 0)],
+            activeWorkspaceIndex: 0,
+            nextColumnID: nextColumnID,
+            config: .init()
+        )
+    }
+
+    private func snapshot(_ world: World) -> [[String]] {
+        world.workspaces[world.activeWorkspaceIndex].columns.map { $0.windows.map(\.id) }
+    }
+
+    @discardableResult
+    private func assertValid(_ world: World) -> World {
+        #expect(PureLayoutInvariants.validate(world).isEmpty)
+        return world
+    }
+}


### PR DESCRIPTION
## Summary

Share pure Niri layout decisions between the onboarding move demo and runtime layout engine. This extracts a platform-free `PureLayout` reducer, drives the interactive demo through it, routes production Niri focus and focused-window move decisions through the same reducer, and adds bridge assertions so runtime tree mutations stay aligned with the pure model.

## Release notes

Choose one:

- [x] Added a `.changeset/*.md` for user-visible changes (`mise run changeset -- patch "..."`).
- [ ] No user-visible change; apply the `no release note` label to make CI skip intentional.

## Validation

<!-- Commands run, screenshots, or manual checks. -->

- [ ] Ran relevant tests/checks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved focus targeting and window move behavior for horizontal and vertical navigation, including clearer swap/consume/expel handling and more dependable edge-case behavior for stacked windows.
* **Refactor**
  * Updated the interactive onboarding move demo to use the same unified, reducer-driven layout logic as runtime navigation.
* **Tests**
  * Added automated coverage for reducer focus/move semantics, boundary/invariant validation, agreement between pure operations and runtime behavior, and onboarding model correctness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->