### PR TITLE
Fix frameless qutebrowser borders

### DIFF
--- a/.changeset/20260621143644-fix-qutebrowser-frameless-borders.md
+++ b/.changeset/20260621143644-fix-qutebrowser-frameless-borders.md
@@ -1,0 +1,6 @@
+---
+"nehir": patch
+contributors: [stefanpinterBE]
+---
+
+Track frameless qutebrowser windows with malformed fullscreen-button AX facts, and render their focused border without treating the top-level AXDialog as a modal surface.

--- a/Sources/Nehir/Core/Ax/AXWindow.swift
+++ b/Sources/Nehir/Core/Ax/AXWindow.swift
@@ -171,6 +171,35 @@ struct AXWindowFacts: Equatable, Sendable {
     let appPolicy: NSApplication.ActivationPolicy?
     let bundleId: String?
     let attributeFetchSucceeded: Bool
+    let attributeDiagnostics: String?
+
+    init(
+        role: String?,
+        subrole: String?,
+        title: String?,
+        hasCloseButton: Bool,
+        hasFullscreenButton: Bool,
+        fullscreenButtonEnabled: Bool?,
+        hasZoomButton: Bool,
+        hasMinimizeButton: Bool,
+        appPolicy: NSApplication.ActivationPolicy?,
+        bundleId: String?,
+        attributeFetchSucceeded: Bool,
+        attributeDiagnostics: String? = nil
+    ) {
+        self.role = role
+        self.subrole = subrole
+        self.title = title
+        self.hasCloseButton = hasCloseButton
+        self.hasFullscreenButton = hasFullscreenButton
+        self.fullscreenButtonEnabled = fullscreenButtonEnabled
+        self.hasZoomButton = hasZoomButton
+        self.hasMinimizeButton = hasMinimizeButton
+        self.appPolicy = appPolicy
+        self.bundleId = bundleId
+        self.attributeFetchSucceeded = attributeFetchSucceeded
+        self.attributeDiagnostics = attributeDiagnostics
+    }
 }
 
 struct AXWindowHeuristicDisposition: Equatable, Sendable {
@@ -550,6 +579,77 @@ enum AXWindowService {
             &values
         )
 
+        func attributeName(_ index: WindowTypeAttributeIndex) -> String {
+            switch index {
+            case .role:
+                "role"
+            case .subrole:
+                "subrole"
+            case .closeButton:
+                "closeButton"
+            case .fullScreenButton:
+                "fullscreenButton"
+            case .zoomButton:
+                "zoomButton"
+            case .minimizeButton:
+                "minimizeButton"
+            case .title:
+                "title"
+            }
+        }
+
+        func describeAttributeValue(_ value: Any?) -> String {
+            guard let value else { return "nil" }
+            if let error = value as? NSError {
+                return "error:\(error.code)"
+            }
+            if value is NSNull {
+                return "null"
+            }
+            let object = value as AnyObject
+            let typeId = CFGetTypeID(object)
+            if typeId == AXUIElementGetTypeID() {
+                return "axElement"
+            }
+            if let string = value as? String {
+                return "string(len:\(string.count))"
+            }
+            if let bool = value as? Bool {
+                return "bool:\(bool)"
+            }
+            return "type:\(String(describing: type(of: value)))"
+        }
+
+        func makeAttributeDiagnostics(
+            valuesArray: [Any?]?,
+            fetchFailure: String? = nil,
+            enabledResult: AXError? = nil,
+            enabledValue: Any? = nil
+        ) -> String {
+            var parts = ["multipleResult=\(result.rawValue)"]
+            if let valuesArray {
+                parts.append("valueCount=\(valuesArray.count)")
+                let attributeParts = (
+                    WindowTypeAttributeIndex.role.rawValue ... WindowTypeAttributeIndex.title.rawValue
+                )
+                for rawIndex in attributeParts where rawIndex < attributes.count {
+                    guard let index = WindowTypeAttributeIndex(rawValue: rawIndex) else { continue }
+                    let value = valuesArray.indices.contains(rawIndex) ? valuesArray[rawIndex] : nil
+                    parts.append("\(attributeName(index))=\(describeAttributeValue(value))")
+                }
+            } else {
+                parts.append("valueCount=nil")
+            }
+            if let enabledResult {
+                parts.append("fullscreenEnabledResult=\(enabledResult.rawValue)")
+                parts.append("fullscreenEnabled=\(describeAttributeValue(enabledValue))")
+            }
+            if let fetchFailure {
+                parts.append("fetchFailure=\(fetchFailure)")
+            }
+            return parts.joined(separator: ",")
+        }
+
         guard result == .success,
               let valuesArray = values as? [Any?],
               valuesArray.count > WindowTypeAttributeIndex.minimizeButton.rawValue
@@ -565,7 +665,11 @@ enum AXWindowService {
                 hasMinimizeButton: false,
                 appPolicy: appPolicy,
                 bundleId: bundleId,
-                attributeFetchSucceeded: false
+                attributeFetchSucceeded: false,
+                attributeDiagnostics: makeAttributeDiagnostics(
+                    valuesArray: values as? [Any?],
+                    fetchFailure: "multiple_attribute_fetch_failed"
+                )
             )
         }
 
@@ -581,41 +685,41 @@ enum AXWindowService {
 
         let fullscreenButtonElement = attributeValue(.fullScreenButton)
         var attributeFetchSucceeded = true
-        let hasFullscreenButton = hasResolvedAttribute(fullscreenButtonElement)
+        var attributeFetchFailure: String?
+        var fullscreenEnabledResult: AXError?
+        var fullscreenEnabledDiagnosticValue: Any?
+        var hasFullscreenButton = hasResolvedAttribute(fullscreenButtonElement)
 
         var fullscreenButtonEnabled: Bool?
         if hasFullscreenButton, let fullscreenButtonElement {
-            guard CFGetTypeID(fullscreenButtonElement as CFTypeRef) == AXUIElementGetTypeID() else {
-                attributeFetchSucceeded = false
-                return AXWindowFacts(
-                    role: attributeValue(.role) as? String,
-                    subrole: attributeValue(.subrole) as? String,
-                    title: includeTitle ? (attributeValue(.title) as? String) : nil,
-                    hasCloseButton: hasResolvedAttribute(attributeValue(.closeButton)),
-                    hasFullscreenButton: false,
-                    fullscreenButtonEnabled: nil,
-                    hasZoomButton: hasResolvedAttribute(attributeValue(.zoomButton)),
-                    hasMinimizeButton: hasResolvedAttribute(attributeValue(.minimizeButton)),
-                    appPolicy: appPolicy,
-                    bundleId: bundleId,
-                    attributeFetchSucceeded: attributeFetchSucceeded
+            if CFGetTypeID(fullscreenButtonElement as CFTypeRef) == AXUIElementGetTypeID() {
+                let buttonElement = unsafeDowncast(fullscreenButtonElement as AnyObject, to: AXUIElement.self)
+                var enabledValue: CFTypeRef?
+                let enabledResult = AXUIElementCopyAttributeValue(
+                    buttonElement,
+                    kAXEnabledAttribute as CFString,
+                    &enabledValue
                 )
-            }
-            let buttonElement = unsafeDowncast(fullscreenButtonElement as AnyObject, to: AXUIElement.self)
-            var enabledValue: CFTypeRef?
-            let enabledResult = AXUIElementCopyAttributeValue(
-                buttonElement,
-                kAXEnabledAttribute as CFString,
-                &enabledValue
-            )
-            if enabledResult == .success {
-                if let enabledValue {
-                    if let resolvedEnabled = enabledValue as? Bool {
-                        fullscreenButtonEnabled = resolvedEnabled
-                    } else {
-                        attributeFetchSucceeded = false
+                fullscreenEnabledResult = enabledResult
+                fullscreenEnabledDiagnosticValue = enabledValue
+                if enabledResult == .success {
+                    if let enabledValue {
+                        if let resolvedEnabled = enabledValue as? Bool {
+                            fullscreenButtonEnabled = resolvedEnabled
+                        } else {
+                            attributeFetchSucceeded = false
+                            attributeFetchFailure = "invalid_fullscreen_enabled_type"
+                        }
                     }
                 }
+            } else {
+                // Some frameless app windows report a non-error value for the
+                // fullscreen button slot that is not an AXUIElement. Treat that
+                // as an absent fullscreen button instead of discarding otherwise
+                // complete role/subrole/button facts; the heuristic can then
+                // safely classify the surface as floating when appropriate.
+                hasFullscreenButton = false
+                attributeFetchFailure = "invalid_fullscreen_button_type_treated_as_missing"
             }
         }
 
@@ -630,7 +734,13 @@ enum AXWindowService {
             hasMinimizeButton: hasResolvedAttribute(attributeValue(.minimizeButton)),
             appPolicy: appPolicy,
             bundleId: bundleId,
-            attributeFetchSucceeded: attributeFetchSucceeded
+            attributeFetchSucceeded: attributeFetchSucceeded,
+            attributeDiagnostics: makeAttributeDiagnostics(
+                valuesArray: valuesArray,
+                fetchFailure: attributeFetchFailure,
+                enabledResult: fullscreenEnabledResult,
+                enabledValue: fullscreenEnabledDiagnosticValue
+            )
         )
     }
 

--- a/Sources/Nehir/Core/Border/BorderManager.swift
+++ b/Sources/Nehir/Core/Border/BorderManager.swift
@@ -14,6 +14,8 @@ final class BorderManager {
     private var lastAppliedFrame: CGRect?
     private var lastAppliedWindowId: Int?
     private var lastAppliedCornerRadius: CGFloat?
+    private var lastAppliedOrder: SkyLightWindowOrder = .below
+    private var lastAppliedPlacement: BorderPlacement = .outside
     private var cachedCornerRadiusWindowId: Int?
     private var cachedCornerRadius: CGFloat?
     private let borderWindowOperations: BorderWindow.Operations
@@ -55,7 +57,9 @@ final class BorderManager {
     func updateFocusedWindow(
         frame: CGRect,
         windowId: Int?,
-        forceOrdering: Bool = false
+        forceOrdering: Bool = false,
+        order: SkyLightWindowOrder = .below,
+        placement: BorderPlacement = .outside
     ) -> Bool {
         guard config.enabled else { return false }
         guard frame.width > 0, frame.height > 0 else {
@@ -81,13 +85,16 @@ final class BorderManager {
            frame.approximatelyEqual(to: last, tolerance: 0.5)
         {
             if lastRadius == cornerRadius {
-                if forceOrdering || lastWid != windowId {
-                    borderWindow?.reorder(relativeTo: targetWid)
+                if forceOrdering || lastWid != windowId || lastAppliedOrder != order {
+                    borderWindow?.reorder(relativeTo: targetWid, order: order)
                     lastAppliedWindowId = windowId
                     lastAppliedCornerRadius = cornerRadius
+                    lastAppliedOrder = order
                     syncSurfaceRegistration()
                 }
-                return true
+                if lastAppliedPlacement == placement {
+                    return true
+                }
             }
         }
 
@@ -95,7 +102,9 @@ final class BorderManager {
             frame: frame,
             targetWid: targetWid,
             cornerRadius: cornerRadius,
-            forceOrdering: forceOrdering
+            forceOrdering: forceOrdering,
+            order: order,
+            placement: placement
         ) == true else {
             clearCornerRadiusCache()
             return false
@@ -103,6 +112,8 @@ final class BorderManager {
         lastAppliedFrame = frame
         lastAppliedWindowId = windowId
         lastAppliedCornerRadius = cornerRadius
+        lastAppliedOrder = order
+        lastAppliedPlacement = placement
         syncSurfaceRegistration()
         return true
     }
@@ -150,6 +161,8 @@ final class BorderManager {
         lastAppliedFrame = nil
         lastAppliedWindowId = nil
         lastAppliedCornerRadius = nil
+        lastAppliedOrder = .below
+        lastAppliedPlacement = .outside
         clearCornerRadiusCache()
     }
 

--- a/Sources/Nehir/Core/Border/BorderWindow.swift
+++ b/Sources/Nehir/Core/Border/BorderWindow.swift
@@ -7,6 +7,11 @@
 import AppKit
 import QuartzCore
 
+enum BorderPlacement: Equatable {
+    case outside
+    case inside
+}
+
 @MainActor
 final class BorderWindow {
     struct Operations {
@@ -58,6 +63,7 @@ final class BorderWindow {
     private var lastOrderedTargetWid: UInt32 = 0
     private var lastConfiguredScale: CGFloat = 0
     private var currentCornerRadius: CGFloat = 9.0
+    private var currentPlacement: BorderPlacement = .outside
 
     private let padding: CGFloat = 8.0
     private let defaultCornerRadius: CGFloat = 9.0
@@ -78,6 +84,7 @@ final class BorderWindow {
         lastOrderedTargetWid = 0
         currentTargetWid = 0
         currentCornerRadius = defaultCornerRadius
+        currentPlacement = .outside
     }
 
     @discardableResult
@@ -85,25 +92,26 @@ final class BorderWindow {
         frame targetFrame: CGRect,
         targetWid: UInt32,
         cornerRadius: CGFloat = 9.0,
-        forceOrdering: Bool = false
+        forceOrdering: Bool = false,
+        order: SkyLightWindowOrder = .below,
+        placement: BorderPlacement = .outside
     ) -> Bool {
         let borderWidth = config.width
         let scale = operations.backingScaleForFrame(targetFrame)
         let resolvedCornerRadius = max(cornerRadius, 0)
 
-        let borderOffset = -borderWidth - padding
-        var frame = targetFrame.insetBy(dx: borderOffset, dy: borderOffset)
-            .roundedToPhysicalPixels(scale: scale)
+        let geometry = borderGeometry(
+            for: targetFrame,
+            borderWidth: borderWidth,
+            placement: placement,
+            scale: scale
+        )
+        var frame = geometry.frame
 
         origin = ScreenCoordinateSpace.toWindowServer(rect: frame).origin
         frame.origin = .zero
 
-        let drawingBounds = CGRect(
-            x: -borderOffset,
-            y: -borderOffset,
-            width: targetFrame.width,
-            height: targetFrame.height
-        )
+        let drawingBounds = geometry.drawingBounds
 
         let createdWindow: Bool
         if wid == 0 {
@@ -124,23 +132,49 @@ final class BorderWindow {
             reshapeWindow(frame: frame)
             needsRedraw = true
         }
-        if currentCornerRadius != resolvedCornerRadius {
+        if currentCornerRadius != resolvedCornerRadius || currentPlacement != placement {
             needsRedraw = true
         }
         currentTargetFrame = targetFrame
         currentTargetWid = targetWid
         currentFrame = frame
         currentCornerRadius = resolvedCornerRadius
+        currentPlacement = placement
 
         if needsRedraw {
             draw(frame: frame, drawingBounds: drawingBounds)
         }
 
         let needsOrdering = forceOrdering || createdWindow || !isVisible || lastOrderedTargetWid != targetWid
-        move(relativeTo: targetWid, needsOrdering: needsOrdering)
+        move(relativeTo: targetWid, needsOrdering: needsOrdering, order: order)
         isVisible = true
         lastOrderedTargetWid = targetWid
         return true
+    }
+
+    private func borderGeometry(
+        for targetFrame: CGRect,
+        borderWidth: CGFloat,
+        placement: BorderPlacement,
+        scale: CGFloat
+    ) -> (frame: CGRect, drawingBounds: CGRect) {
+        switch placement {
+        case .outside:
+            let borderOffset = -borderWidth - padding
+            let frame = targetFrame.insetBy(dx: borderOffset, dy: borderOffset)
+                .roundedToPhysicalPixels(scale: scale)
+            let drawingBounds = CGRect(
+                x: -borderOffset,
+                y: -borderOffset,
+                width: targetFrame.width,
+                height: targetFrame.height
+            )
+            return (frame, drawingBounds)
+        case .inside:
+            let frame = targetFrame.roundedToPhysicalPixels(scale: scale)
+            let drawingBounds = CGRect(origin: .zero, size: frame.size)
+            return (frame, drawingBounds)
+        }
     }
 
     private func createWindow(frame: CGRect, scale: CGFloat) {
@@ -202,18 +236,22 @@ final class BorderWindow {
         operations.flushWindow(wid)
     }
 
-    private func move(relativeTo targetWid: UInt32, needsOrdering: Bool) {
+    private func move(
+        relativeTo targetWid: UInt32,
+        needsOrdering: Bool,
+        order: SkyLightWindowOrder
+    ) {
         if needsOrdering {
-            operations.transactionMoveAndOrder(wid, origin, orderingLevel, targetWid, .below)
+            operations.transactionMoveAndOrder(wid, origin, orderingLevel, targetWid, order)
             return
         }
 
         operations.transactionMove(wid, origin)
     }
 
-    func reorder(relativeTo targetWid: UInt32) {
+    func reorder(relativeTo targetWid: UInt32, order: SkyLightWindowOrder = .below) {
         guard wid != 0 else { return }
-        move(relativeTo: targetWid, needsOrdering: true)
+        move(relativeTo: targetWid, needsOrdering: true, order: order)
         isVisible = true
         currentTargetWid = targetWid
         lastOrderedTargetWid = targetWid
@@ -238,7 +276,8 @@ final class BorderWindow {
                 update(
                     frame: currentTargetFrame,
                     targetWid: currentTargetWid,
-                    cornerRadius: currentCornerRadius
+                    cornerRadius: currentCornerRadius,
+                    placement: currentPlacement
                 )
             }
         }

--- a/Sources/Nehir/Core/Border/FocusBorderController.swift
+++ b/Sources/Nehir/Core/Border/FocusBorderController.swift
@@ -262,7 +262,9 @@ final class FocusBorderController {
         return borderManager.updateFocusedWindow(
             frame: frame,
             windowId: target.windowId,
-            forceOrdering: forceOrdering
+            forceOrdering: forceOrdering,
+            order: borderOrdering(for: target),
+            placement: borderPlacement(for: target)
         )
     }
 
@@ -290,7 +292,7 @@ final class FocusBorderController {
             return .hide
         }
 
-        if isSystemModalSurface(target.axRef) {
+        if isSystemModalSurface(target) {
             return .hide
         }
 
@@ -316,15 +318,58 @@ final class FocusBorderController {
         return controller.axEventHandler.focusedWindowToken(for: target.pid) == target.token
     }
 
-    private func isSystemModalSurface(_ axRef: AXWindowRef) -> Bool {
-        let attributes = windowRoleProviderForTests?(axRef) ?? (
-            role: AXWindowService.role(axRef),
-            subrole: AXWindowService.subrole(axRef)
+    private func borderOrdering(for target: KeyboardFocusTarget) -> SkyLightWindowOrder {
+        let attributes = windowRoleProviderForTests?(target.axRef) ?? (
+            role: AXWindowService.role(target.axRef),
+            subrole: AXWindowService.subrole(target.axRef)
         )
+        return isQutebrowserFramelessTopLevelWindow(target, attributes: attributes) ? .above : .below
+    }
+
+    private func borderPlacement(for target: KeyboardFocusTarget) -> BorderPlacement {
+        let attributes = windowRoleProviderForTests?(target.axRef) ?? (
+            role: AXWindowService.role(target.axRef),
+            subrole: AXWindowService.subrole(target.axRef)
+        )
+        return isQutebrowserFramelessTopLevelWindow(target, attributes: attributes) ? .inside : .outside
+    }
+
+    private func isSystemModalSurface(_ target: KeyboardFocusTarget) -> Bool {
+        let attributes = windowRoleProviderForTests?(target.axRef) ?? (
+            role: AXWindowService.role(target.axRef),
+            subrole: AXWindowService.subrole(target.axRef)
+        )
+
+        if isQutebrowserFramelessTopLevelWindow(target, attributes: attributes) {
+            return false
+        }
 
         return attributes.role == kAXSheetRole as String
             || attributes.subrole == kAXDialogSubrole as String
             || attributes.subrole == kAXSystemDialogSubrole as String
+    }
+
+    private func isQutebrowserFramelessTopLevelWindow(
+        _ target: KeyboardFocusTarget,
+        attributes: (role: String?, subrole: String?)
+    ) -> Bool {
+        guard attributes.role == kAXWindowRole as String,
+              attributes.subrole == kAXDialogSubrole as String,
+              let metadata = controller?.workspaceManager.entry(for: target.token)?.managedReplacementMetadata,
+              metadata.bundleId == "org.qutebrowser.qutebrowser"
+        else {
+            return false
+        }
+
+        if metadata.windowLevel == 0, metadata.parentWindowId == 0 {
+            return true
+        }
+
+        if let info = SkyLight.shared.queryWindowInfo(UInt32(target.windowId)) {
+            return info.level == 0 && info.parentId == 0
+        }
+
+        return false
     }
 
     private func clearSuppressedManagedTargets(

--- a/Sources/Nehir/Core/Controller/AXEventHandler.swift
+++ b/Sources/Nehir/Core/Controller/AXEventHandler.swift
@@ -40,6 +40,16 @@ enum ActivationCallOrigin: String {
     case retry
 }
 
+enum PrepareCreateCandidateRejectionReason: String, Equatable {
+    case missingController = "missing_controller"
+    case missingToken = "missing_token"
+    case tokenWindowIdMismatch = "token_window_id_mismatch"
+    case existingEntry = "existing_entry"
+    case ownedWindow = "owned_window"
+    case missingAXRef = "missing_ax_ref"
+    case untrackedDecision = "untracked_decision"
+}
+
 struct NiriCreateFocusTraceEvent: Equatable {
     enum Kind: Equatable {
         case createSeen(windowId: UInt32)
@@ -72,6 +82,26 @@ struct NiriCreateFocusTraceEvent: Equatable {
         case focusConfirmed(token: WindowToken, workspaceId: WorkspaceDescriptor.ID, source: ActivationEventSource)
         case borderReapplied(token: WindowToken, phase: ManagedBorderReapplyPhase)
         case nonManagedFallbackEntered(pid: pid_t, source: ActivationEventSource)
+        case prepareCreateRejected(
+            windowId: UInt32,
+            token: WindowToken?,
+            context: String,
+            reason: PrepareCreateCandidateRejectionReason,
+            hasWindowInfo: Bool,
+            windowInfoPid: pid_t?,
+            fallbackToken: WindowToken?,
+            hasFallbackAXRef: Bool,
+            createContextSource: String?
+        )
+        case unrequestedAdmissionDuringNonManagedFocusDecision(
+            token: WindowToken,
+            suppressed: Bool,
+            reason: String,
+            createContextSource: String?,
+            recentPidWorkspaceId: WorkspaceDescriptor.ID?,
+            hasExplicitWorkspaceAssignment: Bool,
+            activeManagedRequestToken: WindowToken?
+        )
         case windowDecision(
             token: WindowToken,
             context: String,
@@ -85,8 +115,16 @@ struct NiriCreateFocusTraceEvent: Equatable {
             titleLength: Int?,
             axRole: String?,
             axSubrole: String?,
+            hasCloseButton: Bool,
+            hasFullscreenButton: Bool,
+            fullscreenButtonEnabled: Bool?,
+            hasZoomButton: Bool,
+            hasMinimizeButton: Bool,
+            appPolicy: NSApplication.ActivationPolicy?,
+            attributeDiagnostics: String?,
             windowLevel: Int32?,
             windowTags: UInt64?,
+            windowAttributes: UInt32?,
             parentWindowId: UInt32?,
             windowFrame: CGRect?
         )
@@ -170,6 +208,28 @@ extension NiriCreateFocusTraceEvent: CustomStringConvertible {
             "border_reapplied token=\(token) phase=\(phase.rawValue)"
         case let .nonManagedFallbackEntered(pid, source):
             "non_managed_fallback_entered pid=\(pid) source=\(source.rawValue)"
+        case let .prepareCreateRejected(
+            windowId,
+            token,
+            context,
+            reason,
+            hasWindowInfo,
+            windowInfoPid,
+            fallbackToken,
+            hasFallbackAXRef,
+            createContextSource
+        ):
+            "prepare_create_rejected window=\(windowId) token=\(String(describing: token)) context=\(context) reason=\(reason.rawValue) has_window_info=\(hasWindowInfo) window_info_pid=\(windowInfoPid.map(String.init) ?? "nil") fallback_token=\(String(describing: fallbackToken)) has_fallback_ax_ref=\(hasFallbackAXRef) create_context_source=\(createContextSource ?? "nil")"
+        case let .unrequestedAdmissionDuringNonManagedFocusDecision(
+            token,
+            suppressed,
+            reason,
+            createContextSource,
+            recentPidWorkspaceId,
+            hasExplicitWorkspaceAssignment,
+            activeManagedRequestToken
+        ):
+            "unrequested_admission_nonmanaged_focus_decision token=\(token) suppressed=\(suppressed) reason=\(reason) context_source=\(createContextSource ?? "nil") recent_pid_workspace=\(recentPidWorkspaceId?.uuidString ?? "nil") explicit_workspace_assignment=\(hasExplicitWorkspaceAssignment) active_managed_request_token=\(String(describing: activeManagedRequestToken))"
         case let .windowDecision(
             token,
             context,
@@ -183,12 +243,20 @@ extension NiriCreateFocusTraceEvent: CustomStringConvertible {
             titleLength,
             axRole,
             axSubrole,
+            hasCloseButton,
+            hasFullscreenButton,
+            fullscreenButtonEnabled,
+            hasZoomButton,
+            hasMinimizeButton,
+            appPolicy,
+            attributeDiagnostics,
             windowLevel,
             windowTags,
+            windowAttributes,
             parentWindowId,
             windowFrame
         ):
-            "window_decision token=\(token) context=\(context) existingMode=\(existingMode.map { String(describing: $0) } ?? "nil") disposition=\(disposition) source=\(source) outcome=\(outcome) layout=\(layout) deferred=\(deferred ?? "nil") bundleId=\(bundleId ?? "nil") titleLength=\(titleLength.map(String.init) ?? "nil") axRole=\(axRole ?? "nil") axSubrole=\(axSubrole ?? "nil") wsLevel=\(windowLevel.map(String.init) ?? "nil") wsTags=\(windowTags.map { String(format: "0x%llx", $0) } ?? "nil") wsParent=\(parentWindowId.map(String.init) ?? "nil") wsFrame=\(windowFrame.map { "(\($0.origin.x),\($0.origin.y),\($0.size.width),\($0.size.height))" } ?? "nil")"
+            "window_decision token=\(token) context=\(context) existingMode=\(existingMode.map { String(describing: $0) } ?? "nil") disposition=\(disposition) source=\(source) outcome=\(outcome) layout=\(layout) deferred=\(deferred ?? "nil") bundleId=\(bundleId ?? "nil") titleLength=\(titleLength.map(String.init) ?? "nil") axRole=\(axRole ?? "nil") axSubrole=\(axSubrole ?? "nil") hasCloseButton=\(hasCloseButton) hasFullscreenButton=\(hasFullscreenButton) fullscreenButtonEnabled=\(fullscreenButtonEnabled.map(String.init) ?? "nil") hasZoomButton=\(hasZoomButton) hasMinimizeButton=\(hasMinimizeButton) appPolicy=\(appPolicy.map { String(describing: $0) } ?? "nil") axAttributeDiagnostics=\(attributeDiagnostics ?? "nil") wsLevel=\(windowLevel.map(String.init) ?? "nil") wsTags=\(windowTags.map { String(format: "0x%llx", $0) } ?? "nil") wsAttributes=\(windowAttributes.map { String(format: "0x%x", $0) } ?? "nil") wsParent=\(parentWindowId.map(String.init) ?? "nil") wsFrame=\(windowFrame.map { "(\($0.origin.x),\($0.origin.y),\($0.size.width),\($0.size.height))" } ?? "nil")"
         }
     }
 }
@@ -643,10 +711,31 @@ final class AXEventHandler: CGSEventDelegate {
         hasExplicitWorkspaceAssignment: Bool = false
     ) -> Bool {
         guard let controller,
-              controller.workspaceManager.isNonManagedFocusActive,
-              !hasExplicitWorkspaceAssignment,
-              controller.focusBridge.activeManagedRequest?.token != token
+              controller.workspaceManager.isNonManagedFocusActive
         else {
+            return false
+        }
+        let activeManagedRequestToken = controller.focusBridge.activeManagedRequest?.token
+        guard !hasExplicitWorkspaceAssignment else {
+            recordUnrequestedAdmissionDuringNonManagedFocusDecision(
+                token: token,
+                suppressed: false,
+                reason: "explicit_workspace_assignment",
+                createPlacementContext: createPlacementContext,
+                hasExplicitWorkspaceAssignment: hasExplicitWorkspaceAssignment,
+                activeManagedRequestToken: activeManagedRequestToken
+            )
+            return false
+        }
+        guard activeManagedRequestToken != token else {
+            recordUnrequestedAdmissionDuringNonManagedFocusDecision(
+                token: token,
+                suppressed: false,
+                reason: "matches_active_managed_request",
+                createPlacementContext: createPlacementContext,
+                hasExplicitWorkspaceAssignment: hasExplicitWorkspaceAssignment,
+                activeManagedRequestToken: activeManagedRequestToken
+            )
             return false
         }
 
@@ -657,8 +746,61 @@ final class AXEventHandler: CGSEventDelegate {
         // focus is active. Existing AX/WindowServer surfaces without either
         // signal are not reliable placement/focus inputs; admitting them here
         // pulls random apps into the active workspace.
-        return createPlacementContext?.source != "cgs_created"
-            && createPlacementContext?.recentPidWorkspaceId == nil
+        if createPlacementContext?.source == "cgs_created" {
+            recordUnrequestedAdmissionDuringNonManagedFocusDecision(
+                token: token,
+                suppressed: false,
+                reason: "cgs_created_context",
+                createPlacementContext: createPlacementContext,
+                hasExplicitWorkspaceAssignment: hasExplicitWorkspaceAssignment,
+                activeManagedRequestToken: activeManagedRequestToken
+            )
+            return false
+        }
+        if createPlacementContext?.recentPidWorkspaceId != nil {
+            recordUnrequestedAdmissionDuringNonManagedFocusDecision(
+                token: token,
+                suppressed: false,
+                reason: "recent_pid_workspace",
+                createPlacementContext: createPlacementContext,
+                hasExplicitWorkspaceAssignment: hasExplicitWorkspaceAssignment,
+                activeManagedRequestToken: activeManagedRequestToken
+            )
+            return false
+        }
+
+        recordUnrequestedAdmissionDuringNonManagedFocusDecision(
+            token: token,
+            suppressed: true,
+            reason: "stale_unrequested_nonmanaged_focus",
+            createPlacementContext: createPlacementContext,
+            hasExplicitWorkspaceAssignment: hasExplicitWorkspaceAssignment,
+            activeManagedRequestToken: activeManagedRequestToken
+        )
+        return true
+    }
+
+    private func recordUnrequestedAdmissionDuringNonManagedFocusDecision(
+        token: WindowToken,
+        suppressed: Bool,
+        reason: String,
+        createPlacementContext: WindowCreatePlacementContext?,
+        hasExplicitWorkspaceAssignment: Bool,
+        activeManagedRequestToken: WindowToken?
+    ) {
+        recordNiriCreateFocusTrace(
+            .init(
+                kind: .unrequestedAdmissionDuringNonManagedFocusDecision(
+                    token: token,
+                    suppressed: suppressed,
+                    reason: reason,
+                    createContextSource: createPlacementContext?.source,
+                    recentPidWorkspaceId: createPlacementContext?.recentPidWorkspaceId,
+                    hasExplicitWorkspaceAssignment: hasExplicitWorkspaceAssignment,
+                    activeManagedRequestToken: activeManagedRequestToken
+                )
+            )
+        )
     }
 
     func structuralReplacementWorkspaceIdForCreate(
@@ -2013,7 +2155,8 @@ final class AXEventHandler: CGSEventDelegate {
             windowInfo: windowInfo,
             fallbackToken: token,
             fallbackAXRef: axRef,
-            createPlacementContext: createPlacementContext
+            createPlacementContext: createPlacementContext,
+            traceContext: "focused_admission"
         ) else {
             if let windowInfo {
                 _ = scheduleCreatedWindowRetryIfNeeded(
@@ -2837,17 +2980,75 @@ final class AXEventHandler: CGSEventDelegate {
         windowInfo: WindowServerInfo?,
         fallbackToken: WindowToken? = nil,
         fallbackAXRef: AXWindowRef? = nil,
-        createPlacementContext: WindowCreatePlacementContext? = nil
+        createPlacementContext: WindowCreatePlacementContext? = nil,
+        traceContext: String = "create"
     ) -> PreparedCreate? {
-        guard let controller else { return nil }
+        guard let controller else {
+            recordPrepareCreateRejection(
+                windowId: windowId,
+                token: fallbackToken ?? windowInfo.map { WindowToken(pid: pid_t($0.pid), windowId: Int(windowId)) },
+                context: traceContext,
+                reason: .missingController,
+                windowInfo: windowInfo,
+                fallbackToken: fallbackToken,
+                fallbackAXRef: fallbackAXRef,
+                createPlacementContext: createPlacementContext
+            )
+            return nil
+        }
         let ownedWindow = controller.isOwnedWindow(windowNumber: Int(windowId))
         let windowInfoToken = windowInfo.map { WindowToken(pid: pid_t($0.pid), windowId: Int(windowId)) }
         let token = fallbackToken ?? windowInfoToken
-        guard let token,
-              token.windowId == Int(windowId)
-        else { return nil }
-        if controller.workspaceManager.entry(for: token) != nil { return nil }
+        guard let token else {
+            recordPrepareCreateRejection(
+                windowId: windowId,
+                token: nil,
+                context: traceContext,
+                reason: .missingToken,
+                windowInfo: windowInfo,
+                fallbackToken: fallbackToken,
+                fallbackAXRef: fallbackAXRef,
+                createPlacementContext: createPlacementContext
+            )
+            return nil
+        }
+        guard token.windowId == Int(windowId) else {
+            recordPrepareCreateRejection(
+                windowId: windowId,
+                token: token,
+                context: traceContext,
+                reason: .tokenWindowIdMismatch,
+                windowInfo: windowInfo,
+                fallbackToken: fallbackToken,
+                fallbackAXRef: fallbackAXRef,
+                createPlacementContext: createPlacementContext
+            )
+            return nil
+        }
+        if controller.workspaceManager.entry(for: token) != nil {
+            recordPrepareCreateRejection(
+                windowId: windowId,
+                token: token,
+                context: traceContext,
+                reason: .existingEntry,
+                windowInfo: windowInfo,
+                fallbackToken: fallbackToken,
+                fallbackAXRef: fallbackAXRef,
+                createPlacementContext: createPlacementContext
+            )
+            return nil
+        }
         if ownedWindow {
+            recordPrepareCreateRejection(
+                windowId: windowId,
+                token: token,
+                context: traceContext,
+                reason: .ownedWindow,
+                windowInfo: windowInfo,
+                fallbackToken: fallbackToken,
+                fallbackAXRef: fallbackAXRef,
+                createPlacementContext: createPlacementContext
+            )
             discardCreatePlacementContext(windowId: windowId)
             return nil
         }
@@ -2855,7 +3056,19 @@ final class AXEventHandler: CGSEventDelegate {
         guard let axRef = fallbackAXRef?.windowId == Int(windowId)
             ? fallbackAXRef
             : resolveAXWindowRef(windowId: windowId, pid: token.pid)
-        else { return nil }
+        else {
+            recordPrepareCreateRejection(
+                windowId: windowId,
+                token: token,
+                context: traceContext,
+                reason: .missingAXRef,
+                windowInfo: windowInfo,
+                fallbackToken: fallbackToken,
+                fallbackAXRef: fallbackAXRef,
+                createPlacementContext: createPlacementContext
+            )
+            return nil
+        }
 
         let app = NSRunningApplication(processIdentifier: token.pid)
         let bundleId = resolveBundleId(token.pid) ?? app?.bundleIdentifier
@@ -2866,7 +3079,7 @@ final class AXEventHandler: CGSEventDelegate {
             pid: token.pid,
             appFullscreen: appFullscreen,
             windowInfo: matchingWindowInfo,
-            traceContext: "create",
+            traceContext: traceContext,
             existingModeForTrace: nil
         )
 
@@ -2882,7 +3095,19 @@ final class AXEventHandler: CGSEventDelegate {
             )
         }
 
-        guard let trackedMode else { return nil }
+        guard let trackedMode else {
+            recordPrepareCreateRejection(
+                windowId: windowId,
+                token: token,
+                context: traceContext,
+                reason: .untrackedDecision,
+                windowInfo: windowInfo,
+                fallbackToken: fallbackToken,
+                fallbackAXRef: fallbackAXRef,
+                createPlacementContext: createPlacementContext
+            )
+            return nil
+        }
         subscribeToWindows([windowId])
 
         let resolvedBundleId = bundleId ?? evaluation.facts.ax.bundleId
@@ -2934,6 +3159,33 @@ final class AXEventHandler: CGSEventDelegate {
             requiresPostCreateLifecycleVerification: requiresPostCreateLifecycleVerification(
                 trackedMode: trackedMode,
                 facts: evaluation.facts
+            )
+        )
+    }
+
+    private func recordPrepareCreateRejection(
+        windowId: UInt32,
+        token: WindowToken?,
+        context: String,
+        reason: PrepareCreateCandidateRejectionReason,
+        windowInfo: WindowServerInfo?,
+        fallbackToken: WindowToken?,
+        fallbackAXRef: AXWindowRef?,
+        createPlacementContext: WindowCreatePlacementContext?
+    ) {
+        recordNiriCreateFocusTrace(
+            .init(
+                kind: .prepareCreateRejected(
+                    windowId: windowId,
+                    token: token,
+                    context: context,
+                    reason: reason,
+                    hasWindowInfo: windowInfo != nil,
+                    windowInfoPid: windowInfo.map { pid_t($0.pid) },
+                    fallbackToken: fallbackToken,
+                    hasFallbackAXRef: fallbackAXRef != nil,
+                    createContextSource: createPlacementContext?.source
+                )
             )
         )
     }

--- a/Sources/Nehir/Core/Controller/WMController.swift
+++ b/Sources/Nehir/Core/Controller/WMController.swift
@@ -2231,7 +2231,7 @@ final class WMController {
         context: String,
         existingMode: TrackedWindowMode?
     ) {
-        guard shouldTraceWindowDecision(evaluation) else { return }
+        guard shouldTraceWindowDecision(evaluation, context: context) else { return }
         let windowServer = evaluation.facts.windowServer
         recordNiriCreateFocusTrace(
             .windowDecision(
@@ -2247,16 +2247,41 @@ final class WMController {
                 titleLength: evaluation.facts.ax.title?.count,
                 axRole: evaluation.facts.ax.role,
                 axSubrole: evaluation.facts.ax.subrole,
+                hasCloseButton: evaluation.facts.ax.hasCloseButton,
+                hasFullscreenButton: evaluation.facts.ax.hasFullscreenButton,
+                fullscreenButtonEnabled: evaluation.facts.ax.fullscreenButtonEnabled,
+                hasZoomButton: evaluation.facts.ax.hasZoomButton,
+                hasMinimizeButton: evaluation.facts.ax.hasMinimizeButton,
+                appPolicy: evaluation.facts.ax.appPolicy,
+                attributeDiagnostics: evaluation.facts.ax.attributeDiagnostics,
                 windowLevel: windowServer?.level,
                 windowTags: windowServer?.tags,
+                windowAttributes: windowServer?.attributes,
                 parentWindowId: windowServer?.parentId,
                 windowFrame: windowServer?.frame
             )
         )
     }
 
-    private func shouldTraceWindowDecision(_ evaluation: WindowDecisionEvaluation) -> Bool {
+    private func shouldTraceWindowDecision(_ evaluation: WindowDecisionEvaluation, context: String) -> Bool {
+        if context == "focused_admission" {
+            return true
+        }
         if evaluation.facts.ax.bundleId?.lowercased() == "com.mitchellh.ghostty" {
+            return true
+        }
+        if evaluation.decision.trackedMode == nil {
+            return true
+        }
+        if evaluation.facts.ax.subrole == (kAXDialogSubrole as String) {
+            return true
+        }
+        if !evaluation.facts.ax.hasCloseButton,
+           !evaluation.facts.ax.hasFullscreenButton,
+           !evaluation.facts.ax.hasZoomButton,
+           !evaluation.facts.ax.hasMinimizeButton,
+           evaluation.facts.ax.subrole != (kAXStandardWindowSubrole as String)
+        {
             return true
         }
         if evaluation.decision.disposition == .unmanaged {

--- a/Sources/Nehir/Core/SkyLight/SkyLight.swift
+++ b/Sources/Nehir/Core/SkyLight/SkyLight.swift
@@ -8,7 +8,7 @@ import CoreGraphics
 import Foundation
 
 enum SkyLightWindowOrder: Int32 {
-    case above = 0
+    case above = 1
     case below = -1
 }
 

--- a/Tests/NehirTests/AXEventHandlerTests.swift
+++ b/Tests/NehirTests/AXEventHandlerTests.swift
@@ -9670,6 +9670,90 @@ private func waitUntilAXEventTest(
         }
     }
 
+    @Test @MainActor func qutebrowserTopLevelAXDialogAllowsFocusedBorder() {
+        let controller = makeAXEventTestController()
+        guard let workspaceId = controller.interactionWorkspace()?.id else {
+            Issue.record("Missing active workspace")
+            return
+        }
+        let windowId = 9_130
+        let axRef = AXWindowRef(element: AXUIElementCreateSystemWide(), windowId: windowId)
+        let token = controller.workspaceManager.addWindow(
+            axRef,
+            pid: 9_129,
+            windowId: windowId,
+            to: workspaceId,
+            mode: .tiling,
+            managedReplacementMetadata: ManagedReplacementMetadata(
+                bundleId: "org.qutebrowser.qutebrowser",
+                workspaceId: workspaceId,
+                mode: .tiling,
+                role: kAXWindowRole as String,
+                subrole: kAXDialogSubrole as String,
+                title: "DuckDuckGo Private Search Engine - qutebrowser",
+                windowLevel: 0,
+                parentWindowId: 0,
+                frame: CGRect(x: 80, y: 90, width: 900, height: 620)
+            )
+        )
+        controller.focusBorderController.windowRoleProviderForTests = { _ in
+            (role: kAXWindowRole as String, subrole: kAXDialogSubrole as String)
+        }
+        defer { controller.focusBorderController.windowRoleProviderForTests = nil }
+
+        controller.setBordersEnabled(true)
+        _ = controller.renderKeyboardFocusBorder(
+            for: controller.managedKeyboardFocusTarget(for: token),
+            preferredFrame: CGRect(x: 80, y: 90, width: 900, height: 620),
+            forceOrdering: true
+        )
+
+        #expect(controller.currentBorderTarget()?.token == token)
+        #expect(lastAppliedBorderWindowId(on: controller) == token.windowId)
+    }
+
+    @Test @MainActor func nonQutebrowserAXDialogStillSuppressesFocusedBorder() {
+        let controller = makeAXEventTestController()
+        guard let workspaceId = controller.interactionWorkspace()?.id else {
+            Issue.record("Missing active workspace")
+            return
+        }
+        let windowId = 9_132
+        let axRef = AXWindowRef(element: AXUIElementCreateSystemWide(), windowId: windowId)
+        let token = controller.workspaceManager.addWindow(
+            axRef,
+            pid: 9_131,
+            windowId: windowId,
+            to: workspaceId,
+            mode: .tiling,
+            managedReplacementMetadata: ManagedReplacementMetadata(
+                bundleId: "com.example.dialog",
+                workspaceId: workspaceId,
+                mode: .tiling,
+                role: kAXWindowRole as String,
+                subrole: kAXDialogSubrole as String,
+                title: "Dialog",
+                windowLevel: 0,
+                parentWindowId: 0,
+                frame: CGRect(x: 80, y: 90, width: 900, height: 620)
+            )
+        )
+        controller.focusBorderController.windowRoleProviderForTests = { _ in
+            (role: kAXWindowRole as String, subrole: kAXDialogSubrole as String)
+        }
+        defer { controller.focusBorderController.windowRoleProviderForTests = nil }
+
+        controller.setBordersEnabled(true)
+        _ = controller.renderKeyboardFocusBorder(
+            for: controller.managedKeyboardFocusTarget(for: token),
+            preferredFrame: CGRect(x: 80, y: 90, width: 900, height: 620),
+            forceOrdering: true
+        )
+
+        #expect(controller.currentBorderTarget()?.token == token)
+        #expect(lastAppliedBorderWindowId(on: controller) == nil)
+    }
+
     @Test @MainActor func unmanagedFocusedDestroyClearsFocusedBorderTarget() {
         let controller = makeAXEventTestController()
         let token = WindowToken(pid: 9_140, windowId: 9141)

--- a/Tests/NehirTests/BorderWindowTests.swift
+++ b/Tests/NehirTests/BorderWindowTests.swift
@@ -23,6 +23,11 @@ private func makeBorderTestContext() -> CGContext? {
 }
 
 @Suite struct BorderWindowTests {
+    @Test func skyLightWindowOrderAboveUsesShowOrderingMode() {
+        #expect(SkyLightWindowOrder.above.rawValue == 1)
+        #expect(SkyLightWindowOrder.below.rawValue == -1)
+    }
+
     @Test @MainActor func moveOnlyUpdateSkipsRedrawAndReorder() {
         var reshapeFrames: [CGRect] = []
         var flushCount = 0
@@ -105,6 +110,80 @@ private func makeBorderTestContext() -> CGContext? {
         #expect(flushCount == 1)
         #expect(moveOnlyCount == 0)
         #expect(orderedTargets == [101, 101])
+    }
+
+    @Test @MainActor func orderingChangeReordersWithoutRedraw() {
+        var flushCount = 0
+        var moveOnlyCount = 0
+        var ordered: [(UInt32, SkyLightWindowOrder)] = []
+        var backingScaleLookups = 0
+
+        let operations = BorderWindow.Operations(
+            createBorderWindow: { _ in 906 },
+            releaseBorderWindow: { _ in },
+            configureWindow: { _, _, _ in },
+            setWindowTags: { _, _ in },
+            createWindowContext: { _ in makeBorderTestContext() },
+            setWindowShape: { _, _ in },
+            flushWindow: { _ in flushCount += 1 },
+            transactionMove: { _, _ in moveOnlyCount += 1 },
+            transactionMoveAndOrder: { _, _, _, targetWid, order in ordered.append((targetWid, order)) },
+            transactionHide: { _ in },
+            backingScaleForFrame: { _ in
+                backingScaleLookups += 1
+                return 2.0
+            }
+        )
+        let manager = BorderManager(
+            config: BorderConfig(enabled: true, width: 4, color: .systemBlue),
+            borderWindowOperations: operations,
+            cornerRadiusProvider: { _ in nil }
+        )
+        defer { manager.cleanup() }
+
+        let frame = CGRect(x: 120, y: 90, width: 800, height: 600)
+        manager.updateFocusedWindow(frame: frame, windowId: 101)
+        manager.updateFocusedWindow(frame: frame, windowId: 101, order: .above)
+
+        #expect(flushCount == 1)
+        #expect(moveOnlyCount == 0)
+        #expect(backingScaleLookups == 1)
+        #expect(ordered.map(\.0) == [101, 101])
+        #expect(ordered.map(\.1) == [.below, .above])
+    }
+
+    @Test @MainActor func placementChangeRedrawsSameTargetFrame() {
+        var reshapeFrames: [CGRect] = []
+        var flushCount = 0
+        var ordered: [(UInt32, SkyLightWindowOrder)] = []
+
+        let operations = BorderWindow.Operations(
+            createBorderWindow: { _ in 908 },
+            releaseBorderWindow: { _ in },
+            configureWindow: { _, _, _ in },
+            setWindowTags: { _, _ in },
+            createWindowContext: { _ in makeBorderTestContext() },
+            setWindowShape: { _, frame in reshapeFrames.append(frame) },
+            flushWindow: { _ in flushCount += 1 },
+            transactionMove: { _, _ in },
+            transactionMoveAndOrder: { _, _, _, targetWid, order in ordered.append((targetWid, order)) },
+            transactionHide: { _ in },
+            backingScaleForFrame: { _ in 2.0 }
+        )
+        let manager = BorderManager(
+            config: BorderConfig(enabled: true, width: 4, color: .systemBlue),
+            borderWindowOperations: operations,
+            cornerRadiusProvider: { _ in nil }
+        )
+        defer { manager.cleanup() }
+
+        let frame = CGRect(x: 120, y: 90, width: 800, height: 600)
+        manager.updateFocusedWindow(frame: frame, windowId: 101)
+        manager.updateFocusedWindow(frame: frame, windowId: 101, order: .above, placement: .inside)
+
+        #expect(flushCount == 2)
+        #expect(reshapeFrames.count == 2)
+        #expect(ordered.map(\.1) == [.below, .above])
     }
 
     @Test @MainActor func radiusChangeRedrawsWithoutReshape() {

--- a/docs/offscreen-clamp-fix.md
+++ b/docs/offscreen-clamp-fix.md
@@ -201,8 +201,8 @@ while earlier traces showed ~34px. The threshold may vary with window size or ti
 | 7 | `isNearViewport` gate in NiriLayout | Bypassed the hide for columns hidden due to neighboring monitor overflow, causing cross-monitor frame leaking | |
 | 8 | `y=-10000` vertical push alone | macOS also clamps y — `y=-10000` becomes `y≈-1034`, leaving ~34px visible | Trace: `hidePlan.verify observed=(1728,-11068)` but live AX shows `liveAXFrame={{1727,-1036},{1626,1068}}` |
 | 9 | `SLSWindowSetShape` with 1×1 offscreen region | No visible effect. Regular app windows override the shape on each draw cycle. Only works on windows created via `SLSNewWindow`. | |
-| 10 | `SLSTransactionOrderWindow` with mode 1 (kCGSOrderOut) | Transaction ordered the window but `isWindowOrderedIn` still returns `true`. Window remains rendered. | Trace: `hidePlan.orderOut id=985 orderedIn=true` |
-| 11 | `SLSOrderWindow` (direct, non-transaction) with mode 1 | Same result — `isWindowOrderedIn` still `true`. Neither transaction nor direct call orders out regular app windows. | Trace: `hidePlan.orderOut id=985 orderedIn=true` |
+| 10 | `SLSTransactionOrderWindow` with order-out mode (`kCGSOrderOut`, raw value `0`) | Transaction ordered the window but `isWindowOrderedIn` still returns `true`. Window remains rendered. | Trace: `hidePlan.orderOut id=985 orderedIn=true` |
+| 11 | `SLSOrderWindow` (direct, non-transaction) with order-out mode (`kCGSOrderOut`, raw value `0`) | Same result — `isWindowOrderedIn` still `true`. Neither transaction nor direct call orders out regular app windows. | Trace: `hidePlan.orderOut id=985 orderedIn=true` |
 | 12 | Stale cache in `applyPositionPlans` | `observedWindowOrigin` returned pre-move position from cache, making SkyLight moves appear to fail or hiding the real clamp result. Fixed for hide verification by reading live WindowServer bounds; useful diagnostic finding, not a hiding approach. | |
 | 13 | Push all hidden windows to x=monitor.maxX (right edge) | With AX fallback this parks windows at the same 1px right-edge position as workspace-inactive hide, but left-hidden windows visibly fly across the screen to get there. Without AX fallback, SkyLight-only moves can leave left-edge clamps. | |
 | 14 | `SLSSetWindowTransform` / `CGSSetWindowTransform` raw near-zero scale | API returns success but does not hide external app pixels reliably. Raw scale pulls windows toward global origin, causing random-width left-edge clamp artifacts. | Trace: `hideTransform.apply ... result=CGError(rawValue: 0)` followed by visible artifacts |
@@ -232,11 +232,11 @@ reintroduce explicit 1px edge parking as a claimed fix without new runtime evide
 hidePlan.orderOut id=985 orderedIn=true
 ```
 
-Both `SLSTransactionOrderWindow(cid, wid, 1, 0)` and `SLSOrderWindow(cid, wid, 1)` are
+Both `SLSTransactionOrderWindow(cid, wid, 0, 0)` and `SLSOrderWindow(cid, wid, 0)` are
 accepted without error but **do not actually order out windows belonging to other processes**.
 The window server appears to protect managed application windows from being ordered out
-by external processes. `kCGSOrderOut` (mode 1) likely only works on windows the caller
-owns (created via `SLSNewWindow`).
+by external processes. `kCGSOrderOut` (raw value `0`) likely only works on windows the
+caller owns (created via `SLSNewWindow`).
 
 ## Pitfalls
 
@@ -272,9 +272,10 @@ their own process override the shape on each draw cycle.
 
 ### `orderWindow(.out)` Does Not Work on External Windows
 
-Both `SLSTransactionOrderWindow` and `SLSOrderWindow` with mode 1 (kCGSOrderOut) are
-silently ignored for windows owned by other processes. `isWindowOrderedIn` continues
-returning `true` after the call. This API only works on windows the caller created.
+Both `SLSTransactionOrderWindow` and `SLSOrderWindow` with order-out mode
+(`kCGSOrderOut`, raw value `0`) are silently ignored for windows owned by other
+processes. `isWindowOrderedIn` continues returning `true` after the call. This API
+only works on windows the caller created.
 
 ### Restore Path for Tiled Windows
 


### PR DESCRIPTION
## Summary

Track frameless qutebrowser windows with malformed fullscreen-button AX facts, and render their focused border without treating the top-level AXDialog as a modal surface.

resolves #66 

## Release notes

Choose one:

- [x] Added a `.changeset/*.md` for user-visible changes (`mise run changeset -- patch "..."`).
- [ ] No user-visible change; apply the `no release note` label to make CI skip intentional.

## Validation

<!-- Commands run, screenshots, or manual checks. -->

- [ ] Ran relevant tests/checks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed focused border rendering for frameless Qutebrowser windows
  * Corrected modal surface detection for top-level dialogs
  * Improved window tracking when accessibility attributes are malformed

* **New Features**
  * Added configurable border placement (inside or outside window frames)

* **Tests**
  * Added coverage for Qutebrowser frameless window border behavior

* **Documentation**
  * Updated window ordering documentation for accuracy

<!-- end of auto-generated comment: release notes by coderabbit.ai -->