### PR TITLE
Add command palette fallback to other sources on empty results

### DIFF
--- a/.changeset/20260622071232-command-palette-now-falls-back-to-matches-from-o.md
+++ b/.changeset/20260622071232-command-palette-now-falls-back-to-matches-from-o.md
@@ -1,0 +1,6 @@
+---
+"nehir": minor
+
+---
+
+Command palette now falls back to matches from other sources when the active source has no results for your query, so a search that misses in one tab surfaces Windows/Commands/Menu hits from the other sources instead of a dead-end.

--- a/Sources/Nehir/UI/CommandPalette/CommandPaletteController.swift
+++ b/Sources/Nehir/UI/CommandPalette/CommandPaletteController.swift
@@ -60,6 +60,20 @@ enum CommandPaletteSelectionID: Hashable {
     case command(String)
 }
 
+struct CommandPaletteFallbackSection: Identifiable {
+    let source: CommandPaletteMode
+    let windowItems: [CommandPaletteWindowItem]
+    let menuItems: [MenuItemModel]
+    let commandItems: [CommandPaletteCommandItem]
+    var id: CommandPaletteMode {
+        source
+    }
+
+    var isEmpty: Bool {
+        windowItems.isEmpty && menuItems.isEmpty && commandItems.isEmpty
+    }
+}
+
 struct CommandPaletteCommandItem: Identifiable {
     let id: String
     let command: HotkeyCommand
@@ -228,6 +242,70 @@ final class CommandPaletteController: NSObject, ObservableObject, NSWindowDelega
 
     var filteredCommandItems: [CommandPaletteCommandItem] {
         filterCommandItems(commandItems, query: searchText)
+    }
+
+    var activeModeFilteredIsEmpty: Bool {
+        switch selectedMode {
+        case .windows:
+            return filteredWindowItems.isEmpty
+        case .menu:
+            return !isMenuLoading && (!isMenuModeAvailable || filteredMenuItems.isEmpty)
+        case .commands:
+            return filteredCommandItems.isEmpty
+        }
+    }
+
+    var fallbackSections: [CommandPaletteFallbackSection] {
+        let trimmedQuery = searchText.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedQuery.isEmpty, activeModeFilteredIsEmpty else {
+            return []
+        }
+
+        var sections: [CommandPaletteFallbackSection] = []
+
+        let matchedWindows = filterWindowItems(windows, query: searchText)
+        if !matchedWindows.isEmpty {
+            sections.append(
+                CommandPaletteFallbackSection(
+                    source: .windows,
+                    windowItems: matchedWindows,
+                    menuItems: [],
+                    commandItems: []
+                )
+            )
+        }
+
+        let matchedCommands = filterCommandItems(commandItems, query: searchText)
+        if !matchedCommands.isEmpty {
+            sections.append(
+                CommandPaletteFallbackSection(
+                    source: .commands,
+                    windowItems: [],
+                    menuItems: [],
+                    commandItems: matchedCommands
+                )
+            )
+        }
+
+        if isMenuModeAvailable, hasLoadedMenuItems {
+            let matchedMenu = filterMenuItems(menuItems, query: searchText)
+            if !matchedMenu.isEmpty {
+                sections.append(
+                    CommandPaletteFallbackSection(
+                        source: .menu,
+                        windowItems: [],
+                        menuItems: matchedMenu,
+                        commandItems: []
+                    )
+                )
+            }
+        }
+
+        return sections
+    }
+
+    var fallbackActive: Bool {
+        !fallbackSections.isEmpty
     }
 
     var isMenuModeAvailable: Bool {
@@ -820,12 +898,14 @@ final class CommandPaletteController: NSObject, ObservableObject, NSWindowDelega
     private func resolvedSelectionAction(
         for trigger: CommandPaletteSelectionTrigger
     ) -> SelectionAction? {
-        switch selectedMode {
-        case .windows:
-            let filtered = filteredWindowItems
+        guard let selectedItemID else { return nil }
+        switch selectedItemID {
+        case .window(let token):
+            let resolvedItems = fallbackActive
+                ? (section(in: .windows)?.windowItems ?? [])
+                : filteredWindowItems
             guard let wmController,
-                  case let .window(token)? = selectedItemID,
-                  let item = filtered.first(where: { $0.id == token })
+                  let item = resolvedItems.first(where: { $0.id == token })
             else {
                 return nil
             }
@@ -836,24 +916,31 @@ final class CommandPaletteController: NSObject, ObservableObject, NSWindowDelega
                 guard let summonAnchor else { return nil }
                 return .summonWindowRight(wmController, item.handle, summonAnchor)
             }
-        case .menu:
-            let filtered = filteredMenuItems
-            guard case let .menu(id)? = selectedItemID,
-                  let item = filtered.first(where: { $0.id == id }),
+        case .menu(let id):
+            let resolvedItems = fallbackActive
+                ? (section(in: .menu)?.menuItems ?? [])
+                : filteredMenuItems
+            guard let item = resolvedItems.first(where: { $0.id == id }),
                   let menuFocusTarget
             else {
                 return nil
             }
             return .pressMenu(menuFocusTarget, item.axElement)
-        case .commands:
+        case .command(let id):
+            let resolvedItems = fallbackActive
+                ? (section(in: .commands)?.commandItems ?? [])
+                : filteredCommandItems
             guard let wmController,
-                  case let .command(id)? = selectedItemID,
-                  let item = filteredCommandItems.first(where: { $0.id == id })
+                  let item = resolvedItems.first(where: { $0.id == id })
             else {
                 return nil
             }
             return .executeCommand(wmController, item.command)
         }
+    }
+
+    private func section(in source: CommandPaletteMode) -> CommandPaletteFallbackSection? {
+        fallbackSections.first { $0.source == source }
     }
 
     private func performSelectionAction(_ action: SelectionAction) {
@@ -920,6 +1007,18 @@ final class CommandPaletteController: NSObject, ObservableObject, NSWindowDelega
     }
 
     private func currentSelectionList() -> [CommandPaletteSelectionID] {
+        if fallbackActive {
+            return fallbackSections.flatMap { fallbackSection -> [CommandPaletteSelectionID] in
+                switch fallbackSection.source {
+                case .windows:
+                    return fallbackSection.windowItems.map { .window($0.id) }
+                case .menu:
+                    return fallbackSection.menuItems.map { .menu($0.id) }
+                case .commands:
+                    return fallbackSection.commandItems.map { .command($0.id) }
+                }
+            }
+        }
         switch selectedMode {
         case .windows:
             return filteredWindowItems.map { CommandPaletteSelectionID.window($0.id) }
@@ -1057,6 +1156,57 @@ final class CommandPaletteController: NSObject, ObservableObject, NSWindowDelega
     var panelForTests: NSPanel? {
         panel
     }
+
+    func setCommandItemsForTests(
+        _ items: [CommandPaletteCommandItem],
+        wmController: WMController
+    ) {
+        self.wmController = wmController
+        commandItems = items
+    }
+
+    struct CommandPaletteFallbackTestState {
+        let wmController: WMController
+        let windows: [CommandPaletteWindowItem]
+        let menuItems: [MenuItemModel]
+        let commands: [CommandPaletteCommandItem]
+        let selectedMode: CommandPaletteMode
+        let selectedItemID: CommandPaletteSelectionID?
+        let hasLoadedMenuItems: Bool
+    }
+
+    func setFallbackStateForTests(_ state: CommandPaletteFallbackTestState) {
+        wmController = state.wmController
+        windows = state.windows
+        menuItems = state.menuItems
+        commandItems = state.commands
+        selectedMode = state.selectedMode
+        selectedItemID = state.selectedItemID
+        hasLoadedMenuItems = state.hasLoadedMenuItems
+    }
+
+    func currentSelectionListForTests() -> [CommandPaletteSelectionID] {
+        currentSelectionList()
+    }
+
+    enum CommandPaletteResolvedActionKindForTests: Equatable {
+        case navigateWindow
+        case summonWindowRight
+        case pressMenu
+        case executeCommand
+    }
+
+    func resolvedSelectionActionKindForTests(
+        trigger: CommandPaletteSelectionTrigger
+    ) -> CommandPaletteResolvedActionKindForTests? {
+        guard let action = resolvedSelectionAction(for: trigger) else { return nil }
+        switch action {
+        case .navigateWindow: return .navigateWindow
+        case .summonWindowRight: return .summonWindowRight
+        case .pressMenu: return .pressMenu
+        case .executeCommand: return .executeCommand
+        }
+    }
 }
 
 private struct CommandPaletteView: View {
@@ -1101,6 +1251,23 @@ private struct CommandPaletteView: View {
 
             if controller.selectedMode == .menu && controller.isMenuLoading {
                 CommandPaletteLoadingView(text: "Loading menu items...")
+            } else if isEmptyStateVisible && controller.fallbackActive {
+                ScrollViewReader { proxy in
+                    ScrollView {
+                        LazyVStack(spacing: 0) {
+                            ForEach(controller.fallbackSections) { section in
+                                fallbackSection(section)
+                            }
+                        }
+                    }
+                    .onChange(of: controller.selectedItemID) { _, newValue in
+                        if let newValue {
+                            withAnimation(.easeInOut(duration: 0.1)) {
+                                proxy.scrollTo(newValue, anchor: .center)
+                            }
+                        }
+                    }
+                }
             } else if isEmptyStateVisible {
                 CommandPaletteEmptyStateView(
                     symbolName: emptyStateSymbol,
@@ -1178,28 +1345,23 @@ private struct CommandPaletteView: View {
     }
 
     private var statusText: String {
+        if controller.fallbackActive {
+            return "No \(controller.selectedMode.displayName.lowercased()) matches — showing other sources."
+        }
         switch controller.selectedMode {
         case .windows:
-            CommandPaletteController.windowsStatusText(
+            return CommandPaletteController.windowsStatusText(
                 isSummonRightAvailable: controller.isSummonRightAvailable
             )
         case .menu:
-            controller.menuStatusText
+            return controller.menuStatusText
         case .commands:
-            "Enter executes the selected command."
+            return "Enter executes the selected command."
         }
     }
 
     private var isEmptyStateVisible: Bool {
-        switch controller.selectedMode {
-        case .windows:
-            controller.filteredWindowItems.isEmpty
-        case .menu:
-            !controller.isMenuLoading &&
-                (!controller.isMenuModeAvailable || controller.filteredMenuItems.isEmpty)
-        case .commands:
-            controller.filteredCommandItems.isEmpty
-        }
+        controller.activeModeFilteredIsEmpty
     }
 
     private var emptyStateSymbol: String {
@@ -1224,6 +1386,50 @@ private struct CommandPaletteView: View {
             return controller.searchText.isEmpty ? "No menu items available" : "No menu items found"
         case .commands:
             return controller.searchText.isEmpty ? "No commands available" : "No commands found"
+        }
+    }
+
+    @ViewBuilder
+    private func fallbackSection(_ section: CommandPaletteFallbackSection) -> some View {
+        CommandPaletteFallbackSectionHeader(title: section.source.displayName)
+        switch section.source {
+        case .windows:
+            ForEach(section.windowItems) { item in
+                CommandPaletteWindowRow(
+                    item: item,
+                    isSelected: controller.selectedItemID == .window(item.id),
+                    isSummonRightAvailable: controller.isSummonRightAvailable
+                )
+                .id(CommandPaletteSelectionID.window(item.id))
+                .onTapGesture {
+                    controller.selectedItemID = .window(item.id)
+                    controller.selectCurrent()
+                }
+            }
+        case .menu:
+            ForEach(section.menuItems) { item in
+                CommandPaletteMenuRow(
+                    item: item,
+                    isSelected: controller.selectedItemID == .menu(item.id)
+                )
+                .id(CommandPaletteSelectionID.menu(item.id))
+                .onTapGesture {
+                    controller.selectedItemID = .menu(item.id)
+                    controller.selectCurrent()
+                }
+            }
+        case .commands:
+            ForEach(section.commandItems) { item in
+                CommandPaletteCommandRow(
+                    item: item,
+                    isSelected: controller.selectedItemID == .command(item.id)
+                )
+                .id(CommandPaletteSelectionID.command(item.id))
+                .onTapGesture {
+                    controller.selectedItemID = .command(item.id)
+                    controller.selectCurrent()
+                }
+            }
         }
     }
 }
@@ -1369,6 +1575,20 @@ private struct CommandPaletteEmptyStateView: View {
             Spacer()
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+}
+
+private struct CommandPaletteFallbackSectionHeader: View {
+    let title: String
+
+    var body: some View {
+        Text(title)
+            .font(.system(size: 11, weight: .semibold))
+            .foregroundColor(.secondary)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.horizontal, 16)
+            .padding(.top, 8)
+            .padding(.bottom, 4)
     }
 }
 

--- a/Tests/NehirTests/CommandPaletteControllerTests.swift
+++ b/Tests/NehirTests/CommandPaletteControllerTests.swift
@@ -60,6 +60,33 @@ private func makeCommandPaletteAppSnapshot(
     )
 }
 
+private func makeCommandPaletteCommandItem(
+    id: String,
+    title: String,
+    searchTerms: [String],
+    command: HotkeyCommand = .toggleFocusedWindowFloating,
+    category: HotkeyCategory = .layout
+) -> CommandPaletteCommandItem {
+    CommandPaletteCommandItem(
+        id: id,
+        command: command,
+        title: title,
+        category: category,
+        bindingDisplay: nil,
+        searchTerms: searchTerms
+    )
+}
+
+private func makeCommandPaletteMenuItem(title: String, parent: String = "View") -> MenuItemModel {
+    MenuItemModel(
+        title: title,
+        fullPath: "\(parent) > \(title)",
+        keyboardShortcut: nil,
+        axElement: AXUIElementCreateSystemWide(),
+        parentTitles: [parent]
+    )
+}
+
 @Suite(.serialized) @MainActor struct CommandPaletteControllerTests {
     @Test func toggleShowsPaletteWhenHidden() {
         var environment = CommandPaletteEnvironment()
@@ -560,5 +587,289 @@ private func makeCommandPaletteAppSnapshot(
 
         #expect(anchor?.token == storedHandle.id)
         #expect(anchor?.workspaceId == workspaceId)
+    }
+
+    @Test func fallbackShowsCommandHitsWhenWindowsModeIsEmpty() {
+        let controller = CommandPaletteController()
+        let wmController = makeCommandPaletteTestWMController()
+        let command = makeCommandPaletteCommandItem(
+            id: "test.float",
+            title: "Toggle Floating",
+            searchTerms: ["float", "toggle floating"]
+        )
+
+        controller.setFallbackStateForTests(.init(
+            wmController: wmController,
+            windows: [],
+            menuItems: [],
+            commands: [command],
+            selectedMode: .windows,
+            selectedItemID: nil,
+            hasLoadedMenuItems: false
+        ))
+        controller.searchText = "float"
+
+        #expect(controller.fallbackActive)
+        #expect(controller.fallbackSections.count == 1)
+        #expect(controller.fallbackSections.first?.source == .commands)
+        #expect(controller.filteredWindowItems.isEmpty)
+        #expect(controller.selectedMode == .windows)
+    }
+
+    @Test func fallbackDispatchesCommandFromWindowsMode() {
+        let controller = CommandPaletteController()
+        let wmController = makeCommandPaletteTestWMController()
+        let command = makeCommandPaletteCommandItem(
+            id: "test.float",
+            title: "Toggle Floating",
+            searchTerms: ["float"]
+        )
+
+        controller.setFallbackStateForTests(.init(
+            wmController: wmController,
+            windows: [],
+            menuItems: [],
+            commands: [command],
+            selectedMode: .windows,
+            selectedItemID: nil,
+            hasLoadedMenuItems: false
+        ))
+        controller.searchText = "float"
+        controller.selectedItemID = .command(command.id)
+
+        let kind = controller.resolvedSelectionActionKindForTests(trigger: .primary)
+
+        #expect(kind == .executeCommand)
+        #expect(controller.selectedMode == .windows)
+    }
+
+    @Test func fallbackOmitsMenuWhenNotLoaded() {
+        let controller = CommandPaletteController()
+        let wmController = makeCommandPaletteTestWMController()
+        controller.setMenuAvailabilityForTests(
+            makeCommandPaletteAppSnapshot(pid: 600, bundleIdentifier: "com.app", localizedName: "App")
+        )
+        let command = makeCommandPaletteCommandItem(
+            id: "test.float",
+            title: "Toggle Floating",
+            searchTerms: ["float"]
+        )
+        let matchingMenu = makeCommandPaletteMenuItem(title: "Float")
+
+        controller.setFallbackStateForTests(.init(
+            wmController: wmController,
+            windows: [],
+            menuItems: [matchingMenu],
+            commands: [command],
+            selectedMode: .windows,
+            selectedItemID: nil,
+            hasLoadedMenuItems: false
+        ))
+        controller.searchText = "float"
+
+        #expect(controller.fallbackActive)
+        #expect(controller.fallbackSections.contains { $0.source == .commands })
+        #expect(!controller.fallbackSections.contains { $0.source == .menu })
+    }
+
+    @Test func fallbackOmitsMenuWhenMenuModeUnavailable() {
+        let controller = CommandPaletteController()
+        let wmController = makeCommandPaletteTestWMController()
+        controller.setMenuAvailabilityForTests(nil)
+        let command = makeCommandPaletteCommandItem(
+            id: "test.float",
+            title: "Toggle Floating",
+            searchTerms: ["float"]
+        )
+        let matchingMenu = makeCommandPaletteMenuItem(title: "Float")
+
+        controller.setFallbackStateForTests(.init(
+            wmController: wmController,
+            windows: [],
+            menuItems: [matchingMenu],
+            commands: [command],
+            selectedMode: .windows,
+            selectedItemID: nil,
+            hasLoadedMenuItems: true
+        ))
+        controller.searchText = "float"
+
+        #expect(controller.fallbackActive)
+        #expect(controller.fallbackSections.contains { $0.source == .commands })
+        #expect(!controller.fallbackSections.contains { $0.source == .menu })
+    }
+
+    @Test func fallbackIncludesMenuWhenAlreadyLoaded() async {
+        let matchingMenu = makeCommandPaletteMenuItem(title: "Float Panel")
+        var environment = CommandPaletteEnvironment()
+        environment.fetchMenuItems = { _ in [matchingMenu] }
+        let controller = CommandPaletteController(environment: environment)
+        let wmController = makeCommandPaletteTestWMController()
+        let target = makeCommandPaletteAppSnapshot(
+            pid: 610,
+            bundleIdentifier: "com.app",
+            localizedName: "App"
+        )
+
+        controller.setMenuLoadingStateForTests(wmController: wmController, target: target)
+        controller.loadMenuItemsForTests()
+
+        for _ in 0 ..< 200 {
+            if controller.menuItems.count == 1, !controller.isMenuLoading {
+                break
+            }
+            try? await Task.sleep(for: .milliseconds(5))
+        }
+
+        #expect(controller.menuItems.count == 1)
+        #expect(!controller.isMenuLoading)
+
+        controller.selectedMode = .windows
+        controller.searchText = "float"
+
+        #expect(controller.fallbackActive)
+        #expect(controller.fallbackSections.contains { $0.source == .menu })
+    }
+
+    @Test func noFallbackWhenActiveModeHasMatches() {
+        let controller = CommandPaletteController()
+        let wmController = makeCommandPaletteTestWMController()
+        let window = makeCommandPaletteWindowItem(windowId: 505)
+        let command = makeCommandPaletteCommandItem(
+            id: "test.window",
+            title: "Some Command",
+            searchTerms: ["window"]
+        )
+
+        controller.setFallbackStateForTests(.init(
+            wmController: wmController,
+            windows: [window],
+            menuItems: [],
+            commands: [command],
+            selectedMode: .windows,
+            selectedItemID: nil,
+            hasLoadedMenuItems: false
+        ))
+        controller.searchText = "Window"
+
+        #expect(!controller.fallbackActive)
+        #expect(controller.currentSelectionListForTests() == [.window(window.id)])
+    }
+
+    @Test func noFallbackWhenQueryIsEmpty() {
+        let controller = CommandPaletteController()
+        let wmController = makeCommandPaletteTestWMController()
+        let command = makeCommandPaletteCommandItem(
+            id: "test.float",
+            title: "Toggle Floating",
+            searchTerms: ["float"]
+        )
+
+        controller.setFallbackStateForTests(.init(
+            wmController: wmController,
+            windows: [],
+            menuItems: [],
+            commands: [command],
+            selectedMode: .windows,
+            selectedItemID: nil,
+            hasLoadedMenuItems: false
+        ))
+        controller.searchText = ""
+
+        #expect(!controller.fallbackActive)
+    }
+
+    @Test func trueEmptyStateWhenAllSourcesEmpty() {
+        let controller = CommandPaletteController()
+        let wmController = makeCommandPaletteTestWMController()
+
+        controller.setFallbackStateForTests(.init(
+            wmController: wmController,
+            windows: [],
+            menuItems: [],
+            commands: [],
+            selectedMode: .windows,
+            selectedItemID: nil,
+            hasLoadedMenuItems: false
+        ))
+        controller.searchText = "zzzz"
+
+        #expect(!controller.fallbackActive)
+        #expect(controller.activeModeFilteredIsEmpty)
+    }
+
+    @Test func fallbackSelectionAdvancesToFirstHit() {
+        let controller = CommandPaletteController()
+        let wmController = makeCommandPaletteTestWMController()
+        let firstCommand = makeCommandPaletteCommandItem(
+            id: "test.alpha",
+            title: "Alpha Float",
+            searchTerms: ["float"]
+        )
+        let secondCommand = makeCommandPaletteCommandItem(
+            id: "test.beta",
+            title: "Beta Float",
+            searchTerms: ["float"]
+        )
+
+        controller.setFallbackStateForTests(.init(
+            wmController: wmController,
+            windows: [],
+            menuItems: [],
+            commands: [firstCommand, secondCommand],
+            selectedMode: .windows,
+            selectedItemID: nil,
+            hasLoadedMenuItems: false
+        ))
+        controller.searchText = "float"
+
+        #expect(controller.fallbackActive)
+        #expect(controller.selectedItemID == .command(firstCommand.id))
+    }
+
+    @Test func resolvedSelectionActionUnchangedWhenFallbackInactiveWindows() {
+        let controller = CommandPaletteController()
+        let wmController = makeCommandPaletteTestWMController()
+        let window = makeCommandPaletteWindowItem(windowId: 707)
+
+        controller.setFallbackStateForTests(.init(
+            wmController: wmController,
+            windows: [window],
+            menuItems: [],
+            commands: [],
+            selectedMode: .windows,
+            selectedItemID: .window(window.id),
+            hasLoadedMenuItems: false
+        ))
+        controller.searchText = "Window"
+
+        #expect(!controller.fallbackActive)
+        let kind = controller.resolvedSelectionActionKindForTests(trigger: .primary)
+        #expect(kind == .navigateWindow)
+    }
+
+    @Test func resolvedSelectionActionUnchangedWhenFallbackInactiveCommands() {
+        let controller = CommandPaletteController()
+        let wmController = makeCommandPaletteTestWMController()
+        let command = makeCommandPaletteCommandItem(
+            id: "test.float",
+            title: "Toggle Floating",
+            searchTerms: ["float"]
+        )
+
+        controller.setFallbackStateForTests(.init(
+            wmController: wmController,
+            windows: [],
+            menuItems: [],
+            commands: [command],
+            selectedMode: .commands,
+            selectedItemID: .command(command.id),
+            hasLoadedMenuItems: false
+        ))
+        controller.searchText = "float"
+
+        #expect(!controller.fallbackActive)
+        let kind = controller.resolvedSelectionActionKindForTests(trigger: .primary)
+        #expect(kind == .executeCommand)
     }
 }


### PR DESCRIPTION
## Summary

When the active source has no matches for a non-empty query, the palette now surfaces matching Windows/Commands/Menu items from the other sources as a sectioned list, and dispatches across sources without switching tabs.

Menu is included only when already loaded (no eager AX cost). Dispatch is generalized to resolve from the selection's source tag rather than the active mode, so a fallback hit dispatches correctly while the active tab stays selected.

## Release notes

Choose one:

- [x] Added a `.changeset/*.md` for user-visible changes (`mise run changeset -- patch "..."`).
- [ ] No user-visible change; apply the `no release note` label to make CI skip intentional.

## Validation

<!-- Commands run, screenshots, or manual checks. -->

- [ ] Ran relevant tests/checks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Command palette now falls back to matching Windows, Commands, and Menus when the currently active source has no results for your trimmed query, surfacing relevant hits instead of showing an empty state.

* **Bug Fixes**
  * Improved keyboard selection and action resolution during fallback so selecting results executes/navigates the correct item from the fallback sources.

* **Tests**
  * Added unit tests covering fallback activation, mixed source availability (including menu loading), selection advancement, and empty/no-fallback scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->