### PR TITLE
Exempt managed windows on inactive native Spaces from full-rescan eviction

### DIFF
--- a/.changeset/20260619185816-preserve-managed-windows-hidden-on-inactive-nati.md
+++ b/.changeset/20260619185816-preserve-managed-windows-hidden-on-inactive-nati.md
@@ -1,0 +1,6 @@
+---
+"nehir": patch
+
+---
+
+Preserve managed windows hidden on inactive native Spaces during full rescans

--- a/.provenance.json
+++ b/.provenance.json
@@ -94,6 +94,9 @@
     "Sources/Nehir/Core/Config/MonitorGapSettings.swift": [
       {"repo": "https://github.com/BarutSRB/OmniWM", "hash": "dacccb8"}
     ],
+    "Sources/Nehir/Core/Controller/LayoutRefreshController.swift": [
+      {"repo": "https://github.com/BarutSRB/OmniWM", "hash": "2dcab36"}
+    ],
     "Sources/Nehir/Core/Controller/WMController.swift": [
       {"repo": "https://github.com/BarutSRB/OmniWM", "hash": "713280e"}
     ],
@@ -105,6 +108,12 @@
     ],
     "Sources/Nehir/Core/SkyLight/DisplaySpacesMode.swift": [
       {"repo": "https://github.com/BarutSRB/OmniWM", "hash": "ee554c7"}
+    ],
+    "Sources/Nehir/Core/SkyLight/SkyLight.swift": [
+      {"repo": "https://github.com/BarutSRB/OmniWM", "hash": "ee554c7"}
+    ],
+    "Sources/Nehir/Core/SkyLight/SpaceTopology.swift": [
+      {"repo": "https://github.com/BarutSRB/OmniWM", "hash": "e5e368d"}
     ]
   }
 }

--- a/Sources/Nehir/Core/Controller/LayoutRefreshController.swift
+++ b/Sources/Nehir/Core/Controller/LayoutRefreshController.swift
@@ -181,6 +181,8 @@ import QuartzCore
     var layoutState = LayoutState()
     var debugCounters = RefreshDebugCounters()
     var debugHooks = RefreshDebugHooks()
+    var spaceTopologyProviderForTests: (([Monitor], [UInt32]) -> SpaceTopology)?
+    private var lastSpaceTopologyDebugSummary = "notCaptured"
     private var activeFrameContext: RefreshFrameContext?
     private var pendingRevealTransactionsByWindowId: [Int: PendingRevealTransaction] = [:]
     private var pendingRevealVerificationTasksByWindowId: [Int: Task<Void, Never>] = [:]
@@ -684,10 +686,23 @@ import QuartzCore
     func resetDebugState() {
         debugCounters = RefreshDebugCounters()
         debugHooks = RefreshDebugHooks()
+        lastSpaceTopologyDebugSummary = "notCaptured"
     }
 
     func refreshDebugSnapshot() -> RefreshDebugCounters {
         debugCounters
+    }
+
+    private func currentSpaceTopology(monitors: [Monitor], trackedEntries: [WindowModel.Entry]) -> SpaceTopology {
+        let windowIds = trackedEntries.compactMap { UInt32(exactly: $0.windowId) }
+        if let provider = spaceTopologyProviderForTests {
+            return provider(monitors, windowIds)
+        }
+        return SpaceTopology.current(monitors: monitors, windowIds: windowIds)
+    }
+
+    func spaceTopologyDebugDump() -> String {
+        lastSpaceTopologyDebugSummary
     }
 
     func requestRefresh(
@@ -1424,6 +1439,11 @@ import QuartzCore
             hadLifecycleContextAtStart: hadNativeFullscreenLifecycleContextAtStart
         )
         let trackedEntries = controller.workspaceManager.allEntries()
+        let spaceTopology = currentSpaceTopology(
+            monitors: controller.workspaceManager.monitors,
+            trackedEntries: trackedEntries
+        )
+        lastSpaceTopologyDebugSummary = spaceTopology.debugSummary
         if shouldPreserveMissingWindows {
             // Native macOS fullscreen moves the app onto its own Space, so visible-window
             // enumeration temporarily excludes the rest of the managed workspace.
@@ -1443,6 +1463,21 @@ import QuartzCore
                 where enumerationSnapshot.failedPIDs.contains(entry.handle.pid)
             {
                 seenKeys.insert(.init(pid: entry.handle.pid, windowId: entry.windowId))
+            }
+
+            var inactiveSpaceExemptions = 0
+            for entry in trackedEntries {
+                guard let windowId = UInt32(exactly: entry.windowId),
+                      spaceTopology.isWindowOnKnownInactiveSpace(windowId: windowId)
+                else { continue }
+                seenKeys.insert(.init(pid: entry.handle.pid, windowId: entry.windowId))
+                inactiveSpaceExemptions += 1
+                controller.recordRuntimeInsertionTrace(
+                    "spaceTopology.exempt windowId=\(entry.windowId) pid=\(entry.handle.pid) mode=\(spaceTopology.mode.rawValue)"
+                )
+            }
+            if inactiveSpaceExemptions > 0 {
+                lastSpaceTopologyDebugSummary += " exempted=\(inactiveSpaceExemptions)"
             }
 
             preserveScratchpadHiddenWindowsDuringFullRescan(

--- a/Sources/Nehir/Core/Controller/WMController.swift
+++ b/Sources/Nehir/Core/Controller/WMController.swift
@@ -3014,6 +3014,8 @@ final class WMController {
             focusTargetDebugDump(),
             "-- Monitor Topology --",
             workspaceManager.monitorTopologyDebugDump(),
+            "-- SpaceTopology --",
+            layoutRefreshController.spaceTopologyDebugDump(),
             "-- WorkspaceManager --",
             workspaceManager.runtimeStateDebugSummary(),
             "-- AXManager --",

--- a/Sources/Nehir/Core/SkyLight/SkyLight.swift
+++ b/Sources/Nehir/Core/SkyLight/SkyLight.swift
@@ -63,6 +63,7 @@ final class SkyLight {
         -> CGError
     private typealias TransactionSetWindowLevelFunc = @convention(c) (CFTypeRef, UInt32, Int32) -> CGError
     private typealias CopyManagedDisplaySpacesFunc = @convention(c) (Int32) -> CFArray?
+    private typealias CopySpacesForWindowsFunc = @convention(c) (Int32, Int32, CFArray) -> CFArray?
     private typealias DisplayCreateUUIDFromDisplayIDFunc = @convention(c) (CGDirectDisplayID) -> Unmanaged<CFUUID>?
     // SLSGetSpaceManagementMode returns non-zero when "Displays have separate Spaces"
     // is enabled, zero when disabled. Optional: may be missing/renamed on some macOS
@@ -148,13 +149,17 @@ final class SkyLight {
     private let newRegionWithRect: NewRegionWithRectFunc?
     private let transactionSetWindowLevel: TransactionSetWindowLevelFunc?
     private let copyManagedDisplaySpaces: CopyManagedDisplaySpacesFunc?
+    private let copySpacesForWindows: CopySpacesForWindowsFunc?
     private let getSpaceManagementMode: SpaceManagementModeFunc?
+
+    private static let allSpacesMask: Int32 = 0x7
 
     @MainActor static var orderedStateProviderForTests: ((UInt32) -> Bool?)?
     /// Test injection hook for `displaySpacesMode`. When non-nil it fully replaces
     /// the runtime detection. Restore to `nil` in a `defer`. Mirrors
     /// `orderedStateProviderForTests`.
     @MainActor static var displaySpacesModeOverrideForTests: (() -> DisplaySpacesMode)?
+    @MainActor static var spacesForWindowOverrideForTests: ((UInt32) -> [UInt64])?
     private static let displayCreateUUIDFromDisplayID: DisplayCreateUUIDFromDisplayIDFunc? = {
         let handle = dlopen("/System/Library/Frameworks/ApplicationServices.framework/ApplicationServices", RTLD_LAZY)
             ?? dlopen("/System/Library/Frameworks/CoreGraphics.framework/CoreGraphics", RTLD_LAZY)
@@ -293,6 +298,11 @@ final class SkyLight {
             as: CopyManagedDisplaySpacesFunc.self
         )
             ?? resolveOptional("CGSCopyManagedDisplaySpaces", as: CopyManagedDisplaySpacesFunc.self)
+        copySpacesForWindows = resolveOptional(
+            "SLSCopySpacesForWindows",
+            as: CopySpacesForWindowsFunc.self
+        )
+            ?? resolveOptional("CGSCopySpacesForWindows", as: CopySpacesForWindowsFunc.self)
         // Optional — must NOT gate startup. Fallback in `displaySpacesMode`.
         getSpaceManagementMode = resolveOptional(
             "SLSGetSpaceManagementMode",
@@ -317,6 +327,57 @@ final class SkyLight {
             }
         }
         return displaySpacesModeFromManagedDisplaySpaces(monitors: monitors ?? Monitor.current())
+    }
+
+    struct ManagedDisplaySpacesSnapshot: Sendable, Equatable {
+        let displayId: CGDirectDisplayID
+        let spaceIds: [UInt64]
+        let currentSpaceId: UInt64
+    }
+
+    func managedDisplaySpaces(monitors: [Monitor]) -> [ManagedDisplaySpacesSnapshot] {
+        guard let copyManagedDisplaySpaces, !monitors.isEmpty else { return [] }
+        let cid = getMainConnectionID()
+        guard cid != 0, let spacesRef = copyManagedDisplaySpaces(cid) else { return [] }
+        defer { cfRelease(spacesRef) }
+        guard let displaySpaces = spacesRef as? [[String: Any]] else { return [] }
+
+        let displayIdByIdentifier = Self.managedDisplayIdentifierMap(for: monitors)
+        var snapshots: [ManagedDisplaySpacesSnapshot] = []
+        for display in displaySpaces {
+            guard let identifier = display["Display Identifier"] as? String,
+                  let displayId = displayIdByIdentifier[identifier]
+            else {
+                continue
+            }
+            guard let spaces = display["Spaces"] as? [[String: Any]] else { return [] }
+            let spaceIds = spaces.compactMap(Self.spaceId).filter { $0 != 0 }
+            let currentSpaceId = (display["Current Space"] as? [String: Any]).flatMap(Self.spaceId) ?? 0
+            snapshots.append(
+                ManagedDisplaySpacesSnapshot(
+                    displayId: displayId,
+                    spaceIds: spaceIds,
+                    currentSpaceId: currentSpaceId
+                )
+            )
+        }
+        return snapshots
+    }
+
+    func spacesForWindow(_ windowId: UInt32) -> [UInt64] {
+        if let override = Self.spacesForWindowOverrideForTests {
+            return override(windowId)
+        }
+        guard let copySpacesForWindows else { return [] }
+        let cid = getMainConnectionID()
+        guard cid != 0 else { return [] }
+        var widValue = Int32(bitPattern: windowId)
+        guard let widNumber = CFNumberCreate(nil, .sInt32Type, &widValue) else { return [] }
+        defer { cfRelease(widNumber) }
+        guard let result = copySpacesForWindows(cid, Self.allSpacesMask, [widNumber] as CFArray) else { return [] }
+        defer { cfRelease(result) }
+        guard let values = result as? [Any] else { return [] }
+        return values.compactMap(Self.numericUInt64).filter { $0 != 0 }
     }
 
     private func displaySpacesModeFromManagedDisplaySpaces(monitors: [Monitor]) -> DisplaySpacesMode {
@@ -485,6 +546,12 @@ final class SkyLight {
         numericUInt64(space["id64"]) == spaceId ||
             numericUInt64(space["ManagedSpaceID"]) == spaceId ||
             numericUInt64(space["id"]) == spaceId
+    }
+
+    private static func spaceId(_ space: [String: Any]) -> UInt64? {
+        numericUInt64(space["id64"])
+            ?? numericUInt64(space["ManagedSpaceID"])
+            ?? numericUInt64(space["id"])
     }
 
     private static func numericUInt64(_ value: Any?) -> UInt64? {

--- a/Sources/Nehir/Core/SkyLight/SpaceTopology.swift
+++ b/Sources/Nehir/Core/SkyLight/SpaceTopology.swift
@@ -1,0 +1,89 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
+import CoreGraphics
+import Foundation
+
+struct SpaceTopology: Equatable, Sendable {
+    let mode: DisplaySpacesMode
+    let activeSpaceIdsByDisplayId: [CGDirectDisplayID: UInt64]
+    let knownSpaceIds: Set<UInt64>
+    let spaceIdsByWindowId: [UInt32: [UInt64]]
+
+    static let empty = SpaceTopology(mode: .unavailable)
+
+    init(
+        mode: DisplaySpacesMode,
+        activeSpaceIdsByDisplayId: [CGDirectDisplayID: UInt64] = [:],
+        knownSpaceIds: Set<UInt64> = [],
+        spaceIdsByWindowId: [UInt32: [UInt64]] = [:]
+    ) {
+        self.mode = mode
+        self.activeSpaceIdsByDisplayId = activeSpaceIdsByDisplayId
+        self.knownSpaceIds = knownSpaceIds
+        self.spaceIdsByWindowId = spaceIdsByWindowId
+    }
+
+    var isEnabledAndPopulated: Bool {
+        mode == .enabled && !activeSpaceIdsByDisplayId.isEmpty && !knownSpaceIds.isEmpty
+    }
+
+    func isWindowOnKnownInactiveSpace(windowId: UInt32) -> Bool {
+        guard isEnabledAndPopulated,
+              let candidates = spaceIdsByWindowId[windowId],
+              !candidates.isEmpty
+        else { return false }
+
+        let activeIds = Set(activeSpaceIdsByDisplayId.values)
+        if candidates.contains(where: activeIds.contains) {
+            return false
+        }
+
+        let knownCandidates = candidates.filter(knownSpaceIds.contains)
+        return !knownCandidates.isEmpty
+    }
+
+    @MainActor
+    static func current(monitors: [Monitor], windowIds: [UInt32]) -> SpaceTopology {
+        let skyLight = SkyLight.shared
+        let mode = skyLight.displaySpacesMode(monitors: monitors)
+        guard mode == .enabled else { return SpaceTopology(mode: mode) }
+
+        let snapshots = skyLight.managedDisplaySpaces(monitors: monitors)
+        var activeSpaceIdsByDisplayId: [CGDirectDisplayID: UInt64] = [:]
+        var knownSpaceIds = Set<UInt64>()
+        for snapshot in snapshots {
+            if snapshot.currentSpaceId != 0 {
+                activeSpaceIdsByDisplayId[snapshot.displayId] = snapshot.currentSpaceId
+                knownSpaceIds.insert(snapshot.currentSpaceId)
+            }
+            knownSpaceIds.formUnion(snapshot.spaceIds.filter { $0 != 0 })
+        }
+
+        guard !activeSpaceIdsByDisplayId.isEmpty, !knownSpaceIds.isEmpty else {
+            return SpaceTopology(mode: mode)
+        }
+
+        var spaceIdsByWindowId: [UInt32: [UInt64]] = [:]
+        for windowId in Set(windowIds).filter({ $0 != 0 }) {
+            let spaceIds = skyLight.spacesForWindow(windowId).filter { $0 != 0 }
+            if !spaceIds.isEmpty {
+                spaceIdsByWindowId[windowId] = spaceIds
+            }
+        }
+
+        return SpaceTopology(
+            mode: mode,
+            activeSpaceIdsByDisplayId: activeSpaceIdsByDisplayId,
+            knownSpaceIds: knownSpaceIds,
+            spaceIdsByWindowId: spaceIdsByWindowId
+        )
+    }
+
+    var debugSummary: String {
+        "mode=\(mode.rawValue) activeSpaces=\(activeSpaceIdsByDisplayId.count) knownSpaces=\(knownSpaceIds.count) windowRecords=\(spaceIdsByWindowId.count)"
+    }
+}

--- a/Tests/NehirTests/RefreshRoutingTests.swift
+++ b/Tests/NehirTests/RefreshRoutingTests.swift
@@ -145,6 +145,7 @@ private func cleanupRefreshTestController(_ controller: WMController) {
     controller.axManager.currentWindowsAsyncOverride = nil
     controller.axManager.fullRescanEnumerationOverrideForTests = nil
     controller.axManager.frameApplyOverrideForTests = nil
+    controller.layoutRefreshController.spaceTopologyProviderForTests = nil
     controller.axEventHandler.resetDebugStateForTests()
     controller.axEventHandler.isFullscreenProvider = nil
 }
@@ -3274,6 +3275,136 @@ private func syncNiriWorkspaceStatesForRefreshTests(
         #expect(axState.retryBudgetCount == 0)
         #expect(axState.forceApplyWindowIdCount == 0)
         #expect(axState.inactiveWorkspaceWindowIdCount == 0)
+    }
+
+    @Test @MainActor func fullRescanPreservesWindowOnKnownInactiveNativeSpace() async {
+        let controller = makeRefreshTestController()
+        controller.axManager.fullRescanEnumerationOverrideForTests = {
+            AXManager.FullRescanEnumerationSnapshot(windows: [], failedPIDs: [])
+        }
+        guard let workspaceId = controller.interactionWorkspace()?.id,
+              let displayId = controller.workspaceManager.monitors.first?.displayId
+        else {
+            Issue.record("Missing active workspace")
+            return
+        }
+
+        let pid = getpid()
+        let windowId = 3_071
+        _ = addWindow(on: controller, workspaceId: workspaceId, pid: pid, windowId: windowId)
+        controller.layoutRefreshController.spaceTopologyProviderForTests = { _, _ in
+            SpaceTopology(
+                mode: .enabled,
+                activeSpaceIdsByDisplayId: [displayId: 10],
+                knownSpaceIds: [10, 20],
+                spaceIdsByWindowId: [UInt32(windowId): [20]]
+            )
+        }
+
+        controller.layoutRefreshController.requestFullRescan(reason: .startup)
+        await waitForRefreshWork(on: controller)
+        controller.layoutRefreshController.requestFullRescan(reason: .startup)
+        await waitForRefreshWork(on: controller)
+
+        #expect(controller.workspaceManager.entry(forPid: pid, windowId: windowId) != nil)
+        #expect(controller.layoutRefreshController.spaceTopologyDebugDump().contains("exempted=1"))
+    }
+
+    @Test @MainActor func fullRescanStillEvictsMissingWindowWithoutSpaceRecord() async {
+        let controller = makeRefreshTestController()
+        controller.axManager.fullRescanEnumerationOverrideForTests = {
+            AXManager.FullRescanEnumerationSnapshot(windows: [], failedPIDs: [])
+        }
+        guard let workspaceId = controller.interactionWorkspace()?.id,
+              let displayId = controller.workspaceManager.monitors.first?.displayId
+        else {
+            Issue.record("Missing active workspace")
+            return
+        }
+
+        let pid = getpid()
+        let windowId = 3_072
+        _ = addWindow(on: controller, workspaceId: workspaceId, pid: pid, windowId: windowId)
+        controller.layoutRefreshController.spaceTopologyProviderForTests = { _, _ in
+            SpaceTopology(
+                mode: .enabled,
+                activeSpaceIdsByDisplayId: [displayId: 10],
+                knownSpaceIds: [10, 20],
+                spaceIdsByWindowId: [:]
+            )
+        }
+
+        controller.layoutRefreshController.requestFullRescan(reason: .startup)
+        await waitForRefreshWork(on: controller)
+        #expect(controller.workspaceManager.entry(forPid: pid, windowId: windowId) != nil)
+
+        controller.layoutRefreshController.requestFullRescan(reason: .startup)
+        await waitForRefreshWork(on: controller)
+        #expect(controller.workspaceManager.entry(forPid: pid, windowId: windowId) == nil)
+    }
+
+    @Test @MainActor func fullRescanDoesNotExemptWhenSeparateSpacesDisabled() async {
+        let controller = makeRefreshTestController()
+        controller.axManager.fullRescanEnumerationOverrideForTests = {
+            AXManager.FullRescanEnumerationSnapshot(windows: [], failedPIDs: [])
+        }
+        guard let workspaceId = controller.interactionWorkspace()?.id,
+              let displayId = controller.workspaceManager.monitors.first?.displayId
+        else {
+            Issue.record("Missing active workspace")
+            return
+        }
+
+        let pid = getpid()
+        let windowId = 3_073
+        _ = addWindow(on: controller, workspaceId: workspaceId, pid: pid, windowId: windowId)
+        controller.layoutRefreshController.spaceTopologyProviderForTests = { _, _ in
+            SpaceTopology(
+                mode: .disabled,
+                activeSpaceIdsByDisplayId: [displayId: 10],
+                knownSpaceIds: [10, 20],
+                spaceIdsByWindowId: [UInt32(windowId): [20]]
+            )
+        }
+
+        controller.layoutRefreshController.requestFullRescan(reason: .startup)
+        await waitForRefreshWork(on: controller)
+        controller.layoutRefreshController.requestFullRescan(reason: .startup)
+        await waitForRefreshWork(on: controller)
+
+        #expect(controller.workspaceManager.entry(forPid: pid, windowId: windowId) == nil)
+    }
+
+    @Test @MainActor func fullRescanDoesNotExemptWindowOnActiveSpace() async {
+        let controller = makeRefreshTestController()
+        controller.axManager.fullRescanEnumerationOverrideForTests = {
+            AXManager.FullRescanEnumerationSnapshot(windows: [], failedPIDs: [])
+        }
+        guard let workspaceId = controller.interactionWorkspace()?.id,
+              let displayId = controller.workspaceManager.monitors.first?.displayId
+        else {
+            Issue.record("Missing active workspace")
+            return
+        }
+
+        let pid = getpid()
+        let windowId = 3_074
+        _ = addWindow(on: controller, workspaceId: workspaceId, pid: pid, windowId: windowId)
+        controller.layoutRefreshController.spaceTopologyProviderForTests = { _, _ in
+            SpaceTopology(
+                mode: .enabled,
+                activeSpaceIdsByDisplayId: [displayId: 10],
+                knownSpaceIds: [10, 20],
+                spaceIdsByWindowId: [UInt32(windowId): [10]]
+            )
+        }
+
+        controller.layoutRefreshController.requestFullRescan(reason: .startup)
+        await waitForRefreshWork(on: controller)
+        controller.layoutRefreshController.requestFullRescan(reason: .startup)
+        await waitForRefreshWork(on: controller)
+
+        #expect(controller.workspaceManager.entry(forPid: pid, windowId: windowId) == nil)
     }
 
     @Test @MainActor func fullRescanClearsFocusedFloatingBorderWhenWindowMissing() async {

--- a/Tests/NehirTests/SpaceTopologyTests.swift
+++ b/Tests/NehirTests/SpaceTopologyTests.swift
@@ -1,0 +1,93 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
+import CoreGraphics
+@testable import Nehir
+import Testing
+
+struct SpaceTopologyTests {
+    @Test func emptyTopologyNeverExempts() {
+        let disabled = SpaceTopology(
+            mode: .disabled,
+            activeSpaceIdsByDisplayId: [1: 10],
+            knownSpaceIds: [10, 20],
+            spaceIdsByWindowId: [100: [20]]
+        )
+        let unavailable = SpaceTopology(
+            mode: .unavailable,
+            activeSpaceIdsByDisplayId: [1: 10],
+            knownSpaceIds: [10, 20],
+            spaceIdsByWindowId: [100: [20]]
+        )
+        let emptyEnabled = SpaceTopology(mode: .enabled)
+
+        #expect(!disabled.isWindowOnKnownInactiveSpace(windowId: 100))
+        #expect(!unavailable.isWindowOnKnownInactiveSpace(windowId: 100))
+        #expect(!emptyEnabled.isWindowOnKnownInactiveSpace(windowId: 100))
+        #expect(!SpaceTopology.empty.isWindowOnKnownInactiveSpace(windowId: 100))
+    }
+
+    @Test func inactiveKnownSpaceExempts() {
+        let topology = SpaceTopology(
+            mode: .enabled,
+            activeSpaceIdsByDisplayId: [1: 10],
+            knownSpaceIds: [10, 20],
+            spaceIdsByWindowId: [100: [20]]
+        )
+
+        #expect(topology.isWindowOnKnownInactiveSpace(windowId: 100))
+    }
+
+    @Test func activeCandidateDoesNotExempt() {
+        let topology = SpaceTopology(
+            mode: .enabled,
+            activeSpaceIdsByDisplayId: [1: 10],
+            knownSpaceIds: [10, 20],
+            spaceIdsByWindowId: [101: [10]]
+        )
+
+        #expect(!topology.isWindowOnKnownInactiveSpace(windowId: 101))
+    }
+
+    @Test func mixedActiveAndInactiveDoesNotExempt() {
+        let topology = SpaceTopology(
+            mode: .enabled,
+            activeSpaceIdsByDisplayId: [1: 10],
+            knownSpaceIds: [10, 20],
+            spaceIdsByWindowId: [102: [10, 20]]
+        )
+
+        #expect(!topology.isWindowOnKnownInactiveSpace(windowId: 102))
+    }
+
+    @Test func unknownCandidateDoesNotExempt() {
+        let topology = SpaceTopology(
+            mode: .enabled,
+            activeSpaceIdsByDisplayId: [1: 10],
+            knownSpaceIds: [10],
+            spaceIdsByWindowId: [103: [999]]
+        )
+
+        #expect(!topology.isWindowOnKnownInactiveSpace(windowId: 103))
+    }
+
+    @Test func debugSummaryIsCompact() {
+        let topology = SpaceTopology(
+            mode: .enabled,
+            activeSpaceIdsByDisplayId: [1: 10, 2: 30],
+            knownSpaceIds: [10, 20, 30],
+            spaceIdsByWindowId: [9_999: [20]]
+        )
+
+        let summary = topology.debugSummary
+        #expect(summary.contains("mode=enabled"))
+        #expect(summary.contains("activeSpaces=2"))
+        #expect(summary.contains("knownSpaces=3"))
+        #expect(summary.contains("windowRecords=1"))
+        #expect(!summary.contains("9999"))
+        #expect(!summary.contains("["))
+    }
+}


### PR DESCRIPTION
## Summary

With macOS "Displays have separate Spaces" enabled, a managed window parked on a native Space that is inactive on every display disappears from both the AX visible-window feed and the on-screen CGWindowList fallback. The full rescan path previously treated such a window as missing and let WorkspaceManager.removeMissing evict it after the miss hysteresis.

Add a small per-rescan SpaceTopology value built from the tracked window ids and consult it only in the full-rescan eviction path. If Separate Spaces is disabled/unavailable, or SkyLight cannot prove a tracked window's native Space membership, behavior is unchanged. If a tracked window has a non-empty native Space list with at least one known id and no active candidate Space, insert its token into seenKeys before removeMissing so the miss counter resets instead of evicting it.

Depends on the DisplaySpacesMode detection already on main. This is not upstream's full SpaceTracker: no event-driven topology cache, no native-fullscreen reconciliation, no startup requirement. A compact last-topology summary is surfaced via the runtime debug dump.

Accepted residual risk: there is no max-exemption counter, so a stale SkyLight Space list could retain a window indefinitely. Field-test and add a follow-up cap if that proves to be a real concern.

Adapted from upstream OmniWM (BarutSRB), recorded per-file in .provenance.json: the SpaceTopology value type from e5e368d, the spacesForWindow / managed-Spaces SkyLight helpers from ee554c7, and the inactive-Space miss-eviction exemption concept from 2dcab36. Nehir ports the exemption to the controller's seenKeys seam (queried per tracked window, guarded by Separate-Spaces mode) rather than upstream's WindowModel.confirmedMissingKeys; see NOTICE.md.

Plan: planned/20260619-m4s2-space-topology-eviction-exemption.md
Discovery: discovery/20260618-space-topology-eviction-exemption.md
## Release notes

Choose one:

- [x] Added a `.changeset/*.md` for user-visible changes (`mise run changeset -- patch "..."`).
- [ ] No user-visible change; apply the `no release note` label to make CI skip intentional.

## Validation

<!-- Commands run, screenshots, or manual checks. -->

- [ ] Ran relevant tests/checks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Managed windows now remain hidden on inactive native Spaces during full rescans, improving window management consistency.

* **Tests**
  * Added comprehensive test coverage for managed window preservation behavior across different Space configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->