### PR TITLE
Keep transient popup surfaces out of managed activation

### DIFF
--- a/.changeset/20260622095818-leave-dock-contextual-menus-unmanaged-so-right-c.md
+++ b/.changeset/20260622095818-leave-dock-contextual-menus-unmanaged-so-right-c.md
@@ -1,0 +1,7 @@
+---
+"nehir": patch
+contributors: [syepes, dagrlx]
+
+---
+
+Keep transient native popup surfaces out of tiled layouts and avoid focusing them so browser suggestions and contextual menus stay in place. Fixes #98 and #104

--- a/Sources/Nehir/Core/Controller/AXEventHandler.swift
+++ b/Sources/Nehir/Core/Controller/AXEventHandler.swift
@@ -1176,7 +1176,8 @@ final class AXEventHandler: CGSEventDelegate {
         }
         recordRecentManagedAdmission(token: trackedToken, workspaceId: trackedEntry.workspaceId)
 
-        if trackedEntry.mode == .floating {
+        let shouldActivateFloatingCreate = shouldActivateFloatingCreate(candidate, trackedEntry: trackedEntry)
+        if shouldActivateFloatingCreate {
             controller.focusPolicyEngine.beginLease(
                 owner: .ruleCreatedFloatingWindow,
                 reason: "floating_window_create",
@@ -1210,7 +1211,8 @@ final class AXEventHandler: CGSEventDelegate {
             )
         }
 
-        if let floatingTargetFrame,
+        if shouldActivateFloatingCreate,
+           let floatingTargetFrame,
            shouldApplyFloatingCreateFrameImmediately(for: trackedEntry.workspaceId)
         {
             scheduleFloatingCreateFrameApplication(
@@ -1223,7 +1225,7 @@ final class AXEventHandler: CGSEventDelegate {
         } else {
             scheduleAXContextWarmup(for: trackedEntry.pid)
         }
-        if trackedEntry.mode == .floating {
+        if shouldActivateFloatingCreate {
             controller.windowActionHandler.raiseFloatingWindow(trackedToken)
         }
         if candidate.requiresPostCreateLifecycleVerification {
@@ -1235,6 +1237,18 @@ final class AXEventHandler: CGSEventDelegate {
             affectedWorkspaceIds: [trackedEntry.workspaceId]
         )
         scheduleWindowRuleReevaluationIfNeeded(targets: [.pid(trackedEntry.pid)])
+    }
+
+    private func shouldActivateFloatingCreate(
+        _ candidate: PreparedCreate,
+        trackedEntry: WindowModel.Entry
+    ) -> Bool {
+        guard trackedEntry.mode == .floating else { return false }
+
+        // WindowServer transient floating surfaces are native menus/popovers/contextual UI.
+        // They are safe to observe for lifecycle bookkeeping, but forcing an AX focus/raise
+        // or immediate frame write dismisses the menu in apps such as Telegram and Dock (#104).
+        return !candidate.replacementMetadata.transientWindowServerEvidence
     }
 
     private func shouldApplyFloatingCreateFrameImmediately(

--- a/Sources/Nehir/Core/Rules/WindowRuleEngine.swift
+++ b/Sources/Nehir/Core/Rules/WindowRuleEngine.swift
@@ -204,6 +204,7 @@ struct WindowDecisionDebugSnapshot: Equatable, Sendable {
 final class WindowRuleEngine {
     static let cleanShotBundleId = "pl.maketheweb.cleanshotx"
     static let systemTextInputPanelRuleName = "systemTextInputPanel"
+    private static let transientWindowServerSurfaceRuleName = "transientWindowServerSurface"
     private static let cleanShotRecordingOverlayRuleName = "cleanShotRecordingOverlay"
     private static let ghosttyQuickTerminalRuleName = "ghosttyQuickTerminalOverlay"
     private static let ghosttyBundleId = "com.mitchellh.ghostty"
@@ -355,6 +356,24 @@ final class WindowRuleEngine {
             minHeight: userRule?.rule.minHeight,
             matchedRuleId: userRule?.rule.id
         )
+
+        // Floating-tagged non-document WindowServer surfaces are native popups/menus.
+        // Keep them out of the tiled tree even when a broad user rule matches the app (#98).
+        if facts.ax.attributeFetchSucceeded,
+           let windowServer = facts.windowServer,
+           windowServer.hasFloatingTag,
+           !windowServer.hasDocumentTag
+        {
+            return WindowDecision(
+                disposition: .floating,
+                source: .builtInRule(Self.transientWindowServerSurfaceRuleName),
+                layoutDecisionKind: .fallbackLayout,
+                workspaceName: workspaceName,
+                ruleEffects: effects,
+                heuristicReasons: [],
+                deferredReason: nil
+            )
+        }
 
         if let userRule,
            let userDecision = explicitDecision(

--- a/Tests/NehirTests/AXEventHandlerTests.swift
+++ b/Tests/NehirTests/AXEventHandlerTests.swift
@@ -8393,6 +8393,50 @@ private func waitUntilAXEventTest(
         #expect(controller.axManager.lastAppliedFrame(for: 828) != nil)
     }
 
+    @Test @MainActor func transientFloatingCreateDoesNotActivateOrApplyFrameImmediately() async {
+        let controller = makeAXEventTestController()
+        let windowId: UInt32 = 830
+        let pid = getpid()
+        let frame = CGRect(x: 309, y: 583, width: 172, height: 260)
+        var windowServer = WindowServerInfo(id: windowId, pid: pid, level: 101, frame: frame)
+        windowServer.tags = 0x1000c2002
+
+        controller.axEventHandler.windowInfoProvider = { candidateWindowId in
+            candidateWindowId == windowId ? windowServer : nil
+        }
+        controller.axEventHandler.axWindowRefProvider = { candidateWindowId, candidatePid in
+            guard candidateWindowId == windowId, candidatePid == pid else { return nil }
+            return AXWindowRef(element: AXUIElementCreateSystemWide(), windowId: Int(candidateWindowId))
+        }
+        controller.axEventHandler.frameProvider = { _ in frame }
+        controller.axEventHandler.windowFactsProvider = { _, _ in
+            makeAXEventWindowRuleFacts(
+                bundleId: "com.example.transient-popup",
+                subrole: "AXUnknown",
+                hasFullscreenButton: false,
+                fullscreenButtonEnabled: nil,
+                windowServer: windowServer
+            )
+        }
+        defer { controller.axEventHandler.frameProvider = nil }
+
+        controller.axEventHandler.cgsEventObserver(
+            CGSEventObserver.shared,
+            didReceive: .created(windowId: windowId, spaceId: 0)
+        )
+        await controller.layoutRefreshController.waitForRefreshWorkForTests()
+
+        guard let entry = controller.workspaceManager.entry(forPid: pid, windowId: Int(windowId)) else {
+            Issue.record("Expected transient popup entry")
+            return
+        }
+
+        #expect(entry.mode == .floating)
+        #expect(entry.managedReplacementMetadata?.transientWindowServerEvidence == true)
+        #expect(controller.focusPolicyEngine.activeLease?.owner != .ruleCreatedFloatingWindow)
+        #expect(controller.axManager.lastAppliedFrame(for: Int(windowId)) == nil)
+    }
+
     @Test @MainActor func floatingCreateWithDegradedAxFactsStillAppliesFloatRule() async {
         let controller = makeAXEventTestController()
         controller.windowRuleEngine.rebuild(

--- a/Tests/NehirTests/MouseEventHandlerTests.swift
+++ b/Tests/NehirTests/MouseEventHandlerTests.swift
@@ -632,7 +632,7 @@ private func prepareMouseWheelScrollFixtureWithDefaultSensitivity() async -> (
             return
         }
 
-        populateNiriWorkspaceForMouseTests(
+        let focusedHandle = populateNiriWorkspaceForMouseTests(
             controller: controller,
             engine: engine,
             workspaceId: workspaceId,
@@ -643,21 +643,27 @@ private func prepareMouseWheelScrollFixtureWithDefaultSensitivity() async -> (
         controller.layoutRefreshController.requestImmediateRelayout(reason: .workspaceTransition)
         await controller.layoutRefreshController.waitForRefreshWorkForTests()
 
-        let focusedToken = controller.workspaceManager.confirmedManagedFocusToken
-        let entries = controller.workspaceManager.entries(in: workspaceId)
-        let hoverTarget = entries.compactMap { entry -> (WindowModel.Entry, CGPoint)? in
-            guard entry.token != focusedToken,
-                  let node = engine.findNode(for: entry.handle),
-                  let frame = node.renderedFrame ?? node.frame
-            else { return nil }
-            let point = frame.center
-            guard monitor.visibleFrame.contains(point),
-                  engine.hitTestFocusableWindow(point: point, in: workspaceId)?.token == entry.token
-            else { return nil }
-            return (entry, point)
-        }.first
+        let hoverTarget = engine.columns(in: workspaceId)
+            .flatMap(\.windowNodes)
+            .compactMap { node -> (WindowModel.Entry, CGPoint)? in
+                guard node.token != focusedHandle.token,
+                      let entry = controller.workspaceManager.entry(for: node.handle),
+                      let frame = node.renderedFrame ?? node.frame
+                else { return nil }
+
+                let point = frame.center
+                guard engine.hitTestFocusableWindow(point: point, in: workspaceId)?.token == entry.token else {
+                    return nil
+                }
+                return (entry, point)
+            }
+            .first
+
         guard let hoverTarget else {
-            Issue.record("Expected a visible non-focused Niri window for post-animation focus-follow regression test")
+            Issue
+                .record(
+                    "Expected a hit-testable non-focused Niri window for post-animation focus-follow regression test"
+                )
             return
         }
 

--- a/Tests/NehirTests/WindowRuleEngineTests.swift
+++ b/Tests/NehirTests/WindowRuleEngineTests.swift
@@ -115,6 +115,46 @@ private func makeWindowRuleFacts(
         #expect(decision.heuristicReasons.isEmpty)
     }
 
+    @Test func floatingTaggedPopupSurfaceOverridesBroadTileRule() {
+        let engine = WindowRuleEngine()
+        let rule = AppRule(
+            id: UUID(uuidString: "00000000-0000-0000-0000-000000000123")!,
+            bundleId: "com.example.browser",
+            layout: .tile,
+            assignToWorkspace: "2",
+            minWidth: 700
+        )
+        engine.rebuild(rules: [rule])
+        var windowServer = WindowServerInfo(
+            id: 3301,
+            pid: 3301,
+            level: 101,
+            frame: CGRect(x: 300, y: 500, width: 180, height: 260)
+        )
+        windowServer.tags = 0x1000c2002
+
+        let decision = engine.decision(
+            for: makeWindowRuleFacts(
+                bundleId: "com.example.browser",
+                role: kAXWindowRole as String,
+                subrole: "AXUnknown",
+                hasFullscreenButton: false,
+                fullscreenButtonEnabled: nil,
+                windowServer: windowServer
+            ),
+            token: nil,
+            appFullscreen: false
+        )
+
+        #expect(decision.disposition == .floating)
+        #expect(decision.layoutDecisionKind == .fallbackLayout)
+        #expect(decision.workspaceName == "2")
+        #expect(decision.ruleEffects.minWidth == 700)
+        #expect(decision.ruleEffects.matchedRuleId == rule.id)
+        #expect(decision.source == .builtInRule("transientWindowServerSurface"))
+        #expect(decision.heuristicReasons.isEmpty)
+    }
+
     @Test func moreSpecificTitleRuleBeatsGenericBundleRule() {
         let engine = WindowRuleEngine()
         let genericRule = AppRule(


### PR DESCRIPTION
## Summary

Keep transient native popup surfaces out of tiled layouts and avoid focusing them so browser suggestions and contextual menus stay in place. Fixes #98 and #104

## Release notes

Choose one:

- [x] Added a `.changeset/*.md` for user-visible changes (`mise run changeset -- patch "..."`).
- [ ] No user-visible change; apply the `no release note` label to make CI skip intentional.

## Validation

<!-- Commands run, screenshots, or manual checks. -->

- [ ] Ran relevant tests/checks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented transient native popup surfaces (such as browser suggestions/contextual menus) from being claimed by the tiling system; they remain unmanaged and are no longer activated/focused.
  * Improved transient, tagged floating-like window handling so they don’t immediately receive focus leases or apply managed floating frames.
  * Updated window rule decisions so transient-tagged window server surfaces override broad tiling rules to use floating layout while preserving the matched workspace sizing.
* **Tests**
  * Added coverage for transient floating creation behavior and floating layout overrides for transient window server surfaces.
  * Adjusted mouse focus/hover test logic after scroll animation settles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->