### PR TITLE
Hide app-managed transient and parented floating surfaces from the ws bar

### DIFF
--- a/.changeset/20260625111759-hide-app-managed-transient-floating-surfaces-fro.md
+++ b/.changeset/20260625111759-hide-app-managed-transient-floating-surfaces-fro.md
@@ -1,0 +1,24 @@
+---
+"nehir": patch
+---
+
+Stop treating app-managed transient floating windows as user-addressable
+
+App-managed ephemeral surfaces — menus, popovers, and rapidly-recreated helper
+windows such as a Teams or Zoom call mini-window — are now classified as not
+user-addressable when their AX facts do not look like a normal standard window.
+Transient windows with normal standard-window affordances, such as Zoom's full
+call window, remain user-addressable.
+
+- Helper/PIP-style transient surfaces no longer appear as floating-window icons
+  in the workspace bar, and the "toggle focused window floating" command no
+  longer force-tiles them — so they can no longer be assigned into the tiled
+  tree, which the owning app would then destroy and recreate, orphaning the
+  assignment.
+- WindowServer-parented child surfaces now follow niri's model: they are treated
+  as child UI of their parent and auto-float instead of entering the tiled tree.
+  When their parent is already tracked, they inherit the parent's workspace.
+- A newly-created helper/PIP-style transient floating surface now binds to its
+  owning app's primary workspace instead of the currently-viewed workspace, so it
+  no longer "leaks" onto the workspace you happen to be looking at, and can no
+  longer anchor managed focus there to drag later app windows across.

--- a/Sources/Nehir/Core/Controller/AXEventHandler.swift
+++ b/Sources/Nehir/Core/Controller/AXEventHandler.swift
@@ -3537,7 +3537,8 @@ final class AXEventHandler: CGSEventDelegate {
             parentWindowId: normalizedParentWindowId(facts.windowServer?.parentId),
             frame: facts.windowServer?.frame,
             transientWindowServerEvidence: facts.windowServer?.hasTransientSurfaceEvidence ?? false,
-            degradedWindowServerChildEvidence: facts.degradedWindowServerChildEvidence
+            degradedWindowServerChildEvidence: facts.degradedWindowServerChildEvidence,
+            userAddressableTransientWindowServerSurface: facts.userAddressableTransientWindowServerSurface
         )
     }
 

--- a/Sources/Nehir/Core/Controller/LayoutRefreshController.swift
+++ b/Sources/Nehir/Core/Controller/LayoutRefreshController.swift
@@ -1426,7 +1426,10 @@ import QuartzCore
                     || evaluation.facts.windowServer?.hasTransientSurfaceEvidence == true,
                 degradedWindowServerChildEvidence: existingEntry?.managedReplacementMetadata?
                     .degradedWindowServerChildEvidence == true
-                    || evaluation.facts.degradedWindowServerChildEvidence
+                    || evaluation.facts.degradedWindowServerChildEvidence,
+                userAddressableTransientWindowServerSurface: existingEntry?.managedReplacementMetadata?
+                    .userAddressableTransientWindowServerSurface == true
+                    || evaluation.facts.userAddressableTransientWindowServerSurface
             )
 
             _ = controller.workspaceManager.addWindow(

--- a/Sources/Nehir/Core/Controller/WMController.swift
+++ b/Sources/Nehir/Core/Controller/WMController.swift
@@ -1123,6 +1123,7 @@ final class WMController {
         parentWindowId: UInt32? = nil,
         inheritTrackedParentWorkspace: Bool = false,
         preferSameAppSiblingWorkspace: Bool = false,
+        bindTransientFloatingToAppWorkspace: Bool = false,
         structuralReplacementWorkspaceId: WorkspaceDescriptor.ID? = nil,
         restrictWorkspaceRuleToPlacementMonitor: Bool = true,
         createPlacementContext: WindowCreatePlacementContext? = nil,
@@ -1136,6 +1137,7 @@ final class WMController {
             parentWindowId: parentWindowId,
             inheritTrackedParentWorkspace: inheritTrackedParentWorkspace,
             preferSameAppSiblingWorkspace: preferSameAppSiblingWorkspace,
+            bindTransientFloatingToAppWorkspace: bindTransientFloatingToAppWorkspace,
             structuralReplacementWorkspaceId: structuralReplacementWorkspaceId,
             restrictWorkspaceRuleToPlacementMonitor: restrictWorkspaceRuleToPlacementMonitor,
             createPlacementContext: createPlacementContext,
@@ -1159,6 +1161,7 @@ final class WMController {
         parentWindowId: UInt32?,
         inheritTrackedParentWorkspace: Bool,
         preferSameAppSiblingWorkspace: Bool,
+        bindTransientFloatingToAppWorkspace: Bool,
         structuralReplacementWorkspaceId: WorkspaceDescriptor.ID?,
         restrictWorkspaceRuleToPlacementMonitor: Bool,
         createPlacementContext: WindowCreatePlacementContext?,
@@ -1223,6 +1226,23 @@ final class WMController {
             return workspaceId
         }
 
+        // A newly-created non-user-addressable transient floating surface with no
+        // document/parent binding (e.g. a Teams/Zoom call mini-window) is app-managed
+        // ephemeral UI. It must follow its owning app's primary window rather than the
+        // currently-viewed workspace, otherwise it "leaks" onto whatever workspace the
+        // user happens to be viewing and can then anchor managed focus there, dragging
+        // later siblings across. User-addressable transient standard windows (e.g.
+        // Zoom's full call window) keep normal placement; global canJoinAllSpaces
+        // surfaces are reanchored separately by reanchorGlobalWindowsToActiveWorkspaces.
+        if context == .automatic,
+           existingEntry == nil,
+           bindTransientFloatingToAppWorkspace,
+           let pid,
+           let siblingWorkspaceId = workspaceForPrimarySiblingWindow(pid: pid)
+        {
+            return siblingWorkspaceId
+        }
+
         if let existingEntry {
             return existingEntry.workspaceId
         }
@@ -1269,6 +1289,36 @@ final class WMController {
         return workspaceId
     }
 
+    /// The workspace of an app's primary (non-transient) window. Used to bind a
+    /// newly-created small transient floating surface (e.g. a Teams/Zoom call
+    /// mini-window) to its owning app instead of the currently-viewed workspace.
+    /// Prefers a non-transient sibling so a transient helper never anchors placement
+    /// for the app's real windows; falls back to a shared workspace if all siblings
+    /// agree.
+    private func workspaceForPrimarySiblingWindow(pid: pid_t) -> WorkspaceDescriptor.ID? {
+        let entries = workspaceManager.entries(forPid: pid)
+        if let primary = entries.first(where: {
+            $0.managedReplacementMetadata?.transientWindowServerEvidence != true
+        }) {
+            return primary.workspaceId
+        }
+        guard let firstEntry = entries.first else { return nil }
+        let workspaceId = firstEntry.workspaceId
+        if entries.dropFirst().allSatisfy({ $0.workspaceId == workspaceId }) {
+            return workspaceId
+        }
+        return nil
+    }
+
+    private func isNonUserAddressableNonGlobalTransientFloatingSurface(_ entry: WindowModel.Entry) -> Bool {
+        guard entry.managedReplacementMetadata?.transientWindowServerEvidence == true,
+              !workspaceManager.isGlobalStickyWindow(entry.token)
+        else {
+            return false
+        }
+        return entry.managedReplacementMetadata?.userAddressableTransientWindowServerSurface != true
+    }
+
     private func workspace(
         _ workspaceId: WorkspaceDescriptor.ID,
         isOn targetMonitorId: Monitor.ID?
@@ -1298,15 +1348,13 @@ final class WMController {
             return false
         }
 
-        let axFacts = facts.ax
-        if axFacts.attributeFetchSucceeded {
-            if axFacts.role == kAXSheetRole as String
-                || axFacts.subrole == kAXDialogSubrole as String
-                || axFacts.subrole == kAXSystemDialogSubrole as String
-            {
-                return true
-            }
-            return false
+        // Match niri's parented-window model: a window with a concrete parent is
+        // child UI of that parent (dialogs/popovers/sheets), so keep it on the
+        // parent's workspace instead of resolving it against interaction focus.
+        if let parentWindowId = UInt32(exactly: windowServer.parentId),
+           workspaceManager.entry(forWindowId: Int(parentWindowId)) != nil
+        {
+            return true
         }
 
         if windowServer.hasDocumentTag {
@@ -2203,6 +2251,10 @@ final class WMController {
         context: WindowRuleReevaluationContext = .automatic
     ) -> WorkspaceDescriptor.ID {
         let inheritTrackedParentWorkspace = shouldInheritTrackedParentWorkspace(for: evaluation)
+        let bindTransientFloatingToAppWorkspace =
+            evaluation.decision.disposition == .floating
+                && evaluation.facts.windowServer?.hasTransientSurfaceEvidence == true
+                && !evaluation.facts.userAddressableTransientWindowServerSurface
         return resolveWorkspacePlacement(
             workspaceName: evaluation.decision.workspaceName,
             axRef: axRef,
@@ -2213,6 +2265,7 @@ final class WMController {
                 for: evaluation,
                 inheritTrackedParentWorkspace: inheritTrackedParentWorkspace
             ),
+            bindTransientFloatingToAppWorkspace: bindTransientFloatingToAppWorkspace,
             structuralReplacementWorkspaceId: structuralReplacementWorkspaceId,
             restrictWorkspaceRuleToPlacementMonitor: restrictWorkspaceRuleToPlacementMonitor,
             createPlacementContext: createPlacementContext,
@@ -3144,6 +3197,8 @@ final class WMController {
             String(describing: mouseWarpSnapshot),
             "-- CGSEventObserver --",
             String(describing: cgsSnapshot),
+            "-- Workspace Bar Floating Projection Trace --",
+            workspaceManager.floatingBarProjectionTraceDump(),
             "-- Workspace Bar Frame Trace --",
             workspaceBarManager.runtimeFrameTraceDebugDump(),
             "-- Workspace Bar --",
@@ -3397,6 +3452,7 @@ final class WMController {
         syncNiriResizeTraceSink()
         workspaceManager.resetReconcileTraceForDebug()
         workspaceManager.resetInteractionMonitorWriteTraceForDebug()
+        workspaceManager.resetFloatingBarProjectionTraceForDebug()
         AppAXContext.resetRawAXNotificationTraceForDebug()
         workspaceBarManager.update()
         debugBarManager.update()
@@ -3436,6 +3492,7 @@ final class WMController {
             : createFocusTraceEvents.map(\.description).joined(separator: "\n")
         let rawAXNotificationDump = AppAXContext.rawAXNotificationTraceDump()
         let interactionMonitorWriteDump = workspaceManager.interactionMonitorWriteTraceDump()
+        let floatingBarProjectionDump = workspaceManager.floatingBarProjectionTraceDump()
         let body = [
             "Nehir runtime trace capture",
             "startedAt=\(session.startedAt.ISO8601Format())",
@@ -3465,6 +3522,9 @@ final class WMController {
             "",
             "## Interaction monitor writes",
             interactionMonitorWriteDump,
+            "",
+            "## Floating bar projection trace",
+            floatingBarProjectionDump,
             "",
             "## Mouse focus trace",
             mouseTraceDump,
@@ -3777,7 +3837,10 @@ final class WMController {
                             || evaluation.facts.windowServer?.hasTransientSurfaceEvidence == true,
                         degradedWindowServerChildEvidence: updatedEntry.managedReplacementMetadata?
                             .degradedWindowServerChildEvidence == true
-                            || evaluation.facts.degradedWindowServerChildEvidence
+                            || evaluation.facts.degradedWindowServerChildEvidence,
+                        userAddressableTransientWindowServerSurface: updatedEntry.managedReplacementMetadata?
+                            .userAddressableTransientWindowServerSurface == true
+                            || evaluation.facts.userAddressableTransientWindowServerSurface
                     ),
                     for: token
                 )
@@ -3815,6 +3878,16 @@ final class WMController {
         guard let token,
               let entry = workspaceManager.entry(for: token)
         else {
+            return .notFound
+        }
+
+        // A non-user-addressable transient, non-global-sticky floating surface (e.g.
+        // a Teams/Zoom call mini-window) is app-managed ephemeral UI the owning app
+        // destroys and recreates at will. It is hidden from the workspace bar for the
+        // same reason, so it must not be force-tiled via the toggle command either —
+        // treat it as not a valid command target. User-addressable transient call
+        // windows and genuinely global PiP windows remain toggleable.
+        if isNonUserAddressableNonGlobalTransientFloatingSurface(entry) {
             return .notFound
         }
 

--- a/Sources/Nehir/Core/Rules/WindowRuleEngine.swift
+++ b/Sources/Nehir/Core/Rules/WindowRuleEngine.swift
@@ -112,6 +112,20 @@ struct WindowRuleFacts: Equatable, Sendable {
         }
         return windowServer.hasModalTag || (windowServer.hasFloatingTag && !windowServer.hasDocumentTag)
     }
+
+    var userAddressableTransientWindowServerSurface: Bool {
+        guard windowServer?.hasTransientSurfaceEvidence == true,
+              ax.attributeFetchSucceeded,
+              ax.role == kAXWindowRole as String,
+              ax.subrole == kAXStandardWindowSubrole as String,
+              ax.hasCloseButton,
+              ax.hasFullscreenButton,
+              ax.fullscreenButtonEnabled == true
+        else {
+            return false
+        }
+        return true
+    }
 }
 
 enum WindowRuleReevaluationTarget: Hashable, Sendable {
@@ -205,6 +219,8 @@ final class WindowRuleEngine {
     static let cleanShotBundleId = "pl.maketheweb.cleanshotx"
     static let systemTextInputPanelRuleName = "systemTextInputPanel"
     private static let transientWindowServerSurfaceRuleName = "transientWindowServerSurface"
+    private static let parentedWindowServerSurfaceRuleName = "parentedWindowServerSurface"
+    private static let transientSystemDialogSurfaceRuleName = "transientSystemDialogSurface"
     private static let cleanShotRecordingOverlayRuleName = "cleanShotRecordingOverlay"
     private static let ghosttyQuickTerminalRuleName = "ghosttyQuickTerminalOverlay"
     private static let ghosttyBundleId = "com.mitchellh.ghostty"
@@ -347,6 +363,10 @@ final class WindowRuleEngine {
             return ghosttyQuickTerminalDecision
         }
 
+        if let transientSystemDialogDecision = transientSystemDialogSurfaceDecision(for: facts) {
+            return transientSystemDialogDecision
+        }
+
         let userRule = bestMatch(in: compiledUserRules, facts: facts)
         let builtInRule = bestMatch(in: builtInRules, facts: facts)
 
@@ -356,6 +376,14 @@ final class WindowRuleEngine {
             minHeight: userRule?.rule.minHeight,
             matchedRuleId: userRule?.rule.id
         )
+
+        if let parentedSurfaceDecision = parentedWindowServerSurfaceDecision(
+            for: facts,
+            workspaceName: workspaceName,
+            effects: effects
+        ) {
+            return parentedSurfaceDecision
+        }
 
         // Floating-tagged non-document WindowServer surfaces are native popups/menus.
         // Keep them out of the tiled tree even when a broad user rule matches the app (#98).
@@ -492,6 +520,48 @@ final class WindowRuleEngine {
             workspaceName: workspaceName,
             ruleEffects: effects,
             heuristicReasons: heuristicReasons,
+            deferredReason: nil
+        )
+    }
+
+    private func parentedWindowServerSurfaceDecision(
+        for facts: WindowRuleFacts,
+        workspaceName: String?,
+        effects: ManagedWindowRuleEffects
+    ) -> WindowDecision? {
+        guard let parentId = facts.windowServer?.parentId,
+              parentId != 0
+        else {
+            return nil
+        }
+
+        return WindowDecision(
+            disposition: .floating,
+            source: .builtInRule(Self.parentedWindowServerSurfaceRuleName),
+            layoutDecisionKind: .fallbackLayout,
+            workspaceName: workspaceName,
+            ruleEffects: effects,
+            heuristicReasons: [],
+            deferredReason: nil
+        )
+    }
+
+    private func transientSystemDialogSurfaceDecision(for facts: WindowRuleFacts) -> WindowDecision? {
+        guard facts.ax.attributeFetchSucceeded,
+              facts.ax.role == kAXWindowRole as String,
+              facts.ax.subrole == kAXSystemDialogSubrole as String,
+              facts.windowServer?.parentId == nil || facts.windowServer?.parentId == 0
+        else {
+            return nil
+        }
+
+        return WindowDecision(
+            disposition: .unmanaged,
+            source: .builtInRule(Self.transientSystemDialogSurfaceRuleName),
+            layoutDecisionKind: .explicitLayout,
+            workspaceName: nil,
+            ruleEffects: .none,
+            heuristicReasons: [],
             deferredReason: nil
         )
     }

--- a/Sources/Nehir/Core/Workspace/WindowModel.swift
+++ b/Sources/Nehir/Core/Workspace/WindowModel.swift
@@ -24,6 +24,7 @@ struct ManagedReplacementMetadata: Equatable, Sendable {
     var frame: CGRect?
     var transientWindowServerEvidence = false
     var degradedWindowServerChildEvidence = false
+    var userAddressableTransientWindowServerSurface = false
 
     func mergingNonNilValues(from overlay: ManagedReplacementMetadata) -> ManagedReplacementMetadata {
         ManagedReplacementMetadata(
@@ -38,7 +39,9 @@ struct ManagedReplacementMetadata: Equatable, Sendable {
             frame: overlay.frame ?? frame,
             transientWindowServerEvidence: transientWindowServerEvidence || overlay.transientWindowServerEvidence,
             degradedWindowServerChildEvidence: degradedWindowServerChildEvidence
-                || overlay.degradedWindowServerChildEvidence
+                || overlay.degradedWindowServerChildEvidence,
+            userAddressableTransientWindowServerSurface: userAddressableTransientWindowServerSurface
+                || overlay.userAddressableTransientWindowServerSurface
         )
     }
 }

--- a/Sources/Nehir/Core/Workspace/WorkspaceManager.swift
+++ b/Sources/Nehir/Core/Workspace/WorkspaceManager.swift
@@ -209,6 +209,7 @@ final class WorkspaceManager {
     private let windows = WindowModel()
     private let reconcileTrace = ReconcileTraceRecorder()
     private let interactionMonitorWriteTrace = InteractionMonitorWriteRecorder()
+    private var recentFloatingBarProjectionTraceRecords: [String] = []
     private lazy var runtimeStore = RuntimeStore(traceRecorder: reconcileTrace)
     private let restorePlanner = RestorePlanner()
     private var bootPersistedWindowRestoreCatalog: PersistedWindowRestoreCatalog
@@ -340,6 +341,16 @@ final class WorkspaceManager {
         interactionMonitorWriteTrace.dump()
     }
 
+    func floatingBarProjectionTraceDump() -> String {
+        recentFloatingBarProjectionTraceRecords
+            .isEmpty ? "floating bar projection trace empty" : recentFloatingBarProjectionTraceRecords
+            .joined(separator: "\n")
+    }
+
+    func resetFloatingBarProjectionTraceForDebug() {
+        recentFloatingBarProjectionTraceRecords.removeAll()
+    }
+
     func resetInteractionMonitorWriteTraceForDebug() {
         interactionMonitorWriteTrace.reset()
     }
@@ -414,11 +425,39 @@ final class WorkspaceManager {
                 "desiredFloating=\(runtimeDebugFrame(entry.desiredState.floatingFrame))",
                 "replacementFrame=\(runtimeDebugFrame(entry.managedReplacementMetadata?.frame))"
             ]
-            if let bundleId = entry.managedReplacementMetadata?.bundleId, !bundleId.isEmpty {
-                parts.append("bundleId=\(bundleId)")
+            if entry.mode == .floating {
+                let decision = barProjectionDecision(for: entry)
+                let barProjection: String
+                switch decision {
+                case let .accepted(reason):
+                    barProjection = "accepted(\(reason))"
+                case let .rejected(reason):
+                    barProjection = "rejected(\(reason))"
+                }
+                parts.append("barFloating=\(barProjection)")
+                parts.append("barFrame=\(runtimeDebugFrame(floatingBarProjectionFrame(for: entry)))")
             }
-            if let title = entry.managedReplacementMetadata?.title, !title.isEmpty {
-                parts.append("title=\(title.debugDescription)")
+            if let metadata = entry.managedReplacementMetadata {
+                if let bundleId = metadata.bundleId, !bundleId.isEmpty {
+                    parts.append("bundleId=\(bundleId)")
+                }
+                if let role = metadata.role, !role.isEmpty {
+                    parts.append("role=\(role)")
+                }
+                if let subrole = metadata.subrole, !subrole.isEmpty {
+                    parts.append("subrole=\(subrole)")
+                }
+                if let windowLevel = metadata.windowLevel {
+                    parts.append("windowLevel=\(windowLevel)")
+                }
+                if let parentWindowId = metadata.parentWindowId {
+                    parts.append("parentWindowId=\(parentWindowId)")
+                }
+                parts.append("transientWindowServerEvidence=\(metadata.transientWindowServerEvidence)")
+                parts.append("degradedWindowServerChildEvidence=\(metadata.degradedWindowServerChildEvidence)")
+                if let title = metadata.title, !title.isEmpty {
+                    parts.append("title=\(title.debugDescription)")
+                }
             }
             return parts.joined(separator: " ")
         }
@@ -470,6 +509,7 @@ final class WorkspaceManager {
 
     func resetRuntimeStateForDebug() {
         reconcileTrace.reset()
+        recentFloatingBarProjectionTraceRecords.removeAll()
         runtimeStore = RuntimeStore(traceRecorder: reconcileTrace)
         nativeFullscreenRecordsByOriginalToken.removeAll()
         nativeFullscreenOriginalTokenByCurrentToken.removeAll()
@@ -2636,8 +2676,99 @@ final class WorkspaceManager {
     }
 
     private func barVisibleFloatingEntries(in workspace: WorkspaceDescriptor.ID) -> [WindowModel.Entry] {
-        floatingEntries(in: workspace).filter {
-            !isScratchpadToken($0.token) && hiddenState(for: $0.token)?.isScratchpad != true
+        floatingEntries(in: workspace).compactMap { entry in
+            let decision = barProjectionDecision(for: entry)
+            recordFloatingBarProjectionTrace(entry: entry, workspace: workspace, decision: decision)
+            switch decision {
+            case .accepted:
+                return entry
+            case .rejected:
+                return nil
+            }
+        }
+    }
+
+    private func barProjectionDecision(for entry: WindowModel.Entry) -> FloatingBarProjectionDecision {
+        if isScratchpadToken(entry.token) || hiddenState(for: entry.token)?.isScratchpad == true {
+            return .rejected(reason: "scratchpad")
+        }
+
+        let isGlobalSticky = isGlobalStickyWindow(entry.token)
+        if entry.layoutReason != .standard, !isGlobalSticky {
+            return .rejected(reason: "layoutReason=\(String(describing: entry.layoutReason))")
+        }
+
+        let metadata = entry.managedReplacementMetadata
+        let frame = floatingBarProjectionFrame(for: entry)
+        let hasTransientEvidence = metadata?.transientWindowServerEvidence == true
+        let hasChildEvidence = metadata?.parentWindowId != nil
+            || metadata?.degradedWindowServerChildEvidence == true
+
+        if isGlobalSticky {
+            return .accepted(reason: "globalSticky")
+        }
+
+        if !isStandardAXWindowSurface(metadata) {
+            return .rejected(reason: "nonStandardAXSurface")
+        }
+
+        // Non-global transient surfaces are only user-addressable when their AX facts
+        // look like a normal standard window. Helper/PIP surfaces without normal
+        // window affordances are app-managed ephemeral UI that the owning app destroys
+        // and recreates at will, orphaning any user assignment.
+        if hasTransientEvidence {
+            if frame == nil {
+                return .rejected(reason: "transientWindowServerSurface(noFrame)")
+            }
+            if metadata?.userAddressableTransientWindowServerSurface != true {
+                return .rejected(reason: "transientSurfaceNotUserAddressable")
+            }
+        }
+
+        if hasChildEvidence {
+            return .rejected(reason: "windowServerChildSurface")
+        }
+
+        return .accepted(reason: "userAddressable")
+    }
+
+    private enum FloatingBarProjectionDecision: Equatable {
+        case accepted(reason: String)
+        case rejected(reason: String)
+    }
+
+    private func floatingBarProjectionFrame(for entry: WindowModel.Entry) -> CGRect? {
+        resolvedFloatingFrame(for: entry.token)
+            ?? entry.desiredState.floatingFrame
+            ?? entry.observedState.frame
+            ?? entry.managedReplacementMetadata?.frame
+    }
+
+    private func isStandardAXWindowSurface(_ metadata: ManagedReplacementMetadata?) -> Bool {
+        guard metadata?.role == kAXWindowRole as String else { return false }
+        return metadata?.subrole == nil || metadata?.subrole == kAXStandardWindowSubrole as String
+    }
+
+    private func recordFloatingBarProjectionTrace(
+        entry: WindowModel.Entry,
+        workspace: WorkspaceDescriptor.ID,
+        decision: FloatingBarProjectionDecision
+    ) {
+        let outcome: String
+        switch decision {
+        case let .accepted(reason):
+            outcome = "accepted reason=\(reason)"
+        case let .rejected(reason):
+            outcome = "rejected reason=\(reason)"
+        }
+        let metadata = entry.managedReplacementMetadata
+        let bundleId = metadata?.bundleId ?? "nil"
+        let parentWindowId = metadata?.parentWindowId.map(String.init) ?? "nil"
+        let isScratchpad = isScratchpadToken(entry.token) || hiddenState(for: entry.token)?.isScratchpad == true
+        let record = "\(Date().ISO8601Format()) workspace=\(workspace.uuidString) token=\(entry.token) bundleId=\(bundleId) \(outcome) frame=\(runtimeDebugFrame(floatingBarProjectionFrame(for: entry))) layoutReason=\(String(describing: entry.layoutReason)) transientWindowServerEvidence=\(metadata?.transientWindowServerEvidence == true) degradedWindowServerChildEvidence=\(metadata?.degradedWindowServerChildEvidence == true) parentWindowId=\(parentWindowId) globalSticky=\(isGlobalStickyWindow(entry.token)) scratchpad=\(isScratchpad)"
+        recentFloatingBarProjectionTraceRecords.append(record)
+        if recentFloatingBarProjectionTraceRecords.count > 120 {
+            recentFloatingBarProjectionTraceRecords.removeFirst(recentFloatingBarProjectionTraceRecords.count - 120)
         }
     }
 
@@ -2838,7 +2969,12 @@ final class WorkspaceManager {
     /// Replaces the set of windows treated as global (present on every known Space).
     /// Called by `LayoutRefreshController` after recomputing `SpaceTopology`.
     func setGlobalStickyWindowTokens(_ tokens: Set<WindowToken>) {
+        guard globalStickyWindowTokens != tokens else { return }
         globalStickyWindowTokens = tokens
+        // The bar projection decision uses `isGlobalStickyWindow(_:)` to accept
+        // PiP-like surfaces, so a change in sticky membership must force the
+        // workspace bar to re-evaluate rather than waiting for an unrelated update.
+        invalidateWorkspaceProjection(reason: "globalStickyWindowTokensChanged")
     }
 
     func isGlobalStickyWindow(_ token: WindowToken) -> Bool {

--- a/Tests/NehirTests/AXEventHandlerTests.swift
+++ b/Tests/NehirTests/AXEventHandlerTests.swift
@@ -5127,7 +5127,9 @@ private func waitUntilAXEventTest(
 
         #expect(controller.interactionWorkspace()?.id == laterWorkspaceId)
         #expect(controller.workspaceManager.entry(forPid: getpid(), windowId: Int(windowId))?
-            .workspaceId == laterWorkspaceId)
+            .workspaceId == createWorkspaceId)
+        #expect(controller.workspaceManager.entry(forPid: getpid(), windowId: Int(windowId))?
+            .mode == .floating)
         #expect(controller.axEventHandler.pendingCreatePlacementContext(for: Int(windowId)) == nil)
     }
 
@@ -6008,8 +6010,9 @@ private func waitUntilAXEventTest(
         #expect(controller.workspaceManager.entry(for: oldToken) == nil)
         #expect(firstNewEntry.handle !== oldEntry.handle)
         #expect(secondNewEntry.handle !== oldEntry.handle)
-        #expect(controller.workspaceManager.tiledEntries(in: workspaceId).count == 2)
-        #expect(engine.columns(in: workspaceId).count == 2)
+        #expect(controller.workspaceManager.tiledEntries(in: workspaceId).isEmpty)
+        #expect(controller.workspaceManager.floatingEntries(in: workspaceId).count == 2)
+        #expect(engine.columns(in: workspaceId).isEmpty)
     }
 
     @Test @MainActor func structuralReplacementRekeysUnlistedAppWithoutAllowlist() async {
@@ -6772,7 +6775,7 @@ private func waitUntilAXEventTest(
         }
     }
 
-    @Test @MainActor func createdStandardWindowOnSecondaryMonitorIgnoresCrossMonitorSiblingAndRule() async {
+    @Test @MainActor func createdParentedStandardWindowInheritsTrackedSiblingWorkspace() async {
         let bundleId = "com.example.cross-monitor-sibling-rule"
         let controller = makeAXEventTestController(
             trackedBundleId: bundleId,
@@ -6847,7 +6850,9 @@ private func waitUntilAXEventTest(
         }
 
         #expect(controller.workspaceManager.entry(forPid: pid, windowId: Int(createdWindowId))?
-            .workspaceId == secondaryWorkspaceId)
+            .workspaceId == primaryWorkspaceId)
+        #expect(controller.workspaceManager.entry(forPid: pid, windowId: Int(createdWindowId))?
+            .mode == .floating)
     }
 
     @Test @MainActor func createdWindowUsesFreshMonitorWorkspaceWhenNativeDisplayResolutionSawStaleWorkspace() async {
@@ -7671,7 +7676,7 @@ private func waitUntilAXEventTest(
             .workspaceId == activeWorkspaceId)
     }
 
-    @Test @MainActor func niriParentedStandardCreateUsesActiveWorkspaceNotTrackedParentWorkspace() async {
+    @Test @MainActor func niriParentedStandardCreateUsesTrackedParentWorkspaceAsFloating() async {
         let bundleId = "com.example.parented-standard-niri"
         let controller = makeAXEventTestController(
             trackedBundleId: bundleId,
@@ -7742,13 +7747,13 @@ private func waitUntilAXEventTest(
         )
         await waitUntilAXEventTest {
             controller.workspaceManager.entry(for: createdToken) != nil
-                && engine.findNode(for: createdToken) != nil
         }
 
         let createWorkspaceTokens = engine.columns(in: createWorkspaceId).flatMap(\.windowNodes).map(\.token)
         let parentWorkspaceTokens = engine.columns(in: parentWorkspaceId).flatMap(\.windowNodes).map(\.token)
-        #expect(controller.workspaceManager.entry(for: createdToken)?.workspaceId == createWorkspaceId)
-        #expect(createWorkspaceTokens.contains(createdToken))
+        #expect(controller.workspaceManager.entry(for: createdToken)?.workspaceId == parentWorkspaceId)
+        #expect(controller.workspaceManager.entry(for: createdToken)?.mode == .floating)
+        #expect(!createWorkspaceTokens.contains(createdToken))
         #expect(!parentWorkspaceTokens.contains(createdToken))
     }
 
@@ -8590,7 +8595,7 @@ private func waitUntilAXEventTest(
         #expect(controller.workspaceManager.entry(for: entry.token) != nil)
     }
 
-    @Test @MainActor func parentedCreateWithDegradedAxFactsRemainsDeferred() async {
+    @Test @MainActor func parentedCreateWithDegradedAxFactsTracksAsFloating() async {
         let controller = makeAXEventTestController()
         var info = makeAXEventWindowInfo(
             id: 830,
@@ -8619,11 +8624,11 @@ private func waitUntilAXEventTest(
         )
         await controller.layoutRefreshController.waitForRefreshWorkForTests()
 
-        #expect(controller.workspaceManager.entry(forPid: getpid(), windowId: 830) == nil)
+        #expect(controller.workspaceManager.entry(forPid: getpid(), windowId: 830)?.mode == .floating)
         #expect(controller.axManager.lastAppliedFrame(for: 830) == nil)
     }
 
-    @Test @MainActor func parentedFloatingTaggedCreateWithDegradedAxFactsRemainsDeferred() async {
+    @Test @MainActor func parentedFloatingTaggedCreateWithDegradedAxFactsTracksAsFloating() async {
         let controller = makeAXEventTestController()
         var info = makeAXEventWindowInfo(
             id: 833,
@@ -8651,7 +8656,7 @@ private func waitUntilAXEventTest(
         )
         await controller.layoutRefreshController.waitForRefreshWorkForTests()
 
-        #expect(controller.workspaceManager.entry(forPid: getpid(), windowId: 833) == nil)
+        #expect(controller.workspaceManager.entry(forPid: getpid(), windowId: 833)?.mode == .floating)
         #expect(controller.axManager.lastAppliedFrame(for: 833) == nil)
     }
 
@@ -8680,7 +8685,7 @@ private func waitUntilAXEventTest(
         #expect(controller.workspaceManager.entry(forPid: getpid(), windowId: 831) == nil)
     }
 
-    @Test @MainActor func helpTagShapedDegradedCreateRemainsDeferred() async {
+    @Test @MainActor func parentedHelpTagShapedDegradedCreateTracksAsFloating() async {
         let controller = makeAXEventTestController()
         var info = makeAXEventWindowInfo(id: 832, parentId: 410)
         info = WindowServerInfo(
@@ -8711,7 +8716,7 @@ private func waitUntilAXEventTest(
         )
         await controller.layoutRefreshController.waitForRefreshWorkForTests()
 
-        #expect(controller.workspaceManager.entry(forPid: getpid(), windowId: 832) == nil)
+        #expect(controller.workspaceManager.entry(forPid: getpid(), windowId: 832)?.mode == .floating)
     }
 
     @Test @MainActor func browserHelperSurfaceWithAutoAssignRuleStaysTrackedAtCreateTime() async {

--- a/Tests/NehirTests/IPCQueryRouterTests.swift
+++ b/Tests/NehirTests/IPCQueryRouterTests.swift
@@ -13,6 +13,24 @@ import Testing
 private let ipcQueryRouterSessionToken = "ipc-query-router-tests"
 private let ipcQueryRouterAuthorization = "ipc-query-router-secret"
 
+private func makeIPCWorkspaceBarTestMetadata(
+    bundleId: String,
+    workspaceId: WorkspaceDescriptor.ID,
+    frame: CGRect? = CGRect(x: 100, y: 100, width: 640, height: 480)
+) -> ManagedReplacementMetadata {
+    ManagedReplacementMetadata(
+        bundleId: bundleId,
+        workspaceId: workspaceId,
+        mode: .floating,
+        role: "AXWindow",
+        subrole: "AXStandardWindow",
+        title: nil,
+        windowLevel: 0,
+        parentWindowId: nil,
+        frame: frame
+    )
+}
+
 @MainActor
 private func prepareIPCQueryRouterNiriState(
     on controller: WMController,
@@ -172,14 +190,22 @@ private func prepareIPCQueryRouterNiriState(
             pid: 7102,
             windowId: 1102,
             to: workspace1,
-            mode: .floating
+            mode: .floating,
+            managedReplacementMetadata: makeIPCWorkspaceBarTestMetadata(
+                bundleId: "com.example.floating",
+                workspaceId: workspace1
+            )
         )
         _ = controller.workspaceManager.addWindow(
             makeLayoutPlanTestWindow(windowId: 1103),
             pid: 7103,
             windowId: 1103,
             to: workspace2,
-            mode: .floating
+            mode: .floating,
+            managedReplacementMetadata: makeIPCWorkspaceBarTestMetadata(
+                bundleId: "com.example.floating-only",
+                workspaceId: workspace2
+            )
         )
 
         let router = IPCQueryRouter(controller: controller, sessionToken: ipcQueryRouterSessionToken)

--- a/Tests/NehirTests/WindowRuleEngineTests.swift
+++ b/Tests/NehirTests/WindowRuleEngineTests.swift
@@ -208,7 +208,7 @@ private func makeWindowRuleFacts(
         #expect(decision.heuristicReasons == [.attributeFetchFailed])
     }
 
-    @Test func degradedAxParentedWindowServerTransientRemainsUndecided() {
+    @Test func degradedAxParentedWindowServerTransientFloats() {
         let engine = WindowRuleEngine()
         let rule = AppRule(
             id: UUID(uuidString: "00000000-0000-0000-0000-000000000164")!,
@@ -231,13 +231,13 @@ private func makeWindowRuleFacts(
             appFullscreen: false
         )
 
-        #expect(decision.disposition == .undecided)
+        #expect(decision.disposition == .floating)
         #expect(decision.layoutDecisionKind == .fallbackLayout)
         #expect(decision.workspaceName == "2")
-        #expect(decision.source == .userRule(rule.id))
-        #expect(decision.deferredReason == .attributeFetchFailed)
-        #expect(decision.trackedMode == nil)
-        #expect(decision.heuristicReasons == [.attributeFetchFailed])
+        #expect(decision.source == .builtInRule("parentedWindowServerSurface"))
+        #expect(decision.deferredReason == nil)
+        #expect(decision.trackedMode == .floating)
+        #expect(decision.heuristicReasons == [])
     }
 
     @Test func degradedAxFloatingTaggedWindowServerTransientRemainsUndecided() {
@@ -282,7 +282,7 @@ private func makeWindowRuleFacts(
         #expect(decision.deferredReason == .attributeFetchFailed)
     }
 
-    @Test func degradedAxDocumentAndHelpTagSurfacesRemainUndecided() {
+    @Test func degradedAxDocumentRemainsUndecidedAndParentedHelpTagFloats() {
         let engine = WindowRuleEngine()
         var documentWindowServer = WindowServerInfo(id: 3203, pid: 3203, level: 0, frame: .zero)
         documentWindowServer.tags = 0x1
@@ -312,8 +312,9 @@ private func makeWindowRuleFacts(
 
         #expect(documentDecision.disposition == .undecided)
         #expect(documentDecision.deferredReason == .attributeFetchFailed)
-        #expect(helpDecision.disposition == .undecided)
-        #expect(helpDecision.deferredReason == .attributeFetchFailed)
+        #expect(helpDecision.disposition == .floating)
+        #expect(helpDecision.source == .builtInRule("parentedWindowServerSurface"))
+        #expect(helpDecision.deferredReason == nil)
     }
 
     @Test func tileRuleDefersWhenAttributeFetchFails() {

--- a/Tests/NehirTests/WorkspaceBarDataSourceTests.swift
+++ b/Tests/NehirTests/WorkspaceBarDataSourceTests.swift
@@ -9,6 +9,25 @@ import Foundation
 @testable import Nehir
 import Testing
 
+private func makeWorkspaceBarTestMetadata(
+    bundleId: String,
+    workspaceId: WorkspaceDescriptor.ID,
+    mode: TrackedWindowMode = .floating,
+    frame: CGRect? = CGRect(x: 100, y: 100, width: 640, height: 480)
+) -> ManagedReplacementMetadata {
+    ManagedReplacementMetadata(
+        bundleId: bundleId,
+        workspaceId: workspaceId,
+        mode: mode,
+        role: kAXWindowRole as String,
+        subrole: kAXStandardWindowSubrole as String,
+        title: nil,
+        windowLevel: 0,
+        parentWindowId: nil,
+        frame: frame
+    )
+}
+
 @Suite struct WorkspaceBarDataSourceTests {
     @Test @MainActor func floatingOnlyWorkspaceIsHiddenWhenFloatingWindowsAreDisabled() throws {
         let controller = makeLayoutPlanTestController()
@@ -34,7 +53,11 @@ import Testing
             pid: 6002,
             windowId: 902,
             to: workspace2,
-            mode: .floating
+            mode: .floating,
+            managedReplacementMetadata: makeWorkspaceBarTestMetadata(
+                bundleId: "com.example.console",
+                workspaceId: workspace2
+            )
         )
 
         let items = WorkspaceBarDataSource.workspaceBarItems(
@@ -70,7 +93,11 @@ import Testing
             pid: 6102,
             windowId: 912,
             to: workspace2,
-            mode: .floating
+            mode: .floating,
+            managedReplacementMetadata: makeWorkspaceBarTestMetadata(
+                bundleId: "com.example.console",
+                workspaceId: workspace2
+            )
         )
 
         let items = WorkspaceBarDataSource.workspaceBarItems(
@@ -156,7 +183,11 @@ import Testing
             pid: 6301,
             windowId: 931,
             to: workspace1,
-            mode: .floating
+            mode: .floating,
+            managedReplacementMetadata: makeWorkspaceBarTestMetadata(
+                bundleId: "com.example.floating",
+                workspaceId: workspace1
+            )
         )
         let scratchpadToken = controller.workspaceManager.addWindow(
             makeLayoutPlanTestWindow(windowId: 932),
@@ -211,7 +242,11 @@ import Testing
             pid: 7002,
             windowId: 1002,
             to: workspace1,
-            mode: .floating
+            mode: .floating,
+            managedReplacementMetadata: makeWorkspaceBarTestMetadata(
+                bundleId: "com.example.floating",
+                workspaceId: workspace1
+            )
         )
 
         let items = WorkspaceBarDataSource.workspaceBarItems(
@@ -263,7 +298,11 @@ import Testing
             pid: 8001,
             windowId: 1103,
             to: workspace1,
-            mode: .floating
+            mode: .floating,
+            managedReplacementMetadata: makeWorkspaceBarTestMetadata(
+                bundleId: "com.example.terminal",
+                workspaceId: workspace1
+            )
         )
 
         let items = WorkspaceBarDataSource.workspaceBarItems(

--- a/Tests/NehirTests/WorkspaceBarManagerTests.swift
+++ b/Tests/NehirTests/WorkspaceBarManagerTests.swift
@@ -9,6 +9,24 @@ import Foundation
 @testable import Nehir
 import Testing
 
+private func makeWorkspaceBarManagerTestMetadata(
+    bundleId: String,
+    workspaceId: WorkspaceDescriptor.ID,
+    frame: CGRect? = CGRect(x: 100, y: 100, width: 640, height: 480)
+) -> ManagedReplacementMetadata {
+    ManagedReplacementMetadata(
+        bundleId: bundleId,
+        workspaceId: workspaceId,
+        mode: .floating,
+        role: kAXWindowRole as String,
+        subrole: kAXStandardWindowSubrole as String,
+        title: nil,
+        windowLevel: 0,
+        parentWindowId: nil,
+        frame: frame
+    )
+}
+
 private final class RecordingPanelStore: @unchecked Sendable {
     var panels: [WorkspaceBarPanel] = []
 }
@@ -188,7 +206,11 @@ private func makeRecordingPanelFactory(
                 pid: pid,
                 windowId: windowId,
                 to: workspaceId,
-                mode: .floating
+                mode: .floating,
+                managedReplacementMetadata: makeWorkspaceBarManagerTestMetadata(
+                    bundleId: "com.example.floating.\(index)",
+                    workspaceId: workspaceId
+                )
             )
         }
 


### PR DESCRIPTION
## Summary

Parented child surfaces now auto-float following niri's model and inherit their parent's workspace instead of entering the tiled tree. App-managed transient helper/PIP surfaces that lack standard-window AX affordances are no longer treated as user-addressable: they are hidden from the workspace bar, excluded from the toggle-floating command, and bound to their owning app's primary workspace so they can no longer leak focus onto the viewed workspace.

relevant #108 

## Release notes

Choose one:

- [x] Added a `.changeset/*.md` for user-visible changes (`mise run changeset -- patch "..."`).
- [ ] No user-visible change; apply the `no release note` label to make CI skip intentional.

## Validation

<!-- Commands run, screenshots, or manual checks. -->

- [ ] Ran relevant tests/checks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * App-managed transient windows are now treated as non-user-addressable when they don’t resemble standard windows, improving consistent focus, tiling behavior, and workspace assignment.
  * Parented transient surfaces now inherit workspace placement from their parent (or the owning app when appropriate).

* **Bug Fixes**
  * Helper/PIP-style transient floating windows no longer clutter the workspace bar and won’t be forced into the tiled tree by focus/floating toggles.
  * Prevented transient floating surfaces from leaking onto the currently viewed workspace.

* **Debug/Diagnostics**
  * Floating-window debug tracing now includes floating-bar projection visibility and detailed decision reasons.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->