### PR TITLE
Setup GPL attribution harness; improve attribution across surfaces

### DIFF
--- a/.changeset/20260620174500-surface-license-attribution-across-about-nehirctl.md
+++ b/.changeset/20260620174500-surface-license-attribution-across-about-nehirctl.md
@@ -1,0 +1,15 @@
+---
+"nehir": patch
+---
+
+Surface license attribution across About, nehirctl, and source headers
+
+- About tab now shows GPL-2.0-only, OmniWM lineage, and links to LICENSE and
+  NOTICE.md.
+- `nehirctl` gains `license`/`about`/`legal`/`attribution` commands plus
+  license/attribution lines in `--help`.
+- Source files carry generated SPDX headers: upstream-derived files keep the
+  BarutSRB copyright alongside Nehir contributors; nehir-original files carry
+  Nehir only. NOTICE.md documents the policy.
+- Current project/source links point to the apphane-dev Nehir repository while
+  preserving upstream OmniWM and historical fork links.

--- a/.config/mise/conf.d/tasks-quality.toml
+++ b/.config/mise/conf.d/tasks-quality.toml
@@ -1,9 +1,11 @@
 [tasks."format"]
 description = "Format code with SwiftFormat"
+depends = ["license"]
 run = "swiftformat ."
 
 [tasks."format:check"]
 description = "Check formatting without modifying files"
+depends = ["license:check"]
 run = "swiftformat --lint ."
 
 [tasks."lint"]

--- a/.config/mise/tasks/license/_default
+++ b/.config/mise/tasks/license/_default
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+#MISE description="Update generated SPDX source headers from .provenance.json"
+"""Generate maintainable SPDX headers from .provenance.json.
+
+Headers carry stable legal facts only (copyright, license, provenance category).
+Per-file upstream commit detail is intentionally NOT rendered here; it lives in
+the non-rendering ``upstreamCommits`` map of the manifest and in the provenance
+audit on the ``plans`` branch. This keeps headers uniform and low-maintenance.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from fnmatch import fnmatch
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(subprocess.check_output(["git", "rev-parse", "--show-toplevel"], text=True).strip())
+MANIFEST = ROOT / ".provenance.json"
+
+SPDX_HEADER_RE = re.compile(
+    r"\A(?:(?:// SPDX-(?:FileCopyrightText|FileContributor|FileComment|License-Identifier):[^\n]*\n)|(?://\s*\n))+"
+)
+
+
+def load_manifest() -> dict[str, Any]:
+    with MANIFEST.open(encoding="utf-8") as manifest_file:
+        return json.load(manifest_file)
+
+
+def tracked_files() -> list[Path]:
+    result = subprocess.run(
+        ["git", "ls-files"],
+        cwd=ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return [ROOT / line for line in result.stdout.splitlines() if line]
+
+
+def matches_any(path: str, patterns: list[str]) -> bool:
+    return any(fnmatch(path, pattern) for pattern in patterns)
+
+
+def matching_entries(manifest: dict[str, Any]) -> dict[Path, dict[str, Any]]:
+    entries: dict[Path, dict[str, Any]] = {}
+    relative_files = [(path, path.relative_to(ROOT).as_posix()) for path in tracked_files()]
+
+    for rule in manifest.get("rules", []):
+        patterns = rule.get("paths", [])
+        for path, relative in relative_files:
+            if matches_any(relative, patterns):
+                entries[path] = rule
+
+    for override in manifest.get("overrides", []):
+        patterns = override.get("paths", [])
+        for path, relative in relative_files:
+            if matches_any(relative, patterns):
+                merged = dict(entries.get(path, {}))
+                merged.update(override)
+                entries[path] = merged
+
+    return dict(sorted(entries.items(), key=lambda item: item[0].relative_to(ROOT).as_posix()))
+
+
+def render_header(entry: dict[str, Any]) -> str:
+    lines: list[str] = []
+
+    for item in entry.get("copyright", []):
+        lines.append(f"// SPDX-FileCopyrightText: {item}")
+
+    for item in entry.get("contributors", []):
+        lines.append(f"// SPDX-FileContributor: {item}")
+
+    file_comment = entry.get("fileComment")
+    if file_comment:
+        lines.append(f"// SPDX-FileComment: {file_comment}")
+
+    lines.append("//")
+    lines.append(f"// SPDX-License-Identifier: {entry['license']}")
+    lines.append("")
+    return "\n".join(lines) + "\n"
+
+
+def split_leading_sentinel(text: str) -> tuple[str, str]:
+    """Keep shebang or swift-tools-version as the first physical line."""
+    if text.startswith("#!") or text.startswith("// swift-tools-version:"):
+        newline_index = text.find("\n")
+        if newline_index == -1:
+            return text + "\n", ""
+        return text[: newline_index + 1], text[newline_index + 1 :]
+    return "", text
+
+
+def update_text(text: str, entry: dict[str, Any]) -> str:
+    sentinel, body = split_leading_sentinel(text)
+    body = SPDX_HEADER_RE.sub("", body, count=1).lstrip("\n")
+    return sentinel + render_header(entry) + body
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--check", action="store_true", help="fail if any header is stale")
+    args = parser.parse_args()
+
+    manifest = load_manifest()
+    stale: list[str] = []
+
+    for path, entry in matching_entries(manifest).items():
+        original = path.read_text(encoding="utf-8")
+        updated = update_text(original, entry)
+        if updated == original:
+            continue
+        relative = path.relative_to(ROOT).as_posix()
+        stale.append(relative)
+        if not args.check:
+            path.write_text(updated, encoding="utf-8")
+
+    if stale:
+        action = "would update" if args.check else "updated"
+        for relative in stale:
+            print(f"{action}: {relative}")
+        return 1 if args.check else 0
+
+    print("SPDX headers are up to date.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.config/mise/tasks/license/check
+++ b/.config/mise/tasks/license/check
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+#MISE description="Check generated SPDX source headers without modifying files"
+set -euo pipefail
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+exec "$DIR/_default" --check

--- a/.provenance.json
+++ b/.provenance.json
@@ -1,0 +1,106 @@
+{
+  "rules": [
+    {
+      "name": "Swift sources and package manifest shipped with Nehir (upstream-derived default)",
+      "paths": [
+        "Package.swift",
+        "Sources/**/*.swift",
+        "Tests/**/*.swift"
+      ],
+      "license": "GPL-2.0-only",
+      "copyright": [
+        "2026 BarutSRB",
+        "2026 Aleksei Gurianov and Nehir contributors"
+      ],
+      "fileComment": "Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md"
+    }
+  ],
+  "overrides": [
+    {
+      "name": "Nehir-original files (no prior existence in OmniWM; provenance audit)",
+      "paths": [
+        "Sources/Nehir/Core/Ax/RawAXNotificationTrace.swift",
+        "Sources/Nehir/Core/Config/AppRuleFileStore.swift",
+        "Sources/Nehir/Core/Config/ConfigAssistancePrompt.swift",
+        "Sources/Nehir/Core/Config/ConfigMismatchDetector.swift",
+        "Sources/Nehir/Core/Config/HotkeyConfigMapping.swift",
+        "Sources/Nehir/Core/Config/HotkeysTOMLCodec.swift",
+        "Sources/Nehir/Core/Config/MonitorOverrideFileStore.swift",
+        "Sources/Nehir/Core/Config/OnboardingStateStore.swift",
+        "Sources/Nehir/Core/Config/SettingsDiagnosticsIssue.swift",
+        "Sources/Nehir/Core/Config/SettingsMigrationRegistry.swift",
+        "Sources/Nehir/Core/Config/SettingsMigrationStateStore.swift",
+        "Sources/Nehir/Core/Config/SettingsTOMLUnknownValue.swift",
+        "Sources/Nehir/Core/Config/WorkspacesTOMLCodec.swift",
+        "Sources/Nehir/Core/Controller/LayoutTrace.swift",
+        "Sources/Nehir/Core/Controller/WMCommandTarget.swift",
+        "Sources/Nehir/Core/Layout/Niri/NiriLayoutEngine+PureLayoutBridge.swift",
+        "Sources/Nehir/Core/Monitor/DisplayEnvironmentDiagnostics.swift",
+        "Sources/Nehir/Core/ProjectionInvalidation.swift",
+        "Sources/Nehir/Core/PureLayout/PureDirection.swift",
+        "Sources/Nehir/Core/PureLayout/PureLayoutInvariants.swift",
+        "Sources/Nehir/Core/PureLayout/PureLayoutModels.swift",
+        "Sources/Nehir/Core/PureLayout/PureLayoutReducer.swift",
+        "Sources/Nehir/Core/Support/BuildVersion.swift",
+        "Sources/Nehir/Core/Workspace/InteractionMonitorWriteTrace.swift",
+        "Sources/Nehir/UI/AboutSettingsTab.swift",
+        "Sources/Nehir/UI/BehaviorSettingsTab.swift",
+        "Sources/Nehir/UI/ConfigurationFilesSection.swift",
+        "Sources/Nehir/UI/DestructiveConfirmationAlert.swift",
+        "Sources/Nehir/UI/DeveloperBadge.swift",
+        "Sources/Nehir/UI/DisplayDiagnosticsSettingsTab.swift",
+        "Sources/Nehir/UI/ExperimentalBadge.swift",
+        "Sources/Nehir/UI/LayoutSettingsTab.swift",
+        "Sources/Nehir/UI/Onboarding/Animations/StaticStepIcon.swift",
+        "Sources/Nehir/UI/Onboarding/Animations/WelcomeAnimation.swift",
+        "Sources/Nehir/UI/Onboarding/Animations/WorkspaceBarAnimation.swift",
+        "Sources/Nehir/UI/Onboarding/ConfigRecoveryView.swift",
+        "Sources/Nehir/UI/Onboarding/InteractiveMoveDemo.swift",
+        "Sources/Nehir/UI/Onboarding/NehirLogo.swift",
+        "Sources/Nehir/UI/Onboarding/OnboardingStepControls.swift",
+        "Sources/Nehir/UI/Onboarding/OnboardingStepView.swift",
+        "Sources/Nehir/UI/Onboarding/OnboardingSteps.swift",
+        "Sources/Nehir/UI/Onboarding/OnboardingView.swift",
+        "Sources/Nehir/UI/Onboarding/OnboardingWindowController.swift",
+        "Sources/Nehir/UI/Onboarding/ReleaseNotes.swift",
+        "Sources/Nehir/UI/Onboarding/WhatsNewContent.swift",
+        "Sources/Nehir/UI/Onboarding/WhatsNewView.swift",
+        "Sources/Nehir/UI/SettingInfo.swift",
+        "Sources/NehirCtl/CLILegalNotice.swift",
+        "Tests/NehirTests/ConfigMismatchDetectorTests.swift",
+        "Tests/NehirTests/DisplayEnvironmentDiagnosticsTests.swift",
+        "Tests/NehirTests/DisplaySpacesModeTests.swift",
+        "Tests/NehirTests/InteractiveMoveDemoModelTests.swift",
+        "Tests/NehirTests/MonitorIdentityMatchingTests.swift",
+        "Tests/NehirTests/NiriMonitorTests.swift",
+        "Tests/NehirTests/PureLayoutAgreementTests.swift",
+        "Tests/NehirTests/PureLayoutBoundaryTests.swift",
+        "Tests/NehirTests/PureLayoutReducerTests.swift",
+        "Tests/NehirTests/ResizeMinimumLearnerTests.swift",
+        "Tests/NehirTests/SettingsMigrationStateStoreTests.swift",
+        "Tests/NehirTests/ViewportSnapContextTests.swift",
+        "Tests/NehirTests/WhatsNewAutoShowTests.swift",
+        "Tests/NehirTests/WorkspaceNavigationHandlerTests.swift",
+        "Tests/NehirTests/WorkspacesTOMLCodecTests.swift"
+      ],
+      "copyright": [
+        "2026 Aleksei Gurianov and Nehir contributors"
+      ],
+      "fileComment": "Provenance=nehir-original; See=NOTICE.md"
+    }
+  ],
+  "upstreamCommits": {
+    "Sources/Nehir/Core/Config/MonitorGapSettings.swift": [
+      {"repo": "https://github.com/BarutSRB/OmniWM", "hash": "dacccb8"}
+    ],
+    "Sources/Nehir/Core/Multitouch/MultitouchBinding.swift": [
+      {"repo": "https://github.com/BarutSRB/OmniWM", "hash": "06eb42d"}
+    ],
+    "Sources/Nehir/Core/Multitouch/MultitouchGestureSource.swift": [
+      {"repo": "https://github.com/BarutSRB/OmniWM", "hash": "06eb42d"}
+    ],
+    "Sources/Nehir/Core/SkyLight/DisplaySpacesMode.swift": [
+      {"repo": "https://github.com/BarutSRB/OmniWM", "hash": "ee554c7"}
+    ]
+  }
+}

--- a/.swiftformat
+++ b/.swiftformat
@@ -11,7 +11,7 @@
 --commas inline
 --trimwhitespace always
 --semicolons never
---header strip
+--header ignore
 
 --disable all
 --enable blankLineAfterImports,blankLinesAroundMark,blankLinesAtEndOfScope,blankLinesAtStartOfScope

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -26,6 +26,77 @@ in layout behavior, settings, defaults, and maintenance direction, with a
 deliberately narrower, Niri-style scope. Nehir is a GPL project; fixes that land
 here are welcome to be reused or backported upstream.
 
+## Source attribution policy
+
+Nehir keeps upstream attribution visible because this project exists thanks to
+OmniWM being released as free software. Upstream OmniWM itself carries this
+notice on every source file:
+
+```text
+// SPDX-License-Identifier: GPL-2.0-only
+// Copyright (C) 2026 BarutSRB — https://github.com/BarutSRB/OmniWM
+```
+
+The fork base predates per-file attribution: neither OmniWM at the fork point
+nor Nehir's source tree carried per-file notices. Upstream OmniWM has since
+introduced its own per-file notice, and Nehir now introduces a structured form
+too — making upstream authorship explicit on every file and separating legal
+authorship from project lineage. Each shipped Swift file carries an SPDX block
+with one of two provenance markers:
+
+- **`Provenance=upstream-derived`** — the file originates from OmniWM (copied,
+  adapted, or significantly rewritten in Nehir). It carries **two** copyright
+  lines, preserving upstream authorship **in addition to** Nehir's:
+  ```text
+  // SPDX-FileCopyrightText: 2026 BarutSRB
+  // SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+  // SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+  //
+  // SPDX-License-Identifier: GPL-2.0-only
+  ```
+  Exact upstream commit hashes for a few post-fork-base borrows are tracked in
+  `.provenance.json`'s non-rendering `upstreamCommits` map and in the provenance
+  audit, not rendered into every file header. Each path maps to an array of
+  `{repo, hash}` entries, so a file can record more than one borrow, including
+  from different upstream sources.
+
+- **`Provenance=nehir-original`** — the file was written from scratch for Nehir
+  with no prior existence anywhere in OmniWM. It carries only Nehir copyright:
+  ```text
+  // SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+  // SPDX-FileComment: Provenance=nehir-original; See=NOTICE.md
+  //
+  // SPDX-License-Identifier: GPL-2.0-only
+  ```
+
+`SPDX-License-Identifier`, `SPDX-FileCopyrightText`, and `SPDX-FileComment` are
+standard SPDX file tags. The `Provenance=`, `Upstream-Project=`,
+`Upstream-Author=`, and `Nehir-Changes-Since=` keys inside `SPDX-FileComment`
+are Nehir's own convention, documented here; SPDX lets a file comment carry
+arbitrary structured text, but does not standardize these keys.
+
+The default marker is `upstream-derived`: this is the conservative choice for a
+GPL-2.0-only fork (most files originate upstream), so any new file is assumed to
+be upstream-derived until it is explicitly reclassified. A file is marked
+`nehir-original` only when its own code is absent from all of upstream history.
+This split is backed by a file-by-file provenance audit recorded on the `plans`
+branch under `provenance/`.
+
+Rules of thumb:
+
+- Do **not** add `2026 BarutSRB` to a file merely as thanks — only to files that
+  actually contain OmniWM-origin code. New from-scratch Nehir files go in the
+  `nehir-original` override (Nehir-only copyright).
+- Do **not** drop `2026 BarutSRB` from files derived from OmniWM. Upstream
+copyright is preserved **in addition to** Nehir's, never instead of it.
+- For a file later shown to be copied or heavily adapted from a specific upstream
+  commit, record that commit in `.provenance.json`'s `upstreamCommits` audit map
+  and in the durable provenance audit. Keep rendered headers focused on stable
+  legal facts instead of per-file commit bookkeeping.
+
+Generated Swift headers are driven by `.provenance.json` and the mise task files
+under `.config/mise/tasks/license/` (`mise run license`, `mise run license:check`).
+
 ## Git history
 
 This repository ships a squashed/fresh Git history to keep the clone small. The

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,10 @@
 // swift-tools-version: 6.3
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import Foundation
 import PackageDescription
 

--- a/README.md
+++ b/README.md
@@ -246,7 +246,7 @@ Nehir is one of several projects exploring this workflow:
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/chart?repos=guria/nehir&type=date&legend=top-left)](https://www.star-history.com/?type=date&repos=guria%2Fnehir)
+[![Star History Chart](https://api.star-history.com/chart?repos=apphane-dev/nehir&type=date&legend=top-left)](https://www.star-history.com/?type=date&repos=apphane-dev%2Fnehir)
 
 ## License
 

--- a/Sources/Nehir/App/AppBootstrapPlanner.swift
+++ b/Sources/Nehir/App/AppBootstrapPlanner.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import Foundation
 
 enum AppBootstrapDecision: Equatable {

--- a/Sources/Nehir/App/AppCLIManager.swift
+++ b/Sources/Nehir/App/AppCLIManager.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import Foundation
 
 enum AppCLIExposureStatus: Equatable {

--- a/Sources/Nehir/App/AppDelegate.swift
+++ b/Sources/Nehir/App/AppDelegate.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import AppKit
 import Observation
 

--- a/Sources/Nehir/App/OwnedWindowRegistry.swift
+++ b/Sources/Nehir/App/OwnedWindowRegistry.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import AppKit
 import Foundation
 

--- a/Sources/Nehir/Core/Animation/AnimationClock.swift
+++ b/Sources/Nehir/Core/Animation/AnimationClock.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import Foundation
 import QuartzCore
 

--- a/Sources/Nehir/Core/Animation/CubicAnimation.swift
+++ b/Sources/Nehir/Core/Animation/CubicAnimation.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import Foundation
 import QuartzCore
 

--- a/Sources/Nehir/Core/Animation/MotionPolicy.swift
+++ b/Sources/Nehir/Core/Animation/MotionPolicy.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import Observation
 
 struct MotionSnapshot: Equatable, Sendable {

--- a/Sources/Nehir/Core/Animation/MoveAnimation.swift
+++ b/Sources/Nehir/Core/Animation/MoveAnimation.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import Foundation
 
 struct MoveAnimation {

--- a/Sources/Nehir/Core/Animation/SpringAnimation.swift
+++ b/Sources/Nehir/Core/Animation/SpringAnimation.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import Foundation
 
 struct SpringConfig {

--- a/Sources/Nehir/Core/Animation/SwipeTracker.swift
+++ b/Sources/Nehir/Core/Animation/SwipeTracker.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import Foundation
 
 struct SwipeEvent {

--- a/Sources/Nehir/Core/AppInfoCache.swift
+++ b/Sources/Nehir/Core/AppInfoCache.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import AppKit
 import Foundation
 

--- a/Sources/Nehir/Core/Ax/AXManager.swift
+++ b/Sources/Nehir/Core/Ax/AXManager.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import AppKit
 import ApplicationServices
 import CoreGraphics

--- a/Sources/Nehir/Core/Ax/AXTrustedPrompt.swift
+++ b/Sources/Nehir/Core/Ax/AXTrustedPrompt.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 @preconcurrency import ApplicationServices
 import Foundation
 

--- a/Sources/Nehir/Core/Ax/AXWindow.swift
+++ b/Sources/Nehir/Core/Ax/AXWindow.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import AppKit
 import ApplicationServices
 import Foundation

--- a/Sources/Nehir/Core/Ax/AccessibilityPermissionMonitor.swift
+++ b/Sources/Nehir/Core/Ax/AccessibilityPermissionMonitor.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import ApplicationServices
 import Foundation
 

--- a/Sources/Nehir/Core/Ax/AppAXContext.swift
+++ b/Sources/Nehir/Core/Ax/AppAXContext.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import AppKit
 import ApplicationServices
 import Foundation

--- a/Sources/Nehir/Core/Ax/AppThreadToken.swift
+++ b/Sources/Nehir/Core/Ax/AppThreadToken.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import Foundation
 
 @TaskLocal

--- a/Sources/Nehir/Core/Ax/DefaultFloatingApps.swift
+++ b/Sources/Nehir/Core/Ax/DefaultFloatingApps.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import Foundation
 
 enum DefaultFloatingApps {

--- a/Sources/Nehir/Core/Ax/RawAXNotificationTrace.swift
+++ b/Sources/Nehir/Core/Ax/RawAXNotificationTrace.swift
@@ -1,3 +1,8 @@
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=nehir-original; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import Foundation
 
 /// One entry in the raw AX notification trace ring.

--- a/Sources/Nehir/Core/Ax/RunLoopJob.swift
+++ b/Sources/Nehir/Core/Ax/RunLoopJob.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import Foundation
 import Synchronization
 

--- a/Sources/Nehir/Core/Ax/Thread+RunLoop.swift
+++ b/Sources/Nehir/Core/Ax/Thread+RunLoop.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import Foundation
 
 struct RunLoopTimeoutError: Error, Sendable {

--- a/Sources/Nehir/Core/Ax/ThreadGuardedValue.swift
+++ b/Sources/Nehir/Core/Ax/ThreadGuardedValue.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import Foundation
 
 @usableFromInline

--- a/Sources/Nehir/Core/Border/BorderConfig.swift
+++ b/Sources/Nehir/Core/Border/BorderConfig.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import AppKit
 
 struct BorderConfig: Equatable {

--- a/Sources/Nehir/Core/Border/BorderManager.swift
+++ b/Sources/Nehir/Core/Border/BorderManager.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import AppKit
 import Foundation
 

--- a/Sources/Nehir/Core/Border/BorderWindow.swift
+++ b/Sources/Nehir/Core/Border/BorderWindow.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import AppKit
 import QuartzCore
 

--- a/Sources/Nehir/Core/Border/FocusBorderController.swift
+++ b/Sources/Nehir/Core/Border/FocusBorderController.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import ApplicationServices
 import CoreGraphics
 import Foundation

--- a/Sources/Nehir/Core/CommandPaletteMode.swift
+++ b/Sources/Nehir/Core/CommandPaletteMode.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import Foundation
 
 enum CommandPaletteMode: String, CaseIterable, Codable {

--- a/Sources/Nehir/Core/Config/AppRule.swift
+++ b/Sources/Nehir/Core/Config/AppRule.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import Foundation
 
 enum WindowRuleManageAction: String, Codable, CaseIterable, Identifiable {

--- a/Sources/Nehir/Core/Config/AppRuleFileStore.swift
+++ b/Sources/Nehir/Core/Config/AppRuleFileStore.swift
@@ -1,3 +1,8 @@
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=nehir-original; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import Foundation
 
 /// Reads and writes app rules from `apprules.d/*.toml` — one file per rule.

--- a/Sources/Nehir/Core/Config/AppearanceMode.swift
+++ b/Sources/Nehir/Core/Config/AppearanceMode.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import AppKit
 
 @MainActor

--- a/Sources/Nehir/Core/Config/BuiltInSettingsDefaults.swift
+++ b/Sources/Nehir/Core/Config/BuiltInSettingsDefaults.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import Foundation
 
 enum BuiltInSettingsDefaults {

--- a/Sources/Nehir/Core/Config/CanonicalTOMLConfig.swift
+++ b/Sources/Nehir/Core/Config/CanonicalTOMLConfig.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import Foundation
 
 private extension CanonicalTOMLConfig {

--- a/Sources/Nehir/Core/Config/ConfigAssistancePrompt.swift
+++ b/Sources/Nehir/Core/Config/ConfigAssistancePrompt.swift
@@ -1,3 +1,8 @@
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=nehir-original; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import Foundation
 
 enum ConfigAssistancePrompt {

--- a/Sources/Nehir/Core/Config/ConfigMismatchDetector.swift
+++ b/Sources/Nehir/Core/Config/ConfigMismatchDetector.swift
@@ -1,3 +1,8 @@
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=nehir-original; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import Foundation
 import TOML
 

--- a/Sources/Nehir/Core/Config/GestureFingerCount.swift
+++ b/Sources/Nehir/Core/Config/GestureFingerCount.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 enum GestureFingerCount: Int, CaseIterable, Codable {
     case two = 2
     case three = 3

--- a/Sources/Nehir/Core/Config/HotkeyConfigMapping.swift
+++ b/Sources/Nehir/Core/Config/HotkeyConfigMapping.swift
@@ -1,3 +1,8 @@
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=nehir-original; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import Carbon
 import Foundation
 

--- a/Sources/Nehir/Core/Config/HotkeysTOMLCodec.swift
+++ b/Sources/Nehir/Core/Config/HotkeysTOMLCodec.swift
@@ -1,3 +1,8 @@
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=nehir-original; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import Foundation
 
 /// Encodes and decodes hotkey bindings to/from the `hotkeys.toml` format.

--- a/Sources/Nehir/Core/Config/MonitorBarSettings.swift
+++ b/Sources/Nehir/Core/Config/MonitorBarSettings.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import CoreGraphics
 import Foundation
 

--- a/Sources/Nehir/Core/Config/MonitorGapSettings.swift
+++ b/Sources/Nehir/Core/Config/MonitorGapSettings.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import CoreGraphics
 import Foundation
 

--- a/Sources/Nehir/Core/Config/MonitorNiriSettings.swift
+++ b/Sources/Nehir/Core/Config/MonitorNiriSettings.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import CoreGraphics
 import Foundation
 

--- a/Sources/Nehir/Core/Config/MonitorOrientationSettings.swift
+++ b/Sources/Nehir/Core/Config/MonitorOrientationSettings.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import CoreGraphics
 
 struct MonitorOrientationSettings: MonitorSettingsType {

--- a/Sources/Nehir/Core/Config/MonitorOverrideFileStore.swift
+++ b/Sources/Nehir/Core/Config/MonitorOverrideFileStore.swift
@@ -1,3 +1,8 @@
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=nehir-original; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import CoreGraphics
 import Foundation
 

--- a/Sources/Nehir/Core/Config/MonitorSettingsType.swift
+++ b/Sources/Nehir/Core/Config/MonitorSettingsType.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import CoreGraphics
 import Foundation
 

--- a/Sources/Nehir/Core/Config/MouseResizeModifierKey.swift
+++ b/Sources/Nehir/Core/Config/MouseResizeModifierKey.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 enum MouseResizeModifierKey: String, CaseIterable, Codable {
     case option
     case control

--- a/Sources/Nehir/Core/Config/MouseWarpAxis.swift
+++ b/Sources/Nehir/Core/Config/MouseWarpAxis.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import CoreGraphics
 
 enum MouseWarpAxis: String, Codable, CaseIterable {

--- a/Sources/Nehir/Core/Config/NehirStoragePaths.swift
+++ b/Sources/Nehir/Core/Config/NehirStoragePaths.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import Foundation
 
 struct NehirStoragePaths: Equatable {

--- a/Sources/Nehir/Core/Config/OnboardingStateStore.swift
+++ b/Sources/Nehir/Core/Config/OnboardingStateStore.swift
@@ -1,4 +1,8 @@
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=nehir-original; See=NOTICE.md
+//
 // SPDX-License-Identifier: GPL-2.0-only
+
 import Darwin
 import Foundation
 

--- a/Sources/Nehir/Core/Config/RuntimeStateStore.swift
+++ b/Sources/Nehir/Core/Config/RuntimeStateStore.swift
@@ -1,4 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
 // SPDX-License-Identifier: GPL-2.0-only
+
 import CoreGraphics
 import Darwin
 import Foundation

--- a/Sources/Nehir/Core/Config/ScrollModifierKey.swift
+++ b/Sources/Nehir/Core/Config/ScrollModifierKey.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 enum ScrollModifierKey: String, CaseIterable, Codable {
     case optionShift
     case controlShift

--- a/Sources/Nehir/Core/Config/SettingsDiagnosticsIssue.swift
+++ b/Sources/Nehir/Core/Config/SettingsDiagnosticsIssue.swift
@@ -1,3 +1,8 @@
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=nehir-original; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import Foundation
 
 struct UnknownSettingsKeysIssue: Identifiable, Equatable {

--- a/Sources/Nehir/Core/Config/SettingsExport.swift
+++ b/Sources/Nehir/Core/Config/SettingsExport.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import Foundation
 import NehirIPC
 

--- a/Sources/Nehir/Core/Config/SettingsFilePersistence.swift
+++ b/Sources/Nehir/Core/Config/SettingsFilePersistence.swift
@@ -1,4 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
 // SPDX-License-Identifier: GPL-2.0-only
+
 import Darwin
 import Foundation
 

--- a/Sources/Nehir/Core/Config/SettingsMigrationRegistry.swift
+++ b/Sources/Nehir/Core/Config/SettingsMigrationRegistry.swift
@@ -1,3 +1,8 @@
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=nehir-original; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import Foundation
 
 extension Notification.Name {

--- a/Sources/Nehir/Core/Config/SettingsMigrationStateStore.swift
+++ b/Sources/Nehir/Core/Config/SettingsMigrationStateStore.swift
@@ -1,3 +1,8 @@
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=nehir-original; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import Darwin
 import Foundation
 

--- a/Sources/Nehir/Core/Config/SettingsStore.swift
+++ b/Sources/Nehir/Core/Config/SettingsStore.swift
@@ -1,4 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
 // SPDX-License-Identifier: GPL-2.0-only
+
 import AppKit
 import Carbon
 import Foundation

--- a/Sources/Nehir/Core/Config/SettingsTOMLCodec.swift
+++ b/Sources/Nehir/Core/Config/SettingsTOMLCodec.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import Foundation
 import TOML
 

--- a/Sources/Nehir/Core/Config/SettingsTOMLUnknownValue.swift
+++ b/Sources/Nehir/Core/Config/SettingsTOMLUnknownValue.swift
@@ -1,3 +1,8 @@
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=nehir-original; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import Foundation
 import TOML
 

--- a/Sources/Nehir/Core/Config/WindowCapabilityProfile.swift
+++ b/Sources/Nehir/Core/Config/WindowCapabilityProfile.swift
@@ -1,4 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
 // SPDX-License-Identifier: GPL-2.0-only
+
 import Foundation
 
 struct WindowCapabilityProfile: Equatable, Sendable {

--- a/Sources/Nehir/Core/Config/WorkspaceConfig.swift
+++ b/Sources/Nehir/Core/Config/WorkspaceConfig.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import Foundation
 import NehirIPC
 

--- a/Sources/Nehir/Core/Config/WorkspacesTOMLCodec.swift
+++ b/Sources/Nehir/Core/Config/WorkspacesTOMLCodec.swift
@@ -1,3 +1,8 @@
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=nehir-original; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import CoreGraphics
 import Foundation
 import NehirIPC

--- a/Sources/Nehir/Core/Controller/AXEventHandler.swift
+++ b/Sources/Nehir/Core/Controller/AXEventHandler.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import AppKit
 import Foundation
 

--- a/Sources/Nehir/Core/Controller/CommandHandler.swift
+++ b/Sources/Nehir/Core/Controller/CommandHandler.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import AppKit
 import Foundation
 

--- a/Sources/Nehir/Core/Controller/Direction.swift
+++ b/Sources/Nehir/Core/Controller/Direction.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import AppKit
 
 enum Direction: String, Codable {

--- a/Sources/Nehir/Core/Controller/FocusCoordinator.swift
+++ b/Sources/Nehir/Core/Controller/FocusCoordinator.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import AppKit
 import Foundation
 

--- a/Sources/Nehir/Core/Controller/FocusNotifications.swift
+++ b/Sources/Nehir/Core/Controller/FocusNotifications.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import Foundation
 
 enum NehirFocusNotificationKey {

--- a/Sources/Nehir/Core/Controller/KeyboardFocusLifecycleCoordinator.swift
+++ b/Sources/Nehir/Core/Controller/KeyboardFocusLifecycleCoordinator.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import Foundation
 
 struct KeyboardFocusTarget {

--- a/Sources/Nehir/Core/Controller/LayoutCoordinator.swift
+++ b/Sources/Nehir/Core/Controller/LayoutCoordinator.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import AppKit
 import Foundation
 

--- a/Sources/Nehir/Core/Controller/LayoutRefreshController.swift
+++ b/Sources/Nehir/Core/Controller/LayoutRefreshController.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import AppKit
 import Foundation
 import QuartzCore

--- a/Sources/Nehir/Core/Controller/LayoutTrace.swift
+++ b/Sources/Nehir/Core/Controller/LayoutTrace.swift
@@ -1,3 +1,8 @@
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=nehir-original; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import Foundation
 import os
 

--- a/Sources/Nehir/Core/Controller/MouseEventHandler.swift
+++ b/Sources/Nehir/Core/Controller/MouseEventHandler.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import AppKit
 import Foundation
 

--- a/Sources/Nehir/Core/Controller/MouseWarpHandler.swift
+++ b/Sources/Nehir/Core/Controller/MouseWarpHandler.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import AppKit
 import Foundation
 

--- a/Sources/Nehir/Core/Controller/NativeFullscreenPlaceholderManager.swift
+++ b/Sources/Nehir/Core/Controller/NativeFullscreenPlaceholderManager.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import AppKit
 
 struct NativeFullscreenPlaceholderUpdate {

--- a/Sources/Nehir/Core/Controller/NiriLayoutHandler.swift
+++ b/Sources/Nehir/Core/Controller/NiriLayoutHandler.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import AppKit
 import Foundation
 import QuartzCore

--- a/Sources/Nehir/Core/Controller/RefreshReason.swift
+++ b/Sources/Nehir/Core/Controller/RefreshReason.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import Foundation
 
 enum RelayoutSchedulingPolicy: Equatable, Sendable {

--- a/Sources/Nehir/Core/Controller/ServiceLifecycleManager.swift
+++ b/Sources/Nehir/Core/Controller/ServiceLifecycleManager.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import AppKit
 import Foundation
 

--- a/Sources/Nehir/Core/Controller/WMCommandTarget.swift
+++ b/Sources/Nehir/Core/Controller/WMCommandTarget.swift
@@ -1,3 +1,8 @@
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=nehir-original; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import Foundation
 
 struct WMCommandTarget: Equatable {

--- a/Sources/Nehir/Core/Controller/WMController.swift
+++ b/Sources/Nehir/Core/Controller/WMController.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import AppKit
 import Foundation
 import NehirIPC

--- a/Sources/Nehir/Core/Controller/WindowActionHandler.swift
+++ b/Sources/Nehir/Core/Controller/WindowActionHandler.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import AppKit
 import Foundation
 

--- a/Sources/Nehir/Core/Controller/WorkspaceNavigationHandler.swift
+++ b/Sources/Nehir/Core/Controller/WorkspaceNavigationHandler.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import AppKit
 import Foundation
 import NehirIPC

--- a/Sources/Nehir/Core/Input/ActionCatalog.swift
+++ b/Sources/Nehir/Core/Input/ActionCatalog.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import Carbon
 import NehirIPC
 

--- a/Sources/Nehir/Core/Input/DefaultHotkeyBindings.swift
+++ b/Sources/Nehir/Core/Input/DefaultHotkeyBindings.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import Carbon
 
 enum DefaultHotkeyBindings {

--- a/Sources/Nehir/Core/Input/HotkeyBinding.swift
+++ b/Sources/Nehir/Core/Input/HotkeyBinding.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import Carbon
 import Foundation
 

--- a/Sources/Nehir/Core/Input/HotkeyCommand.swift
+++ b/Sources/Nehir/Core/Input/HotkeyCommand.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import Foundation
 
 enum HotkeyCommand: Codable, Equatable, Hashable {

--- a/Sources/Nehir/Core/Input/Hotkeys.swift
+++ b/Sources/Nehir/Core/Input/Hotkeys.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 @preconcurrency import AppKit
 import Carbon
 import Foundation

--- a/Sources/Nehir/Core/Input/KeySymbolMapper.swift
+++ b/Sources/Nehir/Core/Input/KeySymbolMapper.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import Carbon
 import Foundation
 

--- a/Sources/Nehir/Core/Input/NiriScrollTracker.swift
+++ b/Sources/Nehir/Core/Input/NiriScrollTracker.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import Foundation
 
 /// Swift port of Niri's `input/scroll_tracker.rs` for wheel/touchpad bind ticks.

--- a/Sources/Nehir/Core/Layout/DNode.swift
+++ b/Sources/Nehir/Core/Layout/DNode.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import ApplicationServices
 import CoreGraphics
 import Foundation

--- a/Sources/Nehir/Core/Layout/LayoutBoundary.swift
+++ b/Sources/Nehir/Core/Layout/LayoutBoundary.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import AppKit
 import Foundation
 

--- a/Sources/Nehir/Core/Layout/Niri/DragGhostController.swift
+++ b/Sources/Nehir/Core/Layout/Niri/DragGhostController.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import AppKit
 import ScreenCaptureKit
 

--- a/Sources/Nehir/Core/Layout/Niri/DragGhostWindow.swift
+++ b/Sources/Nehir/Core/Layout/Niri/DragGhostWindow.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import AppKit
 
 @MainActor

--- a/Sources/Nehir/Core/Layout/Niri/InteractiveMove.swift
+++ b/Sources/Nehir/Core/Layout/Niri/InteractiveMove.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import AppKit
 import Foundation
 

--- a/Sources/Nehir/Core/Layout/Niri/InteractiveResize.swift
+++ b/Sources/Nehir/Core/Layout/Niri/InteractiveResize.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import AppKit
 import Foundation
 

--- a/Sources/Nehir/Core/Layout/Niri/NiriConstraintSolver.swift
+++ b/Sources/Nehir/Core/Layout/Niri/NiriConstraintSolver.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import Foundation
 
 enum NiriAxisSolver {

--- a/Sources/Nehir/Core/Layout/Niri/NiriLayout.swift
+++ b/Sources/Nehir/Core/Layout/Niri/NiriLayout.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import AppKit
 import Foundation
 

--- a/Sources/Nehir/Core/Layout/Niri/NiriLayoutEngine+Animation.swift
+++ b/Sources/Nehir/Core/Layout/Niri/NiriLayoutEngine+Animation.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import AppKit
 import Foundation
 

--- a/Sources/Nehir/Core/Layout/Niri/NiriLayoutEngine+ColumnOps.swift
+++ b/Sources/Nehir/Core/Layout/Niri/NiriLayoutEngine+ColumnOps.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import AppKit
 import Foundation
 

--- a/Sources/Nehir/Core/Layout/Niri/NiriLayoutEngine+InteractiveMove.swift
+++ b/Sources/Nehir/Core/Layout/Niri/NiriLayoutEngine+InteractiveMove.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import AppKit
 import Foundation
 

--- a/Sources/Nehir/Core/Layout/Niri/NiriLayoutEngine+InteractiveResize.swift
+++ b/Sources/Nehir/Core/Layout/Niri/NiriLayoutEngine+InteractiveResize.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import AppKit
 import Foundation
 

--- a/Sources/Nehir/Core/Layout/Niri/NiriLayoutEngine+Monitors.swift
+++ b/Sources/Nehir/Core/Layout/Niri/NiriLayoutEngine+Monitors.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import AppKit
 import Foundation
 

--- a/Sources/Nehir/Core/Layout/Niri/NiriLayoutEngine+PureLayoutBridge.swift
+++ b/Sources/Nehir/Core/Layout/Niri/NiriLayoutEngine+PureLayoutBridge.swift
@@ -1,3 +1,8 @@
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=nehir-original; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import AppKit
 import Foundation
 import OSLog

--- a/Sources/Nehir/Core/Layout/Niri/NiriLayoutEngine+Restore.swift
+++ b/Sources/Nehir/Core/Layout/Niri/NiriLayoutEngine+Restore.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import Foundation
 
 extension NiriLayoutEngine {

--- a/Sources/Nehir/Core/Layout/Niri/NiriLayoutEngine+Sizing.swift
+++ b/Sources/Nehir/Core/Layout/Niri/NiriLayoutEngine+Sizing.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import AppKit
 import Foundation
 

--- a/Sources/Nehir/Core/Layout/Niri/NiriLayoutEngine+TabbedMode.swift
+++ b/Sources/Nehir/Core/Layout/Niri/NiriLayoutEngine+TabbedMode.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import AppKit
 import Foundation
 

--- a/Sources/Nehir/Core/Layout/Niri/NiriLayoutEngine+ViewportCommands.swift
+++ b/Sources/Nehir/Core/Layout/Niri/NiriLayoutEngine+ViewportCommands.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import AppKit
 
 extension NiriLayoutEngine {

--- a/Sources/Nehir/Core/Layout/Niri/NiriLayoutEngine+WindowOps.swift
+++ b/Sources/Nehir/Core/Layout/Niri/NiriLayoutEngine+WindowOps.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import AppKit
 import Foundation
 

--- a/Sources/Nehir/Core/Layout/Niri/NiriLayoutEngine+Windows.swift
+++ b/Sources/Nehir/Core/Layout/Niri/NiriLayoutEngine+Windows.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import AppKit
 import Foundation
 

--- a/Sources/Nehir/Core/Layout/Niri/NiriLayoutEngine+WorkspaceOps.swift
+++ b/Sources/Nehir/Core/Layout/Niri/NiriLayoutEngine+WorkspaceOps.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import AppKit
 import Foundation
 

--- a/Sources/Nehir/Core/Layout/Niri/NiriLayoutEngine.swift
+++ b/Sources/Nehir/Core/Layout/Niri/NiriLayoutEngine.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import AppKit
 import Foundation
 

--- a/Sources/Nehir/Core/Layout/Niri/NiriMonitor.swift
+++ b/Sources/Nehir/Core/Layout/Niri/NiriMonitor.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import AppKit
 import CoreGraphics
 import Foundation

--- a/Sources/Nehir/Core/Layout/Niri/NiriNavigation.swift
+++ b/Sources/Nehir/Core/Layout/Niri/NiriNavigation.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import AppKit
 import Foundation
 

--- a/Sources/Nehir/Core/Layout/Niri/NiriNode.swift
+++ b/Sources/Nehir/Core/Layout/Niri/NiriNode.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import AppKit
 import Foundation
 

--- a/Sources/Nehir/Core/Layout/Niri/NiriOverviewSnapshot.swift
+++ b/Sources/Nehir/Core/Layout/Niri/NiriOverviewSnapshot.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import CoreGraphics
 import Foundation
 

--- a/Sources/Nehir/Core/Layout/Niri/NiriSizeChange.swift
+++ b/Sources/Nehir/Core/Layout/Niri/NiriSizeChange.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import Foundation
 
 enum NiriSizeChange: Codable, Equatable, Hashable {

--- a/Sources/Nehir/Core/Layout/Niri/SwapTargetOverlay.swift
+++ b/Sources/Nehir/Core/Layout/Niri/SwapTargetOverlay.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import AppKit
 
 @MainActor

--- a/Sources/Nehir/Core/Layout/Niri/TabbedColumnOverlay.swift
+++ b/Sources/Nehir/Core/Layout/Niri/TabbedColumnOverlay.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import AppKit
 
 private enum TabbedOverlayMetrics {

--- a/Sources/Nehir/Core/Layout/Niri/ViewportState+Animation.swift
+++ b/Sources/Nehir/Core/Layout/Niri/ViewportState+Animation.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import AppKit
 import Foundation
 

--- a/Sources/Nehir/Core/Layout/Niri/ViewportState+ColumnTransitions.swift
+++ b/Sources/Nehir/Core/Layout/Niri/ViewportState+ColumnTransitions.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import AppKit
 import Foundation
 

--- a/Sources/Nehir/Core/Layout/Niri/ViewportState+Geometry.swift
+++ b/Sources/Nehir/Core/Layout/Niri/ViewportState+Geometry.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import CoreGraphics
 import Foundation
 

--- a/Sources/Nehir/Core/Layout/Niri/ViewportState+Gestures.swift
+++ b/Sources/Nehir/Core/Layout/Niri/ViewportState+Gestures.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import AppKit
 import Foundation
 

--- a/Sources/Nehir/Core/Layout/Niri/ViewportState.swift
+++ b/Sources/Nehir/Core/Layout/Niri/ViewportState.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import AppKit
 import Foundation
 

--- a/Sources/Nehir/Core/Layout/SideHiding.swift
+++ b/Sources/Nehir/Core/Layout/SideHiding.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import CoreGraphics
 import Foundation
 

--- a/Sources/Nehir/Core/LockScreen/LockScreenObserver.swift
+++ b/Sources/Nehir/Core/LockScreen/LockScreenObserver.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import AppKit
 import Foundation
 

--- a/Sources/Nehir/Core/Menu/MenuAnywhereFetcher.swift
+++ b/Sources/Nehir/Core/Menu/MenuAnywhereFetcher.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import AppKit
 @preconcurrency import ApplicationServices
 

--- a/Sources/Nehir/Core/Menu/MenuExtractor.swift
+++ b/Sources/Nehir/Core/Menu/MenuExtractor.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import AppKit
 import ApplicationServices
 import ObjectiveC

--- a/Sources/Nehir/Core/Menu/MenuItemModel.swift
+++ b/Sources/Nehir/Core/Menu/MenuItemModel.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import ApplicationServices
 import Foundation
 

--- a/Sources/Nehir/Core/Monitor/DisplayConfigurationObserver.swift
+++ b/Sources/Nehir/Core/Monitor/DisplayConfigurationObserver.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import AppKit
 import CoreGraphics
 import Foundation

--- a/Sources/Nehir/Core/Monitor/DisplayEnvironmentDiagnostics.swift
+++ b/Sources/Nehir/Core/Monitor/DisplayEnvironmentDiagnostics.swift
@@ -1,3 +1,8 @@
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=nehir-original; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import CoreGraphics
 import Foundation
 

--- a/Sources/Nehir/Core/Monitor/Monitor.swift
+++ b/Sources/Nehir/Core/Monitor/Monitor.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import AppKit
 import CoreGraphics
 

--- a/Sources/Nehir/Core/Monitor/MonitorDescription.swift
+++ b/Sources/Nehir/Core/Monitor/MonitorDescription.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import Foundation
 
 enum MonitorDescription: Equatable {

--- a/Sources/Nehir/Core/Monitor/MonitorRestoreAssignments.swift
+++ b/Sources/Nehir/Core/Monitor/MonitorRestoreAssignments.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import CoreGraphics
 import Foundation
 

--- a/Sources/Nehir/Core/Monitor/OutputId.swift
+++ b/Sources/Nehir/Core/Monitor/OutputId.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import CoreGraphics
 import Foundation
 

--- a/Sources/Nehir/Core/Multitouch/MultitouchBinding.swift
+++ b/Sources/Nehir/Core/Multitouch/MultitouchBinding.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import Darwin
 import Foundation
 

--- a/Sources/Nehir/Core/Multitouch/MultitouchGestureSource.swift
+++ b/Sources/Nehir/Core/Multitouch/MultitouchGestureSource.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import AppKit
 import Foundation
 

--- a/Sources/Nehir/Core/Overview/OverviewAnimator.swift
+++ b/Sources/Nehir/Core/Overview/OverviewAnimator.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import AppKit
 import Foundation
 import QuartzCore

--- a/Sources/Nehir/Core/Overview/OverviewController.swift
+++ b/Sources/Nehir/Core/Overview/OverviewController.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import AppKit
 import Foundation
 import ScreenCaptureKit

--- a/Sources/Nehir/Core/Overview/OverviewInputHandler.swift
+++ b/Sources/Nehir/Core/Overview/OverviewInputHandler.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import AppKit
 import Carbon
 import Foundation

--- a/Sources/Nehir/Core/Overview/OverviewLayoutCalculator.swift
+++ b/Sources/Nehir/Core/Overview/OverviewLayoutCalculator.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import AppKit
 import Foundation
 

--- a/Sources/Nehir/Core/Overview/OverviewRenderer.swift
+++ b/Sources/Nehir/Core/Overview/OverviewRenderer.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import AppKit
 import CoreGraphics
 import Foundation

--- a/Sources/Nehir/Core/Overview/OverviewSearchFilter.swift
+++ b/Sources/Nehir/Core/Overview/OverviewSearchFilter.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import Foundation
 
 struct OverviewSearchFilter {

--- a/Sources/Nehir/Core/Overview/OverviewState.swift
+++ b/Sources/Nehir/Core/Overview/OverviewState.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import AppKit
 import Foundation
 

--- a/Sources/Nehir/Core/Overview/OverviewThumbnailSizing.swift
+++ b/Sources/Nehir/Core/Overview/OverviewThumbnailSizing.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import CoreGraphics
 
 struct OverviewThumbnailCaptureRequest: Equatable {

--- a/Sources/Nehir/Core/Overview/OverviewWindow.swift
+++ b/Sources/Nehir/Core/Overview/OverviewWindow.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import AppKit
 import Foundation
 

--- a/Sources/Nehir/Core/PrivateAPIs.swift
+++ b/Sources/Nehir/Core/PrivateAPIs.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import ApplicationServices
 import Foundation
 

--- a/Sources/Nehir/Core/ProjectionInvalidation.swift
+++ b/Sources/Nehir/Core/ProjectionInvalidation.swift
@@ -1,3 +1,8 @@
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=nehir-original; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import Foundation
 
 /// Kinds of derived projections that can be invalidated by state mutations.

--- a/Sources/Nehir/Core/PureLayout/PureDirection.swift
+++ b/Sources/Nehir/Core/PureLayout/PureDirection.swift
@@ -1,3 +1,8 @@
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=nehir-original; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import Foundation
 
 enum PureDirection: Equatable {

--- a/Sources/Nehir/Core/PureLayout/PureLayoutInvariants.swift
+++ b/Sources/Nehir/Core/PureLayout/PureLayoutInvariants.swift
@@ -1,3 +1,8 @@
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=nehir-original; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import Foundation
 
 struct PureLayoutInvariantViolation: Equatable, CustomStringConvertible {

--- a/Sources/Nehir/Core/PureLayout/PureLayoutModels.swift
+++ b/Sources/Nehir/Core/PureLayout/PureLayoutModels.swift
@@ -1,3 +1,8 @@
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=nehir-original; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import Foundation
 
 struct PureLayoutConfig: Equatable {

--- a/Sources/Nehir/Core/PureLayout/PureLayoutReducer.swift
+++ b/Sources/Nehir/Core/PureLayout/PureLayoutReducer.swift
@@ -1,3 +1,8 @@
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=nehir-original; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import Foundation
 
 enum PureLayoutReducer {

--- a/Sources/Nehir/Core/Reconcile/ActionPlan.swift
+++ b/Sources/Nehir/Core/Reconcile/ActionPlan.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import CoreGraphics
 import Foundation
 

--- a/Sources/Nehir/Core/Reconcile/DebugDump.swift
+++ b/Sources/Nehir/Core/Reconcile/DebugDump.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import Foundation
 
 enum ReconcileDebugDump {

--- a/Sources/Nehir/Core/Reconcile/EventNormalizer.swift
+++ b/Sources/Nehir/Core/Reconcile/EventNormalizer.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import Foundation
 
 enum EventNormalizer {

--- a/Sources/Nehir/Core/Reconcile/FocusPolicyEngine.swift
+++ b/Sources/Nehir/Core/Reconcile/FocusPolicyEngine.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import Foundation
 
 enum FocusPolicyLeaseOwner: String, Equatable {

--- a/Sources/Nehir/Core/Reconcile/InvariantChecks.swift
+++ b/Sources/Nehir/Core/Reconcile/InvariantChecks.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import Foundation
 
 enum InvariantChecks {

--- a/Sources/Nehir/Core/Reconcile/PersistedWindowRestoreCatalog.swift
+++ b/Sources/Nehir/Core/Reconcile/PersistedWindowRestoreCatalog.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import CoreGraphics
 import Foundation
 

--- a/Sources/Nehir/Core/Reconcile/Planner.swift
+++ b/Sources/Nehir/Core/Reconcile/Planner.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import Foundation
 
 struct Planner {

--- a/Sources/Nehir/Core/Reconcile/ReconcileSnapshot.swift
+++ b/Sources/Nehir/Core/Reconcile/ReconcileSnapshot.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import CoreGraphics
 import Foundation
 

--- a/Sources/Nehir/Core/Reconcile/ReconcileTrace.swift
+++ b/Sources/Nehir/Core/Reconcile/ReconcileTrace.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import Foundation
 
 struct ReconcileTraceRecord: Equatable {

--- a/Sources/Nehir/Core/Reconcile/ReconcileTxn.swift
+++ b/Sources/Nehir/Core/Reconcile/ReconcileTxn.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import Foundation
 
 struct ReconcileInvariantViolation: Equatable {

--- a/Sources/Nehir/Core/Reconcile/RestorePlanner.swift
+++ b/Sources/Nehir/Core/Reconcile/RestorePlanner.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import CoreGraphics
 import Foundation
 

--- a/Sources/Nehir/Core/Reconcile/RuntimeStore.swift
+++ b/Sources/Nehir/Core/Reconcile/RuntimeStore.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import Foundation
 
 @MainActor

--- a/Sources/Nehir/Core/Reconcile/StateReducer.swift
+++ b/Sources/Nehir/Core/Reconcile/StateReducer.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import CoreGraphics
 import Foundation
 

--- a/Sources/Nehir/Core/Reconcile/WMEvent.swift
+++ b/Sources/Nehir/Core/Reconcile/WMEvent.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import CoreGraphics
 import Foundation
 

--- a/Sources/Nehir/Core/Rules/WindowRuleEngine.swift
+++ b/Sources/Nehir/Core/Rules/WindowRuleEngine.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import AppKit
 import Foundation
 

--- a/Sources/Nehir/Core/SkyLight/CGSEventObserver.swift
+++ b/Sources/Nehir/Core/SkyLight/CGSEventObserver.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import Foundation
 import os
 

--- a/Sources/Nehir/Core/SkyLight/DisplaySpacesMode.swift
+++ b/Sources/Nehir/Core/SkyLight/DisplaySpacesMode.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import Foundation
 
 /// Whether macOS "Displays have separate Spaces" is enabled, as observed by Nehir.

--- a/Sources/Nehir/Core/SkyLight/SkyLight.swift
+++ b/Sources/Nehir/Core/SkyLight/SkyLight.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import CoreGraphics
 import Foundation
 

--- a/Sources/Nehir/Core/Sleep/SleepPreventionManager.swift
+++ b/Sources/Nehir/Core/Sleep/SleepPreventionManager.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import AppKit
 import IOKit.pwr_mgt
 

--- a/Sources/Nehir/Core/Support/BuildVersion.swift
+++ b/Sources/Nehir/Core/Support/BuildVersion.swift
@@ -1,3 +1,8 @@
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=nehir-original; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import Foundation
 
 enum BuildVersion {

--- a/Sources/Nehir/Core/Support/Bundle+Extensions.swift
+++ b/Sources/Nehir/Core/Support/Bundle+Extensions.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import Foundation
 
 extension Bundle {

--- a/Sources/Nehir/Core/Support/CGGeometry+Extensions.swift
+++ b/Sources/Nehir/Core/Support/CGGeometry+Extensions.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import AppKit
 import Foundation
 

--- a/Sources/Nehir/Core/Support/ParseError.swift
+++ b/Sources/Nehir/Core/Support/ParseError.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import Foundation
 
 struct ParseError: Error, CustomStringConvertible {

--- a/Sources/Nehir/Core/Surface/SurfaceCoordinator.swift
+++ b/Sources/Nehir/Core/Surface/SurfaceCoordinator.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import AppKit
 import Foundation
 

--- a/Sources/Nehir/Core/Surface/SurfaceScene.swift
+++ b/Sources/Nehir/Core/Surface/SurfaceScene.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import AppKit
 import Foundation
 

--- a/Sources/Nehir/Core/Workspace/InteractionMonitorWriteTrace.swift
+++ b/Sources/Nehir/Core/Workspace/InteractionMonitorWriteTrace.swift
@@ -1,3 +1,8 @@
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=nehir-original; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import Foundation
 
 /// One recorded assignment to the interaction-monitor session state.

--- a/Sources/Nehir/Core/Workspace/WindowModel.swift
+++ b/Sources/Nehir/Core/Workspace/WindowModel.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import CoreGraphics
 import Foundation
 

--- a/Sources/Nehir/Core/Workspace/WindowState.swift
+++ b/Sources/Nehir/Core/Workspace/WindowState.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import Foundation
 
 enum LayoutReason: Codable, Equatable {

--- a/Sources/Nehir/Core/Workspace/WorkspaceEntryOrdering.swift
+++ b/Sources/Nehir/Core/Workspace/WorkspaceEntryOrdering.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import Foundation
 
 @MainActor

--- a/Sources/Nehir/Core/Workspace/WorkspaceManager.swift
+++ b/Sources/Nehir/Core/Workspace/WorkspaceManager.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import AppKit
 import Foundation
 import NehirIPC

--- a/Sources/Nehir/Core/Workspace/WorkspaceName.swift
+++ b/Sources/Nehir/Core/Workspace/WorkspaceName.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import Foundation
 
 struct WorkspaceName: Equatable, Hashable {

--- a/Sources/Nehir/Core/Workspace/WorkspaceTargetResolver.swift
+++ b/Sources/Nehir/Core/Workspace/WorkspaceTargetResolver.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import Foundation
 import NehirIPC
 

--- a/Sources/Nehir/IPC/ExternalCommandResult.swift
+++ b/Sources/Nehir/IPC/ExternalCommandResult.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import Foundation
 
 enum ExternalCommandResult: Equatable, Sendable, Error {

--- a/Sources/Nehir/IPC/IPCApplicationBridge.swift
+++ b/Sources/Nehir/IPC/IPCApplicationBridge.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import Foundation
 import NehirIPC
 

--- a/Sources/Nehir/IPC/IPCCommandRouter.swift
+++ b/Sources/Nehir/IPC/IPCCommandRouter.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import Foundation
 import NehirIPC
 

--- a/Sources/Nehir/IPC/IPCConnection.swift
+++ b/Sources/Nehir/IPC/IPCConnection.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import Foundation
 import NehirIPC
 

--- a/Sources/Nehir/IPC/IPCEventBroker.swift
+++ b/Sources/Nehir/IPC/IPCEventBroker.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import Foundation
 import NehirIPC
 

--- a/Sources/Nehir/IPC/IPCQueryRouter.swift
+++ b/Sources/Nehir/IPC/IPCQueryRouter.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import Foundation
 import NehirIPC
 

--- a/Sources/Nehir/IPC/IPCRuleProjection.swift
+++ b/Sources/Nehir/IPC/IPCRuleProjection.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import Foundation
 import NehirIPC
 

--- a/Sources/Nehir/IPC/IPCRuleRouter.swift
+++ b/Sources/Nehir/IPC/IPCRuleRouter.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import Foundation
 import NehirIPC
 

--- a/Sources/Nehir/IPC/IPCServer.swift
+++ b/Sources/Nehir/IPC/IPCServer.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import Darwin
 import Foundation
 import NehirIPC

--- a/Sources/Nehir/UI/AboutSettingsTab.swift
+++ b/Sources/Nehir/UI/AboutSettingsTab.swift
@@ -1,3 +1,8 @@
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=nehir-original; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import SwiftUI
 
 struct AboutSettingsTab: View {
@@ -7,7 +12,9 @@ struct AboutSettingsTab: View {
     private static let issuesURL = URL(string: "\(ReleaseNotes.repositoryURLString)/issues")!
     private static let discussionsURL = URL(string: "\(ReleaseNotes.repositoryURLString)/discussions")!
     private static let sponsorsURL = URL(string: "https://github.com/sponsors/guria")!
+    private static let upstreamSponsorsURL = URL(string: "https://github.com/sponsors/barutsrb")!
     private static let licenseURL = URL(string: "\(ReleaseNotes.repositoryURLString)/blob/main/LICENSE")!
+    private static let noticeURL = URL(string: "\(ReleaseNotes.repositoryURLString)/blob/main/NOTICE.md")!
     private static let omniWMURL = URL(string: "https://github.com/BarutSRB/OmniWM")!
 
     private var versionText: String {
@@ -28,14 +35,14 @@ struct AboutSettingsTab: View {
 
     var body: some View {
         ScrollView {
-            VStack(alignment: .leading, spacing: 12) {
+            VStack(alignment: .leading, spacing: 8) {
                 header
                 sponsorShowcase
                 githubLinks
                 licenseAndAttributionSection
             }
-            .padding(20)
-            .frame(maxWidth: 760, alignment: .topLeading)
+            .padding(14)
+            .frame(maxWidth: 740, alignment: .topLeading)
             .frame(maxWidth: .infinity, alignment: .leading)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
@@ -47,7 +54,7 @@ struct AboutSettingsTab: View {
     private var header: some View {
         HStack(alignment: .center, spacing: 16) {
             NehirLogo()
-                .frame(width: 132, height: 54)
+                .frame(width: 112, height: 46)
                 .accessibilityLabel("Nehir")
 
             Text(versionText)
@@ -59,21 +66,21 @@ struct AboutSettingsTab: View {
     }
 
     private var sponsorShowcase: some View {
-        VStack(spacing: 12) {
+        VStack(spacing: 8) {
             Spacer(minLength: 0)
 
             Image(systemName: "heart.circle.fill")
-                .font(.system(size: 44, weight: .semibold))
+                .font(.system(size: 34, weight: .semibold))
                 .foregroundStyle(.pink)
                 .symbolRenderingMode(.hierarchical)
 
-            VStack(spacing: 6) {
+            VStack(spacing: 4) {
                 Text("Sponsor Showcase")
-                    .font(.title3.weight(.semibold))
+                    .font(.callout.weight(.semibold))
                 Text(
                     "This space is reserved for the people and organizations who support Nehir. There are no sponsors yet — become the first one and help keep development moving."
                 )
-                .font(.subheadline)
+                .font(.caption)
                 .foregroundStyle(.secondary)
                 .multilineTextAlignment(.center)
                 .fixedSize(horizontal: false, vertical: true)
@@ -87,19 +94,19 @@ struct AboutSettingsTab: View {
                     Label("Spread the word", systemImage: "megaphone.fill")
                 }
                 .buttonStyle(.bordered)
-                .controlSize(.regular)
+                .controlSize(.small)
 
                 Link(destination: Self.sponsorsURL) {
                     Label("Sponsor Nehir", systemImage: "heart.fill")
                 }
                 .buttonStyle(.borderedProminent)
-                .controlSize(.regular)
+                .controlSize(.small)
             }
 
             Spacer(minLength: 0)
         }
-        .padding(20)
-        .frame(maxWidth: .infinity, minHeight: 210)
+        .padding(14)
+        .frame(maxWidth: .infinity, minHeight: 152)
         .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 22, style: .continuous))
         .overlay {
             RoundedRectangle(cornerRadius: 22, style: .continuous)
@@ -108,7 +115,7 @@ struct AboutSettingsTab: View {
     }
 
     private var githubLinks: some View {
-        VStack(alignment: .leading, spacing: 10) {
+        VStack(alignment: .leading, spacing: 6) {
             Text("GitHub")
                 .font(.headline)
 
@@ -140,25 +147,26 @@ struct AboutSettingsTab: View {
 
     private var licenseAndAttributionSection: some View {
         VStack(alignment: .leading, spacing: 8) {
-            Text("License & Attribution")
-                .font(.headline)
-
-            HStack(alignment: .top, spacing: 10) {
+            VStack(alignment: .leading, spacing: 6) {
+                Text("License")
+                    .font(.headline)
                 AboutInfoCard(
-                    title: "GPL-2.0-only",
-                    caption: "Nehir is free software distributed under the GNU General Public License v2.0-only.",
+                    title: "GPL-2.0-only free software",
+                    caption: "Distributed with no warranty. You can inspect, modify, and share Nehir under GPL v2 terms.",
                     iconName: "doc.text",
                     tint: .secondary,
                     linkTitle: "View License",
                     url: Self.licenseURL
                 )
-                AboutInfoCard(
-                    title: "Based on OmniWM",
-                    caption: "Nehir builds on the original OmniWM work by BarutSRB and is maintained independently.",
-                    iconName: "arrow.triangle.branch",
-                    tint: .purple,
-                    linkTitle: "View OmniWM",
-                    url: Self.omniWMURL
+            }
+
+            VStack(alignment: .leading, spacing: 6) {
+                Text("OmniWM Attribution")
+                    .font(.headline)
+                AboutAttributionCard(
+                    noticeURL: Self.noticeURL,
+                    upstreamURL: Self.omniWMURL,
+                    upstreamSponsorsURL: Self.upstreamSponsorsURL
                 )
             }
         }
@@ -174,37 +182,87 @@ private struct AboutInfoCard: View {
     let url: URL
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            HStack(alignment: .top, spacing: 8) {
-                Image(systemName: iconName)
+        HStack(alignment: .center, spacing: 10) {
+            Image(systemName: iconName)
+                .font(.callout.weight(.semibold))
+                .foregroundStyle(tint)
+                .frame(width: 22)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(title)
+                    .font(.subheadline.weight(.semibold))
+                Text(caption)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            Spacer(minLength: 12)
+
+            Link(linkTitle, destination: url)
+                .font(.caption.weight(.semibold))
+        }
+        .padding(12)
+        .frame(maxWidth: .infinity, minHeight: 68, alignment: .leading)
+        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 14, style: .continuous))
+        .overlay {
+            RoundedRectangle(cornerRadius: 14, style: .continuous)
+                .strokeBorder(Color.secondary.opacity(0.15), lineWidth: 1)
+        }
+    }
+}
+
+private struct AboutAttributionCard: View {
+    let noticeURL: URL
+    let upstreamURL: URL
+    let upstreamSponsorsURL: URL
+
+    private let sponsorTooltip = "This fork brought some unspoken traction and misunderstanding. " +
+        "Sponsoring BarutSRB is a direct way to acknowledge the original OmniWM work."
+    private let attributionText = "Nehir is an independent GPL fork of OmniWM by BarutSRB. " +
+        "Source headers and NOTICE.md preserve that lineage while Nehir-specific changes are attributed separately."
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 9) {
+            HStack(alignment: .top, spacing: 10) {
+                Image(systemName: "arrow.triangle.branch")
                     .font(.callout.weight(.semibold))
-                    .foregroundStyle(tint)
-                    .frame(width: 20)
+                    .foregroundStyle(.purple)
+                    .frame(width: 22)
 
                 VStack(alignment: .leading, spacing: 3) {
-                    Text(title)
-                        .font(.callout.weight(.medium))
-                    Text(caption)
+                    Text("Built from OmniWM")
+                        .font(.subheadline.weight(.semibold))
+                    Text(attributionText)
                         .font(.caption)
                         .foregroundStyle(.secondary)
                         .fixedSize(horizontal: false, vertical: true)
                 }
             }
 
-            Spacer(minLength: 0)
+            HStack(spacing: 8) {
+                Link("Notice", destination: noticeURL)
+                    .buttonStyle(.bordered)
+                Link("OmniWM", destination: upstreamURL)
+                    .buttonStyle(.bordered)
 
-            HStack {
+                Link(destination: upstreamSponsorsURL) {
+                    Label("Share some love to BarutSRB", systemImage: "heart.fill")
+                }
+                .buttonStyle(.borderedProminent)
+                .tint(.purple)
+                .help(Text(sponsorTooltip))
+
                 Spacer(minLength: 0)
-                Link(linkTitle, destination: url)
-                    .font(.caption.weight(.medium))
             }
+            .controlSize(.small)
         }
         .padding(12)
-        .frame(maxWidth: .infinity, minHeight: 96, alignment: .topLeading)
+        .frame(maxWidth: .infinity, alignment: .topLeading)
         .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 14, style: .continuous))
         .overlay {
             RoundedRectangle(cornerRadius: 14, style: .continuous)
-                .strokeBorder(Color.secondary.opacity(0.15), lineWidth: 1)
+                .strokeBorder(Color.purple.opacity(0.22), lineWidth: 1)
         }
     }
 }
@@ -218,7 +276,7 @@ private struct AboutLinkCard: View {
 
     var body: some View {
         Link(destination: url) {
-            VStack(alignment: .leading, spacing: 10) {
+            VStack(alignment: .leading, spacing: 6) {
                 HStack(spacing: 8) {
                     Image(systemName: iconName)
                         .font(.callout.weight(.semibold))
@@ -239,8 +297,8 @@ private struct AboutLinkCard: View {
                         .fixedSize(horizontal: false, vertical: true)
                 }
             }
-            .padding(12)
-            .frame(maxWidth: .infinity, minHeight: 82, alignment: .topLeading)
+            .padding(10)
+            .frame(maxWidth: .infinity, minHeight: 68, alignment: .topLeading)
             .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 14, style: .continuous))
             .overlay {
                 RoundedRectangle(cornerRadius: 14, style: .continuous)

--- a/Sources/Nehir/UI/AppRuleDraft.swift
+++ b/Sources/Nehir/UI/AppRuleDraft.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import Foundation
 import NehirIPC
 

--- a/Sources/Nehir/UI/AppRulesView.swift
+++ b/Sources/Nehir/UI/AppRulesView.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import SwiftUI
 
 struct RunningAppInfo: Identifiable {

--- a/Sources/Nehir/UI/BehaviorSettingsTab.swift
+++ b/Sources/Nehir/UI/BehaviorSettingsTab.swift
@@ -1,3 +1,8 @@
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=nehir-original; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import SwiftUI
 
 struct BehaviorSettingsTab: View {

--- a/Sources/Nehir/UI/BorderSettingsTab.swift
+++ b/Sources/Nehir/UI/BorderSettingsTab.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import AppKit
 import SwiftUI
 

--- a/Sources/Nehir/UI/CommandPalette/CommandPaletteController.swift
+++ b/Sources/Nehir/UI/CommandPalette/CommandPaletteController.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import AppKit
 import ApplicationServices
 import Carbon

--- a/Sources/Nehir/UI/ConfigurationFilesSection.swift
+++ b/Sources/Nehir/UI/ConfigurationFilesSection.swift
@@ -1,3 +1,8 @@
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=nehir-original; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import SwiftUI
 
 /// Reveal/edit controls for Nehir's on-disk configuration files, rendered as a

--- a/Sources/Nehir/UI/DestructiveConfirmationAlert.swift
+++ b/Sources/Nehir/UI/DestructiveConfirmationAlert.swift
@@ -1,3 +1,8 @@
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=nehir-original; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import AppKit
 
 @MainActor

--- a/Sources/Nehir/UI/DeveloperBadge.swift
+++ b/Sources/Nehir/UI/DeveloperBadge.swift
@@ -1,3 +1,8 @@
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=nehir-original; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import SwiftUI
 
 struct DeveloperBadge: View {

--- a/Sources/Nehir/UI/DisplayDiagnosticsSettingsTab.swift
+++ b/Sources/Nehir/UI/DisplayDiagnosticsSettingsTab.swift
@@ -1,3 +1,8 @@
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=nehir-original; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import AppKit
 import SwiftUI
 

--- a/Sources/Nehir/UI/ExperimentalBadge.swift
+++ b/Sources/Nehir/UI/ExperimentalBadge.swift
@@ -1,3 +1,8 @@
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=nehir-original; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import SwiftUI
 
 struct ExperimentalBadge: View {

--- a/Sources/Nehir/UI/HotkeySettingsView.swift
+++ b/Sources/Nehir/UI/HotkeySettingsView.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import Carbon
 import SwiftUI
 

--- a/Sources/Nehir/UI/KeyRecorderView.swift
+++ b/Sources/Nehir/UI/KeyRecorderView.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import AppKit
 import Carbon
 import SwiftUI

--- a/Sources/Nehir/UI/LayoutSettingsTab.swift
+++ b/Sources/Nehir/UI/LayoutSettingsTab.swift
@@ -1,3 +1,8 @@
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=nehir-original; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import SwiftUI
 
 struct LayoutSettingsTab: View {

--- a/Sources/Nehir/UI/LiquidGlassStyles.swift
+++ b/Sources/Nehir/UI/LiquidGlassStyles.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import SwiftUI
 
 struct GlassButtonStyle: ButtonStyle {

--- a/Sources/Nehir/UI/MenuAnywhere/MenuAnywhereController.swift
+++ b/Sources/Nehir/UI/MenuAnywhere/MenuAnywhereController.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 @preconcurrency import AppKit
 @preconcurrency import ApplicationServices
 

--- a/Sources/Nehir/UI/MonitorSettingsTab.swift
+++ b/Sources/Nehir/UI/MonitorSettingsTab.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import AppKit
 import SwiftUI
 

--- a/Sources/Nehir/UI/Onboarding/Animations/StaticStepIcon.swift
+++ b/Sources/Nehir/UI/Onboarding/Animations/StaticStepIcon.swift
@@ -1,3 +1,8 @@
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=nehir-original; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import SwiftUI
 
 struct StaticStepIcon: View {

--- a/Sources/Nehir/UI/Onboarding/Animations/WelcomeAnimation.swift
+++ b/Sources/Nehir/UI/Onboarding/Animations/WelcomeAnimation.swift
@@ -1,3 +1,8 @@
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=nehir-original; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import SwiftUI
 
 /// Merged first-slide animation. Two phases loop:

--- a/Sources/Nehir/UI/Onboarding/Animations/WorkspaceBarAnimation.swift
+++ b/Sources/Nehir/UI/Onboarding/Animations/WorkspaceBarAnimation.swift
@@ -1,3 +1,8 @@
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=nehir-original; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import SwiftUI
 
 /// Miniature recreation of the real workspace bar (see `WorkspaceBarView`). Shows the bar's

--- a/Sources/Nehir/UI/Onboarding/ConfigRecoveryView.swift
+++ b/Sources/Nehir/UI/Onboarding/ConfigRecoveryView.swift
@@ -1,3 +1,8 @@
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=nehir-original; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import AppKit
 import SwiftUI
 

--- a/Sources/Nehir/UI/Onboarding/InteractiveMoveDemo.swift
+++ b/Sources/Nehir/UI/Onboarding/InteractiveMoveDemo.swift
@@ -1,3 +1,8 @@
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=nehir-original; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import AppKit
 import Carbon
 import SwiftUI

--- a/Sources/Nehir/UI/Onboarding/NehirLogo.swift
+++ b/Sources/Nehir/UI/Onboarding/NehirLogo.swift
@@ -1,3 +1,8 @@
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=nehir-original; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import AppKit
 import SwiftUI
 

--- a/Sources/Nehir/UI/Onboarding/OnboardingStepControls.swift
+++ b/Sources/Nehir/UI/Onboarding/OnboardingStepControls.swift
@@ -1,3 +1,8 @@
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=nehir-original; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import AppKit
 import SwiftUI
 

--- a/Sources/Nehir/UI/Onboarding/OnboardingStepView.swift
+++ b/Sources/Nehir/UI/Onboarding/OnboardingStepView.swift
@@ -1,3 +1,8 @@
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=nehir-original; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import SwiftUI
 
 struct OnboardingStepView<Animation: View, Control: View>: View {

--- a/Sources/Nehir/UI/Onboarding/OnboardingSteps.swift
+++ b/Sources/Nehir/UI/Onboarding/OnboardingSteps.swift
@@ -1,3 +1,8 @@
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=nehir-original; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import Foundation
 
 enum OnboardingStep: String, CaseIterable, Identifiable {

--- a/Sources/Nehir/UI/Onboarding/OnboardingView.swift
+++ b/Sources/Nehir/UI/Onboarding/OnboardingView.swift
@@ -1,3 +1,8 @@
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=nehir-original; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import SwiftUI
 
 struct OnboardingView: View {

--- a/Sources/Nehir/UI/Onboarding/OnboardingWindowController.swift
+++ b/Sources/Nehir/UI/Onboarding/OnboardingWindowController.swift
@@ -1,3 +1,8 @@
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=nehir-original; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import AppKit
 import SwiftUI
 

--- a/Sources/Nehir/UI/Onboarding/ReleaseNotes.swift
+++ b/Sources/Nehir/UI/Onboarding/ReleaseNotes.swift
@@ -1,3 +1,8 @@
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=nehir-original; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import Foundation
 
 /// Shared Nehir repository and release-note URLs.
@@ -7,7 +12,7 @@ import Foundation
 /// `releases/tag/v<version>` convention keeps them from drifting apart.
 enum ReleaseNotes {
     /// The canonical GitHub repository URL (no trailing slash).
-    static let repositoryURLString = "https://github.com/guria/nehir"
+    static let repositoryURLString = "https://github.com/apphane-dev/nehir"
 
     /// The "all releases" index page.
     static var releasesURL: URL {

--- a/Sources/Nehir/UI/Onboarding/WhatsNewContent.swift
+++ b/Sources/Nehir/UI/Onboarding/WhatsNewContent.swift
@@ -1,3 +1,8 @@
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=nehir-original; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import Foundation
 
 /// Bundled, developer-written "What's New" highlights for the current release.

--- a/Sources/Nehir/UI/Onboarding/WhatsNewView.swift
+++ b/Sources/Nehir/UI/Onboarding/WhatsNewView.swift
@@ -1,3 +1,8 @@
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=nehir-original; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import AppKit
 import SwiftUI
 

--- a/Sources/Nehir/UI/OverridableControls.swift
+++ b/Sources/Nehir/UI/OverridableControls.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import SwiftUI
 
 struct SettingsPage<Content: View>: View {

--- a/Sources/Nehir/UI/SettingInfo.swift
+++ b/Sources/Nehir/UI/SettingInfo.swift
@@ -1,3 +1,8 @@
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=nehir-original; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import SwiftUI
 
 struct SettingInfo: View {

--- a/Sources/Nehir/UI/SettingsColor+SwiftUI.swift
+++ b/Sources/Nehir/UI/SettingsColor+SwiftUI.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import AppKit
 import SwiftUI
 

--- a/Sources/Nehir/UI/SettingsDetailView.swift
+++ b/Sources/Nehir/UI/SettingsDetailView.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import SwiftUI
 
 struct SettingsDetailView: View {

--- a/Sources/Nehir/UI/SettingsFileWorkflow.swift
+++ b/Sources/Nehir/UI/SettingsFileWorkflow.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import AppKit
 import SwiftUI
 

--- a/Sources/Nehir/UI/SettingsSection.swift
+++ b/Sources/Nehir/UI/SettingsSection.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import SwiftUI
 
 enum SettingsSection: String, CaseIterable, Identifiable {

--- a/Sources/Nehir/UI/SettingsSidebar.swift
+++ b/Sources/Nehir/UI/SettingsSidebar.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import SwiftUI
 
 struct SettingsSidebar: View {

--- a/Sources/Nehir/UI/SettingsView.swift
+++ b/Sources/Nehir/UI/SettingsView.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import Observation
 import SwiftUI
 

--- a/Sources/Nehir/UI/SettingsWindowController.swift
+++ b/Sources/Nehir/UI/SettingsWindowController.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import AppKit
 import SwiftUI
 

--- a/Sources/Nehir/UI/StatusBar/StatusBarController.swift
+++ b/Sources/Nehir/UI/StatusBar/StatusBarController.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import AppKit
 
 @MainActor

--- a/Sources/Nehir/UI/StatusBar/StatusBarMenu.swift
+++ b/Sources/Nehir/UI/StatusBar/StatusBarMenu.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import AppKit
 
 private let menuWidth: CGFloat = 280

--- a/Sources/Nehir/UI/VisualEffectsCompatibility.swift
+++ b/Sources/Nehir/UI/VisualEffectsCompatibility.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import SwiftUI
 
 extension View {

--- a/Sources/Nehir/UI/WorkspaceBar/WorkspaceBarDataSource.swift
+++ b/Sources/Nehir/UI/WorkspaceBar/WorkspaceBarDataSource.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import AppKit
 import Foundation
 

--- a/Sources/Nehir/UI/WorkspaceBar/WorkspaceBarGeometry.swift
+++ b/Sources/Nehir/UI/WorkspaceBar/WorkspaceBarGeometry.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import CoreGraphics
 
 struct WorkspaceBarGeometry: Equatable {

--- a/Sources/Nehir/UI/WorkspaceBar/WorkspaceBarManager.swift
+++ b/Sources/Nehir/UI/WorkspaceBar/WorkspaceBarManager.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import AppKit
 import os
 import SwiftUI

--- a/Sources/Nehir/UI/WorkspaceBar/WorkspaceBarPanel.swift
+++ b/Sources/Nehir/UI/WorkspaceBar/WorkspaceBarPanel.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import AppKit
 
 @MainActor

--- a/Sources/Nehir/UI/WorkspaceBar/WorkspaceBarProjectionOptions.swift
+++ b/Sources/Nehir/UI/WorkspaceBar/WorkspaceBarProjectionOptions.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import Foundation
 
 struct WorkspaceBarProjectionOptions: Equatable {

--- a/Sources/Nehir/UI/WorkspaceBar/WorkspaceBarView.swift
+++ b/Sources/Nehir/UI/WorkspaceBar/WorkspaceBarView.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import AppKit
 import Observation
 import SwiftUI

--- a/Sources/Nehir/UI/WorkspaceBarSettingsTab.swift
+++ b/Sources/Nehir/UI/WorkspaceBarSettingsTab.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import AppKit
 import SwiftUI
 

--- a/Sources/Nehir/UI/WorkspacesSettingsTab.swift
+++ b/Sources/Nehir/UI/WorkspacesSettingsTab.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import NehirIPC
 import SwiftUI
 

--- a/Sources/NehirApp/NehirApp.swift
+++ b/Sources/NehirApp/NehirApp.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import AppKit
 @testable import Nehir
 import SwiftUI

--- a/Sources/NehirApp/SettingsSceneRedirectView.swift
+++ b/Sources/NehirApp/SettingsSceneRedirectView.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import AppKit
 @testable import Nehir
 import Observation

--- a/Sources/NehirCtl/CLICompletionGenerator.swift
+++ b/Sources/NehirCtl/CLICompletionGenerator.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import Foundation
 import NehirIPC
 
@@ -284,6 +290,10 @@ enum CLICompletionGenerator {
             "ping",
             "version",
             "help",
+            "license",
+            "legal",
+            "attribution",
+            "about",
             "completion",
             "command",
             "query",

--- a/Sources/NehirCtl/CLIEntry.swift
+++ b/Sources/NehirCtl/CLIEntry.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import Darwin
 
 @main

--- a/Sources/NehirCtl/CLILegalNotice.swift
+++ b/Sources/NehirCtl/CLILegalNotice.swift
@@ -1,0 +1,19 @@
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=nehir-original; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
+enum CLILegalNotice {
+    static let text = """
+    Nehir / nehirctl
+    Copyright (C) 2026 Aleksei Gurianov and Nehir contributors
+    License: GNU General Public License v2.0 only (GPL-2.0-only)
+
+    Nehir is an independent GPL-2.0-only derivative fork of OmniWM by BarutSRB.
+    Upstream: https://github.com/BarutSRB/OmniWM
+    Source, license, and notice: https://github.com/apphane-dev/nehir (see LICENSE and NOTICE.md)
+
+    This is free software: you are free to change and redistribute it under the GPL-2.0-only terms.
+    There is NO WARRANTY, to the extent permitted by law.
+    """
+}

--- a/Sources/NehirCtl/CLIOutputFormat.swift
+++ b/Sources/NehirCtl/CLIOutputFormat.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import Foundation
 import NehirIPC
 
@@ -24,6 +30,7 @@ enum CLIOutputFormat: String, Equatable {
 
 enum CLILocalAction: Equatable {
     case help
+    case legalNotice
     case completion(CLIShell)
 }
 

--- a/Sources/NehirCtl/CLIParser.swift
+++ b/Sources/NehirCtl/CLIParser.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import Foundation
 import NehirIPC
 
@@ -154,6 +160,19 @@ enum CLIParser {
              "-h":
             return ParsedCLICommand(
                 invocation: .local(.help),
+                outputFormat: .text,
+                expectsEventStream: false,
+                watchConfiguration: nil
+            )
+        case "about",
+             "attribution",
+             "legal",
+             "license":
+            guard filteredArguments.count == 1 else {
+                throw CLIParseError.usage(usageText)
+            }
+            return ParsedCLICommand(
+                invocation: .local(.legalNotice),
                 outputFormat: .text,
                 expectsEventStream: false,
                 watchConfiguration: nil
@@ -720,6 +739,7 @@ enum CLIParser {
             "  nehirctl ping",
             "  nehirctl version",
             "  nehirctl help",
+            "  nehirctl license   # GPL terms and upstream attribution",
             "  nehirctl completion <zsh|bash|fish>"
         ]
         lines += commandLines.map { "  nehirctl \($0)" }
@@ -737,6 +757,10 @@ enum CLIParser {
             "",
             "Formats:",
             "  --format json|table|tsv|text",
+            "",
+            "Legal:",
+            "  GPL-2.0-only. Nehir is an independent derivative fork of OmniWM by BarutSRB.",
+            "  Run `nehirctl license` for source, license, warranty, and attribution details.",
             "",
             "Rule Options:"
         ]

--- a/Sources/NehirCtl/CLIRenderer.swift
+++ b/Sources/NehirCtl/CLIRenderer.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import Foundation
 import NehirIPC
 

--- a/Sources/NehirCtl/CLIRuntime.swift
+++ b/Sources/NehirCtl/CLIRuntime.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import Darwin
 import Foundation
 import NehirIPC
@@ -403,6 +409,8 @@ enum CLIRuntime {
         switch action {
         case .help:
             text = CLIParser.usageText
+        case .legalNotice:
+            text = CLILegalNotice.text
         case let .completion(shell):
             text = CLICompletionGenerator.script(for: shell)
         }

--- a/Sources/NehirCtl/IPCClient.swift
+++ b/Sources/NehirCtl/IPCClient.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import Darwin
 import Foundation
 import NehirIPC

--- a/Sources/NehirIPC/IPCAutomationManifest.swift
+++ b/Sources/NehirIPC/IPCAutomationManifest.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import Foundation
 
 public enum IPCQuerySelectorName: String, Codable, CaseIterable, Equatable, Hashable, Sendable {

--- a/Sources/NehirIPC/IPCModels.swift
+++ b/Sources/NehirIPC/IPCModels.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import Foundation
 
 public enum NehirIPCProtocol {

--- a/Sources/NehirIPC/IPCRuleValidator.swift
+++ b/Sources/NehirIPC/IPCRuleValidator.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import Foundation
 
 public struct IPCRuleValidationReport: Equatable, Sendable {

--- a/Sources/NehirIPC/IPCSocketPath.swift
+++ b/Sources/NehirIPC/IPCSocketPath.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import Foundation
 
 public enum IPCSocketPath {

--- a/Sources/NehirIPC/IPCWire.swift
+++ b/Sources/NehirIPC/IPCWire.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import Foundation
 
 public enum IPCWire {

--- a/Sources/NehirIPC/WorkspaceAddressing.swift
+++ b/Sources/NehirIPC/WorkspaceAddressing.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import Foundation
 
 public enum WorkspaceIDPolicy {

--- a/Tests/NehirTests/AXEventHandlerTests.swift
+++ b/Tests/NehirTests/AXEventHandlerTests.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import AppKit
 import ApplicationServices
 import CoreGraphics

--- a/Tests/NehirTests/AXManagerTests.swift
+++ b/Tests/NehirTests/AXManagerTests.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import ApplicationServices
 import CoreGraphics
 import Foundation

--- a/Tests/NehirTests/AXWindowServiceTests.swift
+++ b/Tests/NehirTests/AXWindowServiceTests.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import ApplicationServices
 import CoreGraphics
 @testable import Nehir

--- a/Tests/NehirTests/ActionCatalogTests.swift
+++ b/Tests/NehirTests/ActionCatalogTests.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import Carbon
 @testable import Nehir
 import Testing

--- a/Tests/NehirTests/AppAXContextTests.swift
+++ b/Tests/NehirTests/AppAXContextTests.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import AppKit
 import ApplicationServices
 import Foundation

--- a/Tests/NehirTests/AppCLIManagerTests.swift
+++ b/Tests/NehirTests/AppCLIManagerTests.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import Foundation
 @testable import Nehir
 import Testing

--- a/Tests/NehirTests/AppDelegateIPCTests.swift
+++ b/Tests/NehirTests/AppDelegateIPCTests.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import AppKit
 import Foundation
 @testable import Nehir

--- a/Tests/NehirTests/AppRuleDraftTests.swift
+++ b/Tests/NehirTests/AppRuleDraftTests.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 @testable import Nehir
 import Testing
 

--- a/Tests/NehirTests/BorderWindowTests.swift
+++ b/Tests/NehirTests/BorderWindowTests.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import AppKit
 import CoreGraphics
 @testable import Nehir

--- a/Tests/NehirTests/CGSEventObserverTests.swift
+++ b/Tests/NehirTests/CGSEventObserverTests.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import Foundation
 @testable import Nehir
 import Testing

--- a/Tests/NehirTests/CLICompletionGeneratorTests.swift
+++ b/Tests/NehirTests/CLICompletionGeneratorTests.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 @testable import NehirCtl
 import Testing
 
@@ -17,6 +23,8 @@ import Testing
         #expect(script.contains("switch-workspace"))
         #expect(script.contains("prev"))
         #expect(script.contains("back-and-forth"))
+        #expect(script.contains("license"))
+        #expect(script.contains("attribution"))
     }
 
     @Test func bashScriptIncludesRuleApplyQueryAndSubscriptionFlags() {

--- a/Tests/NehirTests/CLIParserTests.swift
+++ b/Tests/NehirTests/CLIParserTests.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import Foundation
 @testable import NehirCtl
 import NehirIPC
@@ -720,5 +726,25 @@ private func sampleRuleOptionValue(for flag: String) -> String {
         #expect(parsed.expectsEventStream == false)
         #expect(parsed.watchConfiguration == nil)
         #expect(parsed.invocation == .local(.completion(.bash)))
+    }
+
+    @Test func parsesLegalAttributionAliasesAsLocalInvocation() throws {
+        for command in ["about", "attribution", "legal", "license"] {
+            let parsed = try CLIParser.parse(arguments: ["nehirctl", command])
+
+            #expect(parsed.outputFormat == .text)
+            #expect(parsed.expectsEventStream == false)
+            #expect(parsed.watchConfiguration == nil)
+            #expect(parsed.invocation == .local(.legalNotice))
+        }
+    }
+
+    @Test func usageIncludesLegalAttribution() {
+        #expect(CLIParser.usageText.contains("nehirctl license"))
+        #expect(CLIParser.usageText.contains("GPL-2.0-only"))
+        #expect(CLIParser.usageText.contains("OmniWM by BarutSRB"))
+        #expect(CLILegalNotice.text.contains("GNU General Public License v2.0 only"))
+        #expect(CLILegalNotice.text.contains("OmniWM by BarutSRB"))
+        #expect(CLILegalNotice.text.contains("NO WARRANTY"))
     }
 }

--- a/Tests/NehirTests/CLIRendererTests.swift
+++ b/Tests/NehirTests/CLIRendererTests.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import Foundation
 @testable import NehirCtl
 import NehirIPC

--- a/Tests/NehirTests/CLIRuntimeTests.swift
+++ b/Tests/NehirTests/CLIRuntimeTests.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import Foundation
 @testable import Nehir
 @testable import NehirCtl

--- a/Tests/NehirTests/CommandHandlerTests.swift
+++ b/Tests/NehirTests/CommandHandlerTests.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import CoreGraphics
 @testable import Nehir
 import Testing

--- a/Tests/NehirTests/CommandPaletteControllerTests.swift
+++ b/Tests/NehirTests/CommandPaletteControllerTests.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import AppKit
 import ApplicationServices
 import Foundation

--- a/Tests/NehirTests/ConfigMismatchDetectorTests.swift
+++ b/Tests/NehirTests/ConfigMismatchDetectorTests.swift
@@ -1,3 +1,8 @@
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=nehir-original; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import Foundation
 @testable import Nehir
 import Testing

--- a/Tests/NehirTests/DisplayEnvironmentDiagnosticsTests.swift
+++ b/Tests/NehirTests/DisplayEnvironmentDiagnosticsTests.swift
@@ -1,3 +1,8 @@
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=nehir-original; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import CoreGraphics
 import Foundation
 @testable import Nehir

--- a/Tests/NehirTests/DisplaySpacesModeTests.swift
+++ b/Tests/NehirTests/DisplaySpacesModeTests.swift
@@ -1,3 +1,8 @@
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=nehir-original; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import CoreGraphics
 import Foundation
 @testable import Nehir

--- a/Tests/NehirTests/HotkeyBindingEditorTests.swift
+++ b/Tests/NehirTests/HotkeyBindingEditorTests.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import Carbon
 import Foundation
 @testable import Nehir

--- a/Tests/NehirTests/HotkeyCenterTests.swift
+++ b/Tests/NehirTests/HotkeyCenterTests.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 @testable import Nehir
 import Testing
 

--- a/Tests/NehirTests/HotkeySettingsViewTests.swift
+++ b/Tests/NehirTests/HotkeySettingsViewTests.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import Carbon
 import Foundation
 @testable import Nehir

--- a/Tests/NehirTests/IPCCommandRouterTests.swift
+++ b/Tests/NehirTests/IPCCommandRouterTests.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import Foundation
 @testable import Nehir
 import NehirIPC

--- a/Tests/NehirTests/IPCEventBrokerTests.swift
+++ b/Tests/NehirTests/IPCEventBrokerTests.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 @testable import Nehir
 import NehirIPC
 import Testing

--- a/Tests/NehirTests/IPCModelsTests.swift
+++ b/Tests/NehirTests/IPCModelsTests.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import Foundation
 import NehirIPC
 import Testing

--- a/Tests/NehirTests/IPCQueryRouterTests.swift
+++ b/Tests/NehirTests/IPCQueryRouterTests.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import CoreGraphics
 import Foundation
 @testable import Nehir

--- a/Tests/NehirTests/IPCRuleRouterTests.swift
+++ b/Tests/NehirTests/IPCRuleRouterTests.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import Foundation
 @testable import Nehir
 import NehirIPC

--- a/Tests/NehirTests/IPCServerTests.swift
+++ b/Tests/NehirTests/IPCServerTests.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import AppKit
 import Foundation
 @testable import Nehir

--- a/Tests/NehirTests/IPCSocketPathTests.swift
+++ b/Tests/NehirTests/IPCSocketPathTests.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import Foundation
 import NehirIPC
 import Testing

--- a/Tests/NehirTests/InteractiveMoveDemoModelTests.swift
+++ b/Tests/NehirTests/InteractiveMoveDemoModelTests.swift
@@ -1,3 +1,8 @@
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=nehir-original; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 @testable import Nehir
 import Testing
 

--- a/Tests/NehirTests/KeyRecorderViewTests.swift
+++ b/Tests/NehirTests/KeyRecorderViewTests.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import AppKit
 import Carbon
 @testable import Nehir

--- a/Tests/NehirTests/LayoutPlanTestSupport.swift
+++ b/Tests/NehirTests/LayoutPlanTestSupport.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import ApplicationServices
 import CoreGraphics
 import Foundation

--- a/Tests/NehirTests/LayoutRefreshControllerTests.swift
+++ b/Tests/NehirTests/LayoutRefreshControllerTests.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import ApplicationServices
 import CoreGraphics
 import Foundation

--- a/Tests/NehirTests/MonitorDescriptionTests.swift
+++ b/Tests/NehirTests/MonitorDescriptionTests.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import CoreGraphics
 import Foundation
 @testable import Nehir

--- a/Tests/NehirTests/MonitorIdentityMatchingTests.swift
+++ b/Tests/NehirTests/MonitorIdentityMatchingTests.swift
@@ -1,3 +1,8 @@
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=nehir-original; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import CoreGraphics
 import Foundation
 @testable import Nehir

--- a/Tests/NehirTests/MonitorRestoreAssignmentsTests.swift
+++ b/Tests/NehirTests/MonitorRestoreAssignmentsTests.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import CoreGraphics
 import Foundation
 @testable import Nehir

--- a/Tests/NehirTests/MonitorSettingsTabTests.swift
+++ b/Tests/NehirTests/MonitorSettingsTabTests.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import CoreGraphics
 @testable import Nehir
 import Testing

--- a/Tests/NehirTests/MotionTestSupport.swift
+++ b/Tests/NehirTests/MotionTestSupport.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import AppKit
 import Foundation
 @testable import Nehir

--- a/Tests/NehirTests/MouseEventHandlerTests.swift
+++ b/Tests/NehirTests/MouseEventHandlerTests.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import AppKit
 import ApplicationServices
 import CoreGraphics

--- a/Tests/NehirTests/MouseWarpHandlerTests.swift
+++ b/Tests/NehirTests/MouseWarpHandlerTests.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import CoreGraphics
 import Foundation
 @testable import Nehir

--- a/Tests/NehirTests/NiriLayoutEngineTests.swift
+++ b/Tests/NehirTests/NiriLayoutEngineTests.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import AppKit
 import ApplicationServices
 import Foundation

--- a/Tests/NehirTests/NiriMonitorTests.swift
+++ b/Tests/NehirTests/NiriMonitorTests.swift
@@ -1,3 +1,8 @@
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=nehir-original; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import CoreGraphics
 import Foundation
 @testable import Nehir

--- a/Tests/NehirTests/OptimizationCompletionTests.swift
+++ b/Tests/NehirTests/OptimizationCompletionTests.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import ApplicationServices
 import CoreGraphics
 import Foundation

--- a/Tests/NehirTests/OverviewModalInteractionTests.swift
+++ b/Tests/NehirTests/OverviewModalInteractionTests.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import AppKit
 import Carbon
 import Foundation

--- a/Tests/NehirTests/OverviewProjectionTests.swift
+++ b/Tests/NehirTests/OverviewProjectionTests.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import ApplicationServices
 import Foundation
 @testable import Nehir

--- a/Tests/NehirTests/OverviewRendererTests.swift
+++ b/Tests/NehirTests/OverviewRendererTests.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import CoreGraphics
 @testable import Nehir
 import Testing

--- a/Tests/NehirTests/OverviewScrollBoundsTests.swift
+++ b/Tests/NehirTests/OverviewScrollBoundsTests.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import Foundation
 @testable import Nehir
 import Testing

--- a/Tests/NehirTests/OverviewThumbnailSizingTests.swift
+++ b/Tests/NehirTests/OverviewThumbnailSizingTests.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import Foundation
 @testable import Nehir
 import Testing

--- a/Tests/NehirTests/OwnedWindowRegistryTests.swift
+++ b/Tests/NehirTests/OwnedWindowRegistryTests.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import AppKit
 import Foundation
 @testable import Nehir

--- a/Tests/NehirTests/PureLayoutAgreementTests.swift
+++ b/Tests/NehirTests/PureLayoutAgreementTests.swift
@@ -1,3 +1,8 @@
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=nehir-original; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import AppKit
 @testable import Nehir
 import Testing

--- a/Tests/NehirTests/PureLayoutBoundaryTests.swift
+++ b/Tests/NehirTests/PureLayoutBoundaryTests.swift
@@ -1,3 +1,8 @@
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=nehir-original; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import Foundation
 import Testing
 

--- a/Tests/NehirTests/PureLayoutReducerTests.swift
+++ b/Tests/NehirTests/PureLayoutReducerTests.swift
@@ -1,3 +1,8 @@
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=nehir-original; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 @testable import Nehir
 import Testing
 

--- a/Tests/NehirTests/ReconcileStateTests.swift
+++ b/Tests/NehirTests/ReconcileStateTests.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import Foundation
 @testable import Nehir
 import Testing

--- a/Tests/NehirTests/RefreshRoutingTests.swift
+++ b/Tests/NehirTests/RefreshRoutingTests.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import ApplicationServices
 import CoreGraphics
 import Foundation

--- a/Tests/NehirTests/ResizeMinimumLearnerTests.swift
+++ b/Tests/NehirTests/ResizeMinimumLearnerTests.swift
@@ -1,3 +1,8 @@
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=nehir-original; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import CoreGraphics
 import Foundation
 @testable import Nehir

--- a/Tests/NehirTests/RestorePlannerTests.swift
+++ b/Tests/NehirTests/RestorePlannerTests.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import CoreGraphics
 import Foundation
 @testable import Nehir

--- a/Tests/NehirTests/ServiceLifecycleManagerTests.swift
+++ b/Tests/NehirTests/ServiceLifecycleManagerTests.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import AppKit
 import ApplicationServices
 import CoreGraphics

--- a/Tests/NehirTests/SettingsMigrationStateStoreTests.swift
+++ b/Tests/NehirTests/SettingsMigrationStateStoreTests.swift
@@ -1,3 +1,8 @@
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=nehir-original; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import Foundation
 @testable import Nehir
 import Testing

--- a/Tests/NehirTests/SettingsStoreTests.swift
+++ b/Tests/NehirTests/SettingsStoreTests.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import AppKit
 import ApplicationServices
 import Carbon

--- a/Tests/NehirTests/SettingsTOMLCodecTests.swift
+++ b/Tests/NehirTests/SettingsTOMLCodecTests.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import Foundation
 @testable import Nehir
 import Testing

--- a/Tests/NehirTests/SettingsViewTests.swift
+++ b/Tests/NehirTests/SettingsViewTests.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import Foundation
 @testable import Nehir
 import Testing

--- a/Tests/NehirTests/SpringAnimationTests.swift
+++ b/Tests/NehirTests/SpringAnimationTests.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import Foundation
 @testable import Nehir
 import Testing

--- a/Tests/NehirTests/StatusBarMenuTests.swift
+++ b/Tests/NehirTests/StatusBarMenuTests.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import AppKit
 import Foundation
 @testable import Nehir

--- a/Tests/NehirTests/TestSharedStateSupport.swift
+++ b/Tests/NehirTests/TestSharedStateSupport.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import AppKit
 import Foundation
 @testable import Nehir

--- a/Tests/NehirTests/ThreadRunLoopTests.swift
+++ b/Tests/NehirTests/ThreadRunLoopTests.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import Foundation
 @testable import Nehir
 import Testing

--- a/Tests/NehirTests/TokenCompatibilityTestSupport.swift
+++ b/Tests/NehirTests/TokenCompatibilityTestSupport.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import Foundation
 @testable import Nehir
 

--- a/Tests/NehirTests/ViewportGeometryTests.swift
+++ b/Tests/NehirTests/ViewportGeometryTests.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import Foundation
 @testable import Nehir
 import Testing

--- a/Tests/NehirTests/ViewportSnapContextTests.swift
+++ b/Tests/NehirTests/ViewportSnapContextTests.swift
@@ -1,3 +1,8 @@
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=nehir-original; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import Foundation
 @testable import Nehir
 import Testing

--- a/Tests/NehirTests/WMControllerFocusTests.swift
+++ b/Tests/NehirTests/WMControllerFocusTests.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import AppKit
 import ApplicationServices
 import CoreGraphics

--- a/Tests/NehirTests/WMControllerScratchpadTests.swift
+++ b/Tests/NehirTests/WMControllerScratchpadTests.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import ApplicationServices
 import CoreGraphics
 import Foundation

--- a/Tests/NehirTests/WhatsNewAutoShowTests.swift
+++ b/Tests/NehirTests/WhatsNewAutoShowTests.swift
@@ -1,3 +1,8 @@
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=nehir-original; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 @testable import Nehir
 import Testing
 

--- a/Tests/NehirTests/WindowRuleEngineTests.swift
+++ b/Tests/NehirTests/WindowRuleEngineTests.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import AppKit
 import ApplicationServices
 @testable import Nehir

--- a/Tests/NehirTests/WorkspaceBarDataSourceTests.swift
+++ b/Tests/NehirTests/WorkspaceBarDataSourceTests.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import AppKit
 import Foundation
 @testable import Nehir

--- a/Tests/NehirTests/WorkspaceBarManagerTests.swift
+++ b/Tests/NehirTests/WorkspaceBarManagerTests.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import AppKit
 import Foundation
 @testable import Nehir

--- a/Tests/NehirTests/WorkspaceManagerTests.swift
+++ b/Tests/NehirTests/WorkspaceManagerTests.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import ApplicationServices
 import CoreGraphics
 import Foundation

--- a/Tests/NehirTests/WorkspaceNavigationHandlerTests.swift
+++ b/Tests/NehirTests/WorkspaceNavigationHandlerTests.swift
@@ -1,3 +1,8 @@
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=nehir-original; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import ApplicationServices
 import CoreGraphics
 import Foundation

--- a/Tests/NehirTests/WorkspacesSettingsTabTests.swift
+++ b/Tests/NehirTests/WorkspacesSettingsTabTests.swift
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import Foundation
 @testable import Nehir
 import Testing

--- a/Tests/NehirTests/WorkspacesTOMLCodecTests.swift
+++ b/Tests/NehirTests/WorkspacesTOMLCodecTests.swift
@@ -1,3 +1,8 @@
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=nehir-original; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
 import Foundation
 @testable import Nehir
 import Testing


### PR DESCRIPTION
## Summary

### What changed and why?

Nehir already carried project-level upstream attribution from its initial commit. The first Nehir commit included both:

- [README attribution to Hiro/OmniWM by BarutSRB](https://github.com/apphane-dev/nehir/blob/9a4687794565be5cc97dac1dbd120fe0a60c326c/README.md#L92)
- [NOTICE attribution to Hiro / OmniWM by BarutSRB](https://github.com/apphane-dev/nehir/blob/9a4687794565be5cc97dac1dbd120fe0a60c326c/NOTICE.md#L3-L6)

So this PR is not introducing attribution for the first time. It makes existing attribution more durable and visible in places that were still incomplete: generated per-file source headers, user-facing About/CLI surfaces, and current NOTICE/README wording.

Current PR-head docs:

- [NOTICE.md](https://github.com/apphane-dev/nehir/blob/e45a446d5aa5a4e959140a5db700fa35690cbdeb/NOTICE.md)
- [README.md](https://github.com/apphane-dev/nehir/blob/e45a446d5aa5a4e959140a5db700fa35690cbdeb/README.md#code--omniwm)

### Source attribution harness

- Add `.provenance.json` as the source of truth for generated SPDX headers.
- Default files are `upstream-derived` and carry both `2026 BarutSRB` and `2026 Aleksei Gurianov and Nehir contributors`.
- Audited from-scratch Nehir files override to `nehir-original` and carry Nehir-only copyright.
- Keep exact upstream commit hashes out of rendered headers; they live in the non-rendering `upstreamCommits` audit map as `{repo, hash}` arrays so a file can record multiple borrows from multiple sources.
- Add mise tasks: `mise run license` and `mise run license:check`; `format` / `format:check` depend on them, and SwiftFormat is configured not to own headers.

### Applied source headers

- Apply generated SPDX headers to tracked Swift files and `Package.swift`.
- Headers preserve upstream copyright where OmniWM-origin code remains, and avoid adding BarutSRB copyright to Nehir-original files merely as thanks.

### User-facing attribution surfaces

- Improve License and OmniWM Attribution sections at the About screen. It was there since first release it introduced, but made more clean version.
- Add `nehirctl license`, `about`, `legal`, and `attribution` commands, plus license/lineage lines in `--help`.
- Keep current project/source links on `apphane-dev/nehir`, while preserving upstream OmniWM and historical fork-history links.

## Release notes

- [x] Added a `.changeset/*.md` for user-visible changes (`mise run changeset -- patch "..."`).
- [ ] No user-visible change; apply the `no release note` label to make CI skip intentional.

## Validation

- [x] `mise run license:check`
- [x] `mise run format:check`
