### PR TITLE
Hide tiny transient floating helper surfaces from the workspace bar

### DIFF
--- a/.changeset/20260625000520-hide-tiny-transient-floating-helper-surfaces-fro.md
+++ b/.changeset/20260625000520-hide-tiny-transient-floating-helper-surfaces-fro.md
@@ -1,0 +1,6 @@
+---
+"nehir": patch
+
+---
+
+Hide tiny transient floating helper surfaces from the workspace bar

--- a/Sources/Nehir/Core/Controller/WMController.swift
+++ b/Sources/Nehir/Core/Controller/WMController.swift
@@ -3144,6 +3144,8 @@ final class WMController {
             String(describing: mouseWarpSnapshot),
             "-- CGSEventObserver --",
             String(describing: cgsSnapshot),
+            "-- Workspace Bar Floating Projection Trace --",
+            workspaceManager.floatingBarProjectionTraceDump(),
             "-- Workspace Bar Frame Trace --",
             workspaceBarManager.runtimeFrameTraceDebugDump(),
             "-- Workspace Bar --",
@@ -3397,6 +3399,7 @@ final class WMController {
         syncNiriResizeTraceSink()
         workspaceManager.resetReconcileTraceForDebug()
         workspaceManager.resetInteractionMonitorWriteTraceForDebug()
+        workspaceManager.resetFloatingBarProjectionTraceForDebug()
         AppAXContext.resetRawAXNotificationTraceForDebug()
         workspaceBarManager.update()
         debugBarManager.update()
@@ -3436,6 +3439,7 @@ final class WMController {
             : createFocusTraceEvents.map(\.description).joined(separator: "\n")
         let rawAXNotificationDump = AppAXContext.rawAXNotificationTraceDump()
         let interactionMonitorWriteDump = workspaceManager.interactionMonitorWriteTraceDump()
+        let floatingBarProjectionDump = workspaceManager.floatingBarProjectionTraceDump()
         let body = [
             "Nehir runtime trace capture",
             "startedAt=\(session.startedAt.ISO8601Format())",
@@ -3465,6 +3469,9 @@ final class WMController {
             "",
             "## Interaction monitor writes",
             interactionMonitorWriteDump,
+            "",
+            "## Floating bar projection trace",
+            floatingBarProjectionDump,
             "",
             "## Mouse focus trace",
             mouseTraceDump,

--- a/Sources/Nehir/Core/Workspace/WorkspaceManager.swift
+++ b/Sources/Nehir/Core/Workspace/WorkspaceManager.swift
@@ -209,8 +209,13 @@ final class WorkspaceManager {
     private let windows = WindowModel()
     private let reconcileTrace = ReconcileTraceRecorder()
     private let interactionMonitorWriteTrace = InteractionMonitorWriteRecorder()
+    private var recentFloatingBarProjectionTraceRecords: [String] = []
     private lazy var runtimeStore = RuntimeStore(traceRecorder: reconcileTrace)
     private let restorePlanner = RestorePlanner()
+    /// Bar-projection heuristic only: tracked floating surfaces smaller than this
+    /// can still be lifecycle-managed, but are not treated as user-addressable
+    /// when paired with transient/child WindowServer evidence.
+    private let minimumUserAddressableFloatingDimension: CGFloat = 80
     private var bootPersistedWindowRestoreCatalog: PersistedWindowRestoreCatalog
     private var nativeFullscreenRecordsByOriginalToken: [WindowToken: NativeFullscreenRecord] = [:]
     private var nativeFullscreenOriginalTokenByCurrentToken: [WindowToken: WindowToken] = [:]
@@ -340,6 +345,16 @@ final class WorkspaceManager {
         interactionMonitorWriteTrace.dump()
     }
 
+    func floatingBarProjectionTraceDump() -> String {
+        recentFloatingBarProjectionTraceRecords
+            .isEmpty ? "floating bar projection trace empty" : recentFloatingBarProjectionTraceRecords
+            .joined(separator: "\n")
+    }
+
+    func resetFloatingBarProjectionTraceForDebug() {
+        recentFloatingBarProjectionTraceRecords.removeAll()
+    }
+
     func resetInteractionMonitorWriteTraceForDebug() {
         interactionMonitorWriteTrace.reset()
     }
@@ -414,11 +429,39 @@ final class WorkspaceManager {
                 "desiredFloating=\(runtimeDebugFrame(entry.desiredState.floatingFrame))",
                 "replacementFrame=\(runtimeDebugFrame(entry.managedReplacementMetadata?.frame))"
             ]
-            if let bundleId = entry.managedReplacementMetadata?.bundleId, !bundleId.isEmpty {
-                parts.append("bundleId=\(bundleId)")
+            if entry.mode == .floating {
+                let decision = barProjectionDecision(for: entry)
+                let barProjection: String
+                switch decision {
+                case let .accepted(reason):
+                    barProjection = "accepted(\(reason))"
+                case let .rejected(reason):
+                    barProjection = "rejected(\(reason))"
+                }
+                parts.append("barFloating=\(barProjection)")
+                parts.append("barFrame=\(runtimeDebugFrame(floatingBarProjectionFrame(for: entry)))")
             }
-            if let title = entry.managedReplacementMetadata?.title, !title.isEmpty {
-                parts.append("title=\(title.debugDescription)")
+            if let metadata = entry.managedReplacementMetadata {
+                if let bundleId = metadata.bundleId, !bundleId.isEmpty {
+                    parts.append("bundleId=\(bundleId)")
+                }
+                if let role = metadata.role, !role.isEmpty {
+                    parts.append("role=\(role)")
+                }
+                if let subrole = metadata.subrole, !subrole.isEmpty {
+                    parts.append("subrole=\(subrole)")
+                }
+                if let windowLevel = metadata.windowLevel {
+                    parts.append("windowLevel=\(windowLevel)")
+                }
+                if let parentWindowId = metadata.parentWindowId {
+                    parts.append("parentWindowId=\(parentWindowId)")
+                }
+                parts.append("transientWindowServerEvidence=\(metadata.transientWindowServerEvidence)")
+                parts.append("degradedWindowServerChildEvidence=\(metadata.degradedWindowServerChildEvidence)")
+                if let title = metadata.title, !title.isEmpty {
+                    parts.append("title=\(title.debugDescription)")
+                }
             }
             return parts.joined(separator: " ")
         }
@@ -470,6 +513,7 @@ final class WorkspaceManager {
 
     func resetRuntimeStateForDebug() {
         reconcileTrace.reset()
+        recentFloatingBarProjectionTraceRecords.removeAll()
         runtimeStore = RuntimeStore(traceRecorder: reconcileTrace)
         nativeFullscreenRecordsByOriginalToken.removeAll()
         nativeFullscreenOriginalTokenByCurrentToken.removeAll()
@@ -2636,8 +2680,105 @@ final class WorkspaceManager {
     }
 
     private func barVisibleFloatingEntries(in workspace: WorkspaceDescriptor.ID) -> [WindowModel.Entry] {
-        floatingEntries(in: workspace).filter {
-            !isScratchpadToken($0.token) && hiddenState(for: $0.token)?.isScratchpad != true
+        floatingEntries(in: workspace).compactMap { entry in
+            let decision = barProjectionDecision(for: entry)
+            recordFloatingBarProjectionTrace(entry: entry, workspace: workspace, decision: decision)
+            switch decision {
+            case .accepted:
+                return entry
+            case .rejected:
+                return nil
+            }
+        }
+    }
+
+    private func isBarVisibleFloatingEntry(_ entry: WindowModel.Entry) -> Bool {
+        switch barProjectionDecision(for: entry) {
+        case .accepted:
+            true
+        case .rejected:
+            false
+        }
+    }
+
+    private func barProjectionDecision(for entry: WindowModel.Entry) -> FloatingBarProjectionDecision {
+        if isScratchpadToken(entry.token) || hiddenState(for: entry.token)?.isScratchpad == true {
+            return .rejected(reason: "scratchpad")
+        }
+
+        let isGlobalSticky = isGlobalStickyWindow(entry.token)
+        if entry.layoutReason != .standard, !isGlobalSticky {
+            return .rejected(reason: "layoutReason=\(String(describing: entry.layoutReason))")
+        }
+
+        let metadata = entry.managedReplacementMetadata
+        let frame = floatingBarProjectionFrame(for: entry)
+        let isTiny = frame.map(isTinyFloatingBarProjectionFrame) ?? false
+        let hasTransientEvidence = metadata?.transientWindowServerEvidence == true
+        let hasChildEvidence = metadata?.parentWindowId != nil
+            || metadata?.degradedWindowServerChildEvidence == true
+
+        if isGlobalSticky, !isTiny {
+            return .accepted(reason: "globalSticky")
+        }
+
+        if hasTransientEvidence {
+            if frame == nil {
+                return .rejected(reason: "transientWindowServerSurface(noFrame)")
+            }
+            if isTiny {
+                return .rejected(reason: "tinyTransientSurface")
+            }
+        }
+
+        if hasChildEvidence, isTiny {
+            return .rejected(reason: "windowServerChildTinySurface")
+        }
+
+        if isGlobalSticky {
+            return .accepted(reason: "globalSticky")
+        }
+
+        return .accepted(reason: "userAddressable")
+    }
+
+    private enum FloatingBarProjectionDecision: Equatable {
+        case accepted(reason: String)
+        case rejected(reason: String)
+    }
+
+    private func floatingBarProjectionFrame(for entry: WindowModel.Entry) -> CGRect? {
+        resolvedFloatingFrame(for: entry.token)
+            ?? entry.desiredState.floatingFrame
+            ?? entry.observedState.frame
+            ?? entry.managedReplacementMetadata?.frame
+    }
+
+    private func isTinyFloatingBarProjectionFrame(_ frame: CGRect) -> Bool {
+        frame.width < minimumUserAddressableFloatingDimension
+            || frame.height < minimumUserAddressableFloatingDimension
+    }
+
+    private func recordFloatingBarProjectionTrace(
+        entry: WindowModel.Entry,
+        workspace: WorkspaceDescriptor.ID,
+        decision: FloatingBarProjectionDecision
+    ) {
+        let outcome: String
+        switch decision {
+        case let .accepted(reason):
+            outcome = "accepted reason=\(reason)"
+        case let .rejected(reason):
+            outcome = "rejected reason=\(reason)"
+        }
+        let metadata = entry.managedReplacementMetadata
+        let bundleId = metadata?.bundleId ?? "nil"
+        let parentWindowId = metadata?.parentWindowId.map(String.init) ?? "nil"
+        let isScratchpad = isScratchpadToken(entry.token) || hiddenState(for: entry.token)?.isScratchpad == true
+        let record = "\(Date().ISO8601Format()) workspace=\(workspace.uuidString) token=\(entry.token) bundleId=\(bundleId) \(outcome) frame=\(runtimeDebugFrame(floatingBarProjectionFrame(for: entry))) layoutReason=\(String(describing: entry.layoutReason)) transientWindowServerEvidence=\(metadata?.transientWindowServerEvidence == true) degradedWindowServerChildEvidence=\(metadata?.degradedWindowServerChildEvidence == true) parentWindowId=\(parentWindowId) globalSticky=\(isGlobalStickyWindow(entry.token)) scratchpad=\(isScratchpad)"
+        recentFloatingBarProjectionTraceRecords.append(record)
+        if recentFloatingBarProjectionTraceRecords.count > 120 {
+            recentFloatingBarProjectionTraceRecords.removeFirst(recentFloatingBarProjectionTraceRecords.count - 120)
         }
     }
 
@@ -2838,7 +2979,12 @@ final class WorkspaceManager {
     /// Replaces the set of windows treated as global (present on every known Space).
     /// Called by `LayoutRefreshController` after recomputing `SpaceTopology`.
     func setGlobalStickyWindowTokens(_ tokens: Set<WindowToken>) {
+        guard globalStickyWindowTokens != tokens else { return }
         globalStickyWindowTokens = tokens
+        // The bar projection decision uses `isGlobalStickyWindow(_:)` to accept
+        // PiP-like surfaces, so a change in sticky membership must force the
+        // workspace bar to re-evaluate rather than waiting for an unrelated update.
+        invalidateWorkspaceProjection(reason: "globalStickyWindowTokensChanged")
     }
 
     func isGlobalStickyWindow(_ token: WindowToken) -> Bool {

--- a/Tests/NehirTests/WorkspaceBarDataSourceTests.swift
+++ b/Tests/NehirTests/WorkspaceBarDataSourceTests.swift
@@ -234,6 +234,216 @@ import Testing
         #expect(workspaceItem.windows.map(\.windowId) == [1001, 1002])
     }
 
+    @Test @MainActor func tinyTransientFloatingHelperIsExcludedFromFloatingWindows() throws {
+        let controller = makeLayoutPlanTestController()
+        guard let monitor = controller.workspaceManager.monitors.first,
+              let workspace2 = controller.workspaceManager.workspaceId(for: "2", createIfMissing: false)
+        else {
+            Issue.record("Missing workspace bar fixture")
+            return
+        }
+
+        controller.appInfoCache.storeInfoForTests(pid: 6402, name: "Zoom", bundleId: "us.zoom.xos")
+        let helperFrame = CGRect(x: 77, y: 68, width: 56, height: 56)
+        let token = controller.workspaceManager.addWindow(
+            makeLayoutPlanTestWindow(windowId: 942),
+            pid: 6402,
+            windowId: 942,
+            to: workspace2,
+            mode: .floating,
+            managedReplacementMetadata: ManagedReplacementMetadata(
+                bundleId: "us.zoom.xos",
+                workspaceId: workspace2,
+                mode: .floating,
+                role: "AXWindow",
+                subrole: nil,
+                title: nil,
+                windowLevel: nil,
+                parentWindowId: nil,
+                frame: helperFrame,
+                transientWindowServerEvidence: true,
+                degradedWindowServerChildEvidence: false
+            )
+        )
+        controller.workspaceManager.updateFloatingGeometry(frame: helperFrame, for: token)
+
+        let projection = WorkspaceBarDataSource.workspaceBarProjection(
+            for: monitor,
+            options: WorkspaceBarProjectionOptions(
+                deduplicateAppIcons: false,
+                hideEmptyWorkspaces: true,
+                showFloatingWindows: true
+            ),
+            workspaceManager: controller.workspaceManager,
+            appInfoCache: controller.appInfoCache,
+            niriEngine: nil,
+            focusedToken: controller.workspaceManager.confirmedManagedFocusToken,
+            settings: controller.settings
+        )
+
+        #expect(projection.items.map(\.id).contains(workspace2) == false)
+    }
+
+    @Test @MainActor func tinyWindowServerChildHelperIsExcludedFromFloatingWindows() throws {
+        let controller = makeLayoutPlanTestController()
+        guard let monitor = controller.workspaceManager.monitors.first,
+              let workspace1 = controller.workspaceManager.workspaceId(for: "1", createIfMissing: false)
+        else {
+            Issue.record("Missing workspace bar fixture")
+            return
+        }
+
+        controller.appInfoCache.storeInfoForTests(pid: 6501, name: "Helium", bundleId: "net.imput.helium")
+        let helperFrame = CGRect(x: 1034, y: 2, width: 38, height: 43)
+        let token = controller.workspaceManager.addWindow(
+            makeLayoutPlanTestWindow(windowId: 952),
+            pid: 6501,
+            windowId: 952,
+            to: workspace1,
+            mode: .floating,
+            managedReplacementMetadata: ManagedReplacementMetadata(
+                bundleId: "net.imput.helium",
+                workspaceId: workspace1,
+                mode: .floating,
+                role: "AXWindow",
+                subrole: nil,
+                title: nil,
+                windowLevel: nil,
+                parentWindowId: 537,
+                frame: helperFrame,
+                transientWindowServerEvidence: false,
+                degradedWindowServerChildEvidence: false
+            )
+        )
+        controller.workspaceManager.updateFloatingGeometry(frame: helperFrame, for: token)
+
+        let items = WorkspaceBarDataSource.workspaceBarItems(
+            for: monitor,
+            options: WorkspaceBarProjectionOptions(
+                deduplicateAppIcons: false,
+                hideEmptyWorkspaces: false,
+                showFloatingWindows: true
+            ),
+            workspaceManager: controller.workspaceManager,
+            appInfoCache: controller.appInfoCache,
+            niriEngine: nil,
+            focusedToken: controller.workspaceManager.confirmedManagedFocusToken,
+            settings: controller.settings
+        )
+
+        let workspaceItem = try #require(items.first(where: { $0.id == workspace1 }))
+        #expect(workspaceItem.floatingWindows.isEmpty)
+        #expect(workspaceItem.windows.isEmpty)
+    }
+
+    @Test @MainActor func tinyDegradedWindowServerChildHelperIsExcludedFromFloatingWindows() throws {
+        let controller = makeLayoutPlanTestController()
+        guard let monitor = controller.workspaceManager.monitors.first,
+              let workspace1 = controller.workspaceManager.workspaceId(for: "1", createIfMissing: false)
+        else {
+            Issue.record("Missing workspace bar fixture")
+            return
+        }
+
+        controller.appInfoCache.storeInfoForTests(pid: 6701, name: "Helper", bundleId: "com.example.helper")
+        let helperFrame = CGRect(x: 10, y: 10, width: 32, height: 28)
+        let token = controller.workspaceManager.addWindow(
+            makeLayoutPlanTestWindow(windowId: 972),
+            pid: 6701,
+            windowId: 972,
+            to: workspace1,
+            mode: .floating,
+            managedReplacementMetadata: ManagedReplacementMetadata(
+                bundleId: "com.example.helper",
+                workspaceId: workspace1,
+                mode: .floating,
+                role: "AXWindow",
+                subrole: nil,
+                title: nil,
+                windowLevel: nil,
+                parentWindowId: nil,
+                frame: helperFrame,
+                transientWindowServerEvidence: false,
+                degradedWindowServerChildEvidence: true
+            )
+        )
+        controller.workspaceManager.updateFloatingGeometry(frame: helperFrame, for: token)
+
+        let items = WorkspaceBarDataSource.workspaceBarItems(
+            for: monitor,
+            options: WorkspaceBarProjectionOptions(
+                deduplicateAppIcons: false,
+                hideEmptyWorkspaces: false,
+                showFloatingWindows: true
+            ),
+            workspaceManager: controller.workspaceManager,
+            appInfoCache: controller.appInfoCache,
+            niriEngine: nil,
+            focusedToken: controller.workspaceManager.confirmedManagedFocusToken,
+            settings: controller.settings
+        )
+
+        let workspaceItem = try #require(items.first(where: { $0.id == workspace1 }))
+        #expect(workspaceItem.floatingWindows.isEmpty)
+    }
+
+    @Test @MainActor func normalSizedTransientGlobalStickyFloatingWindowRemainsVisible() throws {
+        let controller = makeLayoutPlanTestController()
+        guard let monitor = controller.workspaceManager.monitors.first,
+              let workspace1 = controller.workspaceManager.workspaceId(for: "1", createIfMissing: false)
+        else {
+            Issue.record("Missing workspace bar fixture")
+            return
+        }
+
+        controller.appInfoCache.storeInfoForTests(
+            pid: 6601,
+            name: "Picture in Picture",
+            bundleId: "com.example.browser"
+        )
+        let pipFrame = CGRect(x: 1200, y: 720, width: 360, height: 200)
+        let token = controller.workspaceManager.addWindow(
+            makeLayoutPlanTestWindow(windowId: 962),
+            pid: 6601,
+            windowId: 962,
+            to: workspace1,
+            mode: .floating,
+            managedReplacementMetadata: ManagedReplacementMetadata(
+                bundleId: "com.example.browser",
+                workspaceId: workspace1,
+                mode: .floating,
+                role: "AXWindow",
+                subrole: nil,
+                title: nil,
+                windowLevel: 1,
+                parentWindowId: nil,
+                frame: pipFrame,
+                transientWindowServerEvidence: true,
+                degradedWindowServerChildEvidence: false
+            )
+        )
+        controller.workspaceManager.updateFloatingGeometry(frame: pipFrame, for: token)
+        controller.workspaceManager.setGlobalStickyWindowTokens([token])
+
+        let items = WorkspaceBarDataSource.workspaceBarItems(
+            for: monitor,
+            options: WorkspaceBarProjectionOptions(
+                deduplicateAppIcons: false,
+                hideEmptyWorkspaces: true,
+                showFloatingWindows: true
+            ),
+            workspaceManager: controller.workspaceManager,
+            appInfoCache: controller.appInfoCache,
+            niriEngine: nil,
+            focusedToken: controller.workspaceManager.confirmedManagedFocusToken,
+            settings: controller.settings
+        )
+
+        let workspaceItem = try #require(items.first(where: { $0.id == workspace1 }))
+        #expect(workspaceItem.floatingWindows.map(\.appName) == ["Picture in Picture"])
+        #expect(workspaceItem.windows.map(\.windowId) == [962])
+    }
+
     @Test @MainActor func deduplicatedProjectionKeepsSameAppSeparatedByMode() throws {
         let controller = makeLayoutPlanTestController()
         guard let monitor = controller.workspaceManager.monitors.first,


### PR DESCRIPTION

## Summary

Add a bar-projection predicate that filters out transient helper surfaces (e.g. Zoom hover helpers, Helium top-edge popovers) from the workspace bar. Only user-addressable floating windows — normal-size, global-sticky, or explicitly user-intended — are shown as floating-window icons.

Key changes:
- WorkspaceManager.isBarVisibleFloatingEntry uses size + metadata evidence to reject tiny transient/child surfaces below 80pt minimum dimension
- Floating bar projection decisions are traced for runtime diagnostics
- Runtime debug dump includes bar projection reason and metadata fields
- Added tests for Zoom-like 56×56 and Helium-like 38×43 helpers

## Release notes

Choose one:

- [x] Added a `.changeset/*.md` for user-visible changes (`mise run changeset -- patch "..."`).
- [ ] No user-visible change; apply the `no release note` label to make CI skip intentional.

## Validation

<!-- Commands run, screenshots, or manual checks. -->

- [ ] Ran relevant tests/checks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved workspace bar projection logic to better filter floating windows, hiding tiny transient helper surfaces.
  * Expanded debug/runtime trace output with workspace bar floating projection details.

* **Bug Fixes**
  * Correctly excludes transient/child helper-like floating windows from the workspace bar while keeping normal-sized globally sticky floating windows visible.

* **Tests**
  * Added coverage for tiny transient helper exclusion and globally sticky floating visibility scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->