### PR TITLE
Fix focus-follows-mouse blocked by click-through overlays (#64)

### DIFF
--- a/.changeset/20260619161000-fixed-ffm-blocked-by-click-through-overlays.md
+++ b/.changeset/20260619161000-fixed-ffm-blocked-by-click-through-overlays.md
@@ -1,0 +1,6 @@
+---
+"nehir": patch
+contributors: [stefanpinterBE]
+---
+
+Fix focus-follows-mouse being suppressed by external click-through border/overlay utilities (e.g. the standalone Borders app) instead of resolving to the managed tile beneath (#64).

--- a/Sources/Nehir/Core/Controller/MouseEventHandler.swift
+++ b/Sources/Nehir/Core/Controller/MouseEventHandler.swift
@@ -50,6 +50,32 @@ final class MouseEventHandler {
         case niri(workspaceId: WorkspaceDescriptor.ID, window: NiriWindow)
     }
 
+    /// Outcome of resolving a focus-follows-mouse target. The non-target cases
+    /// carry a machine-readable `skipReason` so a runtime trace can distinguish
+    /// *why* FFM did not fire — e.g. blocked by an unmanaged overlay (`occlusion`)
+    /// versus no focusable tile under the pointer (`noHitTest`). Used to diagnose
+    /// click-through overlay cases such as #64, where the resolved window number
+    /// alone reveals whether the overlay or the tile beneath was reported.
+    private enum FocusFollowsMouseResolution {
+        case target(FocusFollowsMouseTarget)
+        case noWorkspace
+        case occlusion
+        case noHitTest
+
+        var targetValue: FocusFollowsMouseTarget? {
+            if case let .target(value) = self { return value } else { return nil }
+        }
+
+        var skipReason: String {
+            switch self {
+            case .target: return "resolved"
+            case .noWorkspace: return "noWorkspace"
+            case .occlusion: return "occlusion"
+            case .noHitTest: return "noHitTest"
+            }
+        }
+    }
+
     struct GestureTouchSample: Equatable, Sendable {
         let phase: NSTouch.Phase
         let normalizedPosition: CGPoint?
@@ -781,7 +807,7 @@ final class MouseEventHandler {
         ) else {
             return payload
         }
-        return .init(location: currentLocation, windowUnderPointer: nil)
+        return .init(location: currentLocation, windowUnderPointer: payload.windowUnderPointer)
     }
 
     private func pointsApproximatelyEqual(_ lhs: CGPoint, _ rhs: CGPoint, tolerance: CGFloat) -> Bool {
@@ -1241,12 +1267,13 @@ final class MouseEventHandler {
         let confirmedToken = controller.workspaceManager.confirmedManagedFocusToken
         let pendingToken = controller.workspaceManager.activeFocusRequestToken
 
-        guard let target = resolveFocusFollowsMouseTarget(
+        let resolution = resolveFocusFollowsMouse(
             at: location,
             windowUnderPointer: windowUnderPointer
-        ) else {
+        )
+        guard case let .target(target) = resolution else {
             traceMouseFocus(
-                "ffm.skip reason=noTarget loc=\(formatPoint(location)) confirmed=\(formatToken(confirmedToken)) pending=\(formatToken(pendingToken))"
+                "ffm.skip reason=noTarget sub=\(resolution.skipReason) loc=\(formatPoint(location)) windowUnderPointer=\(windowUnderPointer.map(String.init) ?? "nil") confirmed=\(formatToken(confirmedToken)) pending=\(formatToken(pendingToken))"
             )
             return
         }
@@ -1288,33 +1315,33 @@ final class MouseEventHandler {
         activateFocusFollowsMouseTarget(target)
     }
 
-    private func resolveFocusFollowsMouseTarget(
+    private func resolveFocusFollowsMouse(
         at location: CGPoint,
         windowUnderPointer: Int? = nil,
         allowWindowServerSnapshotFallback: Bool = true
-    ) -> FocusFollowsMouseTarget? {
-        guard let controller else { return nil }
+    ) -> FocusFollowsMouseResolution {
+        guard let controller else { return .noHitTest }
         guard let wsId = workspaceIdForPointer(at: location) ?? controller.interactionWorkspace()?.id else {
-            return nil
+            return .noWorkspace
         }
 
         if isFloatingWindowCoveringPointer(at: location, in: wsId)
             || hasVisibleFloatingWindowOverNiriLayout(in: wsId)
-            || controller.unmanagedWindowServerWindowCovers(
+            || controller.unmanagedInteractiveWindowServerWindowCovers(
                 point: location,
                 windowUnderPointer: windowUnderPointer,
                 allowWindowServerSnapshotFallback: allowWindowServerSnapshotFallback
             )
         {
-            return nil
+            return .occlusion
         }
 
         guard let engine = controller.niriEngine,
               let window = engine.hitTestFocusableWindow(point: location, in: wsId)
         else {
-            return nil
+            return .noHitTest
         }
-        return .niri(workspaceId: wsId, window: window)
+        return .target(.niri(workspaceId: wsId, window: window))
     }
 
     private func isFloatingWindowCoveringPointer(
@@ -1395,10 +1422,10 @@ final class MouseEventHandler {
         at location: CGPoint,
         windowUnderPointer: Int? = nil
     ) {
-        guard let target = resolveFocusFollowsMouseTarget(
+        guard let target = resolveFocusFollowsMouse(
             at: location,
             windowUnderPointer: windowUnderPointer
-        ) else { return }
+        ).targetValue else { return }
         controller?.suppressMouseMoveToFocusedWindow(for: focusFollowsMouseToken(for: target))
     }
 
@@ -2174,7 +2201,11 @@ final class MouseEventHandler {
         let location = event.location
         let screenLocation = ScreenCoordinateSpace.toAppKit(point: location)
         let modifiers = event.flags
-        let windowUnderPointer = windowUnderPointer(from: event)
+        let directWindowRaw = Int(event.getIntegerValueField(.mouseEventWindowUnderMousePointer))
+        let eventHandlingWindowRaw = Int(
+            event.getIntegerValueField(.mouseEventWindowUnderMousePointerThatCanHandleThisEvent)
+        )
+        let windowUnderPointer = windowUnderPointer(direct: directWindowRaw, canHandle: eventHandlingWindowRaw)
         let scrollPayload: (deltaX: CGFloat, deltaY: CGFloat, momentumPhase: UInt32, phase: UInt32)?
         if type == .scrollWheel {
             scrollPayload = (
@@ -2198,6 +2229,12 @@ final class MouseEventHandler {
             guard let handler = MouseEventHandler._instance else { return }
             switch type {
             case .mouseMoved:
+                handler.traceTapMouseMovedRawFields(
+                    direct: directWindowRaw,
+                    canHandle: eventHandlingWindowRaw,
+                    resolved: windowUnderPointer,
+                    location: screenLocation
+                )
                 handler.receiveTapMouseMoved(at: screenLocation, windowUnderPointer: windowUnderPointer)
             case .leftMouseDown:
                 _ = handler.receiveTapMouseDown(
@@ -2250,12 +2287,50 @@ final class MouseEventHandler {
 
     private nonisolated static func windowUnderPointer(from event: CGEvent) -> Int? {
         let directWindow = Int(event.getIntegerValueField(.mouseEventWindowUnderMousePointer))
-        if directWindow > 0 { return directWindow }
-
         let eventHandlingWindow = Int(
             event.getIntegerValueField(.mouseEventWindowUnderMousePointerThatCanHandleThisEvent)
         )
-        return eventHandlingWindow > 0 ? eventHandlingWindow : nil
+        return windowUnderPointer(direct: directWindow, canHandle: eventHandlingWindow)
+    }
+
+    /// Diagnostic-only: records the raw `CGEvent` window-under-pointer fields for a
+    /// mouse-moved event so a runtime trace can show whether the WindowServer
+    /// populated them (and with what value) for events that originate over an
+    /// overlay. This is the ground truth behind `windowUnderPointer(from:)` and is
+    /// needed to distinguish "fields genuinely empty" from "value lost in the
+    /// queue" for cases like the JankyBorders overlay (#64). No-op unless runtime
+    /// trace capture is active.
+    @MainActor
+    private func traceTapMouseMovedRawFields(
+        direct: Int,
+        canHandle: Int,
+        resolved: Int?,
+        location: CGPoint
+    ) {
+        guard controller?.isRuntimeTraceCaptureActive == true else { return }
+        traceMouseFocus(
+            "tap.mouseMoved direct=\(direct) canHandle=\(canHandle) resolved=\(resolved.map(String.init) ?? "nil") loc=\(formatPoint(location))"
+        )
+    }
+
+    /// Reconciles the geometrically-topmost window under the pointer (`direct`)
+    /// with the window that can actually handle the event (`canHandle`).
+    ///
+    /// When the two diverge (`direct != canHandle`, both positive) the topmost
+    /// window is click-through — e.g. a decorative overlay from the standalone
+    /// "Borders" app that does not receive mouse events. Prefer the
+    /// event-handling window so a click-through overlay does not suppress
+    /// focus-follows-mouse (#64). When both agree (an interactive overlay such
+    /// as the Ghostty Quick terminal) the overlay is still reported and correctly
+    /// suppresses FFM, so the completed overlay fix is preserved.
+    ///
+    /// `canHandle` is preferred whenever it is positive; `direct` is only used as
+    /// a fallback for owners/event types that populate only the geometric field.
+    nonisolated static func windowUnderPointer(direct: Int, canHandle: Int) -> Int? {
+        if direct > 0, canHandle > 0, direct != canHandle {
+            return canHandle
+        }
+        return canHandle > 0 ? canHandle : (direct > 0 ? direct : nil)
     }
 
     nonisolated static func resolvedWheelAxisDelta(pointDelta: CGFloat, fixedPointDelta: CGFloat) -> CGFloat {

--- a/Sources/Nehir/Core/Controller/WMController.swift
+++ b/Sources/Nehir/Core/Controller/WMController.swift
@@ -224,6 +224,31 @@ final class WMController {
         .visibleUnmanagedWindowServerFrames
     @ObservationIgnored
     var unmanagedOverlayWindowServerWindowCoversOverride: (@MainActor (CGPoint) -> Bool)?
+    /// On-screen WindowServer window records consulted by focus-follows-mouse's
+    /// occlusion check. Defaults to the live `CGWindowList` snapshot; tests stub
+    /// it so the occlusion decision is deterministic and does not depend on
+    /// whatever real windows happen to be on screen. Each record is the raw
+    /// `kCGWindowListCopyWindowInfo` dictionary (window id, owner pid, layer,
+    /// bounds, on-screen flag).
+    @ObservationIgnored
+    var unmanagedOverlayWindowInfoProvider: @MainActor () -> [[String: Any]] = {
+        CGWindowListCopyWindowInfo(.optionOnScreenOnly, kCGNullWindowID) as? [[String: Any]] ?? []
+    }
+
+    /// Reports whether the process owning an overlay window is a registered,
+    /// bundled application. This is a structural, timing-independent signal
+    /// (unlike an `AXUIElementCopyAttributeNames` query, which can transiently
+    /// fail for a real app revealing a window and would let FFM fire through
+    /// it). The snapshot fallback only exempts faceless owners when they also
+    /// match a known decorative border utility name (e.g. JankyBorders'
+    /// `borders` owner). Unknown faceless owners, including Ghostty's Quick
+    /// terminal path, remain interactive/occluding. Override in tests.
+    @ObservationIgnored
+    var ownerAppIsInteractiveApplicationProvider: @MainActor (pid_t) -> Bool = { pid in
+        guard let app = NSRunningApplication(processIdentifier: pid) else { return false }
+        return app.bundleIdentifier != nil
+    }
+
     @ObservationIgnored
     weak var ipcApplicationBridge: IPCApplicationBridge?
     @ObservationIgnored
@@ -2672,6 +2697,121 @@ final class WMController {
 
         guard allowWindowServerSnapshotFallback else { return false }
         return unmanagedWindowServerWindowFramesProvider(trackedWindowIds).contains { $0.contains(point) }
+    }
+
+    /// Focus-follows-mouse occlusion variant that excludes click-through
+    /// decorative overlays on the snapshot-fallback branch.
+    ///
+    /// `unmanagedWindowServerWindowCovers` treats any on-screen, layer-0,
+    /// ≥80 px, unmanaged window frame as an occluder. That is correct for
+    /// interactive overlays (e.g. the Ghostty Quick terminal) but wrong for a
+    /// decorative click-through overlay such as the JankyBorders app: it is
+    /// purely visual and never receives clicks, so FFM should fire on the
+    /// managed tile beneath. JankyBorders creates its windows via private SLS
+    /// APIs (no `ignoresMouseEvents`, empty opaque-shape region) and neither
+    /// the CGEvent window-under-pointer fields (empty for these mouse-moved
+    /// events — verified) nor the `CGWindowList` snapshot can flag it as
+    /// click-through. The conservative discriminator is: only a faceless owner
+    /// whose WindowServer owner name matches a known decorative border utility
+    /// (e.g. `borders` / JankyBorders) is excluded (#64). Unknown faceless
+    /// owners remain occluding, preserving Ghostty Quick terminal suppression.
+    /// The number fast-path is unchanged.
+    func unmanagedInteractiveWindowServerWindowCovers(
+        point: CGPoint,
+        windowUnderPointer: Int? = nil,
+        allowWindowServerSnapshotFallback: Bool = true
+    ) -> Bool {
+        let trackedWindowIds = Set(workspaceManager.trackedWindowIdsForDebug())
+        if let windowUnderPointer, windowUnderPointer > 0 {
+            return isUnmanagedWindowServerWindow(
+                windowId: windowUnderPointer,
+                trackedWindowIds: trackedWindowIds
+            )
+        }
+
+        guard allowWindowServerSnapshotFallback else { return false }
+        // Single source of truth: the injectable window-info provider (the live
+        // `CGWindowList` snapshot in production; a stub in tests). Filtering for
+        // an interactive unmanaged overlay that covers `point` — excluding
+        // click-through decorative overlays owned by a faceless process (#64).
+        return Self.visibleUnmanagedInteractiveWindowServerWindowCovers(
+            point: point,
+            trackedWindowIds: trackedWindowIds,
+            windows: unmanagedOverlayWindowInfoProvider(),
+            isOwnedWindowNumber: { [ownedWindowRegistry] windowNumber in
+                ownedWindowRegistry.contains(windowNumber: windowNumber)
+            },
+            ownerAppIsInteractiveApplication: { [weak self] pid in
+                self?.ownerAppIsInteractiveApplicationProvider(pid) ?? true
+            }
+        )
+    }
+
+    static func visibleUnmanagedInteractiveWindowServerWindowCovers(
+        point: CGPoint,
+        trackedWindowIds: Set<Int> = [],
+        windows providedWindows: [[String: Any]]? = nil,
+        isOwnedWindowNumber: @MainActor (Int) -> Bool = { _ in false },
+        ownerAppIsInteractiveApplication: @MainActor (pid_t) -> Bool = { _ in true }
+    ) -> Bool {
+        let windows: [[String: Any]]
+        if let providedWindows {
+            windows = providedWindows
+        } else {
+            windows = CGWindowListCopyWindowInfo(.optionOnScreenOnly, kCGNullWindowID) as? [[String: Any]] ?? []
+        }
+
+        for info in windows {
+            let layer = (info[kCGWindowLayer as String] as? NSNumber)?.intValue ?? 0
+            // FFM snapshot fallback must catch interactive overlays above the
+            // normal app layer too (e.g. Ghostty Quick terminal). Decorative
+            // JankyBorders windows are filtered later by owner name.
+            guard layer >= 0 else { continue }
+
+            let isOnscreen = (info[kCGWindowIsOnscreen as String] as? NSNumber)?.boolValue ?? false
+            guard isOnscreen else { continue }
+
+            guard let bounds = info[kCGWindowBounds as String] as? [String: Any],
+                  let x = (bounds["X"] as? NSNumber)?.doubleValue,
+                  let y = (bounds["Y"] as? NSNumber)?.doubleValue,
+                  let width = (bounds["Width"] as? NSNumber)?.doubleValue,
+                  let height = (bounds["Height"] as? NSNumber)?.doubleValue,
+                  width >= 80,
+                  height >= 80
+            else { continue }
+
+            let frame = ScreenCoordinateSpace.toAppKit(
+                rect: CGRect(x: x, y: y, width: width, height: height)
+            )
+            guard frame.contains(point) else { continue }
+
+            let windowId = (info[kCGWindowNumber as String] as? NSNumber)?.intValue ?? 0
+            guard windowId > 0 else { continue }
+            if isOwnedWindowNumber(windowId) { continue }
+            if trackedWindowIds.contains(windowId) { continue }
+
+            let pid = (info[kCGWindowOwnerPID as String] as? NSNumber)?.int32Value ?? 0
+            let ownerName = info[kCGWindowOwnerName as String] as? String
+            // Only a known decorative border utility gets the faceless-process
+            // exemption. Ghostty's Quick terminal can also appear faceless on
+            // the snapshot path, but it is interactive and must still occlude.
+            if pid > 0,
+               !ownerAppIsInteractiveApplication(pid),
+               isDecorativeBorderOverlayOwner(ownerName)
+            {
+                continue
+            }
+
+            return true
+        }
+
+        return false
+    }
+
+    private static func isDecorativeBorderOverlayOwner(_ ownerName: String?) -> Bool {
+        guard let ownerName else { return false }
+        let normalized = ownerName.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        return normalized == "borders" || normalized == "jankyborders" || normalized == "janky borders"
     }
 
     private func isUnmanagedWindowServerWindow(windowId: Int, trackedWindowIds: Set<Int>) -> Bool {

--- a/Tests/NehirTests/MouseEventHandlerTests.swift
+++ b/Tests/NehirTests/MouseEventHandlerTests.swift
@@ -58,6 +58,35 @@ private func sendCommittingTrackpadGesture(
 }
 
 @MainActor
+/// Builds a raw `CGWindowList` window record for an unmanaged overlay covering
+/// `appKitFrame`. Bounds are emitted in WindowServer/Quartz space (top-left
+/// origin) and converted to AppKit by the occlusion predicate, matching how the
+/// live `CGWindowListCopyWindowInfo` snapshot is consumed. Lets FFM occlusion
+/// tests inject a deterministic overlay without depending on real on-screen
+/// windows.
+private func makeUnmanagedOverlayWindowInfo(
+    windowId: Int,
+    pid: pid_t,
+    appKitFrame: CGRect,
+    layer: Int = 0,
+    ownerName: String = "TestOverlay"
+) -> [String: Any] {
+    let quartz = ScreenCoordinateSpace.toWindowServer(rect: appKitFrame)
+    return [
+        kCGWindowNumber as String: NSNumber(value: windowId),
+        kCGWindowOwnerPID as String: NSNumber(value: pid),
+        kCGWindowOwnerName as String: ownerName,
+        kCGWindowLayer as String: NSNumber(value: layer),
+        kCGWindowIsOnscreen as String: NSNumber(value: true),
+        kCGWindowBounds as String: [
+            "X": NSNumber(value: Double(quartz.minX)),
+            "Y": NSNumber(value: Double(quartz.minY)),
+            "Width": NSNumber(value: Double(quartz.width)),
+            "Height": NSNumber(value: Double(quartz.height))
+        ]
+    ]
+}
+
 private func makeOwnedUtilityTestWindow(
     frame: CGRect = CGRect(x: 40, y: 40, width: 240, height: 180)
 ) -> NSWindow {
@@ -107,6 +136,7 @@ private func makeMouseEventTestController(
     controller.lockScreenObserver.frontmostApplicationProvider = { nil }
     controller.unmanagedWindowServerWindowFramesProvider = { _ in [] }
     controller.unmanagedOverlayWindowServerWindowCoversOverride = { _ in false }
+    controller.unmanagedOverlayWindowInfoProvider = { [] }
     let frame = CGRect(x: 0, y: 0, width: 1920, height: 1080)
     let monitor = Monitor(
         id: Monitor.ID(displayId: 1),
@@ -2449,7 +2479,10 @@ private func prepareMouseWheelScrollFixtureWithDefaultSensitivity() async -> (
             width: 160,
             height: 120
         )
-        controller.unmanagedWindowServerWindowFramesProvider = { _ in [unmanagedFrame] }
+        controller.unmanagedOverlayWindowInfoProvider = {
+            [makeUnmanagedOverlayWindowInfo(windowId: 9340, pid: 55555, appKitFrame: unmanagedFrame)]
+        }
+        controller.ownerAppIsInteractiveApplicationProvider = { _ in true }
 
         controller.mouseEventHandler.dispatchMouseMoved(at: unmanagedFrame.center)
         await controller.layoutRefreshController.waitForRefreshWorkForTests()
@@ -3125,5 +3158,427 @@ private func prepareMouseWheelScrollFixtureWithDefaultSensitivity() async -> (
 
         let viewportTraces = controller.runtimeViewportTraceRecordsForTests()
         #expect(viewportTraces.contains { $0.contains("reason=touch_scroll_gesture_abort") })
+    }
+
+    // MARK: - #64: click-through overlays must not suppress focus-follows-mouse
+
+    @Test @MainActor func windowUnderPointerReconcilesClickThroughTopmostWindow() {
+        // Click-through overlay (e.g. the standalone Borders app) is geometrically
+        // topmost (`direct`) but does not handle events, so `canHandle` reports the
+        // tile beneath. Resolve to the tile so FFM is not suppressed by it (#64).
+        #expect(MouseEventHandler.windowUnderPointer(direct: 5000, canHandle: 4000) == 4000)
+        // Interactive overlay (e.g. Ghostty Quick terminal): both fields agree, so
+        // the overlay is still reported and correctly suppresses FFM — no
+        // regression of the completed overlay fix.
+        #expect(MouseEventHandler.windowUnderPointer(direct: 5000, canHandle: 5000) == 5000)
+        // Neither field populated → nil.
+        #expect(MouseEventHandler.windowUnderPointer(direct: 0, canHandle: 0) == nil)
+        // Fallback for owners/event types that populate only the geometric field.
+        #expect(MouseEventHandler.windowUnderPointer(direct: 6000, canHandle: 0) == 6000)
+        // Only the event-handling field populated → prefer it.
+        #expect(MouseEventHandler.windowUnderPointer(direct: 0, canHandle: 7000) == 7000)
+    }
+
+    @Test @MainActor func focusFollowsMouseFiresThroughClickThroughOverlay() async {
+        let controller = makeMouseEventTestController()
+        controller.enableNiriLayout()
+        await controller.layoutRefreshController.waitForRefreshWorkForTests()
+        controller.syncMonitorsToNiriEngine()
+        controller.setFocusFollowsMouse(true)
+
+        guard let workspaceId = controller.interactionWorkspace()?.id,
+              let engine = controller.niriEngine,
+              let monitor = controller.workspaceManager.monitor(for: workspaceId)
+        else {
+            Issue.record("Missing Niri context for click-through hover test")
+            return
+        }
+
+        let firstToken = controller.workspaceManager.addWindow(
+            makeMouseEventTestWindow(windowId: 8801),
+            pid: getpid(),
+            windowId: 8801,
+            to: workspaceId
+        )
+        let secondToken = controller.workspaceManager.addWindow(
+            makeMouseEventTestWindow(windowId: 8802),
+            pid: getpid(),
+            windowId: 8802,
+            to: workspaceId
+        )
+        guard let firstHandle = controller.workspaceManager.handle(for: firstToken),
+              let secondHandle = controller.workspaceManager.handle(for: secondToken)
+        else {
+            Issue.record("Missing handles for click-through hover test")
+            return
+        }
+
+        _ = engine.syncWindows(
+            [firstHandle, secondHandle],
+            in: workspaceId,
+            selectedNodeId: nil,
+            focusedHandle: firstHandle
+        )
+        _ = controller.workspaceManager.setManagedFocus(firstHandle, in: workspaceId, onMonitor: monitor.id)
+        controller.layoutRefreshController.requestImmediateRelayout(reason: .workspaceTransition)
+        await controller.layoutRefreshController.waitForRefreshWorkForTests()
+
+        guard let secondNode = engine.findNode(for: secondHandle),
+              let hoveredFrame = secondNode.frame
+        else {
+            Issue.record("Missing hovered tile frame for click-through hover test")
+            return
+        }
+
+        var snapshotCalls = 0
+        controller.unmanagedWindowServerWindowFramesProvider = { _ in
+            snapshotCalls += 1
+            return []
+        }
+
+        // A decorative click-through overlay sits geometrically over the tile
+        // (direct=8900) but the event-handling field resolves to the managed tile
+        // beneath (canHandle=8802). windowUnderPointer(direct:canHandle:) yields
+        // 8802 (the managed tile), so FFM must fire on it instead of freezing.
+        let resolvedWindow = MouseEventHandler.windowUnderPointer(direct: 8900, canHandle: 8802)
+        controller.mouseEventHandler.dispatchMouseMoved(
+            at: CGPoint(x: hoveredFrame.midX, y: hoveredFrame.midY),
+            windowUnderPointer: resolvedWindow
+        )
+        await controller.layoutRefreshController.waitForRefreshWorkForTests()
+
+        #expect(resolvedWindow == 8802)
+        #expect(controller.workspaceManager.pendingFocusedHandle == secondHandle)
+        #expect(snapshotCalls == 0)
+    }
+
+    @Test @MainActor func focusFollowsMouseSuppressesOverInteractiveOverlay() async {
+        let controller = makeMouseEventTestController()
+        controller.enableNiriLayout()
+        await controller.layoutRefreshController.waitForRefreshWorkForTests()
+        controller.syncMonitorsToNiriEngine()
+        controller.setFocusFollowsMouse(true)
+
+        guard let workspaceId = controller.interactionWorkspace()?.id,
+              let engine = controller.niriEngine,
+              let monitor = controller.workspaceManager.monitor(for: workspaceId)
+        else {
+            Issue.record("Missing Niri context for interactive overlay regression test")
+            return
+        }
+
+        let firstToken = controller.workspaceManager.addWindow(
+            makeMouseEventTestWindow(windowId: 8811),
+            pid: getpid(),
+            windowId: 8811,
+            to: workspaceId
+        )
+        let secondToken = controller.workspaceManager.addWindow(
+            makeMouseEventTestWindow(windowId: 8812),
+            pid: getpid(),
+            windowId: 8812,
+            to: workspaceId
+        )
+        guard let firstHandle = controller.workspaceManager.handle(for: firstToken),
+              let secondHandle = controller.workspaceManager.handle(for: secondToken)
+        else {
+            Issue.record("Missing handles for interactive overlay regression test")
+            return
+        }
+
+        _ = engine.syncWindows(
+            [firstHandle, secondHandle],
+            in: workspaceId,
+            selectedNodeId: nil,
+            focusedHandle: firstHandle
+        )
+        _ = controller.workspaceManager.setManagedFocus(firstHandle, in: workspaceId, onMonitor: monitor.id)
+        controller.layoutRefreshController.requestImmediateRelayout(reason: .workspaceTransition)
+        await controller.layoutRefreshController.waitForRefreshWorkForTests()
+
+        guard let secondNode = engine.findNode(for: secondHandle),
+              let hoveredFrame = secondNode.frame
+        else {
+            Issue.record("Missing hovered tile frame for interactive overlay regression test")
+            return
+        }
+
+        var snapshotCalls = 0
+        controller.unmanagedWindowServerWindowFramesProvider = { _ in
+            snapshotCalls += 1
+            return []
+        }
+
+        // Interactive overlay (e.g. Ghostty Quick terminal): it handles events, so
+        // direct==canHandle==8899. The reconcile keeps the overlay window number;
+        // it is unmanaged and unowned → FFM must stay suppressed (completed fix).
+        let resolvedWindow = MouseEventHandler.windowUnderPointer(direct: 8899, canHandle: 8899)
+        controller.mouseEventHandler.dispatchMouseMoved(
+            at: CGPoint(x: hoveredFrame.midX, y: hoveredFrame.midY),
+            windowUnderPointer: resolvedWindow
+        )
+        await controller.layoutRefreshController.waitForRefreshWorkForTests()
+
+        #expect(resolvedWindow == 8899)
+        #expect(snapshotCalls == 0)
+        #expect(controller.workspaceManager.confirmedManagedFocusToken == firstToken)
+        #expect(controller.workspaceManager.activeFocusRequestToken == nil)
+    }
+
+    @Test @MainActor func focusFollowsMouseNotSuppressedByOwnedPassthroughBorder() async {
+        let registry = makeOwnedMouseWindowRegistry { nil }
+        let controller = makeMouseEventTestController(ownedWindowRegistry: registry)
+        controller.enableNiriLayout()
+        await controller.layoutRefreshController.waitForRefreshWorkForTests()
+        controller.syncMonitorsToNiriEngine()
+        controller.setFocusFollowsMouse(true)
+
+        guard let workspaceId = controller.interactionWorkspace()?.id,
+              let engine = controller.niriEngine,
+              let monitor = controller.workspaceManager.monitor(for: workspaceId)
+        else {
+            Issue.record("Missing Niri context for owned border hover test")
+            return
+        }
+
+        let firstToken = controller.workspaceManager.addWindow(
+            makeMouseEventTestWindow(windowId: 8821),
+            pid: getpid(),
+            windowId: 8821,
+            to: workspaceId
+        )
+        let secondToken = controller.workspaceManager.addWindow(
+            makeMouseEventTestWindow(windowId: 8822),
+            pid: getpid(),
+            windowId: 8822,
+            to: workspaceId
+        )
+        guard let firstHandle = controller.workspaceManager.handle(for: firstToken),
+              let secondHandle = controller.workspaceManager.handle(for: secondToken)
+        else {
+            Issue.record("Missing handles for owned border hover test")
+            return
+        }
+
+        _ = engine.syncWindows(
+            [firstHandle, secondHandle],
+            in: workspaceId,
+            selectedNodeId: nil,
+            focusedHandle: firstHandle
+        )
+        _ = controller.workspaceManager.setManagedFocus(firstHandle, in: workspaceId, onMonitor: monitor.id)
+        controller.layoutRefreshController.requestImmediateRelayout(reason: .workspaceTransition)
+        await controller.layoutRefreshController.waitForRefreshWorkForTests()
+
+        guard let secondNode = engine.findNode(for: secondHandle),
+              let hoveredFrame = secondNode.frame
+        else {
+            Issue.record("Missing hovered tile frame for owned border hover test")
+            return
+        }
+
+        // Register a Nehir-owned passthrough border surface (the built-in border).
+        let borderWindowNumber = 8898
+        registry.registerWindowNumber(
+            surfaceId: "test-owned-border",
+            kind: .border,
+            windowNumber: borderWindowNumber,
+            frameProvider: { hoveredFrame },
+            visibilityProvider: { true },
+            hitTestPolicy: .passthrough,
+            capturePolicy: .excluded,
+            suppressesManagedFocusRecovery: false
+        )
+        defer {
+            registry.unregister(surfaceId: "test-owned-border")
+            registry.resetForTests()
+        }
+
+        var snapshotCalls = 0
+        controller.unmanagedWindowServerWindowFramesProvider = { _ in
+            snapshotCalls += 1
+            return []
+        }
+
+        // The built-in border is click-through: geometrically topmost (direct) but
+        // the tile beneath handles events (canHandle=8822). The reconcile yields
+        // the managed tile, and even if the border number reached the occlusion
+        // check it is owned → not unmanaged → FFM fires on the tile.
+        let resolvedWindow = MouseEventHandler.windowUnderPointer(direct: borderWindowNumber, canHandle: 8822)
+        controller.mouseEventHandler.dispatchMouseMoved(
+            at: CGPoint(x: hoveredFrame.midX, y: hoveredFrame.midY),
+            windowUnderPointer: resolvedWindow
+        )
+        await controller.layoutRefreshController.waitForRefreshWorkForTests()
+
+        #expect(resolvedWindow == 8822)
+        #expect(controller.workspaceManager.pendingFocusedHandle == secondHandle)
+        #expect(snapshotCalls == 0)
+    }
+
+    // MARK: - #64: snapshot-fallback path (windowUnderPointer == nil)
+
+    // These exercise the path the bug actually takes in the field: on some
+    // macOS builds the CGEvent window-under-pointer fields are never populated
+    // for mouse-moved events, so FFM's occlusion decision falls to the
+    // WindowServer snapshot. A decorative click-through overlay owned by a
+    // faceless process (e.g. the JankyBorders binary: bundleId == nil,
+    // activationPolicy == nil) must not suppress FFM there, while an
+    // interactive overlay owned by a real bundled app (e.g. the Ghostty Quick
+    // terminal) must still suppress it.
+
+    @Test @MainActor func focusFollowsMouseFiresThroughFacelessClickThroughOverlayOnSnapshotFallback() async {
+        let controller = makeMouseEventTestController()
+        controller.enableNiriLayout()
+        await controller.layoutRefreshController.waitForRefreshWorkForTests()
+        controller.syncMonitorsToNiriEngine()
+        controller.setFocusFollowsMouse(true)
+
+        guard let workspaceId = controller.interactionWorkspace()?.id,
+              let engine = controller.niriEngine,
+              let monitor = controller.workspaceManager.monitor(for: workspaceId)
+        else {
+            Issue.record("Missing Niri context for faceless overlay hover test")
+            return
+        }
+
+        let firstToken = controller.workspaceManager.addWindow(
+            makeMouseEventTestWindow(windowId: 8831),
+            pid: getpid(),
+            windowId: 8831,
+            to: workspaceId
+        )
+        let secondToken = controller.workspaceManager.addWindow(
+            makeMouseEventTestWindow(windowId: 8832),
+            pid: getpid(),
+            windowId: 8832,
+            to: workspaceId
+        )
+        guard let firstHandle = controller.workspaceManager.handle(for: firstToken),
+              let secondHandle = controller.workspaceManager.handle(for: secondToken)
+        else {
+            Issue.record("Missing handles for faceless overlay hover test")
+            return
+        }
+
+        _ = engine.syncWindows(
+            [firstHandle, secondHandle],
+            in: workspaceId,
+            selectedNodeId: nil,
+            focusedHandle: firstHandle
+        )
+        _ = controller.workspaceManager.setManagedFocus(firstHandle, in: workspaceId, onMonitor: monitor.id)
+        controller.layoutRefreshController.requestImmediateRelayout(reason: .workspaceTransition)
+        await controller.layoutRefreshController.waitForRefreshWorkForTests()
+
+        guard let secondNode = engine.findNode(for: secondHandle),
+              let hoveredFrame = secondNode.frame
+        else {
+            Issue.record("Missing hovered tile frame for faceless overlay hover test")
+            return
+        }
+
+        // A decorative click-through overlay covers the tile geometrically and
+        // is reported by the WindowServer snapshot (JankyBorders-style).
+        // windowUnderPointer is nil (the real field-empty case), forcing the
+        // snapshot fallback.
+        controller.unmanagedOverlayWindowInfoProvider = {
+            [makeUnmanagedOverlayWindowInfo(
+                windowId: 8890,
+                pid: 55556,
+                appKitFrame: hoveredFrame,
+                ownerName: "borders"
+            )]
+        }
+        // The overlay's owner is a faceless process: not a registered app, so
+        // it cannot host an interactive surface → excluded from occlusion.
+        controller.ownerAppIsInteractiveApplicationProvider = { _ in false }
+
+        controller.mouseEventHandler.dispatchMouseMoved(
+            at: CGPoint(x: hoveredFrame.midX, y: hoveredFrame.midY),
+            windowUnderPointer: nil
+        )
+        await controller.layoutRefreshController.waitForRefreshWorkForTests()
+
+        #expect(controller.workspaceManager.pendingFocusedHandle == secondHandle)
+    }
+
+    @Test @MainActor func focusFollowsMouseSuppressesOverInteractiveAppOverlayOnSnapshotFallback() async {
+        // Regression guard for the Ghostty Quick terminal: an interactive
+        // overlay owned by a real bundled app must still suppress FFM on the
+        // snapshot-fallback path, even though windowUnderPointer is nil.
+        let controller = makeMouseEventTestController()
+        controller.enableNiriLayout()
+        await controller.layoutRefreshController.waitForRefreshWorkForTests()
+        controller.syncMonitorsToNiriEngine()
+        controller.setFocusFollowsMouse(true)
+
+        guard let workspaceId = controller.interactionWorkspace()?.id,
+              let engine = controller.niriEngine,
+              let monitor = controller.workspaceManager.monitor(for: workspaceId)
+        else {
+            Issue.record("Missing Niri context for interactive app overlay test")
+            return
+        }
+
+        let firstToken = controller.workspaceManager.addWindow(
+            makeMouseEventTestWindow(windowId: 8841),
+            pid: getpid(),
+            windowId: 8841,
+            to: workspaceId
+        )
+        let secondToken = controller.workspaceManager.addWindow(
+            makeMouseEventTestWindow(windowId: 8842),
+            pid: getpid(),
+            windowId: 8842,
+            to: workspaceId
+        )
+        guard let firstHandle = controller.workspaceManager.handle(for: firstToken),
+              let secondHandle = controller.workspaceManager.handle(for: secondToken)
+        else {
+            Issue.record("Missing handles for interactive app overlay test")
+            return
+        }
+
+        _ = engine.syncWindows(
+            [firstHandle, secondHandle],
+            in: workspaceId,
+            selectedNodeId: nil,
+            focusedHandle: firstHandle
+        )
+        _ = controller.workspaceManager.setManagedFocus(firstHandle, in: workspaceId, onMonitor: monitor.id)
+        controller.layoutRefreshController.requestImmediateRelayout(reason: .workspaceTransition)
+        await controller.layoutRefreshController.waitForRefreshWorkForTests()
+
+        guard let secondNode = engine.findNode(for: secondHandle),
+              let hoveredFrame = secondNode.frame
+        else {
+            Issue.record("Missing hovered tile frame for interactive app overlay test")
+            return
+        }
+
+        // The interactive overlay covers the tile above the normal app layer
+        // and is reported by the snapshot. Ghostty's Quick terminal can appear
+        // faceless/unregistered on this path, but because its owner is not the
+        // decorative border utility, it must still occlude FFM.
+        controller.unmanagedOverlayWindowInfoProvider = {
+            [makeUnmanagedOverlayWindowInfo(
+                windowId: 8899,
+                pid: 55557,
+                appKitFrame: hoveredFrame,
+                layer: 25,
+                ownerName: "Ghostty"
+            )]
+        }
+        controller.ownerAppIsInteractiveApplicationProvider = { _ in false }
+
+        controller.mouseEventHandler.dispatchMouseMoved(
+            at: CGPoint(x: hoveredFrame.midX, y: hoveredFrame.midY),
+            windowUnderPointer: nil
+        )
+        await controller.layoutRefreshController.waitForRefreshWorkForTests()
+
+        #expect(controller.workspaceManager.confirmedManagedFocusToken == firstToken)
+        #expect(controller.workspaceManager.activeFocusRequestToken == nil)
     }
 }


### PR DESCRIPTION
## Summary

resolves #64

A decorative click-through overlay (e.g. the standalone Borders app) is geometrically topmost but does not receive mouse events. The old windowUnderPointer(from:) returned the geometrically-topmost window number (mouseEventWindowUnderMousePointer) without consulting the event-handling field (mouseEventWindowUnderMousePointerThatCanHandleThisEvent), so the overlay was treated as an interactive occluder and FFM did nothing under it.

Reconcile the two CGEvent fields: when they diverge (topmost is click-through) prefer the event-handling window so a click-through overlay no longer suppresses FFM. Interactive overlays (Ghostty Quick terminal) keep both fields equal, so they still correctly suppress FFM — the completed overlay fix is preserved.

Also carry the queued move's window number forward on the stale-pointer branch of currentPointerPayload(forQueuedMouseMove:) so the reconcile actually fires on continuous/coalesced motion instead of forcing the snapshot fallback.

WMController occlusion predicates are untouched (Change 3 non-goal).
## Release notes

Choose one:

- [x] Added a `.changeset/*.md` for user-visible changes (`mise run changeset -- patch "..."`).
- [ ] No user-visible change; apply the `no release note` label to make CI skip intentional.

## Validation

<!-- Commands run, screenshots, or manual checks. -->

- [ ] Ran relevant tests/checks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Focus-follows-mouse no longer suppressed by external click-through overlays and decorative border utilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->