### PR TITLE
Anchor workspace bar below menu bar under auto-hide #68

### DIFF
--- a/.changeset/20260619075654-keep-the-workspace-bar-and-managed-windows-below.md
+++ b/.changeset/20260619075654-keep-the-workspace-bar-and-managed-windows-below.md
@@ -1,0 +1,6 @@
+---
+"nehir": patch
+
+---
+
+Keep the workspace bar and managed windows below an auto-hidden menu bar by anchoring to an explicit menu-bar inset instead of the auto-hide-sensitive visible frame (#68). On multi-monitor setups the explicit inset now applies on secondary displays too, keeping them clear of the reveal region even when no menu bar is drawn there.

--- a/.provenance.json
+++ b/.provenance.json
@@ -80,6 +80,7 @@
         "Tests/NehirTests/SettingsMigrationStateStoreTests.swift",
         "Tests/NehirTests/ViewportSnapContextTests.swift",
         "Tests/NehirTests/WhatsNewAutoShowTests.swift",
+        "Tests/NehirTests/WorkspaceBarGeometryTests.swift",
         "Tests/NehirTests/WorkspaceNavigationHandlerTests.swift",
         "Tests/NehirTests/WorkspacesTOMLCodecTests.swift"
       ],

--- a/Sources/Nehir/Core/Controller/WMController.swift
+++ b/Sources/Nehir/Core/Controller/WMController.swift
@@ -820,11 +820,17 @@ final class WMController {
     func insetWorkingFrame(for monitor: Monitor) -> CGRect {
         let scale = NSScreen.screens.first(where: { $0.displayId == monitor.displayId })?.backingScaleFactor ?? 2.0
         let resolved = settings.resolvedBarSettings(for: monitor)
-        let reservedTopInset = WorkspaceBarGeometry.resolve(
+        var reservedTopInset = WorkspaceBarGeometry.resolve(
             monitor: monitor,
             resolved: resolved,
             isVisible: isWorkspaceBarVisible(on: monitor, resolved: resolved)
         ).reservedTopInset
+        // Keep managed windows out of the auto-hidden menu bar's reveal region
+        // so they stay aligned with the (re-anchored) workspace bar. No-op when
+        // the menu bar inset is already in `visibleFrame` (visible menu bar / notch).
+        if WorkspaceBarGeometry.effectivePosition(for: monitor, resolved: resolved) == .belowMenuBar {
+            reservedTopInset += WorkspaceBarGeometry.additionalMenuBarTopStrut(for: monitor)
+        }
         return insetWorkingFrame(
             from: monitor.visibleFrame,
             scale: scale,

--- a/Sources/Nehir/UI/WorkspaceBar/WorkspaceBarGeometry.swift
+++ b/Sources/Nehir/UI/WorkspaceBar/WorkspaceBarGeometry.swift
@@ -38,7 +38,16 @@ struct WorkspaceBarGeometry: Equatable {
     ) -> CGRect {
         let width = max(fittingWidth, 300)
         var x = monitor.frame.midX - width / 2
-        var y = effectivePosition == .belowMenuBar ? monitor.visibleFrame.maxY - barHeight : monitor.visibleFrame.maxY
+        // Anchor "below menu bar" to the physical top edge minus an explicit,
+        // always-≥24 menu-bar reservation. `visibleFrame` no longer carries the
+        // menu-bar inset under "Automatically hide and show the menu bar", so
+        // anchoring to `visibleFrame.maxY` would otherwise land the bar in the
+        // ~24pt strip the menu bar slides into. Idempotent when the menu bar is
+        // visible (there `frame.maxY - visibleFrame.maxY == 24`), and also
+        // correct for notched displays (whose inset already exceeds 24).
+        var y = effectivePosition == .belowMenuBar
+            ? monitor.frame.maxY - Self.standardMenuBarHeight(for: monitor) - barHeight
+            : monitor.visibleFrame.maxY
 
         x += CGFloat(resolved.xOffset)
         y += CGFloat(resolved.yOffset)
@@ -62,5 +71,21 @@ struct WorkspaceBarGeometry: Equatable {
     static func menuBarHeight(for monitor: Monitor) -> CGFloat {
         let height = monitor.frame.maxY - monitor.visibleFrame.maxY
         return height > 0 ? height : 28
+    }
+
+    /// Explicit, always-≥24 menu-bar height used to anchor the workspace bar
+    /// below the menu bar even when macOS auto-hides it. Unlike `visibleFrame`,
+    /// this is immune to auto-hide dropping the top inset. Idempotent for a
+    /// visible menu bar (inferred == 24) and for notched displays (inferred > 24).
+    static func standardMenuBarHeight(for monitor: Monitor) -> CGFloat {
+        max(monitor.frame.maxY - monitor.visibleFrame.maxY, 24)
+    }
+
+    /// Extra top strut the tile working area must reserve so managed windows
+    /// do not underlap the auto-hidden menu bar's reveal region. Zero (no change)
+    /// whenever the menu bar inset is already present in `visibleFrame` (visible
+    /// menu bar or notch); 24 - inferred under auto-hide.
+    static func additionalMenuBarTopStrut(for monitor: Monitor) -> CGFloat {
+        max(0, 24 - (monitor.frame.maxY - monitor.visibleFrame.maxY))
     }
 }

--- a/Tests/NehirTests/WorkspaceBarGeometryTests.swift
+++ b/Tests/NehirTests/WorkspaceBarGeometryTests.swift
@@ -1,0 +1,146 @@
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=nehir-original; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
+import CoreGraphics
+import Foundation
+@testable import Nehir
+import Testing
+
+/// Characterization tests for Nehir #68 — workspace bar must sit below an
+/// auto-hidden menu bar. `frame()` now anchors `.belowMenuBar` to the physical
+/// top edge minus an explicit, always-≥24 menu-bar reservation instead of the
+/// auto-hide-sensitive `visibleFrame.maxY`. See
+/// `planned/20260619-nehir-68-workspace-bar-autohidden-menu-bar.md`.
+@MainActor
+@Suite
+struct WorkspaceBarGeometryTests {
+    private let barHeight: CGFloat = 28
+
+    /// Synthetic monitor: `inset` is `frame.maxY - visibleFrame.maxY`.
+    /// `inset == 0` simulates "Automatically hide and show the menu bar" (AppKit
+    /// no longer reserves the menu bar in visibleFrame); `inset == 24` simulates
+    /// a visible menu bar; `inset == 32` simulates a notched display.
+    private func monitor(
+        width: CGFloat = 1600,
+        height: CGFloat = 1000,
+        inset: CGFloat,
+        hasNotch: Bool = false
+    ) -> Monitor {
+        let frame = CGRect(x: 0, y: 0, width: width, height: height)
+        let visibleFrame = CGRect(x: 0, y: 0, width: width, height: height - inset)
+        return Monitor(
+            id: Monitor.ID(displayId: 1),
+            displayId: 1,
+            frame: frame,
+            visibleFrame: visibleFrame,
+            hasNotch: hasNotch,
+            name: "Test"
+        )
+    }
+
+    private func resolved(position: WorkspaceBarPosition, reserveLayoutSpace: Bool = true) -> ResolvedBarSettings {
+        ResolvedBarSettings(
+            enabled: true,
+            showLabels: true,
+            showFloatingWindows: false,
+            showTraceButton: false,
+            deduplicateAppIcons: false,
+            hideEmptyWorkspaces: false,
+            reserveLayoutSpace: reserveLayoutSpace,
+            notchAware: true,
+            position: position,
+            windowLevel: .popup,
+            height: Double(barHeight),
+            backgroundOpacity: 0.1,
+            xOffset: 0.0,
+            yOffset: 0.0,
+            accentColor: nil,
+            textColor: nil
+        )
+    }
+
+    // MARK: - standardMenuBarHeight / additionalMenuBarTopStrut
+
+    @Test func standardMenuBarHeightFloorsAt24UnderAutoHide() {
+        // inset 0 (auto-hide) -> 24, not 0.
+        #expect(WorkspaceBarGeometry.standardMenuBarHeight(for: monitor(inset: 0)) == 24)
+    }
+
+    @Test func standardMenuBarHeightUsesInferredWhenLarger() {
+        // visible menu bar (inset 24) -> 24; notch (inset 32) -> 32.
+        #expect(WorkspaceBarGeometry.standardMenuBarHeight(for: monitor(inset: 24)) == 24)
+        #expect(WorkspaceBarGeometry.standardMenuBarHeight(for: monitor(inset: 32, hasNotch: true)) == 32)
+    }
+
+    @Test func additionalMenuBarTopStrutIsZeroWhenInsetAlreadyPresent() {
+        // No extra strut when the menu bar / notch inset is already in visibleFrame.
+        #expect(WorkspaceBarGeometry.additionalMenuBarTopStrut(for: monitor(inset: 24)) == 0)
+        #expect(WorkspaceBarGeometry.additionalMenuBarTopStrut(for: monitor(inset: 32, hasNotch: true)) == 0)
+    }
+
+    @Test func additionalMenuBarTopStrutFillsAutoHideGap() {
+        // Auto-hide (inset 0) -> 24pt extra strut so tiles clear the reveal region.
+        #expect(WorkspaceBarGeometry.additionalMenuBarTopStrut(for: monitor(inset: 0)) == 24)
+    }
+
+    // MARK: - frame(): belowMenuBar anchoring
+
+    @Test func belowMenuBarAnchoredBelowExplicitMenuBarInsetUnderAutoHide() {
+        // The reported bug: auto-hide. The bar must drop below the 24pt reveal strip,
+        // NOT sit at the very top edge (frame.maxY - barHeight).
+        let m = monitor(inset: 0)
+        let geometry = WorkspaceBarGeometry.resolve(
+            monitor: m,
+            resolved: resolved(position: .belowMenuBar),
+            isVisible: true
+        )
+        let frame = geometry.frame(fittingWidth: 400, monitor: m, resolved: resolved(position: .belowMenuBar))
+        // Bar bottom = frame.maxY - 24 - barHeight; bar occupies the 28pt above that.
+        #expect(frame.maxY == m.frame.maxY - 24)
+        #expect(frame.minY == m.frame.maxY - 24 - barHeight)
+        // Critical: it must NOT occupy the top reveal strip.
+        #expect(frame.maxY < m.frame.maxY)
+    }
+
+    @Test func belowMenuBarUnchangedForVisibleMenuBar() {
+        // Idempotency: with a visible menu bar (inset 24) the bar placement must
+        // equal the pre-fix `visibleFrame.maxY - barHeight` result.
+        let m = monitor(inset: 24)
+        let geometry = WorkspaceBarGeometry.resolve(
+            monitor: m,
+            resolved: resolved(position: .belowMenuBar),
+            isVisible: true
+        )
+        let frame = geometry.frame(fittingWidth: 400, monitor: m, resolved: resolved(position: .belowMenuBar))
+        let preFixBottom = m.visibleFrame.maxY - barHeight
+        #expect(frame.minY == preFixBottom)
+    }
+
+    @Test func belowMenuBarUnchangedForNotchedDisplay() {
+        // A notched display already has a >24 inset; the reservation must match it.
+        let m = monitor(inset: 32, hasNotch: true)
+        let geometry = WorkspaceBarGeometry.resolve(
+            monitor: m,
+            resolved: resolved(position: .belowMenuBar),
+            isVisible: true
+        )
+        let frame = geometry.frame(fittingWidth: 400, monitor: m, resolved: resolved(position: .belowMenuBar))
+        #expect(frame.minY == m.visibleFrame.maxY - barHeight)
+        #expect(frame.maxY == m.frame.maxY - 32)
+    }
+
+    @Test func overlappingMenuBarAnchoredToVisibleFrameUnchanged() {
+        // Overlap mode is intentionally unchanged: bar bottom at visibleFrame.maxY,
+        // extending upward into the menu-bar region.
+        let m = monitor(inset: 24)
+        let geometry = WorkspaceBarGeometry.resolve(
+            monitor: m,
+            resolved: resolved(position: .overlappingMenuBar),
+            isVisible: true
+        )
+        let frame = geometry.frame(fittingWidth: 400, monitor: m, resolved: resolved(position: .overlappingMenuBar))
+        #expect(frame.minY == m.visibleFrame.maxY)
+    }
+}


### PR DESCRIPTION
## Summary

WorkspaceBarGeometry.frame() anchored .belowMenuBar to monitor.frame.maxY - standardMenuBarHeight - barHeight (max(inferred,24)) instead of the auto-hide-sensitive visibleFrame.maxY, so the bar no longer lands in the ~24pt strip an auto-hidden menu bar slides into. WMController.insetWorkingFrame(for:) reserves the same explicit top strut so managed windows stay aligned with the bar. Idempotent for visible menu bar (inferred==24) and notched displays (inferred>24): both helpers return 0 extra strut there.

Regression-checked: WorkspaceBarGeometryTests (8) cover auto-hide/visible/notch/overlap; NiriLayoutEngineTests (142)

resolves #68 

## Release notes

Choose one:

- [x] Added a `.changeset/*.md` for user-visible changes (`mise run changeset -- patch "..."`).
- [ ] No user-visible change; apply the `no release note` label to make CI skip intentional.

## Validation

<!-- Commands run, screenshots, or manual checks. -->

- [ ] Ran relevant tests/checks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed workspace bar and managed windows positioning to remain properly below the menu bar, including when auto-hidden.
  * Resolved overlap issues with the menu bar reveal region on single and multi-monitor setups.

* **Tests**
  * Added comprehensive test suite for workspace bar positioning behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->