### PR TITLE
Keep PiP visible across workspace switches (#108)

### DIFF
--- a/.changeset/20260624140629-keep-pip-windows-visible-across-workspace-switch.md
+++ b/.changeset/20260624140629-keep-pip-windows-visible-across-workspace-switch.md
@@ -1,0 +1,6 @@
+---
+"nehir": patch
+
+---
+
+Keep PiP windows visible across workspace switches (#108)

--- a/.provenance.json
+++ b/.provenance.json
@@ -95,8 +95,12 @@
     "Sources/Nehir/Core/Config/MonitorGapSettings.swift": [
       {"repo": "https://github.com/BarutSRB/OmniWM", "hash": "dacccb8"}
     ],
+    "Sources/Nehir/Core/Controller/AXEventHandler.swift": [
+      {"repo": "https://github.com/BarutSRB/OmniWM", "hash": "ee554c7"}
+    ],
     "Sources/Nehir/Core/Controller/LayoutRefreshController.swift": [
-      {"repo": "https://github.com/BarutSRB/OmniWM", "hash": "2dcab36"}
+      {"repo": "https://github.com/BarutSRB/OmniWM", "hash": "2dcab36"},
+      {"repo": "https://github.com/BarutSRB/OmniWM", "hash": "ee554c7"}
     ],
     "Sources/Nehir/Core/Controller/WMController.swift": [
       {"repo": "https://github.com/BarutSRB/OmniWM", "hash": "713280e"}
@@ -114,7 +118,11 @@
       {"repo": "https://github.com/BarutSRB/OmniWM", "hash": "ee554c7"}
     ],
     "Sources/Nehir/Core/SkyLight/SpaceTopology.swift": [
-      {"repo": "https://github.com/BarutSRB/OmniWM", "hash": "e5e368d"}
+      {"repo": "https://github.com/BarutSRB/OmniWM", "hash": "e5e368d"},
+      {"repo": "https://github.com/BarutSRB/OmniWM", "hash": "ee554c7"}
+    ],
+    "Sources/Nehir/Core/Workspace/WorkspaceManager.swift": [
+      {"repo": "https://github.com/BarutSRB/OmniWM", "hash": "ee554c7"}
     ]
   }
 }

--- a/Sources/Nehir/Core/Controller/AXEventHandler.swift
+++ b/Sources/Nehir/Core/Controller/AXEventHandler.swift
@@ -518,12 +518,15 @@ final class AXEventHandler: CGSEventDelegate {
         switch event {
         case let .created(windowId, spaceId):
             handleCGSWindowCreated(windowId: windowId, spaceId: spaceId)
+            controller.workspaceManager.noteNativeSpace(windowId: windowId, spaceId: spaceId)
 
         case let .destroyed(windowId, _):
             handleCGSWindowDestroyed(windowId: windowId)
+            controller.workspaceManager.forgetNativeSpace(windowId: windowId)
 
         case let .closed(windowId):
             handleCGSWindowDestroyed(windowId: windowId)
+            controller.workspaceManager.forgetNativeSpace(windowId: windowId)
 
         case let .frameChanged(windowId):
             handleFrameChanged(windowId: windowId)

--- a/Sources/Nehir/Core/Controller/LayoutRefreshController.swift
+++ b/Sources/Nehir/Core/Controller/LayoutRefreshController.swift
@@ -701,6 +701,43 @@ import QuartzCore
         return SpaceTopology.current(monitors: monitors, windowIds: windowIds)
     }
 
+    /// Collects the tokens of windows the given topology reports as present on every
+    /// known Space (global / `canJoinAllSpaces` windows).
+    private func globalStickyWindowTokens(
+        from entries: [WindowModel.Entry],
+        spaceTopology: SpaceTopology
+    ) -> Set<WindowToken> {
+        var tokens = Set<WindowToken>()
+        for entry in entries {
+            guard let windowId = UInt32(exactly: entry.windowId),
+                  spaceTopology.isWindowOnAllKnownSpaces(windowId: windowId)
+            else { continue }
+            tokens.insert(entry.token)
+        }
+        return tokens
+    }
+
+    /// Collects the tokens of windows whose native macOS Space is known and inactive.
+    /// This mirrors upstream OmniWM's hide-path guard: if the system already places a
+    /// surface on an inactive native Space, Nehir should not also park it offscreen.
+    private func nativeInactiveWindowTokens(
+        from entries: [WindowModel.Entry],
+        spaceTopology: SpaceTopology
+    ) -> Set<WindowToken> {
+        guard let controller else { return [] }
+        var tokens = Set<WindowToken>()
+        for entry in entries {
+            guard let windowId = UInt32(exactly: entry.windowId),
+                  spaceTopology.isWindowOnKnownInactiveNativeSpace(
+                      windowId: windowId,
+                      preferredSpaceId: controller.workspaceManager.nativeSpaceId(for: entry.windowId)
+                  )
+            else { continue }
+            tokens.insert(entry.token)
+        }
+        return tokens
+    }
+
     func spaceTopologyDebugDump() -> String {
         lastSpaceTopologyDebugSummary
     }
@@ -1443,7 +1480,21 @@ import QuartzCore
             monitors: controller.workspaceManager.monitors,
             trackedEntries: trackedEntries
         )
+        let globalStickyTokens = globalStickyWindowTokens(
+            from: trackedEntries,
+            spaceTopology: spaceTopology
+        )
+        let nativeInactiveTokens = nativeInactiveWindowTokens(
+            from: trackedEntries,
+            spaceTopology: spaceTopology
+        )
         lastSpaceTopologyDebugSummary = spaceTopology.debugSummary
+            + " globalSticky=\(globalStickyTokens.count) nativeInactive=\(nativeInactiveTokens.count)"
+        // Refresh the WorkspaceManager's set of global (all-Spaces) windows so the
+        // floating-resolution path can treat them as sticky across workspaces (Lever 2).
+        // Computed on every full rescan so the set stays fresh between switches.
+        controller.workspaceManager.setGlobalStickyWindowTokens(globalStickyTokens)
+        controller.workspaceManager.setNativeInactiveWindowTokens(nativeInactiveTokens)
         if shouldPreserveMissingWindows {
             // Native macOS fullscreen moves the app onto its own Space, so visible-window
             // enumeration temporarily excludes the rest of the managed workspace.
@@ -1468,7 +1519,10 @@ import QuartzCore
             var inactiveSpaceExemptions = 0
             for entry in trackedEntries {
                 guard let windowId = UInt32(exactly: entry.windowId),
-                      spaceTopology.isWindowOnKnownInactiveSpace(windowId: windowId)
+                      spaceTopology.isWindowOnKnownInactiveNativeSpace(
+                          windowId: windowId,
+                          preferredSpaceId: controller.workspaceManager.nativeSpaceId(for: entry.windowId)
+                      )
                 else { continue }
                 seenKeys.insert(.init(pid: entry.handle.pid, windowId: entry.windowId))
                 inactiveSpaceExemptions += 1
@@ -2214,6 +2268,15 @@ import QuartzCore
 
     func hideInactiveWorkspaces(activeWorkspaceIds: Set<WorkspaceDescriptor.ID>) {
         guard let controller else { return }
+        // Before taking the visibility snapshot, re-anchor any window macOS reports as
+        // global (present on every known Space, e.g. a browser Picture-in-Picture) to
+        // the active workspace on the monitor it is actually displayed on. Such a window
+        // is shown by macOS on every Space, so parking it offscreen when its original
+        // Nehir workspace goes inactive is exactly the #108 "disappears" symptom, and
+        // leaving its workspaceId pointing at the now-inactive workspace would leave it
+        // logically inactive-while-visible (the bleed/drift family). Re-anchoring here
+        // keeps the snapshot, the frame-suppression set, and the hide loop all coherent.
+        reanchorGlobalWindowsToActiveWorkspaces(activeWorkspaceIds: activeWorkspaceIds)
         let workspaceEntries = workspaceEntriesSnapshot(on: controller)
 
         // Rebuild the workspace-level frame suppression set (live check in applyFramesParallel).
@@ -2270,6 +2333,93 @@ import QuartzCore
         }
     }
 
+    /// Re-anchors windows macOS reports as global (present on every known Space) to
+    /// the active workspace on the monitor they are actually displayed on.
+    ///
+    /// A global window (e.g. a browser Picture-in-Picture with
+    /// `collectionBehavior = .canJoinAllSpaces`) is kept on-screen by macOS across
+    /// every Space. Nehir must not fight that: it must never park such a window when
+    /// its original Nehir workspace goes inactive, and it must keep the model coherent
+    /// so the window is never logically inactive-while-visible.
+    ///
+    /// This recomputes `SpaceTopology`, and for every entry that is present on all
+    /// known Spaces it (1) re-binds its `workspaceId` to the active workspace on the
+    /// monitor its live frame is on (so it belongs to an active workspace), (2)
+    /// refreshes its floating geometry to that live frame (so the floating resolver
+    /// keeps it on that monitor instead of snapping it back), (3) clears any stale
+    /// hide state, and (4) marks it active so its frame writes are not suppressed.
+    /// It also publishes the resulting global-token set to `WorkspaceManager` so the
+    /// floating-resolution path can treat these windows specially (Lever 2).
+    ///
+    /// Only discriminates when `knownSpaceIds.count > 1` (multi-display "Displays have
+    /// separate Spaces"). On a single display every window reports the one active
+    /// Space, so this is a no-op there.
+    private func reanchorGlobalWindowsToActiveWorkspaces(
+        activeWorkspaceIds: Set<WorkspaceDescriptor.ID>
+    ) {
+        guard let controller else { return }
+        let monitors = controller.workspaceManager.monitors
+        let trackedEntries = controller.workspaceManager.allEntries()
+        let spaceTopology = currentSpaceTopology(
+            monitors: monitors,
+            trackedEntries: trackedEntries
+        )
+
+        let globalTokens = globalStickyWindowTokens(
+            from: trackedEntries,
+            spaceTopology: spaceTopology
+        )
+        let nativeInactiveTokens = nativeInactiveWindowTokens(
+            from: trackedEntries,
+            spaceTopology: spaceTopology
+        )
+        lastSpaceTopologyDebugSummary = spaceTopology.debugSummary
+            + " globalSticky=\(globalTokens.count) nativeInactive=\(nativeInactiveTokens.count)"
+        if !nativeInactiveTokens.isEmpty {
+            lastSpaceTopologyDebugSummary += " exempted=\(nativeInactiveTokens.count)"
+        }
+        controller.workspaceManager.setGlobalStickyWindowTokens(globalTokens)
+        controller.workspaceManager.setNativeInactiveWindowTokens(nativeInactiveTokens)
+
+        for entry in trackedEntries where globalTokens.contains(entry.token) {
+            let liveFrame = fastFrame(for: entry.token, axRef: entry.axRef)
+            let physicalMonitor = liveFrame?.center.monitorApproximation(in: monitors)
+                ?? controller.workspaceManager.monitor(for: entry.workspaceId)
+            let targetWorkspaceId = physicalMonitor
+                .flatMap { activeWorkspaceId(on: $0.id, among: activeWorkspaceIds) }
+
+            if let targetWorkspaceId, targetWorkspaceId != entry.workspaceId {
+                controller.workspaceManager.setWorkspace(for: entry.token, to: targetWorkspaceId)
+            }
+            if let liveFrame {
+                controller.workspaceManager.updateFloatingGeometry(
+                    frame: liveFrame,
+                    for: entry.token
+                )
+            }
+            // A global window is never parked offscreen; clear any stale hide state
+            // and make sure its frame writes are not suppressed as inactive-workspace.
+            controller.workspaceManager.setHiddenState(nil, for: entry.token)
+            controller.axManager.unsuppressFrameWrites([(entry.pid, entry.windowId)])
+            controller.axManager.markWindowActive(entry.windowId)
+        }
+    }
+
+    /// Resolves which of the given active workspace IDs lives on a monitor, without
+    /// depending on `WorkspaceManager`'s active-workspace state being committed yet.
+    private func activeWorkspaceId(
+        on monitorId: Monitor.ID,
+        among activeWorkspaceIds: Set<WorkspaceDescriptor.ID>
+    ) -> WorkspaceDescriptor.ID? {
+        guard let controller else { return nil }
+        for workspaceId in activeWorkspaceIds
+            where controller.workspaceManager.monitor(for: workspaceId)?.id == monitorId
+        {
+            return workspaceId
+        }
+        return nil
+    }
+
     private func hideWorkspace(
         _ entries: [WindowModel.Entry],
         monitor: Monitor,
@@ -2281,7 +2431,27 @@ import QuartzCore
             guard controller.workspaceManager.layoutReason(for: entry.token) != .nativeFullscreen else {
                 continue
             }
+            // Lever 1: a window macOS reports as present on every known Space (e.g. a
+            // browser Picture-in-Picture) must never be parked offscreen when a Nehir
+            // workspace goes inactive — macOS is deliberately showing it on every
+            // Space. `reanchorGlobalWindowsToActiveWorkspaces` normally moves such a
+            // window into the active workspace before this point, so this guard is the
+            // defensive backstop that keeps the window visible and active if it reaches
+            // the hide path bound to an inactive workspace.
+            if controller.workspaceManager.isGlobalStickyWindow(entry.token) {
+                controller.workspaceManager.setHiddenState(nil, for: entry.token)
+                controller.axManager.unsuppressFrameWrites([(entry.pid, entry.windowId)])
+                controller.axManager.markWindowActive(entry.windowId)
+                continue
+            }
             controller.axManager.markWindowInactive(entry.windowId)
+            // Upstream OmniWM guard: if the window belongs to a known inactive native
+            // macOS Space already, do not also park it offscreen for Nehir's virtual
+            // workspace switch. It remains inactive from Nehir's perspective, but the
+            // system is responsible for showing it only on its native Space.
+            if controller.workspaceManager.isNativeInactiveWindow(entry.token) {
+                continue
+            }
             // Skip moving windows already hidden offscreen by the layout engine.
             // They're already parked — no need to shuffle them to the other side.
             if let hiddenState = controller.workspaceManager.hiddenState(for: entry.token) {
@@ -2336,7 +2506,9 @@ import QuartzCore
         let entries = controller.workspaceManager.allEntries()
         let lines = entries.compactMap { entry -> String? in
             guard let hiddenState = controller.workspaceManager.hiddenState(for: entry.token),
-                  hiddenState.workspaceInactive
+                  hiddenState.workspaceInactive,
+                  // Global (all-Spaces) windows are intentionally visible across switches.
+                  !controller.workspaceManager.isGlobalStickyWindow(entry.token)
             else { return nil }
             let monitor = controller.workspaceManager.monitor(for: entry.workspaceId)
                 ?? hiddenState.referenceMonitorId.flatMap { controller.workspaceManager.monitor(byId: $0) }
@@ -2381,6 +2553,9 @@ import QuartzCore
         if requireTraceCapture {
             guard controller.isRuntimeTraceCaptureActive else { return nil }
         }
+        // A global (all-Spaces) window is deliberately left visible across workspace
+        // switches; it must never be accused as inactive-while-visible bleed.
+        guard !controller.workspaceManager.isGlobalStickyWindow(entry.token) else { return nil }
         guard hiddenState.workspaceInactive else { return nil }
         guard let liveFrame = AXWindowService.framePreferFast(entry.axRef)
             ?? (try? AXWindowService.frame(entry.axRef))

--- a/Sources/Nehir/Core/SkyLight/SpaceTopology.swift
+++ b/Sources/Nehir/Core/SkyLight/SpaceTopology.swift
@@ -31,6 +31,12 @@ struct SpaceTopology: Equatable, Sendable {
         mode == .enabled && !activeSpaceIdsByDisplayId.isEmpty && !knownSpaceIds.isEmpty
     }
 
+    func isKnownInactiveSpace(_ spaceId: UInt64) -> Bool {
+        guard isEnabledAndPopulated, spaceId != 0 else { return false }
+        return knownSpaceIds.contains(spaceId)
+            && !Set(activeSpaceIdsByDisplayId.values).contains(spaceId)
+    }
+
     func isWindowOnKnownInactiveSpace(windowId: UInt32) -> Bool {
         guard isEnabledAndPopulated,
               let candidates = spaceIdsByWindowId[windowId],
@@ -44,6 +50,38 @@ struct SpaceTopology: Equatable, Sendable {
 
         let knownCandidates = candidates.filter(knownSpaceIds.contains)
         return !knownCandidates.isEmpty
+    }
+
+    func isWindowOnKnownInactiveNativeSpace(windowId: UInt32, preferredSpaceId: UInt64?) -> Bool {
+        if let preferredSpaceId, isKnownInactiveSpace(preferredSpaceId) {
+            return true
+        }
+        return isWindowOnKnownInactiveSpace(windowId: windowId)
+    }
+
+    /// True when a window appears on every known macOS Space.
+    ///
+    /// A window whose `collectionBehavior` includes `.canJoinAllSpaces` (for example a
+    /// browser Picture-in-Picture mini-window) is placed by macOS on every Space, so
+    /// the Space IDs it reports cover all of `knownSpaceIds`. A normal
+    /// workspace-bound window appears on exactly one Space.
+    ///
+    /// This is the correct discriminator for exempting a global window from
+    /// workspace-switch parking — unlike `isWindowOnKnownInactiveSpace`, which
+    /// Nehir's virtual workspaces (simulated within one macOS Space by parking
+    /// windows) make return `false` for both normal and global windows.
+    ///
+    /// It only discriminates when there is more than one known Space (multi-display
+    /// "Displays have separate Spaces", the reporter's setup). On a single display
+    /// `knownSpaceIds.count == 1`, so both a global and a normal window report that
+    /// one active Space and are indistinguishable by Space membership alone; that
+    /// case is left for a future user-declared `sticky` rule.
+    func isWindowOnAllKnownSpaces(windowId: UInt32) -> Bool {
+        guard isEnabledAndPopulated, knownSpaceIds.count > 1 else { return false }
+        guard let candidates = spaceIdsByWindowId[windowId] else { return false }
+        // A `canJoinAllSpaces` window may also report Space IDs Nehir does not track;
+        // what matters is that it covers every Space Nehir knows about.
+        return knownSpaceIds.isSubset(of: Set(candidates))
     }
 
     @MainActor

--- a/Sources/Nehir/Core/Workspace/WorkspaceManager.swift
+++ b/Sources/Nehir/Core/Workspace/WorkspaceManager.swift
@@ -214,6 +214,21 @@ final class WorkspaceManager {
     private var bootPersistedWindowRestoreCatalog: PersistedWindowRestoreCatalog
     private var nativeFullscreenRecordsByOriginalToken: [WindowToken: NativeFullscreenRecord] = [:]
     private var nativeFullscreenOriginalTokenByCurrentToken: [WindowToken: WindowToken] = [:]
+    /// Tokens of windows macOS reports as present on every known Space
+    /// (`collectionBehavior = .canJoinAllSpaces`, e.g. a browser Picture-in-Picture
+    /// mini-window). Refreshed by `LayoutRefreshController` whenever it recomputes
+    /// `SpaceTopology`. Such windows are never parked on workspace switch and must
+    /// not be clamped back to a stale reference monitor on a cross-monitor drag.
+    private var globalStickyWindowTokens: Set<WindowToken> = []
+    /// Last native macOS Space ID observed from CGS create notifications, keyed by
+    /// WindowServer window ID. This mirrors upstream OmniWM's native-space tracking
+    /// and complements `SLSCopySpacesForWindows`: a window may have multiple candidate
+    /// Spaces (or stale candidates), while the CGS create event gives the native Space
+    /// the system reported for that surface at creation time.
+    private var nativeSpaceIdByWindowId: [Int: UInt64] = [:]
+    /// Tokens whose native Space is known and inactive in the current SpaceTopology.
+    /// Refreshed by `LayoutRefreshController` before inactive workspace hiding.
+    private var nativeInactiveWindowTokens: Set<WindowToken> = []
     private var consumedBootPersistedWindowRestoreEntries: Set<PersistedWindowRestoreConsumptionKey> = []
     private var persistedWindowRestoreCatalogDirty = false
     private var persistedWindowRestoreCatalogSaveScheduled = false
@@ -458,6 +473,9 @@ final class WorkspaceManager {
         runtimeStore = RuntimeStore(traceRecorder: reconcileTrace)
         nativeFullscreenRecordsByOriginalToken.removeAll()
         nativeFullscreenOriginalTokenByCurrentToken.removeAll()
+        globalStickyWindowTokens.removeAll()
+        nativeSpaceIdByWindowId.removeAll()
+        nativeInactiveWindowTokens.removeAll()
         consumedBootPersistedWindowRestoreEntries.removeAll()
         disconnectedVisibleWorkspaceCache.removeAll()
         persistedWindowRestoreCatalogDirty = false
@@ -2532,6 +2550,18 @@ final class WorkspaceManager {
             return nil
         }
 
+        if let nativeSpaceId = nativeSpaceIdByWindowId.removeValue(forKey: oldToken.windowId),
+           nativeSpaceIdByWindowId[newToken.windowId] == nil
+        {
+            nativeSpaceIdByWindowId[newToken.windowId] = nativeSpaceId
+        }
+        if globalStickyWindowTokens.remove(oldToken) != nil {
+            globalStickyWindowTokens.insert(newToken)
+        }
+        if nativeInactiveWindowTokens.remove(oldToken) != nil {
+            nativeInactiveWindowTokens.insert(newToken)
+        }
+
         if let originalToken = nativeFullscreenOriginalToken(for: oldToken),
            var record = nativeFullscreenRecordsByOriginalToken[originalToken]
         {
@@ -2805,6 +2835,40 @@ final class WorkspaceManager {
         windows.setManualLayoutOverride(override, for: token)
     }
 
+    /// Replaces the set of windows treated as global (present on every known Space).
+    /// Called by `LayoutRefreshController` after recomputing `SpaceTopology`.
+    func setGlobalStickyWindowTokens(_ tokens: Set<WindowToken>) {
+        globalStickyWindowTokens = tokens
+    }
+
+    func isGlobalStickyWindow(_ token: WindowToken) -> Bool {
+        globalStickyWindowTokens.contains(token)
+    }
+
+    func noteNativeSpace(windowId: UInt32, spaceId: UInt64) {
+        guard spaceId != 0 else { return }
+        nativeSpaceIdByWindowId[Int(windowId)] = spaceId
+    }
+
+    func forgetNativeSpace(windowId: UInt32) {
+        nativeSpaceIdByWindowId.removeValue(forKey: Int(windowId))
+    }
+
+    func nativeSpaceId(for windowId: Int) -> UInt64? {
+        nativeSpaceIdByWindowId[windowId]
+    }
+
+    /// Replaces the set of windows whose native macOS Space is known and inactive.
+    /// These windows are already off the active native Space, so workspace hiding must
+    /// not also park them offscreen.
+    func setNativeInactiveWindowTokens(_ tokens: Set<WindowToken>) {
+        nativeInactiveWindowTokens = tokens
+    }
+
+    func isNativeInactiveWindow(_ token: WindowToken) -> Bool {
+        nativeInactiveWindowTokens.contains(token)
+    }
+
     func updateFloatingGeometry(
         frame: CGRect,
         for token: WindowToken,
@@ -2815,7 +2879,10 @@ final class WorkspaceManager {
 
         let resolvedReferenceMonitor = referenceMonitor
             ?? frame.center.monitorApproximation(in: monitors)
-            ?? monitor(for: entry.workspaceId)
+            // A global (all-Spaces) window must keep whatever monitor its frame is
+            // actually on; falling back to the workspace's monitor here would re-anchor
+            // it to a stale display and snap a cross-monitor drag back on the next resolve.
+            ?? (isGlobalStickyWindow(token) ? nil : monitor(for: entry.workspaceId))
         let referenceVisibleFrame = resolvedReferenceMonitor?.visibleFrame ?? frame
         let normalizedOrigin = normalizedFloatingOrigin(
             for: frame,
@@ -2853,9 +2920,18 @@ final class WorkspaceManager {
             return nil
         }
 
-        let targetMonitor = preferredMonitor
-            ?? monitor(for: entry.workspaceId)
-            ?? floatingState.referenceMonitorId.flatMap { monitor(byId: $0) }
+        // A global (all-Spaces) window follows the monitor it is actually displayed
+        // on (its last frame), not the monitor of its workspace binding, so a
+        // cross-monitor drag is not reverted on the next refresh.
+        let targetMonitor: Monitor?
+        if isGlobalStickyWindow(token) {
+            targetMonitor = preferredMonitor
+                ?? floatingState.lastFrame.center.monitorApproximation(in: monitors)
+        } else {
+            targetMonitor = preferredMonitor
+                ?? monitor(for: entry.workspaceId)
+                ?? floatingState.referenceMonitorId.flatMap { monitor(byId: $0) }
+        }
         let visibleFrame = targetMonitor?.visibleFrame ?? floatingState.lastFrame
 
         if let targetMonitor,
@@ -2926,6 +3002,9 @@ final class WorkspaceManager {
             )
         )
         _ = removeNativeFullscreenRecord(containing: entry.token)
+        nativeSpaceIdByWindowId.removeValue(forKey: entry.windowId)
+        globalStickyWindowTokens.remove(entry.token)
+        nativeInactiveWindowTokens.remove(entry.token)
         handleWindowRemoved(entry.token, in: entry.workspaceId)
         _ = windows.removeWindow(key: entry.token)
         invalidateWorkspaceProjection(reason: "windowRemoved")


### PR DESCRIPTION
## Summary

related to #108 

## Release notes

Choose one:

- [x] Added a `.changeset/*.md` for user-visible changes (`mise run changeset -- patch "..."`).
- [ ] No user-visible change; apply the `no release note` label to make CI skip intentional.

## Validation

<!-- Commands run, screenshots, or manual checks. -->

- [ ] Ran relevant tests/checks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Picture-in-Picture windows now stay visible when switching workspaces.
  * Improved handling for windows that appear on every Space, reducing unexpected hiding or drifting.
  * Enhanced Space/visibility tracking so inactive-workspace hide behavior remains consistent and windows keep the correct on-screen positioning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->