### PR TITLE
Prevent stale async session patches from overwriting newer selection 

### DIFF
--- a/.changeset/20260620005722-prevent-stale-async-session-patches-from-overwriti.md
+++ b/.changeset/20260620005722-prevent-stale-async-session-patches-from-overwriti.md
@@ -1,0 +1,6 @@
+---
+"nehir": patch
+contributors: [BarutSRB]
+---
+
+Prevent stale async session patches from overwriting newer live selection, and clear stale cross-workspace pending managed focus when a token is reassigned.

--- a/.provenance.json
+++ b/.provenance.json
@@ -94,6 +94,9 @@
     "Sources/Nehir/Core/Config/MonitorGapSettings.swift": [
       {"repo": "https://github.com/BarutSRB/OmniWM", "hash": "dacccb8"}
     ],
+    "Sources/Nehir/Core/Controller/WMController.swift": [
+      {"repo": "https://github.com/BarutSRB/OmniWM", "hash": "713280e"}
+    ],
     "Sources/Nehir/Core/Multitouch/MultitouchBinding.swift": [
       {"repo": "https://github.com/BarutSRB/OmniWM", "hash": "06eb42d"}
     ],

--- a/Sources/Nehir/Core/Controller/NiriLayoutHandler.swift
+++ b/Sources/Nehir/Core/Controller/NiriLayoutHandler.swift
@@ -916,7 +916,8 @@ enum NiriWindowMoveResult {
             sessionPatch: WorkspaceSessionPatch(
                 workspaceId: pass.wsId,
                 viewportState: state,
-                rememberedFocusToken: rememberedFocusToken
+                rememberedFocusToken: rememberedFocusToken,
+                plannedSelectionRevision: controller?.workspaceManager.selectionRevision(for: pass.wsId)
             ),
             diff: diff,
             animationDirectives: directives

--- a/Sources/Nehir/Core/Controller/WMController.swift
+++ b/Sources/Nehir/Core/Controller/WMController.swift
@@ -3866,6 +3866,19 @@ final class WMController {
         to workspaceId: WorkspaceDescriptor.ID,
         explicitMoveIntent: Bool = true
     ) {
+        // Cross-workspace stale pending-focus clear: if the token being
+        // reassigned has a pending managed-focus request targeting a DIFFERENT
+        // workspace, cancel it now so a late AX confirmation does not pull
+        // focus/selection back to the old workspace. Callers already reissue
+        // focus for the new workspace after this call.
+        if let activeRequest = focusBridge.activeManagedRequest,
+           activeRequest.token == token,
+           activeRequest.workspaceId != workspaceId
+        {
+            _ = focusBridge.cancelManagedRequest(requestId: activeRequest.requestId)
+            focusBridge.discardPendingFocus(token)
+        }
+
         if explicitMoveIntent {
             recordExplicitWorkspaceMoveIntent(for: token, to: workspaceId)
         }

--- a/Sources/Nehir/Core/Layout/LayoutBoundary.swift
+++ b/Sources/Nehir/Core/Layout/LayoutBoundary.swift
@@ -100,6 +100,11 @@ struct WorkspaceSessionPatch {
     let workspaceId: WorkspaceDescriptor.ID
     var viewportState: ViewportState?
     var rememberedFocusToken: WindowToken?
+    /// Selection revision captured at plan-build time.
+    /// `nil` means "apply unconditionally" (synchronous/fresh callers).
+    /// When set, `applySessionPatch` drops stale selection fields if the live
+    /// revision has advanced past this value.
+    var plannedSelectionRevision: UInt64? = nil
 }
 
 struct WorkspaceSessionTransfer {

--- a/Sources/Nehir/Core/Workspace/WorkspaceManager.swift
+++ b/Sources/Nehir/Core/Workspace/WorkspaceManager.swift
@@ -152,6 +152,12 @@ final class WorkspaceManager {
 
         struct WorkspaceSession {
             var niriViewportState: ViewportState?
+            /// Monotonically increasing counter bumped whenever a LIVE selection
+            /// field (selectedNodeId / activeColumnIndex / selectionProgress)
+            /// changes. Used by the stale-session-patch guard in `applySessionPatch`
+            /// to detect selection changes that happened between plan-build and
+            /// plan-apply.
+            var selectionRevision: UInt64 = 0
         }
 
         struct FocusSession {
@@ -1649,7 +1655,7 @@ final class WorkspaceManager {
 
         let viewportState = niriViewportState(for: workspaceId)
         if viewportState.selectedNodeId != nodeId {
-            withNiriViewportState(for: workspaceId) {
+            mutateSelection(for: workspaceId) {
                 $0.selectedNodeId = nodeId
             }
             changed = true
@@ -1682,6 +1688,23 @@ final class WorkspaceManager {
                 viewportState = niriViewportState(for: patch.workspaceId)
                 rememberedFocusToken = nil
             }
+
+            // Stale-selection guard: if this patch was built against an older
+            // selection revision, the user changed selection (focus hotkey, click)
+            // between plan-build and plan-apply. Drop ONLY the selection fields and
+            // the remembered-focus token so the stale patch cannot clobber the
+            // newer live selection. Preserve viewOffsetPixels to avoid regressing
+            // viewport scroll/animation (narrower than the gesture guard above).
+            if let plannedRevision = patch.plannedSelectionRevision,
+               plannedRevision < selectionRevision(for: patch.workspaceId)
+            {
+                let live = niriViewportState(for: patch.workspaceId)
+                viewportState.selectedNodeId = live.selectedNodeId
+                viewportState.activeColumnIndex = live.activeColumnIndex
+                viewportState.selectionProgress = live.selectionProgress
+                rememberedFocusToken = nil
+            }
+
             updateNiriViewportState(viewportState, for: patch.workspaceId)
             changed = true
         }
@@ -3193,7 +3216,35 @@ final class WorkspaceManager {
 
     func updateNiriViewportState(_ state: ViewportState, for workspaceId: WorkspaceDescriptor.ID) {
         var workspaceSession = sessionState.workspaceSessions[workspaceId] ?? SessionState.WorkspaceSession()
+        let previousViewportState = workspaceSession.niriViewportState
         workspaceSession.niriViewportState = state
+
+        // Bump the per-workspace revision whenever a LIVE selection field
+        // changes. This is the single chokepoint for ALL live ViewportState
+        // writes — `withNiriViewportState`, `applySessionPatch`, and direct
+        // callers all funnel through here. Planning copies in `buildRelayoutPlan`
+        // / `computeLayoutPlan` never reach this method: they are local
+        // `inout ViewportState` values that get embedded in a
+        // `WorkspaceSessionPatch`, arriving here only via `applySessionPatch` —
+        // by which point the stale-selection guard has already reconciled stale
+        // selection fields against live state. So bumping here can never fire
+        // for a planning-copy write.
+        // Treat an absent prior state (the first live write for a workspace) as
+        // the empty default selection, so a nil→state transition that establishes
+        // a real selection also bumps. Otherwise a patch built against a
+        // never-written workspace (revision 0) would not be detected as stale
+        // after that first write — the guard would compare 0 < 0 and let stale
+        // selection fields through. `ViewportState()` is the same baseline
+        // `niriViewportState(for:)` hands the plan-builder, so the comparison is
+        // consistent, and a first write that is itself empty does not bump.
+        let previousSelection = previousViewportState ?? ViewportState()
+        if previousSelection.selectedNodeId != state.selectedNodeId
+            || previousSelection.activeColumnIndex != state.activeColumnIndex
+            || previousSelection.selectionProgress != state.selectionProgress
+        {
+            workspaceSession.selectionRevision &+= 1
+        }
+
         sessionState.workspaceSessions[workspaceId] = workspaceSession
     }
 
@@ -3206,8 +3257,34 @@ final class WorkspaceManager {
         updateNiriViewportState(state, for: workspaceId)
     }
 
+    /// Returns the current selection revision for a workspace.
+    func selectionRevision(for workspaceId: WorkspaceDescriptor.ID) -> UInt64 {
+        sessionState.workspaceSessions[workspaceId]?.selectionRevision ?? 0
+    }
+
+    /// Explicitly bumps the selection revision for a workspace.
+    @discardableResult
+    func bumpSelectionRevision(for workspaceId: WorkspaceDescriptor.ID) -> UInt64 {
+        var workspaceSession = sessionState.workspaceSessions[workspaceId] ?? SessionState.WorkspaceSession()
+        workspaceSession.selectionRevision &+= 1
+        sessionState.workspaceSessions[workspaceId] = workspaceSession
+        return workspaceSession.selectionRevision
+    }
+
+    /// Preferred entry point for LIVE selection mutations.
+    /// Equivalent to `withNiriViewportState` — the auto-bump in
+    /// `updateNiriViewportState` fires when selection fields change — but signals
+    /// intent at the call site so future readers know this write participates in
+    /// the revision guard.
+    func mutateSelection(
+        for workspaceId: WorkspaceDescriptor.ID,
+        _ mutate: (inout ViewportState) -> Void
+    ) {
+        withNiriViewportState(for: workspaceId, mutate)
+    }
+
     func setSelection(_ nodeId: NodeId?, for workspaceId: WorkspaceDescriptor.ID) {
-        withNiriViewportState(for: workspaceId) {
+        mutateSelection(for: workspaceId) {
             $0.selectedNodeId = nodeId
         }
     }

--- a/Tests/NehirTests/LayoutRefreshControllerTests.swift
+++ b/Tests/NehirTests/LayoutRefreshControllerTests.swift
@@ -2036,4 +2036,51 @@ private func makeUnavailableLayoutPlanTestWindow(windowId: Int) -> AXWindowRef {
             #expect(controller.workspaceManager.hiddenState(for: token) == nil)
         }
     }
+
+    // MARK: - Selection revision guard
+
+    @Test @MainActor func staleRelayoutPatchDoesNotOverwriteNewerSelection() {
+        let controller = makeLayoutPlanTestController()
+        guard let monitor = controller.workspaceManager.monitors.first,
+              let workspaceId = controller.workspaceManager.activeWorkspaceOrFirst(on: monitor.id)?.id
+        else {
+            Issue.record("Missing monitor or active workspace")
+            return
+        }
+
+        _ = addLayoutPlanTestWindow(on: controller, workspaceId: workspaceId, windowId: 201)
+
+        // Live selection: selectedNodeId = A (bumps revision)
+        let nodeA = NodeId()
+        controller.workspaceManager.setSelection(nodeA, for: workspaceId)
+        let plannedRevision = controller.workspaceManager.selectionRevision(for: workspaceId)
+
+        // Simulate a user focus change between plan-build and plan-apply:
+        // selectedNodeId = C bumps the revision past plannedRevision.
+        let nodeC = NodeId()
+        controller.workspaceManager.setSelection(nodeC, for: workspaceId)
+        #expect(controller.workspaceManager.selectionRevision(for: workspaceId) > plannedRevision)
+
+        // Stale plan built at plannedRevision with selectedNodeId = B.
+        var staleViewport = controller.workspaceManager.niriViewportState(for: workspaceId)
+        let nodeB = NodeId()
+        staleViewport.selectedNodeId = nodeB
+
+        let plan = WorkspaceLayoutPlan(
+            workspaceId: workspaceId,
+            monitor: controller.layoutRefreshController.buildMonitorSnapshot(for: monitor),
+            sessionPatch: WorkspaceSessionPatch(
+                workspaceId: workspaceId,
+                viewportState: staleViewport,
+                plannedSelectionRevision: plannedRevision
+            ),
+            diff: WorkspaceLayoutDiff()
+        )
+
+        controller.layoutRefreshController.executeLayoutPlan(plan)
+
+        // The stale plan's selectedNodeId (B) must NOT overwrite the live one (C).
+        #expect(controller.workspaceManager.niriViewportState(for: workspaceId).selectedNodeId == nodeC)
+        #expect(controller.workspaceManager.niriViewportState(for: workspaceId).selectedNodeId != nodeB)
+    }
 }

--- a/Tests/NehirTests/WMControllerFocusTests.swift
+++ b/Tests/NehirTests/WMControllerFocusTests.swift
@@ -1535,4 +1535,38 @@ private func waitForFocusRefresh(on controller: WMController) async {
 
         #expect(controller.commandHandler.performCommand(.toggleFocusedWindowFloating) == .notFound)
     }
+
+    // MARK: - Cross-workspace stale pending focus clear
+
+    @Test @MainActor func reassignManagedWindowClearsStalePendingFocus() {
+        let operations = WindowFocusOperations(
+            activateApp: { _ in },
+            focusSpecificWindow: { _, _, _ in },
+            raiseWindow: { _ in }
+        )
+        let fixture = makeTwoMonitorFocusController(windowFocusOperations: operations)
+        let controller = fixture.controller
+
+        let window = makeFocusTestWindow(windowId: 501)
+        let token = controller.workspaceManager.addWindow(
+            window,
+            pid: getpid(),
+            windowId: window.windowId,
+            to: fixture.primaryWorkspaceId
+        )
+
+        // Begin a pending managed-focus request for the token in ws1.
+        _ = controller.focusBridge.beginManagedRequest(
+            token: token,
+            workspaceId: fixture.primaryWorkspaceId
+        )
+        #expect(controller.focusBridge.activeManagedRequest?.token == token)
+        #expect(controller.focusBridge.activeManagedRequest?.workspaceId == fixture.primaryWorkspaceId)
+
+        // Reassign the window to ws2 — the stale pending request targeting ws1
+        // must be cancelled so a late AX confirmation does not pull focus back.
+        controller.reassignManagedWindow(token, to: fixture.secondaryWorkspaceId)
+
+        #expect(controller.focusBridge.activeManagedRequest == nil)
+    }
 }

--- a/Tests/NehirTests/WorkspaceManagerTests.swift
+++ b/Tests/NehirTests/WorkspaceManagerTests.swift
@@ -2411,3 +2411,152 @@ private func workspaceConfigurations(
         "monitorTopologyChanged"
     ])
 }
+
+// MARK: - Selection revision guard
+
+extension WorkspaceManagerTests {
+    @MainActor
+    private func makeSelectionRevisionTestManager()
+        -> (manager: WorkspaceManager, workspaceId: WorkspaceDescriptor.ID)
+    {
+        let defaults = makeWorkspaceManagerTestDefaults()
+        let settings = SettingsStore(defaults: defaults)
+        settings.workspaceConfigurations = [
+            WorkspaceConfiguration(name: "1", monitorAssignment: .main)
+        ]
+        let manager = WorkspaceManager(settings: settings)
+        let monitor = makeWorkspaceManagerTestMonitor(displayId: 400, name: "Main", x: 0, y: 0)
+        manager.applyMonitorConfigurationChange([monitor])
+        guard let workspaceId = manager.workspaceId(for: "1", createIfMissing: true) else {
+            fatalError("Failed to create workspace")
+        }
+        return (manager, workspaceId)
+    }
+
+    @Test @MainActor func staleSelectionRevisionDropsSelectionFields() {
+        let (manager, wsId) = makeSelectionRevisionTestManager()
+        let handle = addWorkspaceManagerTestHandle(manager: manager, windowId: 4201, workspaceId: wsId)
+
+        // Live selection at revision 1: selectedNodeId = A
+        let nodeA = NodeId()
+        manager.setSelection(nodeA, for: wsId)
+        let plannedRevision = manager.selectionRevision(for: wsId)
+
+        // Newer live selection at revision 2: selectedNodeId = C
+        let nodeC = NodeId()
+        manager.setSelection(nodeC, for: wsId)
+        #expect(manager.selectionRevision(for: wsId) > plannedRevision)
+
+        // Stale patch built at plannedRevision with selectedNodeId = B
+        var stalePatch = manager.niriViewportState(for: wsId)
+        let nodeB = NodeId()
+        stalePatch.selectedNodeId = nodeB
+        stalePatch.activeColumnIndex = 5
+
+        _ = manager.applySessionPatch(
+            .init(
+                workspaceId: wsId,
+                viewportState: stalePatch,
+                rememberedFocusToken: handle.id,
+                plannedSelectionRevision: plannedRevision
+            )
+        )
+
+        // Selection fields must reflect the LIVE state, not the stale patch.
+        #expect(manager.niriViewportState(for: wsId).selectedNodeId == nodeC)
+        #expect(manager.niriViewportState(for: wsId).activeColumnIndex != 5)
+        // rememberedFocusToken must have been dropped.
+        #expect(manager.rememberedTiledFocusToken(in: wsId) != handle.id)
+    }
+
+    @Test @MainActor func freshSelectionRevisionAppliesSelection() {
+        let (manager, wsId) = makeSelectionRevisionTestManager()
+
+        let nodeA = NodeId()
+        manager.setSelection(nodeA, for: wsId)
+        let currentRevision = manager.selectionRevision(for: wsId)
+
+        // Fresh patch: plannedRevision == current → selection applies normally.
+        let nodeB = NodeId()
+        var freshPatch = manager.niriViewportState(for: wsId)
+        freshPatch.selectedNodeId = nodeB
+
+        _ = manager.applySessionPatch(
+            .init(
+                workspaceId: wsId,
+                viewportState: freshPatch,
+                plannedSelectionRevision: currentRevision
+            )
+        )
+
+        #expect(manager.niriViewportState(for: wsId).selectedNodeId == nodeB)
+    }
+
+    @Test @MainActor func nilPlannedSelectionRevisionAppliesSelection() {
+        let (manager, wsId) = makeSelectionRevisionTestManager()
+
+        let nodeA = NodeId()
+        manager.setSelection(nodeA, for: wsId)
+        // Bump the revision past 0 so we know the guard would drop if plannedRevision were 0.
+        let nodeC = NodeId()
+        manager.setSelection(nodeC, for: wsId)
+        #expect(manager.selectionRevision(for: wsId) > 0)
+
+        // nil plannedRevision → back-compat: applies unconditionally.
+        let nodeB = NodeId()
+        var patch = manager.niriViewportState(for: wsId)
+        patch.selectedNodeId = nodeB
+
+        _ = manager.applySessionPatch(
+            .init(
+                workspaceId: wsId,
+                viewportState: patch
+            )
+        )
+
+        #expect(manager.niriViewportState(for: wsId).selectedNodeId == nodeB)
+    }
+
+    @Test @MainActor func firstLiveSelectionMutationBumpsRevisionFromZeroToOne() {
+        let (manager, wsId) = makeSelectionRevisionTestManager()
+
+        // A fresh workspace has no viewport state and a zero revision. A patch
+        // built now would stamp plannedSelectionRevision = 0.
+        #expect(manager.selectionRevision(for: wsId) == 0)
+
+        // The first live selection write (nil→state) must advance the revision,
+        // so a stale revision-0 patch built before this write is detected.
+        let nodeA = NodeId()
+        manager.setSelection(nodeA, for: wsId)
+        #expect(manager.selectionRevision(for: wsId) == 1)
+        #expect(manager.niriViewportState(for: wsId).selectedNodeId == nodeA)
+    }
+
+    @Test @MainActor func gesturePathStillReplacesEntireViewportState() {
+        let (manager, wsId) = makeSelectionRevisionTestManager()
+
+        // Establish a live selection.
+        let liveNode = NodeId()
+        manager.setSelection(liveNode, for: wsId)
+
+        // A gesture-marked patch with a DIFFERENT selection.
+        let staleNode = NodeId()
+        var gesturePatch = manager.niriViewportState(for: wsId)
+        gesturePatch.selectedNodeId = staleNode
+        gesturePatch.viewOffsetPixels = .gesture(ViewGesture(currentViewOffset: 999.0, isTrackpad: true))
+
+        _ = manager.applySessionPatch(
+            .init(
+                workspaceId: wsId,
+                viewportState: gesturePatch,
+                plannedSelectionRevision: manager.selectionRevision(for: wsId)
+            )
+        )
+
+        // The gesture guard must replace the ENTIRE viewportState with live,
+        // preserving the live selection — NOT the stale patch values.
+        #expect(manager.niriViewportState(for: wsId).selectedNodeId == liveNode)
+        #expect(manager.niriViewportState(for: wsId).viewOffsetPixels.isGesture == false)
+        #expect(manager.niriViewportState(for: wsId).viewOffsetPixels.current() == 0.0)
+    }
+}


### PR DESCRIPTION
## Summary

Add a per-workspace selectionRevision counter bumped on every LIVE ViewportState selection change, and guard applySessionPatch so a stale relayout patch (built before an await, applied after the user changed focus) drops only the selection fields instead of clobbering the newer selection. viewOffsetPixels is preserved so viewport scroll/animation is unaffected. Also clear stale cross-workspace pending managed focus when a token is reassigned to a different workspace.

The revision bump is centralized in updateNayoutViewportState — the single chokepoint all session writes funnel through — so planning copies cannot trigger it. Existing gesture-path guard unchanged.


## Release notes

Choose one:

- [x] Added a `.changeset/*.md` for user-visible changes (`mise run changeset -- patch "..."`).
- [ ] No user-visible change; apply the `no release note` label to make CI skip intentional.

## Validation

<!-- Commands run, screenshots, or manual checks. -->

- [ ] Ran relevant tests/checks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented stale asynchronous layout plans from overwriting newer live selection states. Selection changes are now properly preserved during concurrent layout updates.
  * Fixed an issue where pending managed focus requests could incorrectly restore window focus to the previous workspace when a window is reassigned to another workspace.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->