### PR TITLE
Surface global-hotkey conflicts in Diagnostics (Nehir #48)

### DIFF
--- a/.changeset/20260620100043-surface-global-hotkey-conflicts-in-diagnostics-and-ad.md
+++ b/.changeset/20260620100043-surface-global-hotkey-conflicts-in-diagnostics-and-ad.md
@@ -1,0 +1,6 @@
+---
+"nehir": minor
+contributors: [syepes]
+---
+
+Surface global-hotkey conflicts in the Diagnostics hub and sidebar badge, and add a curated advisory for the Command Palette default chord (Option+Command+Space) which can co-fire with a macOS system shortcut even when Carbon registration succeeds (fixes #48). Diagnostic rows are advisory only; remediation is to reassign the conflicting Nehir hotkey or clear the overlapping macOS shortcut.

--- a/Sources/Nehir/Core/Config/HotkeyAdvisoryCatalog.swift
+++ b/Sources/Nehir/Core/Config/HotkeyAdvisoryCatalog.swift
@@ -1,0 +1,35 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
+import Foundation
+
+/// One curated Nehir default hotkey that is known to overlap common macOS system
+/// shortcuts (or another launcher). macOS resolves such chords system-wide, so the
+/// system handler fires alongside Nehir even though Nehir's Carbon registration
+/// succeeds — meaning `HotkeyCenter.registrationFailures` cannot capture it. These
+/// advisories make the co-fire case self-diagnosing.
+///
+/// Advisories are consulted by `SettingsDiagnosticsDetector` and surface only while
+/// the user remains on the default chord; reassigning or unassigning the hotkey
+/// suppresses the advisory (no false positives on custom chords).
+struct CuratedHotkeyAdvisory: Equatable {
+    let actionID: String
+    let command: HotkeyCommand
+    let advisoryText: String
+}
+
+enum HotkeyAdvisoryCatalog {
+    /// Hand-maintained list of Nehir default chords known to co-fire with macOS.
+    /// Add new entries here when a default is found to collide with a common system
+    /// shortcut; keep the list small and default-chord-scoped to avoid crying wolf.
+    static let knownSystemConflicts: [CuratedHotkeyAdvisory] = [
+        CuratedHotkeyAdvisory(
+            actionID: "openCommandPalette",
+            command: .openCommandPalette,
+            advisoryText: "Your Command Palette shortcut (Option+Command+Space) can also be claimed by a macOS system shortcut (e.g. Input Sources) or another launcher, which will fire alongside Nehir. If pressing it also opens another app, reassign this Nehir hotkey in Hotkeys, or clear the conflicting shortcut in System Settings → Keyboard → Keyboard Shortcuts."
+        )
+    ]
+}

--- a/Sources/Nehir/Core/Config/SettingsDiagnosticsIssue.swift
+++ b/Sources/Nehir/Core/Config/SettingsDiagnosticsIssue.swift
@@ -18,9 +18,57 @@ struct UnknownSettingsKeysIssue: Identifiable, Equatable {
     }
 }
 
+/// A live (Carbon-level or internal Nehir) hotkey registration failure surfaced as a
+/// Diagnostics row. Built from `HotkeyCenter.registrationFailures`.
+struct HotkeyConflictIssue: Identifiable, Equatable {
+    /// Stable Nehir action identifier (e.g. `"openCommandPalette"`), or a synthesized
+    /// fallback when the failing command has no resolved binding.
+    let actionID: String
+    let command: HotkeyCommand
+    let chordDisplayString: String
+    let reason: HotkeyRegistrationFailureReason
+
+    var id: String {
+        "hotkey-conflict:\(actionID)"
+    }
+
+    var commandDisplayName: String {
+        command.displayName
+    }
+
+    var remediation: String {
+        switch reason {
+        case .systemReserved:
+            return "Another app registered this shortcut; reassign it in Hotkeys or quit the conflicting app."
+        case .duplicateBinding:
+            return "Two Nehir commands share this shortcut; assign a unique chord."
+        }
+    }
+}
+
+/// A curated, default-chord-scoped advisory for Nehir defaults that are known to
+/// co-fire with macOS system shortcuts (where Carbon registration still succeeds,
+/// so `HotkeyConflictIssue` cannot capture them). See `HotkeyAdvisoryCatalog`.
+struct HotkeyAdvisoryIssue: Identifiable, Equatable {
+    let actionID: String
+    let command: HotkeyCommand
+    let chordDisplayString: String
+    let advisoryText: String
+
+    var id: String {
+        "hotkey-advisory:\(actionID)"
+    }
+
+    var commandDisplayName: String {
+        command.displayName
+    }
+}
+
 enum SettingsDiagnosticsIssue: Identifiable, Equatable {
     case softMigration(PendingSettingsMigration)
     case unknownKeys(UnknownSettingsKeysIssue)
+    case hotkeyConflict(HotkeyConflictIssue)
+    case hotkeyAdvisory(HotkeyAdvisoryIssue)
 
     var id: String {
         switch self {
@@ -28,14 +76,65 @@ enum SettingsDiagnosticsIssue: Identifiable, Equatable {
             return "migration:\(migration.id)"
         case .unknownKeys(let issue):
             return issue.id
+        case .hotkeyConflict(let issue):
+            return issue.id
+        case .hotkeyAdvisory(let issue):
+            return issue.id
         }
     }
 }
 
 enum SettingsDiagnosticsDetector {
+    /// Computes all applicable Diagnostics issues. The `hotkeyFailures` and
+    /// `hotkeyBindings` parameters feed the live hotkey diagnostics (registration
+    /// conflicts plus curated default-chord advisories); leaving them empty keeps
+    /// the historical config-file-only behavior.
     static func applicableIssues(
-        configDirectory: URL = SettingsFilePersistence.defaultDirectoryURL
+        configDirectory: URL = SettingsFilePersistence.defaultDirectoryURL,
+        hotkeyFailures: [HotkeyCommand: HotkeyRegistrationFailureReason] = [:],
+        hotkeyBindings: [HotkeyBinding] = []
     ) -> [SettingsDiagnosticsIssue] {
+        var issues = configBasedIssues(configDirectory: configDirectory)
+        issues.append(contentsOf: hotkeyConflictIssues(failures: hotkeyFailures, bindings: hotkeyBindings))
+        issues.append(contentsOf: hotkeyAdvisoryIssues(bindings: hotkeyBindings))
+        return issues
+    }
+
+    static func pendingIssues(
+        configDirectory: URL = SettingsFilePersistence.defaultDirectoryURL,
+        stateStore: SettingsMigrationStateStore = SettingsMigrationStateStore(),
+        appVersion: String = Bundle.main.appVersion ?? "dev",
+        hotkeyFailures: [HotkeyCommand: HotkeyRegistrationFailureReason] = [:],
+        hotkeyBindings: [HotkeyBinding] = []
+    ) -> [SettingsDiagnosticsIssue] {
+        applicableIssues(
+            configDirectory: configDirectory,
+            hotkeyFailures: hotkeyFailures,
+            hotkeyBindings: hotkeyBindings
+        ).filter { issue in
+            !stateStore.isPostponed(migrationID: postponeID(for: issue), currentAppVersion: appVersion)
+        }
+    }
+
+    static func postponeID(for issue: SettingsDiagnosticsIssue) -> String {
+        switch issue {
+        case .softMigration(let migration):
+            return migration.id
+        case .unknownKeys(let issue):
+            return issue.id
+        case .hotkeyConflict,
+             .hotkeyAdvisory:
+            // Live hotkey advisories are not postponable; they clear once the user
+            // reassigns the conflicting chord, so they always pass the postponement filter.
+            return Self.nonPostponableID
+        }
+    }
+
+    /// Sentinel id that `SettingsMigrationStateStore` never records, so non-postponable
+    /// issues are always reported by `pendingIssues`.
+    private static let nonPostponableID = "hotkey:non-postponable"
+
+    private static func configBasedIssues(configDirectory: URL) -> [SettingsDiagnosticsIssue] {
         var issues = SettingsMigrationDetector.applicableMigrations(configDirectory: configDirectory)
             .map(SettingsDiagnosticsIssue.softMigration)
 
@@ -47,22 +146,62 @@ enum SettingsDiagnosticsDetector {
         return issues
     }
 
-    static func pendingIssues(
-        configDirectory: URL = SettingsFilePersistence.defaultDirectoryURL,
-        stateStore: SettingsMigrationStateStore = SettingsMigrationStateStore(),
-        appVersion: String = Bundle.main.appVersion ?? "dev"
+    private static func hotkeyConflictIssues(
+        failures: [HotkeyCommand: HotkeyRegistrationFailureReason],
+        bindings: [HotkeyBinding]
     ) -> [SettingsDiagnosticsIssue] {
-        applicableIssues(configDirectory: configDirectory).filter { issue in
-            !stateStore.isPostponed(migrationID: postponeID(for: issue), currentAppVersion: appVersion)
-        }
+        guard !failures.isEmpty else { return [] }
+        let bindingsByCommand = Dictionary(
+            bindings.map { ($0.command, $0) },
+            uniquingKeysWith: { first, _ in first }
+        )
+        return failures
+            .sorted { lhs, rhs in
+                let lhsName = lhs.key.displayName
+                let rhsName = rhs.key.displayName
+                if lhsName != rhsName { return lhsName < rhsName }
+                return (bindingsByCommand[lhs.key]?.id ?? "") < (bindingsByCommand[rhs.key]?.id ?? "")
+            }
+            .map { command, reason -> SettingsDiagnosticsIssue in
+                let binding = bindingsByCommand[command]
+                let actionID = binding?.id ?? "command:\(String(describing: command))"
+                let chordDisplay = binding?.binding.displayString ?? "unknown"
+                return .hotkeyConflict(HotkeyConflictIssue(
+                    actionID: actionID,
+                    command: command,
+                    chordDisplayString: chordDisplay,
+                    reason: reason
+                ))
+            }
     }
 
-    static func postponeID(for issue: SettingsDiagnosticsIssue) -> String {
-        switch issue {
-        case .softMigration(let migration):
-            return migration.id
-        case .unknownKeys(let issue):
-            return issue.id
+    /// Curated advisories fire only while the user is still on the Nehir default chord
+    /// for the action (reassigning or unassigning suppresses them — no false positives
+    /// on custom chords). The default chord is derived from `HotkeyBindingRegistry` so the
+    /// catalog never hardcodes Carbon key constants.
+    private static func hotkeyAdvisoryIssues(bindings: [HotkeyBinding]) -> [SettingsDiagnosticsIssue] {
+        guard !bindings.isEmpty, !HotkeyAdvisoryCatalog.knownSystemConflicts.isEmpty else { return [] }
+        let currentByID = Dictionary(
+            bindings.map { ($0.id, $0) },
+            uniquingKeysWith: { first, _ in first }
+        )
+        let defaultsByID = Dictionary(
+            HotkeyBindingRegistry.defaults().map { ($0.id, $0) },
+            uniquingKeysWith: { first, _ in first }
+        )
+        return HotkeyAdvisoryCatalog.knownSystemConflicts.compactMap { advisory in
+            guard let current = currentByID[advisory.actionID],
+                  let defaultBinding = defaultsByID[advisory.actionID],
+                  current.binding == defaultBinding.binding,
+                  case let .chord(chord) = current.binding,
+                  !chord.isUnassigned
+            else { return nil }
+            return .hotkeyAdvisory(HotkeyAdvisoryIssue(
+                actionID: advisory.actionID,
+                command: advisory.command,
+                chordDisplayString: chord.displayString,
+                advisoryText: advisory.advisoryText
+            ))
         }
     }
 }

--- a/Sources/Nehir/UI/DisplayDiagnosticsSettingsTab.swift
+++ b/Sources/Nehir/UI/DisplayDiagnosticsSettingsTab.swift
@@ -104,6 +104,10 @@ struct DisplayDiagnosticsSettingsTab: View {
                                 onPostpone: { postponeUnknownKeys(issue) },
                                 onClean: { cleanUnknownKeys(issue) }
                             )
+                        case .hotkeyConflict(let issue):
+                            HotkeyConflictWarningView(conflict: issue)
+                        case .hotkeyAdvisory(let issue):
+                            HotkeyConflictWarningView(advisory: issue)
                         }
                     }
 
@@ -496,7 +500,9 @@ struct DisplayDiagnosticsSettingsTab: View {
 
     private func refreshSettingsIssues() {
         applicableSettingsIssues = SettingsDiagnosticsDetector.applicableIssues(
-            configDirectory: configDirectory
+            configDirectory: configDirectory,
+            hotkeyFailures: controller.hotkeyRegistrationFailures,
+            hotkeyBindings: settings.hotkeyBindings
         )
     }
 
@@ -777,6 +783,62 @@ private struct UnknownSettingsKeysWarningView: View {
             }
         }
         .padding(.vertical, 4)
+    }
+}
+
+/// Advisory-only diagnostics rows for global-hotkey conflicts and curated default-chord
+/// advisories. Remediation is manual (reassign the chord in the Hotkeys tab or clear the
+/// conflicting macOS shortcut), so these rows have no action buttons.
+private struct HotkeyConflictWarningView: View {
+    private enum Content {
+        case conflict(HotkeyConflictIssue)
+        case advisory(HotkeyAdvisoryIssue)
+    }
+
+    private let content: Content
+
+    init(conflict: HotkeyConflictIssue) {
+        content = .conflict(conflict)
+    }
+
+    init(advisory: HotkeyAdvisoryIssue) {
+        content = .advisory(advisory)
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            switch content {
+            case .conflict(let issue):
+                Label("\(issue.commandDisplayName) hotkey conflict", systemImage: "exclamationmark.triangle.fill")
+                    .font(.headline)
+                    .foregroundStyle(Color.yellow)
+                Text(
+                    "The chord \(issue.chordDisplayString) for \(issue.commandDisplayName) could not be registered: \(reasonPhrase(issue.reason))."
+                )
+                .foregroundStyle(.secondary)
+                Text(issue.remediation)
+                    .font(.callout.weight(.semibold))
+            case .advisory(let issue):
+                Label(
+                    "\(issue.commandDisplayName) hotkey may overlap a system shortcut",
+                    systemImage: "exclamationmark.bubble.fill"
+                )
+                .font(.headline)
+                .foregroundStyle(Color.yellow)
+                Text(issue.advisoryText)
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .padding(.vertical, 4)
+    }
+
+    private func reasonPhrase(_ reason: HotkeyRegistrationFailureReason) -> String {
+        switch reason {
+        case .systemReserved:
+            return "reserved by macOS or another app"
+        case .duplicateBinding:
+            return "another Nehir command uses the same chord"
+        }
     }
 }
 

--- a/Sources/Nehir/UI/Onboarding/WhatsNewView.swift
+++ b/Sources/Nehir/UI/Onboarding/WhatsNewView.swift
@@ -114,6 +114,8 @@ struct WhatsNewView: View {
         switch issue {
         case .softMigration: return "arrow.triangle.2.circlepath"
         case .unknownKeys: return "questionmark.circle"
+        case .hotkeyConflict,
+             .hotkeyAdvisory: return "keyboard"
         }
     }
 
@@ -124,6 +126,10 @@ struct WhatsNewView: View {
         case .unknownKeys(let unknownKeys):
             let suffix = unknownKeys.keyPaths.count == 1 ? "key" : "keys"
             return "\(unknownKeys.keyPaths.count) unrecognized settings \(suffix)"
+        case .hotkeyConflict(let conflict):
+            return "\(conflict.commandDisplayName) hotkey conflict"
+        case .hotkeyAdvisory(let advisory):
+            return "\(advisory.commandDisplayName) hotkey advisory"
         }
     }
 

--- a/Sources/Nehir/UI/SettingsSidebar.swift
+++ b/Sources/Nehir/UI/SettingsSidebar.swift
@@ -8,6 +8,8 @@ import SwiftUI
 
 struct SettingsSidebar: View {
     @Binding var selection: SettingsSection
+    var controller: WMController
+    @Bindable var settings: SettingsStore
 
     @State private var diagnosticsIssueCount = 0
 
@@ -41,6 +43,15 @@ struct SettingsSidebar: View {
         .onReceive(NotificationCenter.default.publisher(for: .settingsMigrationStateDidChange)) { _ in
             refreshDiagnostics()
         }
+        .onChange(of: settings.hotkeyBindings) { _, _ in
+            // Keep the badge fresh when a hotkey is reassigned/unassigned/cleared in
+            // the Hotkeys tab. `HotkeyCenter.registrationFailures` is not observable,
+            // but it is always updated synchronously inside the same
+            // `controller.updateHotkeyBindings(...)` call that follows a binding
+            // mutation, so observing the binding fires at the right moment and
+            // `refreshDiagnostics()` then reads both values current.
+            refreshDiagnostics()
+        }
     }
 
     @ViewBuilder
@@ -64,7 +75,10 @@ struct SettingsSidebar: View {
     private func refreshDiagnostics() {
         let diagIssues = DisplayEnvironmentDiagnostics.current().issues.count
         let axIssue = AccessibilityPermissionMonitor.shared.isGranted ? 0 : 1
-        let settingsIssues = SettingsDiagnosticsDetector.pendingIssues().count
+        let settingsIssues = SettingsDiagnosticsDetector.pendingIssues(
+            hotkeyFailures: controller.hotkeyRegistrationFailures,
+            hotkeyBindings: settings.hotkeyBindings
+        ).count
         diagnosticsIssueCount = diagIssues + axIssue + settingsIssues
     }
 }

--- a/Sources/Nehir/UI/SettingsView.swift
+++ b/Sources/Nehir/UI/SettingsView.swift
@@ -28,7 +28,7 @@ struct SettingsView: View {
 
     var body: some View {
         NavigationSplitView {
-            SettingsSidebar(selection: $navigation.selectedSection)
+            SettingsSidebar(selection: $navigation.selectedSection, controller: controller, settings: settings)
         } detail: {
             SettingsDetailView(
                 section: navigation.selectedSection,

--- a/Sources/Nehir/UI/StatusBar/StatusBarMenu.swift
+++ b/Sources/Nehir/UI/StatusBar/StatusBarMenu.swift
@@ -212,6 +212,8 @@ final class StatusBarMenuBuilder {
         switch issue {
         case .softMigration: return "arrow.triangle.2.circlepath"
         case .unknownKeys: return "questionmark.circle"
+        case .hotkeyConflict,
+             .hotkeyAdvisory: return "keyboard"
         }
     }
 
@@ -222,6 +224,10 @@ final class StatusBarMenuBuilder {
         case .unknownKeys(let unknownKeys):
             let suffix = unknownKeys.keyPaths.count == 1 ? "key" : "keys"
             return "\(unknownKeys.keyPaths.count) unrecognized settings \(suffix)"
+        case .hotkeyConflict(let conflict):
+            return "\(conflict.commandDisplayName) hotkey conflict"
+        case .hotkeyAdvisory(let advisory):
+            return "\(advisory.commandDisplayName) hotkey advisory"
         }
     }
 

--- a/Tests/NehirTests/HotkeyConflictDiagnosticsTests.swift
+++ b/Tests/NehirTests/HotkeyConflictDiagnosticsTests.swift
@@ -1,0 +1,229 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
+import Carbon
+import Foundation
+@testable import Nehir
+import Testing
+
+@Suite struct HotkeyConflictDiagnosticsTests {
+    // MARK: - Prong 1: live registration failures
+
+    @Test func hotkeyConflictIssueProducedForSystemReservedFailure() {
+        let failures: [HotkeyCommand: HotkeyRegistrationFailureReason] = [
+            .openCommandPalette: .systemReserved
+        ]
+        let issues = SettingsDiagnosticsDetector.applicableIssues(
+            hotkeyFailures: failures,
+            hotkeyBindings: HotkeyBindingRegistry.defaults()
+        )
+        let conflicts = issues.compactMap { issue -> HotkeyConflictIssue? in
+            if case .hotkeyConflict(let conflict) = issue { return conflict }
+            return nil
+        }
+
+        #expect(conflicts.count == 1)
+        let conflict = conflicts[0]
+        #expect(conflict.command == .openCommandPalette)
+        #expect(conflict.reason == .systemReserved)
+        #expect(conflict.actionID == "openCommandPalette")
+        #expect(conflict.remediation.contains("Another app registered"))
+        #expect(conflict.commandDisplayName == ActionCatalog.title(for: .openCommandPalette))
+    }
+
+    @Test func hotkeyConflictIssuesProducedForDuplicateBindingFailures() {
+        let failures: [HotkeyCommand: HotkeyRegistrationFailureReason] = [
+            .move(.left): .duplicateBinding,
+            .move(.right): .duplicateBinding
+        ]
+        let issues = SettingsDiagnosticsDetector.applicableIssues(
+            hotkeyFailures: failures,
+            hotkeyBindings: HotkeyBindingRegistry.defaults()
+        )
+        let conflicts = issues.compactMap { issue -> HotkeyConflictIssue? in
+            if case .hotkeyConflict(let conflict) = issue { return conflict }
+            return nil
+        }
+
+        #expect(conflicts.count == 2)
+        #expect(Set(conflicts.map(\.command)) == [.move(.left), .move(.right)])
+        #expect(conflicts.allSatisfy { $0.reason == .duplicateBinding })
+        #expect(conflicts.allSatisfy { $0.remediation.contains("unique chord") })
+    }
+
+    @Test func emptyFailureMapYieldsNoHotkeyConflictIssue() {
+        let issues = SettingsDiagnosticsDetector.applicableIssues(
+            hotkeyFailures: [:],
+            hotkeyBindings: HotkeyBindingRegistry.defaults()
+        )
+
+        #expect(issues.allSatisfy { issue in
+            if case .hotkeyConflict = issue { return false }
+            return true
+        })
+    }
+
+    @Test func conflictIssueCarriesCurrentChordDisplayFromBindings() {
+        // A failing command absent from the bindings list falls back to a non-empty
+        // placeholder chord string instead of crashing.
+        let failures: [HotkeyCommand: HotkeyRegistrationFailureReason] = [
+            .toggleFullscreen: .systemReserved
+        ]
+        let issues = SettingsDiagnosticsDetector.applicableIssues(
+            hotkeyFailures: failures,
+            hotkeyBindings: []
+        )
+        let conflict = issues.compactMap { issue -> HotkeyConflictIssue? in
+            if case .hotkeyConflict(let conflict) = issue { return conflict }
+            return nil
+        }.first
+
+        #expect(conflict != nil)
+        #expect(conflict?.chordDisplayString.isEmpty == false)
+    }
+
+    // MARK: - Prong 2: curated default-chord advisory
+
+    @Test func curatedAdvisoryFiresForCommandPaletteDefaultChord() throws {
+        let issues = SettingsDiagnosticsDetector.applicableIssues(
+            hotkeyFailures: [:],
+            hotkeyBindings: HotkeyBindingRegistry.defaults()
+        )
+        let advisories = issues.compactMap { issue -> HotkeyAdvisoryIssue? in
+            if case .hotkeyAdvisory(let advisory) = issue { return advisory }
+            return nil
+        }
+
+        #expect(advisories.count == 1)
+        let advisory = try #require(advisories.first)
+        #expect(advisory.command == .openCommandPalette)
+        #expect(advisory.actionID == "openCommandPalette")
+        #expect(advisory.advisoryText.contains("Command Palette"))
+        #expect(advisory.chordDisplayString.isEmpty == false)
+    }
+
+    @Test func curatedAdvisoryDisappearsAfterReassign() {
+        // Reassign the command palette chord away from its default; the advisory must
+        // not fire on a custom chord (no false positives).
+        let reassigned = HotkeyBindingRegistry.defaults().map { binding in
+            guard binding.id == "openCommandPalette" else { return binding }
+            return HotkeyBinding(
+                id: binding.id,
+                command: binding.command,
+                binding: KeyBinding(keyCode: 123, modifiers: UInt32(cmdKey))
+            )
+        }
+        let issues = SettingsDiagnosticsDetector.applicableIssues(
+            hotkeyFailures: [:],
+            hotkeyBindings: reassigned
+        )
+
+        #expect(issues.allSatisfy { issue in
+            if case .hotkeyAdvisory = issue { return false }
+            return true
+        })
+    }
+
+    @Test func curatedAdvisorySuppressedWhenBindingUnassigned() {
+        let unassigned = HotkeyBindingRegistry.defaults().map { binding in
+            guard binding.id == "openCommandPalette" else { return binding }
+            return HotkeyBinding(id: binding.id, command: binding.command, binding: .unassigned)
+        }
+        let issues = SettingsDiagnosticsDetector.applicableIssues(
+            hotkeyFailures: [:],
+            hotkeyBindings: unassigned
+        )
+
+        #expect(issues.allSatisfy { issue in
+            if case .hotkeyAdvisory = issue { return false }
+            return true
+        })
+    }
+
+    // MARK: - Regression guard for the unified-diagnostics policy
+
+    @Test func applicableIssuesPreservesExistingConfigIssuesUnchanged() throws {
+        let configDirectory = makeIsolatedConfigDirectory()
+        try FileManager.default.createDirectory(at: configDirectory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: configDirectory) }
+
+        // Empty hotkey inputs must produce exactly the same config-only issues as before.
+        let withoutHotkeyData = SettingsDiagnosticsDetector.applicableIssues(configDirectory: configDirectory)
+        let withEmptyHotkeyData = SettingsDiagnosticsDetector.applicableIssues(
+            configDirectory: configDirectory,
+            hotkeyFailures: [:],
+            hotkeyBindings: []
+        )
+        #expect(withoutHotkeyData == withEmptyHotkeyData)
+    }
+
+    @Test func unknownKeysAndHotkeyConflictsCoexistAdditively() throws {
+        let configDirectory = makeIsolatedConfigDirectory()
+        try FileManager.default.createDirectory(at: configDirectory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: configDirectory) }
+
+        let settingsURL = configDirectory.appendingPathComponent(SettingsFilePersistence.fileName, isDirectory: false)
+        try #"completelyUnknownDiagnosticKey = true"#.write(to: settingsURL, atomically: true, encoding: .utf8)
+
+        let issues = SettingsDiagnosticsDetector.applicableIssues(
+            configDirectory: configDirectory,
+            hotkeyFailures: [.openCommandPalette: .systemReserved],
+            hotkeyBindings: HotkeyBindingRegistry.defaults()
+        )
+
+        // Existing unknown-keys detection is preserved alongside the new hotkey rows.
+        #expect(issues.contains { if case .unknownKeys = $0 { return true }
+            return false
+        })
+        #expect(issues.contains { if case .hotkeyConflict = $0 { return true }
+            return false
+        })
+        #expect(issues.contains { if case .hotkeyAdvisory = $0 { return true }
+            return false
+        })
+    }
+
+    // MARK: - Badge / pending count
+
+    @Test func pendingIssuesCountIncreasesWhenHotkeyConflictPresent() {
+        let baseCount = SettingsDiagnosticsDetector.pendingIssues().count
+        let withConflict = SettingsDiagnosticsDetector.pendingIssues(
+            hotkeyFailures: [.openCommandPalette: .systemReserved, .toggleFullscreen: .duplicateBinding],
+            hotkeyBindings: HotkeyBindingRegistry.defaults()
+        ).count
+
+        // Two conflicts plus the curated command-palette advisory all flow through the
+        // pending-issue path that drives the sidebar badge.
+        #expect(withConflict > baseCount)
+        #expect(withConflict - baseCount == 3)
+    }
+
+    @Test func hotkeyIssuesAreNotPostponableAndAlwaysRemainPending() {
+        let conflict = HotkeyConflictIssue(
+            actionID: "openCommandPalette",
+            command: .openCommandPalette,
+            chordDisplayString: "⌥⌘Space",
+            reason: .systemReserved
+        )
+        let advisory = HotkeyAdvisoryIssue(
+            actionID: "openCommandPalette",
+            command: .openCommandPalette,
+            chordDisplayString: "⌥⌘Space",
+            advisoryText: "advisory"
+        )
+        // Hotkey issues share a single non-postponable id sentinel, so they cannot be
+        // hidden by the postponement filter the way migrations can.
+        #expect(SettingsDiagnosticsDetector.postponeID(for: .hotkeyConflict(conflict))
+            == SettingsDiagnosticsDetector.postponeID(for: .hotkeyAdvisory(advisory)))
+    }
+
+    // MARK: - Helpers
+
+    private func makeIsolatedConfigDirectory() -> URL {
+        URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("nehir-hotkey-diagnostics-\(UUID().uuidString)")
+    }
+}


### PR DESCRIPTION
## Summary

Add two advisory-only diagnostics rows for global hotkey conflicts:

Prong 1 — surface live Carbon registration failures (.systemReserved and .duplicateBinding) in the Diagnostics hub + sidebar badge, not only as the inline per-row hint in the Hotkeys tab. Adds HotkeyConflictIssue and feeds SettingsDiagnosticsDetector.applicableIssues(...) from WMController.hotkeyRegistrationFailures.

Prong 2 — a curated, default-chord-scoped advisory (HotkeyAdvisoryCatalog) seeded with the Command Palette default (Option+Command+Space), which co-fires with macOS system shortcuts even when Carbon registration succeeds. Fires only while the user remains on the default chord; reassigning/unassigning suppresses it (no false positives on custom chords). The default chord is derived from HotkeyBindingRegistry so the catalog never hardcodes Carbon key constants.

Both rows are non-blocking and advisory (remediation is manual: reassign the hotkey or clear the macOS shortcut). Existing softMigration/unknownKeys diagnostics are unchanged; StatusBarMenu and WhatsNewView switches are made exhaustive.

11 new tests in HotkeyConflictDiagnosticsTests; full suite (1264 tests) green.

resolves #48

## Release notes

Choose one:

- [x] Added a `.changeset/*.md` for user-visible changes (`mise run changeset -- patch "..."`).
- [ ] No user-visible change; apply the `no release note` label to make CI skip intentional.

## Validation

<!-- Commands run, screenshots, or manual checks. -->

- [ ] Ran relevant tests/checks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Global hotkey conflict detection now surfaces in Diagnostics hub and sidebar badge
  * Command Palette default hotkey displays advisory for potential macOS system shortcut overlap (Option+Command+Space)
  * Hotkey conflict warnings appear in Settings UI and status bar menu with remediation guidance

* **Tests**
  * Added comprehensive test coverage for hotkey conflict and advisory detection

<!-- end of auto-generated comment: release notes by coderabbit.ai -->