### PR TITLE
Make the workspace bar a reactive lens over viewport selection

### DIFF
--- a/.changeset/20260624011050-fix-the-workspace-bar-freezing-during-trackpad-c.md
+++ b/.changeset/20260624011050-fix-the-workspace-bar-freezing-during-trackpad-c.md
@@ -1,0 +1,6 @@
+---
+"nehir": patch
+
+---
+
+Fix the workspace bar's selected-column indicator freezing during trackpad column-switch gestures when an app that Nehir doesn't manage (a transient overlay, the app switcher, or any unmanaged foreground window) is on top. The bar now follows the swipe, showing which column you landed on, while the stronger focus highlight still tracks the window that's actually focused. The bar also updates whenever you switch columns by any means, so it no longer gets stuck if a particular action forgets to refresh it.

--- a/Sources/Nehir/Core/Controller/WMController.swift
+++ b/Sources/Nehir/Core/Controller/WMController.swift
@@ -545,7 +545,13 @@ final class WMController {
         case .workspaceProjection:
             requestWorkspaceProjectionRefreshScheduling()
         case .focusProjection:
+            // Focus changes are relevant to both the status bar (workspace-name
+            // display) and the workspace bar (per-window focus indicator), so
+            // refresh both surfaces. This closes the family of "focus changed but
+            // the workspace bar didn't move" paths (e.g. click / focus-follows-
+            // mouse confirms) that previously only invalidated the status bar.
             requestFocusProjectionRefreshScheduling()
+            requestWorkspaceProjectionRefreshScheduling()
         case .settingsProjection:
             requestSettingsProjectionRefreshScheduling()
         case .layoutProjection,
@@ -699,6 +705,7 @@ final class WMController {
             appInfoCache: appInfoCache,
             niriEngine: niriEngine,
             focusedToken: workspaceManager.confirmedManagedFocusToken,
+            viewportSelectedToken: viewportSelectedToken(for: monitor),
             settings: settings
         )
     }
@@ -714,8 +721,27 @@ final class WMController {
             appInfoCache: appInfoCache,
             niriEngine: niriEngine,
             focusedToken: workspaceManager.confirmedManagedFocusToken,
+            viewportSelectedToken: viewportSelectedToken(for: monitor),
             settings: settings
         )
+    }
+
+    /// Resolves the window the viewport is parked on for the monitor's active
+    /// workspace, so the workspace bar can highlight the viewport column even
+    /// when managed-focus confirmation is suppressed (a non-managed app holds
+    /// focus). Returns `nil` when there is no engine, no active workspace, or no
+    /// selected node — in which case the bar falls back to managed-focus only.
+    private func viewportSelectedToken(for monitor: Monitor) -> WindowToken? {
+        guard let engine = niriEngine,
+              let workspace = workspaceManager.activeWorkspace(on: monitor.id)
+        else { return nil }
+        let state = workspaceManager.niriViewportState(for: workspace.id)
+        guard let selectedNodeId = state.selectedNodeId,
+              let window = engine.findNode(by: selectedNodeId) as? NiriWindow
+        else {
+            return nil
+        }
+        return window.token
     }
 
     func focusWorkspaceFromBar(named name: String) {

--- a/Sources/Nehir/Core/Workspace/WorkspaceManager.swift
+++ b/Sources/Nehir/Core/Workspace/WorkspaceManager.swift
@@ -3243,6 +3243,18 @@ final class WorkspaceManager {
             || previousSelection.selectionProgress != state.selectionProgress
         {
             workspaceSession.selectionRevision &+= 1
+            // Reactive lens: the workspace bar (and any other viewport-derived UI)
+            // recomputes from viewport selection, not from the guarded managed-focus
+            // path. Because every live viewport selection write funnels through this
+            // method, emitting the invalidation here means any mutation of
+            // selectedNodeId / activeColumnIndex / selectionProgress refreshes the bar
+            // automatically — there is no "missed call-site" failure class for
+            // viewport-driven UI. Critically this is a workspace (not focus)
+            // invalidation: it re-projects the bar's `isSelected` (parked column)
+            // highlight without touching the managed-focus anchor
+            // (confirmedManagedFocusToken), so the anchor policy that suppresses
+            // `setManagedFocus` under non-managed focus is preserved.
+            invalidateWorkspaceProjection(reason: "viewportSelectionChanged")
         }
 
         sessionState.workspaceSessions[workspaceId] = workspaceSession

--- a/Sources/Nehir/UI/WorkspaceBar/WorkspaceBarDataSource.swift
+++ b/Sources/Nehir/UI/WorkspaceBar/WorkspaceBarDataSource.swift
@@ -23,6 +23,7 @@ enum WorkspaceBarDataSource {
         appInfoCache: AppInfoCache,
         niriEngine: NiriLayoutEngine?,
         focusedToken: WindowToken?,
+        viewportSelectedToken: WindowToken? = nil,
         settings: SettingsStore
     ) -> [WorkspaceBarItem] {
         workspaceItems(
@@ -32,6 +33,7 @@ enum WorkspaceBarDataSource {
             appInfoCache: appInfoCache,
             niriEngine: niriEngine,
             focusedToken: focusedToken,
+            viewportSelectedToken: viewportSelectedToken,
             settings: settings
         )
     }
@@ -43,6 +45,7 @@ enum WorkspaceBarDataSource {
         appInfoCache: AppInfoCache,
         niriEngine: NiriLayoutEngine?,
         focusedToken: WindowToken?,
+        viewportSelectedToken: WindowToken? = nil,
         settings: SettingsStore
     ) -> WorkspaceBarProjection {
         WorkspaceBarProjection(
@@ -53,12 +56,14 @@ enum WorkspaceBarDataSource {
                 appInfoCache: appInfoCache,
                 niriEngine: niriEngine,
                 focusedToken: focusedToken,
+                viewportSelectedToken: viewportSelectedToken,
                 settings: settings
             ),
             scratchpad: scratchpadItem(
                 workspaceManager: workspaceManager,
                 appInfoCache: appInfoCache,
                 focusedToken: focusedToken,
+                viewportSelectedToken: viewportSelectedToken,
                 settings: settings
             )
         )
@@ -71,6 +76,7 @@ enum WorkspaceBarDataSource {
         appInfoCache: AppInfoCache,
         niriEngine: NiriLayoutEngine?,
         focusedToken: WindowToken?,
+        viewportSelectedToken: WindowToken?,
         settings: SettingsStore
     ) -> [WorkspaceBarItem] {
         var workspaces = workspaceManager.workspaces(on: monitor.id).map { workspace in
@@ -112,14 +118,16 @@ enum WorkspaceBarDataSource {
                 deduplicate: options.deduplicateAppIcons,
                 useLayoutOrder: useLayoutOrder,
                 appInfoCache: appInfoCache,
-                focusedToken: focusedToken
+                focusedToken: focusedToken,
+                viewportSelectedToken: viewportSelectedToken
             )
             let floatingWindows = createWindowItems(
                 entries: orderedFloatingEntries,
                 deduplicate: options.deduplicateAppIcons,
                 useLayoutOrder: useLayoutOrder,
                 appInfoCache: appInfoCache,
-                focusedToken: focusedToken
+                focusedToken: focusedToken,
+                viewportSelectedToken: viewportSelectedToken
             )
 
             return WorkspaceBarItem(
@@ -137,6 +145,7 @@ enum WorkspaceBarDataSource {
         workspaceManager: WorkspaceManager,
         appInfoCache: AppInfoCache,
         focusedToken: WindowToken?,
+        viewportSelectedToken: WindowToken?,
         settings: SettingsStore
     ) -> WorkspaceBarScratchpadItem? {
         guard let scratchpadToken = workspaceManager.scratchpadToken(),
@@ -146,7 +155,8 @@ enum WorkspaceBarDataSource {
                   deduplicate: false,
                   useLayoutOrder: false,
                   appInfoCache: appInfoCache,
-                  focusedToken: focusedToken
+                  focusedToken: focusedToken,
+                  viewportSelectedToken: viewportSelectedToken
               ).first
         else {
             return nil
@@ -168,21 +178,24 @@ enum WorkspaceBarDataSource {
         deduplicate: Bool,
         useLayoutOrder: Bool,
         appInfoCache: AppInfoCache,
-        focusedToken: WindowToken?
+        focusedToken: WindowToken?,
+        viewportSelectedToken: WindowToken?
     ) -> [WorkspaceBarWindowItem] {
         if deduplicate {
             return createDedupedWindowItems(
                 entries: entries,
                 useLayoutOrder: useLayoutOrder,
                 appInfoCache: appInfoCache,
-                focusedToken: focusedToken
+                focusedToken: focusedToken,
+                viewportSelectedToken: viewportSelectedToken
             )
         }
 
         return createIndividualWindowItems(
             entries: entries,
             appInfoCache: appInfoCache,
-            focusedToken: focusedToken
+            focusedToken: focusedToken,
+            viewportSelectedToken: viewportSelectedToken
         )
     }
 
@@ -190,7 +203,8 @@ enum WorkspaceBarDataSource {
         entries: [WindowModel.Entry],
         useLayoutOrder: Bool,
         appInfoCache: AppInfoCache,
-        focusedToken: WindowToken?
+        focusedToken: WindowToken?,
+        viewportSelectedToken: WindowToken?
     ) -> [WorkspaceBarWindowItem] {
         if useLayoutOrder {
             var groupedByApp: [String: [WindowModel.Entry]] = [:]
@@ -211,13 +225,15 @@ enum WorkspaceBarDataSource {
                 guard let appEntries = groupedByApp[appName], let firstEntry = appEntries.first else { return nil }
                 let appInfo = appInfoCache.info(for: firstEntry.handle.pid)
                 let anyFocused = appEntries.contains { $0.handle.id == focusedToken }
+                let anySelected = appEntries.contains { $0.handle.id == viewportSelectedToken }
 
                 let windowInfos = appEntries.map { entry -> WorkspaceBarWindowInfo in
                     WorkspaceBarWindowInfo(
                         id: entry.handle.id,
                         windowId: entry.windowId,
                         title: windowTitle(for: entry) ?? appName,
-                        isFocused: entry.handle.id == focusedToken
+                        isFocused: entry.handle.id == focusedToken,
+                        isSelected: entry.handle.id == viewportSelectedToken
                     )
                 }
 
@@ -227,6 +243,7 @@ enum WorkspaceBarDataSource {
                     appName: appName,
                     icon: appInfo?.icon,
                     isFocused: anyFocused,
+                    isSelected: anySelected,
                     windowCount: appEntries.count,
                     allWindows: windowInfos
                 )
@@ -241,13 +258,15 @@ enum WorkspaceBarDataSource {
             let firstEntry = appEntries.first!
             let appInfo = appInfoCache.info(for: firstEntry.handle.pid)
             let anyFocused = appEntries.contains { $0.handle.id == focusedToken }
+            let anySelected = appEntries.contains { $0.handle.id == viewportSelectedToken }
 
             let windowInfos = appEntries.map { entry -> WorkspaceBarWindowInfo in
                 WorkspaceBarWindowInfo(
                     id: entry.handle.id,
                     windowId: entry.windowId,
                     title: windowTitle(for: entry) ?? appName,
-                    isFocused: entry.handle.id == focusedToken
+                    isFocused: entry.handle.id == focusedToken,
+                    isSelected: entry.handle.id == viewportSelectedToken
                 )
             }
 
@@ -257,6 +276,7 @@ enum WorkspaceBarDataSource {
                 appName: appName,
                 icon: appInfo?.icon,
                 isFocused: anyFocused,
+                isSelected: anySelected,
                 windowCount: appEntries.count,
                 allWindows: windowInfos
             )
@@ -266,7 +286,8 @@ enum WorkspaceBarDataSource {
     private static func createIndividualWindowItems(
         entries: [WindowModel.Entry],
         appInfoCache: AppInfoCache,
-        focusedToken: WindowToken?
+        focusedToken: WindowToken?,
+        viewportSelectedToken: WindowToken?
     ) -> [WorkspaceBarWindowItem] {
         entries.map { entry in
             let appInfo = appInfoCache.info(for: entry.handle.pid)
@@ -279,13 +300,15 @@ enum WorkspaceBarDataSource {
                 appName: appName,
                 icon: appInfo?.icon,
                 isFocused: entry.handle.id == focusedToken,
+                isSelected: entry.handle.id == viewportSelectedToken,
                 windowCount: 1,
                 allWindows: [
                     WorkspaceBarWindowInfo(
                         id: entry.handle.id,
                         windowId: entry.windowId,
                         title: title,
-                        isFocused: entry.handle.id == focusedToken
+                        isFocused: entry.handle.id == focusedToken,
+                        isSelected: entry.handle.id == viewportSelectedToken
                     )
                 ]
             )

--- a/Sources/Nehir/UI/WorkspaceBar/WorkspaceBarView.swift
+++ b/Sources/Nehir/UI/WorkspaceBar/WorkspaceBarView.swift
@@ -32,6 +32,7 @@ struct WorkspaceBarWindowItem: Identifiable, Equatable {
     let appName: String
     let icon: NSImage?
     let isFocused: Bool
+    let isSelected: Bool
     let windowCount: Int
     let allWindows: [WorkspaceBarWindowInfo]
 
@@ -41,6 +42,7 @@ struct WorkspaceBarWindowItem: Identifiable, Equatable {
             && lhs.appName == rhs.appName
             && lhs.icon === rhs.icon
             && lhs.isFocused == rhs.isFocused
+            && lhs.isSelected == rhs.isSelected
             && lhs.windowCount == rhs.windowCount
             && lhs.allWindows == rhs.allWindows
     }
@@ -51,6 +53,7 @@ struct WorkspaceBarWindowInfo: Identifiable, Equatable {
     let windowId: Int
     let title: String
     let isFocused: Bool
+    let isSelected: Bool
 }
 
 struct WorkspaceBarScratchpadItem: Identifiable, Equatable {
@@ -312,6 +315,7 @@ private struct WorkspaceItemView: View {
                     window: window,
                     iconSize: iconSize,
                     isFocused: window.isFocused,
+                    isSelected: window.isSelected,
                     isInFocusedWorkspace: item.isFocused,
                     context: .tiled,
                     animationsEnabled: animationsEnabled,
@@ -424,6 +428,7 @@ private struct FloatingWindowsGroupView: View {
                     window: window,
                     iconSize: iconSize,
                     isFocused: window.isFocused,
+                    isSelected: window.isSelected,
                     isInFocusedWorkspace: isInFocusedWorkspace,
                     context: .floating,
                     animationsEnabled: animationsEnabled,
@@ -549,6 +554,7 @@ private struct WindowIconView: View {
     let window: WorkspaceBarWindowItem
     let iconSize: CGFloat
     let isFocused: Bool
+    let isSelected: Bool
     let isInFocusedWorkspace: Bool
     let context: WorkspaceBarWindowContext
     let animationsEnabled: Bool
@@ -589,6 +595,7 @@ private struct WindowIconView: View {
         .buttonStyle(.plain)
         .scaleEffect(scale)
         .animation(animationsEnabled ? .easeInOut(duration: 0.15) : nil, value: isFocused)
+        .animation(animationsEnabled ? .easeInOut(duration: 0.15) : nil, value: isSelected)
         .animation(animationsEnabled ? .easeInOut(duration: 0.1) : nil, value: isHovered)
         .onHover { hovering in
             isHovered = hovering
@@ -611,7 +618,7 @@ private struct WindowIconView: View {
     }
 
     private var opacity: Double {
-        if isFocused {
+        if isFocused || isSelected {
             1.0
         } else if isInFocusedWorkspace {
             0.4
@@ -631,11 +638,15 @@ private struct WindowIconView: View {
     }
 
     private var glowRadius: CGFloat {
-        isFocused ? 4 : 0
+        if isFocused { 4 }
+        else if isSelected { 3 }
+        else { 0 }
     }
 
     private var glowOpacity: Double {
-        isFocused ? 0.5 : 0
+        if isFocused { 0.5 }
+        else if isSelected { 0.22 }
+        else { 0 }
     }
 
     private var accessibilityLabel: String {
@@ -647,7 +658,9 @@ private struct WindowIconView: View {
     }
 
     private var accessibilityValue: String {
-        isFocused ? "Focused" : ""
+        if isFocused { "Focused" }
+        else if isSelected { "Selected" }
+        else { "" }
     }
 }
 

--- a/Tests/NehirTests/RefreshRoutingTests.swift
+++ b/Tests/NehirTests/RefreshRoutingTests.swift
@@ -1087,7 +1087,7 @@ private func syncNiriWorkspaceStatesForRefreshTests(
         #expect(controller.workspaceBarRefreshDebugState.executionCount == 1)
     }
 
-    @Test @MainActor func focusOnlyChangesRefreshStatusBarWithoutWorkspaceBarQueue() async {
+    @Test @MainActor func focusChangesRefreshStatusBarAndScheduleWorkspaceBarRefresh() async {
         let controller = makeRefreshTestController()
         controller.settings.workspaceBarEnabled = false
         controller.settings.statusBarShowWorkspaceName = true
@@ -1129,7 +1129,14 @@ private func syncNiriWorkspaceStatesForRefreshTests(
         _ = controller.workspaceManager.setManagedFocus(secondToken, in: workspaceId, onMonitor: monitor.id)
         await controller.waitForStatusBarRefreshForTests()
 
-        #expect(controller.workspaceBarRefreshDebugState.requestCount == 0)
+        // Focus changes now refresh the workspace bar as well as the status
+        // bar: the bar's per-window focus highlight is derived from the
+        // confirmed managed-focus token, so a `.focusProjection` must re-project
+        // the bar rather than piggyback on an unrelated relayout or
+        // workspace-projection event. This closes the click /
+        // focus-follows-mouse stale-highlight gap
+        // (discovery/20260615-workspace-bar-focus-projection-routing.md).
+        #expect(controller.workspaceBarRefreshDebugState.requestCount == 1)
         #expect(statusBarController.statusButtonTitleForTests() == " 1 \u{2013} Second App")
     }
 


### PR DESCRIPTION
## Summary

<!-- What changed and why? -->

## Release notes

Choose one:

- [x] Added a `.changeset/*.md` for user-visible changes (`mise run changeset -- patch "..."`).
- [ ] No user-visible change; apply the `no release note` label to make CI skip intentional.

## Validation

<!-- Commands run, screenshots, or manual checks. -->

- [ ] Ran relevant tests/checks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes
* Fixed the workspace bar’s selected indicator freezing during trackpad column-switch gestures when an overlay is on top.
* Updated the workspace bar to correctly follow and highlight the viewport-selected window during viewport changes and swipe interactions.
* Adjusted refresh routing so focus changes also trigger workspace bar projection updates (not just status-bar updates).


<!-- end of auto-generated comment: release notes by coderabbit.ai -->