### PR TITLE
Refine hotkey diagnostics refresh

### DIFF
--- a/.changeset/20260620100043-surface-global-hotkey-conflicts-in-diagnostics-and-ad.md
+++ b/.changeset/20260620100043-surface-global-hotkey-conflicts-in-diagnostics-and-ad.md
@@ -3,4 +3,4 @@
 contributors: [syepes]
 ---
 
-Surface global-hotkey conflicts in the Diagnostics hub and sidebar badge, and add a curated advisory for the Command Palette default chord (Option+Command+Space) which can co-fire with a macOS system shortcut even when Carbon registration succeeds (fixes #48). Diagnostic rows are advisory only; remediation is to reassign the conflicting Nehir hotkey or clear the overlapping macOS shortcut.
+Surface global-hotkey conflicts in the Diagnostics hub and sidebar badge, and add a curated Command Palette advisory that appears only when the overlapping macOS symbolic shortcut is currently enabled (fixes #48, follow-up to #97). Diagnostic rows stay in sync when hotkey bindings or app activation change; remediation is to reassign the conflicting Nehir hotkey or clear the overlapping macOS shortcut.

--- a/Sources/Nehir/Core/Config/HotkeyAdvisoryCatalog.swift
+++ b/Sources/Nehir/Core/Config/HotkeyAdvisoryCatalog.swift
@@ -18,6 +18,7 @@ import Foundation
 struct CuratedHotkeyAdvisory: Equatable {
     let actionID: String
     let command: HotkeyCommand
+    let symbolicHotkeyIDs: Set<Int>
     let advisoryText: String
 }
 
@@ -29,7 +30,8 @@ enum HotkeyAdvisoryCatalog {
         CuratedHotkeyAdvisory(
             actionID: "openCommandPalette",
             command: .openCommandPalette,
-            advisoryText: "Your Command Palette shortcut (Option+Command+Space) can also be claimed by a macOS system shortcut (e.g. Input Sources) or another launcher, which will fire alongside Nehir. If pressing it also opens another app, reassign this Nehir hotkey in Hotkeys, or clear the conflicting shortcut in System Settings → Keyboard → Keyboard Shortcuts."
+            symbolicHotkeyIDs: [65],
+            advisoryText: "Your Command Palette shortcut overlaps the enabled macOS Spotlight → Show Finder search window shortcut, which can fire alongside Nehir. Reassign this Nehir hotkey in Hotkeys, or clear the conflicting shortcut in System Settings → Keyboard → Keyboard Shortcuts."
         )
     ]
 }

--- a/Sources/Nehir/Core/Config/SettingsDiagnosticsIssue.swift
+++ b/Sources/Nehir/Core/Config/SettingsDiagnosticsIssue.swift
@@ -92,11 +92,15 @@ enum SettingsDiagnosticsDetector {
     static func applicableIssues(
         configDirectory: URL = SettingsFilePersistence.defaultDirectoryURL,
         hotkeyFailures: [HotkeyCommand: HotkeyRegistrationFailureReason] = [:],
-        hotkeyBindings: [HotkeyBinding] = []
+        hotkeyBindings: [HotkeyBinding] = [],
+        enabledSystemHotkeyIDs: Set<Int> = Self.enabledAppleSymbolicHotkeyIDs()
     ) -> [SettingsDiagnosticsIssue] {
         var issues = configBasedIssues(configDirectory: configDirectory)
         issues.append(contentsOf: hotkeyConflictIssues(failures: hotkeyFailures, bindings: hotkeyBindings))
-        issues.append(contentsOf: hotkeyAdvisoryIssues(bindings: hotkeyBindings))
+        issues.append(contentsOf: hotkeyAdvisoryIssues(
+            bindings: hotkeyBindings,
+            enabledSystemHotkeyIDs: enabledSystemHotkeyIDs
+        ))
         return issues
     }
 
@@ -105,12 +109,14 @@ enum SettingsDiagnosticsDetector {
         stateStore: SettingsMigrationStateStore = SettingsMigrationStateStore(),
         appVersion: String = Bundle.main.appVersion ?? "dev",
         hotkeyFailures: [HotkeyCommand: HotkeyRegistrationFailureReason] = [:],
-        hotkeyBindings: [HotkeyBinding] = []
+        hotkeyBindings: [HotkeyBinding] = [],
+        enabledSystemHotkeyIDs: Set<Int> = Self.enabledAppleSymbolicHotkeyIDs()
     ) -> [SettingsDiagnosticsIssue] {
         applicableIssues(
             configDirectory: configDirectory,
             hotkeyFailures: hotkeyFailures,
-            hotkeyBindings: hotkeyBindings
+            hotkeyBindings: hotkeyBindings,
+            enabledSystemHotkeyIDs: enabledSystemHotkeyIDs
         ).filter { issue in
             !stateStore.isPostponed(migrationID: postponeID(for: issue), currentAppVersion: appVersion)
         }
@@ -179,8 +185,14 @@ enum SettingsDiagnosticsDetector {
     /// for the action (reassigning or unassigning suppresses them — no false positives
     /// on custom chords). The default chord is derived from `HotkeyBindingRegistry` so the
     /// catalog never hardcodes Carbon key constants.
-    private static func hotkeyAdvisoryIssues(bindings: [HotkeyBinding]) -> [SettingsDiagnosticsIssue] {
-        guard !bindings.isEmpty, !HotkeyAdvisoryCatalog.knownSystemConflicts.isEmpty else { return [] }
+    private static func hotkeyAdvisoryIssues(
+        bindings: [HotkeyBinding],
+        enabledSystemHotkeyIDs: Set<Int>
+    ) -> [SettingsDiagnosticsIssue] {
+        guard !bindings.isEmpty,
+              !enabledSystemHotkeyIDs.isEmpty,
+              !HotkeyAdvisoryCatalog.knownSystemConflicts.isEmpty
+        else { return [] }
         let currentByID = Dictionary(
             bindings.map { ($0.id, $0) },
             uniquingKeysWith: { first, _ in first }
@@ -190,7 +202,8 @@ enum SettingsDiagnosticsDetector {
             uniquingKeysWith: { first, _ in first }
         )
         return HotkeyAdvisoryCatalog.knownSystemConflicts.compactMap { advisory in
-            guard let current = currentByID[advisory.actionID],
+            guard !advisory.symbolicHotkeyIDs.isDisjoint(with: enabledSystemHotkeyIDs),
+                  let current = currentByID[advisory.actionID],
                   let defaultBinding = defaultsByID[advisory.actionID],
                   current.binding == defaultBinding.binding,
                   case let .chord(chord) = current.binding,
@@ -203,5 +216,19 @@ enum SettingsDiagnosticsDetector {
                 advisoryText: advisory.advisoryText
             ))
         }
+    }
+
+    private static func enabledAppleSymbolicHotkeyIDs() -> Set<Int> {
+        guard let symbolicHotkeys = UserDefaults(suiteName: "com.apple.symbolichotkeys")?
+            .dictionary(forKey: "AppleSymbolicHotKeys")
+        else { return [] }
+
+        return Set(symbolicHotkeys.compactMap { key, value in
+            guard let id = Int(key),
+                  let entry = value as? [String: Any],
+                  (entry["enabled"] as? Bool) == true
+            else { return nil }
+            return id
+        })
     }
 }

--- a/Sources/Nehir/UI/DisplayDiagnosticsSettingsTab.swift
+++ b/Sources/Nehir/UI/DisplayDiagnosticsSettingsTab.swift
@@ -222,6 +222,12 @@ struct DisplayDiagnosticsSettingsTab: View {
         .onReceive(NotificationCenter.default.publisher(for: .settingsMigrationStateDidChange)) { _ in
             refreshSettingsIssues()
         }
+        .onReceive(NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)) { _ in
+            refreshSettingsIssues()
+        }
+        .onChange(of: settings.hotkeyBindings) { _, _ in
+            refreshSettingsIssues()
+        }
     }
 
     @ViewBuilder

--- a/Tests/NehirTests/HotkeyConflictDiagnosticsTests.swift
+++ b/Tests/NehirTests/HotkeyConflictDiagnosticsTests.swift
@@ -90,7 +90,8 @@ import Testing
     @Test func curatedAdvisoryFiresForCommandPaletteDefaultChord() throws {
         let issues = SettingsDiagnosticsDetector.applicableIssues(
             hotkeyFailures: [:],
-            hotkeyBindings: HotkeyBindingRegistry.defaults()
+            hotkeyBindings: HotkeyBindingRegistry.defaults(),
+            enabledSystemHotkeyIDs: [65]
         )
         let advisories = issues.compactMap { issue -> HotkeyAdvisoryIssue? in
             if case .hotkeyAdvisory(let advisory) = issue { return advisory }
@@ -103,6 +104,19 @@ import Testing
         #expect(advisory.actionID == "openCommandPalette")
         #expect(advisory.advisoryText.contains("Command Palette"))
         #expect(advisory.chordDisplayString.isEmpty == false)
+    }
+
+    @Test func curatedAdvisorySuppressedWhenSystemShortcutDisabled() {
+        let issues = SettingsDiagnosticsDetector.applicableIssues(
+            hotkeyFailures: [:],
+            hotkeyBindings: HotkeyBindingRegistry.defaults(),
+            enabledSystemHotkeyIDs: []
+        )
+
+        #expect(issues.allSatisfy { issue in
+            if case .hotkeyAdvisory = issue { return false }
+            return true
+        })
     }
 
     @Test func curatedAdvisoryDisappearsAfterReassign() {
@@ -171,7 +185,8 @@ import Testing
         let issues = SettingsDiagnosticsDetector.applicableIssues(
             configDirectory: configDirectory,
             hotkeyFailures: [.openCommandPalette: .systemReserved],
-            hotkeyBindings: HotkeyBindingRegistry.defaults()
+            hotkeyBindings: HotkeyBindingRegistry.defaults(),
+            enabledSystemHotkeyIDs: [65]
         )
 
         // Existing unknown-keys detection is preserved alongside the new hotkey rows.
@@ -192,7 +207,8 @@ import Testing
         let baseCount = SettingsDiagnosticsDetector.pendingIssues().count
         let withConflict = SettingsDiagnosticsDetector.pendingIssues(
             hotkeyFailures: [.openCommandPalette: .systemReserved, .toggleFullscreen: .duplicateBinding],
-            hotkeyBindings: HotkeyBindingRegistry.defaults()
+            hotkeyBindings: HotkeyBindingRegistry.defaults(),
+            enabledSystemHotkeyIDs: [65]
         ).count
 
         // Two conflicts plus the curated command-palette advisory all flow through the


### PR DESCRIPTION
## Summary

Surface global-hotkey conflicts in the Diagnostics hub and sidebar badge, and add a curated Command Palette advisory that appears only when the overlapping macOS symbolic shortcut is currently enabled (fixes #48, follow-up to #97). Diagnostic rows stay in sync when hotkey bindings or app activation change; remediation is to reassign the conflicting Nehir hotkey or clear the overlapping macOS shortcut.

## Release notes

Choose one:

- [x] Added a `.changeset/*.md` for user-visible changes (`mise run changeset -- patch "..."`).
- [ ] No user-visible change; apply the `no release note` label to make CI skip intentional.

## Validation

<!-- Commands run, screenshots, or manual checks. -->

- [ ] Ran relevant tests/checks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Hotkey conflict detection now accurately reflects enabled macOS system shortcuts instead of assuming defaults
  * Diagnostic warnings now refresh when the app becomes active and hotkey bindings change
  * Improved advisory messaging that specifically identifies conflicting macOS system shortcuts
  * Removed false positive advisories for disabled system shortcuts

<!-- end of auto-generated comment: release notes by coderabbit.ai -->