### PR TITLE
Workspace bar modifier click and right click action

### DIFF
--- a/.changeset/20260622072603-shift-click-a-workspace-pill-to-move-the-focused.md
+++ b/.changeset/20260622072603-shift-click-a-workspace-pill-to-move-the-focused.md
@@ -1,0 +1,6 @@
+---
+"nehir": minor
+
+---
+
+Shift+click a workspace pill to move the focused window there (mouse analogue of Opt+Shift+N), with a right-click workspace menu and Workspace Bar settings preview that explain the click behaviors.

--- a/.changeset/20260622212828-add-right-click-context-menus-to-the-workspace-b.md
+++ b/.changeset/20260622212828-add-right-click-context-menus-to-the-workspace-b.md
@@ -1,0 +1,6 @@
+---
+"nehir": minor
+
+---
+
+Add right-click context menus to the workspace bar (window icons, scratchpad, workspace labels) backed by token-parameterized window actions.

--- a/.provenance.json
+++ b/.provenance.json
@@ -83,7 +83,9 @@
         "Tests/NehirTests/SettingsMigrationStateStoreTests.swift",
         "Tests/NehirTests/ViewportSnapContextTests.swift",
         "Tests/NehirTests/WhatsNewAutoShowTests.swift",
+        "Tests/NehirTests/WMControllerWindowActionsTests.swift",
         "Tests/NehirTests/WorkspaceBarGeometryTests.swift",
+        "Tests/NehirTests/WorkspaceBarRightClickWiringTests.swift",
         "Tests/NehirTests/WorkspaceNavigationHandlerTests.swift",
         "Tests/NehirTests/WorkspacesTOMLCodecTests.swift"
       ],

--- a/Sources/Nehir/Core/Controller/WMController.swift
+++ b/Sources/Nehir/Core/Controller/WMController.swift
@@ -785,6 +785,16 @@ final class WMController {
         windowActionHandler.focusWorkspaceFromBar(id: workspaceId, suppressMouseWarp: true)
     }
 
+    /// Shift+click on a workspace pill moves the focused managed window to that
+    /// workspace. Mirrors `focusWorkspaceFromBar(id:)` and reuses the existing
+    /// `moveFocusedWindow(toRawWorkspaceID:)` pipeline (target-viewport reveal +
+    /// `focusFollowsWindowToMonitor`). Silent no-op if the workspace is unknown or
+    /// no managed window is focused (same early-return behavior as the hotkey path).
+    func moveFocusedWindowFromBar(toWorkspaceId id: WorkspaceDescriptor.ID) {
+        guard let rawID = workspaceManager.descriptor(for: id)?.name else { return }
+        workspaceNavigationHandler.moveFocusedWindow(toRawWorkspaceID: rawID)
+    }
+
     func focusWindowFromBar(token: WindowToken) {
         windowActionHandler.focusWindowFromBar(token: token, suppressMouseWarp: true)
     }
@@ -3985,9 +3995,9 @@ final class WMController {
     }
 
     /// Unassigns an explicit token from the scratchpad slot, restoring it to
-    /// tiling. Returns `.notFound` when the token is not the current scratchpad,
-    /// is suspended for native fullscreen, or is hidden in a corner. Backs the
-    /// workspace bar's scratchpad-pill *Unassign* item (plan #18).
+    /// tiling. Returns `.notFound` when the token is not the current scratchpad
+    /// or is suspended for native fullscreen. Backs the workspace bar's
+    /// scratchpad-pill *Unassign* item (plan #18).
     @discardableResult
     func unassignWindowFromScratchpad(token: WindowToken) -> ExternalCommandResult {
         guard workspaceManager.isScratchpadToken(token),
@@ -3997,8 +4007,13 @@ final class WMController {
             return .notFound
         }
 
-        guard !workspaceManager.isHiddenInCorner(token) else {
-            return .notFound
+        if let hiddenState = workspaceManager.hiddenState(for: token) {
+            guard hiddenState.isScratchpad,
+                  let monitor = workspaceManager.monitor(for: entry.workspaceId) ?? monitorForInteraction(),
+                  layoutRefreshController.restoreScratchpadWindow(entry, monitor: monitor)
+            else {
+                return .notFound
+            }
         }
 
         cleanupScratchpadWindowResources(for: token)

--- a/Sources/Nehir/Core/Controller/WMController.swift
+++ b/Sources/Nehir/Core/Controller/WMController.swift
@@ -789,6 +789,34 @@ final class WMController {
         windowActionHandler.focusWindowFromBar(token: token, suppressMouseWarp: true)
     }
 
+    /// Token-based close backing the workspace bar's right-click *Close* item
+    /// (plan #18). Resolves the token to its handle (same lookup as
+    /// `focusWindowFromBar(token:)`) and delegates to the shared
+    /// `WindowActionHandler.closeWindow(handle:)`.
+    @discardableResult
+    func closeWindowFromBar(token: WindowToken) -> ExternalCommandResult {
+        guard windowActionHandler.closeWindow(token: token) else {
+            return .notFound
+        }
+        return .executed
+    }
+
+    /// Token-based move backing the workspace bar's right-click *Move to
+    /// Workspace* submenu (plan #18 / #2). Thin wrapper over
+    /// `WorkspaceNavigationHandler.moveWindow(handle:toWorkspaceId:)`, which is
+    /// already token-targeted via its `WindowHandle` argument.
+    @discardableResult
+    func moveWindowFromBar(token: WindowToken, toWorkspaceId: WorkspaceDescriptor.ID) -> ExternalCommandResult {
+        guard let entry = workspaceManager.entry(for: token) else {
+            return .notFound
+        }
+        let moved = workspaceNavigationHandler.moveWindow(
+            handle: entry.handle,
+            toWorkspaceId: toWorkspaceId
+        )
+        return moved ? .executed : .notFound
+    }
+
     @discardableResult
     func activateScratchpadFromBar(on monitorId: Monitor.ID?) -> ExternalCommandResult {
         guard let scratchpadToken = workspaceManager.scratchpadToken() else {
@@ -3873,11 +3901,11 @@ final class WMController {
         )
     }
 
-    func toggleFocusedWindowFloating() -> ExternalCommandResult {
-        let token = focusedManagedTokenForCommand()
-        guard let token,
-              let entry = workspaceManager.entry(for: token)
-        else {
+    /// Token-parameterized toggle of floating/tiling for an explicit window,
+    /// independent of focus. Backs the workspace bar's right-click *Toggle
+    /// Floating* item (plan #18). The focused wrapper below delegates here.
+    func toggleWindowFloating(token: WindowToken) -> ExternalCommandResult {
+        guard let entry = workspaceManager.entry(for: token) else {
             return .notFound
         }
 
@@ -3902,25 +3930,29 @@ final class WMController {
         return .executed
     }
 
+    func toggleFocusedWindowFloating() -> ExternalCommandResult {
+        guard let token = focusedManagedTokenForCommand() else {
+            return .notFound
+        }
+        return toggleWindowFloating(token: token)
+    }
+
+    /// Assigns an explicit token to the single scratchpad slot, honoring the
+    /// single-slot constraint (#7): returns `.notFound` when the slot is held by
+    /// a different managed window so the right-click menu can disable/relabel
+    /// the item rather than silently no-op'ing. Token-parameterized twin of the
+    /// assign branch of `assignFocusedWindowToScratchpad()` (plan #18 / #8).
     @discardableResult
-    func assignFocusedWindowToScratchpad() -> ExternalCommandResult {
-        guard let token = focusedManagedTokenForCommand(),
-              let entry = workspaceManager.entry(for: token),
+    func assignWindowToScratchpad(token: WindowToken) -> ExternalCommandResult {
+        guard let entry = workspaceManager.entry(for: token),
               !isManagedWindowSuspendedForNativeFullscreen(token)
         else {
             return .notFound
         }
 
-        if workspaceManager.isScratchpadToken(token) {
-            guard !workspaceManager.isHiddenInCorner(token) else {
-                return .notFound
-            }
-            cleanupScratchpadWindowResources(for: token)
-            applyManagedWindowOverride(.forceTile, for: token, entry: entry)
-            return .executed
-        }
-
-        if let existingScratchpadToken = workspaceManager.scratchpadToken() {
+        if let existingScratchpadToken = workspaceManager.scratchpadToken(),
+           existingScratchpadToken != token
+        {
             if workspaceManager.entry(for: existingScratchpadToken) == nil {
                 cleanupScratchpadWindowResources(for: existingScratchpadToken)
             } else {
@@ -3950,6 +3982,47 @@ final class WMController {
         }
 
         return .executed
+    }
+
+    /// Unassigns an explicit token from the scratchpad slot, restoring it to
+    /// tiling. Returns `.notFound` when the token is not the current scratchpad,
+    /// is suspended for native fullscreen, or is hidden in a corner. Backs the
+    /// workspace bar's scratchpad-pill *Unassign* item (plan #18).
+    @discardableResult
+    func unassignWindowFromScratchpad(token: WindowToken) -> ExternalCommandResult {
+        guard workspaceManager.isScratchpadToken(token),
+              let entry = workspaceManager.entry(for: token),
+              !isManagedWindowSuspendedForNativeFullscreen(token)
+        else {
+            return .notFound
+        }
+
+        guard !workspaceManager.isHiddenInCorner(token) else {
+            return .notFound
+        }
+
+        cleanupScratchpadWindowResources(for: token)
+        applyManagedWindowOverride(.forceTile, for: token, entry: entry)
+        return .executed
+    }
+
+    /// Token-aware assign-or-unassign routed by current scratchpad state. Used
+    /// by both the window-icon *Assign to Scratchpad* and the scratchpad-pill
+    /// *Unassign from Scratchpad* menu items (plan #18).
+    @discardableResult
+    func toggleWindowScratchpadAssignment(token: WindowToken) -> ExternalCommandResult {
+        if workspaceManager.isScratchpadToken(token) {
+            return unassignWindowFromScratchpad(token: token)
+        }
+        return assignWindowToScratchpad(token: token)
+    }
+
+    @discardableResult
+    func assignFocusedWindowToScratchpad() -> ExternalCommandResult {
+        guard let token = focusedManagedTokenForCommand() else {
+            return .notFound
+        }
+        return toggleWindowScratchpadAssignment(token: token)
     }
 
     private func applyManagedWindowOverride(

--- a/Sources/Nehir/Core/Controller/WindowActionHandler.swift
+++ b/Sources/Nehir/Core/Controller/WindowActionHandler.swift
@@ -138,6 +138,8 @@ final class WindowActionHandler {
         navigateToWindowInternal(token: handle.id, workspaceId: workspaceId)
     }
 
+    var closeWindowForTests: ((WindowHandle) -> Void)?
+
     /// Closes a managed window by pressing its AX close button. Shared by the
     /// Overview and the workspace bar's right-click *Close* item so both paths
     /// use identical AX-close semantics. Lifted from the Overview's private
@@ -145,6 +147,11 @@ final class WindowActionHandler {
     func closeWindow(handle: WindowHandle) {
         guard let controller else { return }
         guard let entry = controller.workspaceManager.entry(for: handle) else { return }
+
+        if let closeWindowForTests {
+            closeWindowForTests(entry.handle)
+            return
+        }
 
         let element = entry.axRef.element
         AXUIElementPerformAction(element, kAXRaiseAction as CFString)

--- a/Sources/Nehir/Core/Controller/WindowActionHandler.swift
+++ b/Sources/Nehir/Core/Controller/WindowActionHandler.swift
@@ -73,7 +73,7 @@ final class WindowActionHandler {
             self?.activateWindowFromOverview(handle: handle, workspaceId: workspaceId)
         }
         oc.onCloseWindow = { [weak self] handle in
-            self?.closeWindowFromOverview(handle: handle)
+            self?.closeWindow(handle: handle)
         }
         return oc
     }()
@@ -138,7 +138,11 @@ final class WindowActionHandler {
         navigateToWindowInternal(token: handle.id, workspaceId: workspaceId)
     }
 
-    private func closeWindowFromOverview(handle: WindowHandle) {
+    /// Closes a managed window by pressing its AX close button. Shared by the
+    /// Overview and the workspace bar's right-click *Close* item so both paths
+    /// use identical AX-close semantics. Lifted from the Overview's private
+    /// `closeWindowFromOverview(handle:)` (plan #18 / discovery correction #4).
+    func closeWindow(handle: WindowHandle) {
         guard let controller else { return }
         guard let entry = controller.workspaceManager.entry(for: handle) else { return }
 
@@ -152,6 +156,19 @@ final class WindowActionHandler {
         {
             AXUIElementPerformAction(closeButton as! AXUIElement, kAXPressAction as CFString)
         }
+    }
+
+    /// Token-based convenience resolving the handle the same way
+    /// `focusWindowFromBar(token:)` does, then delegating to `closeWindow(handle:)`.
+    @discardableResult
+    func closeWindow(token: WindowToken) -> Bool {
+        guard let controller,
+              let entry = controller.workspaceManager.entry(for: token)
+        else {
+            return false
+        }
+        closeWindow(handle: entry.handle)
+        return true
     }
 
     func raiseAllFloatingWindows() {

--- a/Sources/Nehir/UI/Onboarding/Animations/WorkspaceBarAnimation.swift
+++ b/Sources/Nehir/UI/Onboarding/Animations/WorkspaceBarAnimation.swift
@@ -6,13 +6,14 @@
 import SwiftUI
 
 /// Miniature recreation of the real workspace bar (see `WorkspaceBarView`). Shows the bar's
-/// actual shape — a rounded bar of workspace pills plus a scratchpad capsule — and animates
-/// focus cycling between workspaces so the user sees "this bar tracks active workspaces".
+/// actual shape — a rounded bar of workspace pills — and animates focus cycling between
+/// workspaces so the user sees "this bar tracks active workspaces".
 ///
 /// Reflects the live content settings (`showLabels`, `showFloatingWindows`,
 /// `deduplicateAppIcons`, `hideEmptyWorkspaces`) so the onboarding toggles preview changes
-/// in real time. The focus tour only visits non-empty workspaces so toggling "Hide Empty" can
-/// never strand the highlight on a pill that just vanished.
+/// in real time. Floating windows are rendered inside their owning workspace pill, matching the
+/// real bar. The focus tour only visits non-empty workspaces so toggling "Hide Empty" can never
+/// strand the highlight on a pill that just vanished.
 struct WorkspaceBarAnimation: View {
     let showLabels: Bool
     let showFloatingWindows: Bool
@@ -31,37 +32,74 @@ struct WorkspaceBarAnimation: View {
     private struct MockWorkspace: Identifiable {
         let id: Int
         let label: String
-        let windows: [MockWindow]
+        let tiledWindows: [MockWindow]
+        let floatingWindows: [MockWindow]
     }
 
-    // Workspace 4 is empty so "Hide Empty Workspaces" has something to hide. Workspace 1 has
-    // two `doc.text` windows so "Group Windows by App" can collapse them into a single badge.
+    // Workspace 4 is floating-only so "Show Floating Windows" demonstrates the same ownership
+    // rules as the real bar: floating windows belong to a workspace and count as occupancy only
+    // when floating windows are visible in the bar. Workspace 5 is truly empty so "Hide Empty
+    // Workspaces" always has an obvious effect. Workspace 1 has two `doc.text` tiled windows so
+    // "Group Windows by App" can collapse them into a single badge.
     private let workspaces: [MockWorkspace] = [
-        MockWorkspace(id: 0, label: "1", windows: [
-            MockWindow(symbol: "macwindow"),
-            MockWindow(symbol: "doc.text"),
-            MockWindow(symbol: "doc.text")
-        ]),
-        MockWorkspace(id: 1, label: "2", windows: [
-            MockWindow(symbol: "chart.bar"),
-            MockWindow(symbol: "envelope"),
-            MockWindow(symbol: "doc.text")
-        ]),
-        MockWorkspace(id: 2, label: "3", windows: [MockWindow(symbol: "music.note")]),
-        MockWorkspace(id: 3, label: "4", windows: [])
+        MockWorkspace(
+            id: 0,
+            label: "1",
+            tiledWindows: [
+                MockWindow(symbol: "macwindow"),
+                MockWindow(symbol: "doc.text"),
+                MockWindow(symbol: "doc.text")
+            ],
+            floatingWindows: []
+        ),
+        MockWorkspace(
+            id: 1,
+            label: "2",
+            tiledWindows: [
+                MockWindow(symbol: "chart.bar"),
+                MockWindow(symbol: "envelope"),
+                MockWindow(symbol: "doc.text")
+            ],
+            floatingWindows: [MockWindow(symbol: "bubble.left")]
+        ),
+        MockWorkspace(
+            id: 2,
+            label: "3",
+            tiledWindows: [MockWindow(symbol: "music.note")],
+            floatingWindows: []
+        ),
+        MockWorkspace(
+            id: 3,
+            label: "4",
+            tiledWindows: [],
+            floatingWindows: [
+                MockWindow(symbol: "rectangle.on.rectangle"),
+                MockWindow(symbol: "note.text")
+            ]
+        ),
+        MockWorkspace(
+            id: 4,
+            label: "5",
+            tiledWindows: [],
+            floatingWindows: []
+        )
     ]
-
-    private let scratchpad = [MockWindow(symbol: "rectangle.on.rectangle")]
     private let iconSize: CGFloat = 11
     private let pillHeight: CGFloat = 26
     private let cornerRadius: CGFloat = 6
     private let workspaceSpacing: CGFloat = 8
 
-    /// Workspaces shown in the bar. The empty workspace drops out when "Hide Empty" is on.
+    /// Workspaces shown in the bar. A truly empty workspace drops out when "Hide Empty" is on;
+    /// a floating-only workspace also drops out when floating windows are hidden, matching
+    /// `WorkspaceBarDataSource.hasBarVisibleOccupancy`.
     private var visibleWorkspaces: [MockWorkspace] {
         hideEmptyWorkspaces
-            ? workspaces.filter { !$0.windows.isEmpty }
+            ? workspaces.filter(hasBarVisibleOccupancy)
             : workspaces
+    }
+
+    private func hasBarVisibleOccupancy(_ workspace: MockWorkspace) -> Bool {
+        !workspace.tiledWindows.isEmpty || (showFloatingWindows && !workspace.floatingWindows.isEmpty)
     }
 
     var body: some View {
@@ -73,6 +111,12 @@ struct WorkspaceBarAnimation: View {
                 .frame(width: 180, height: 3)
         }
         .onAppear { startLoop() }
+        .onChange(of: showFloatingWindows) { _, _ in
+            restartLoopIfAnimating()
+        }
+        .onChange(of: hideEmptyWorkspaces) { _, _ in
+            restartLoopIfAnimating()
+        }
         .onDisappear {
             animationTask?.cancel()
             animationTask = nil
@@ -84,9 +128,6 @@ struct WorkspaceBarAnimation: View {
         HStack(spacing: workspaceSpacing) {
             ForEach(visibleWorkspaces) { ws in
                 workspacePill(ws)
-            }
-            if showFloatingWindows {
-                scratchpadPill
             }
         }
         .padding(.horizontal, 10)
@@ -107,14 +148,17 @@ struct WorkspaceBarAnimation: View {
     private func workspacePill(_ ws: MockWorkspace) -> some View {
         let isFocused = ws.id == focusedWorkspace
         return HStack(spacing: 5) {
-            if showLabels {
+            if showLabels || !hasBarVisibleOccupancy(ws) {
                 Text(ws.label)
                     .font(.system(.caption2, design: .monospaced).weight(.semibold))
                     .foregroundStyle(isFocused ? Color.accentColor : Color.secondary)
                     .frame(minWidth: 10)
             }
-            ForEach(Array(displayedWindows(ws.windows).enumerated()), id: \.offset) { _, item in
+            ForEach(Array(displayedWindows(ws.tiledWindows).enumerated()), id: \.offset) { _, item in
                 windowIcon(symbol: item.symbol, count: item.count, isFocused: isFocused)
+            }
+            if showFloatingWindows && !ws.floatingWindows.isEmpty {
+                floatingWindowGroup(ws.floatingWindows, isFocused: isFocused)
             }
         }
         .padding(.horizontal, 8)
@@ -164,19 +208,18 @@ struct WorkspaceBarAnimation: View {
             }
     }
 
-    private var scratchpadPill: some View {
+    private func floatingWindowGroup(_ windows: [MockWindow], isFocused: Bool) -> some View {
         HStack(spacing: 3) {
             Image(systemName: "rectangle.on.rectangle")
-                .font(.system(size: iconSize, weight: .medium))
-                .foregroundStyle(.secondary)
-            ForEach(scratchpad) { window in
-                Image(systemName: window.symbol)
-                    .font(.system(size: iconSize))
-                    .foregroundStyle(.secondary)
+                .font(.system(size: max(9, iconSize * 0.58), weight: .medium))
+                .foregroundStyle(isFocused ? Color.primary : Color.secondary)
+                .accessibilityHidden(true)
+            ForEach(Array(displayedWindows(windows).enumerated()), id: \.offset) { _, item in
+                windowIcon(symbol: item.symbol, count: item.count, isFocused: isFocused)
             }
         }
-        .padding(.horizontal, 6)
-        .frame(height: max(16, pillHeight - 4))
+        .padding(.horizontal, 5)
+        .frame(height: max(16, pillHeight - 2))
         .background {
             Capsule(style: .continuous)
                 .fill(.thinMaterial)
@@ -187,6 +230,11 @@ struct WorkspaceBarAnimation: View {
         }
     }
 
+    private func restartLoopIfAnimating() {
+        guard isAnimating else { return }
+        startLoop()
+    }
+
     private func startLoop() {
         animationTask?.cancel()
         isAnimating = true
@@ -194,7 +242,7 @@ struct WorkspaceBarAnimation: View {
             while isAnimating && !Task.isCancelled {
                 // Only tour non-empty workspaces; the empty pill is illustrative, not a focus
                 // target, so toggling "Hide Empty" can't leave the highlight stranded.
-                for ws in workspaces where !ws.windows.isEmpty {
+                for ws in workspaces where hasBarVisibleOccupancy(ws) {
                     guard isAnimating, !Task.isCancelled else { return }
                     withAnimation(.easeInOut(duration: 0.3)) {
                         focusedWorkspace = ws.id

--- a/Sources/Nehir/UI/WorkspaceBar/WorkspaceBarManager.swift
+++ b/Sources/Nehir/UI/WorkspaceBar/WorkspaceBarManager.swift
@@ -103,6 +103,11 @@ final class WorkspaceBarManager {
 
     var appearanceProvider: @MainActor () -> NSAppearance? = { NSApplication.shared.appearance }
 
+    /// Defaults to the global modifier-flag poll (proven at
+    /// `MultitouchGestureSource.swift:86`). Injectable so the click-wiring dispatch
+    /// is hermetically testable without synthesizing an `NSEvent`.
+    var clickIntentFlagProvider: @MainActor () -> NSEvent.ModifierFlags = { NSEvent.modifierFlags }
+
     private var barsByMonitor: [Monitor.ID: MonitorBarInstance] = [:]
     private var screenObserver: Any?
     private var sleepWakeObserver: Any?
@@ -219,8 +224,11 @@ final class WorkspaceBarManager {
         let hostingView = NSHostingView(
             rootView: WorkspaceBarView(
                 model: model,
-                onFocusWorkspace: { [weak controller] item in
-                    controller?.focusWorkspaceFromBar(id: item.id)
+                onFocusWorkspace: { [weak self] item in
+                    self?.handleWorkspacePillClick(item)
+                },
+                onMoveFocusedWindowToWorkspace: { [weak controller] item in
+                    controller?.moveFocusedWindowFromBar(toWorkspaceId: item.id)
                 },
                 onFocusWindow: { [weak controller] token in
                     controller?.focusWindowFromBar(token: token)
@@ -601,6 +609,21 @@ final class WorkspaceBarManager {
         removeAllBars()
     }
 
+    /// Routes a workspace-pill click to focus or move-focused-window based on the
+    /// held modifiers reported by `clickIntentFlagProvider`. The plain-click path
+    /// is unchanged (`focusWorkspaceFromBar`); Shift routes to
+    /// `moveFocusedWindowFromBar` (the mouse analogue of `Opt+Shift+N`).
+    func handleWorkspacePillClick(_ item: WorkspaceBarItem) {
+        guard let controller else { return }
+        let flags = clickIntentFlagProvider()
+        switch WorkspaceBarClickIntent.resolve(modifiers: flags) {
+        case .focus:
+            controller.focusWorkspaceFromBar(id: item.id)
+        case .moveWindow:
+            controller.moveFocusedWindowFromBar(toWorkspaceId: item.id)
+        }
+    }
+
     private func applySettingsToPanel(_ panel: NSPanel, resolved: ResolvedBarSettings) {
         panel.level = resolved.windowLevel.nsWindowLevel
     }
@@ -686,5 +709,21 @@ extension WorkspaceBarManager {
 
     func hostingViewEffectiveAppearanceForTests(on monitorId: Monitor.ID) -> NSAppearance.Name? {
         barsByMonitor[monitorId]?.hostingView.effectiveAppearance.bestMatch(from: [.aqua, .darkAqua])
+    }
+}
+
+/// Which bar action a workspace-pill click should perform, given held modifiers.
+///
+/// v1 is Shift-only: Shift maps to `.moveWindow` (the mouse analogue of
+/// `Opt+Shift+N`); everything else maps to `.focus`. A `.moveColumn` case is
+/// intentionally absent — the column-move path does not inherit the
+/// target-viewport reveal or the focus-follows policy, so it is a separate
+/// follow-up.
+enum WorkspaceBarClickIntent {
+    case focus
+    case moveWindow
+
+    static func resolve(modifiers: NSEvent.ModifierFlags) -> WorkspaceBarClickIntent {
+        modifiers.contains(.shift) ? .moveWindow : .focus
     }
 }

--- a/Sources/Nehir/UI/WorkspaceBar/WorkspaceBarManager.swift
+++ b/Sources/Nehir/UI/WorkspaceBar/WorkspaceBarManager.swift
@@ -238,6 +238,21 @@ final class WorkspaceBarManager {
                         controller: controller,
                         section: .diagnostics
                     )
+                },
+                onToggleWindowFloating: { [weak controller] token in
+                    _ = controller?.toggleWindowFloating(token: token)
+                },
+                onToggleScratchpadAssignment: { [weak controller] token in
+                    _ = controller?.toggleWindowScratchpadAssignment(token: token)
+                },
+                onCloseWindow: { [weak controller] token in
+                    _ = controller?.closeWindowFromBar(token: token)
+                },
+                onMoveWindowToWorkspace: { [weak controller] token, workspaceId in
+                    _ = controller?.moveWindowFromBar(token: token, toWorkspaceId: workspaceId)
+                },
+                onToggleScratchpadVisible: { [weak controller] in
+                    _ = controller?.toggleScratchpadWindow()
                 }
             )
         )

--- a/Sources/Nehir/UI/WorkspaceBar/WorkspaceBarView.swift
+++ b/Sources/Nehir/UI/WorkspaceBar/WorkspaceBarView.swift
@@ -103,6 +103,11 @@ struct WorkspaceBarView: View {
     let onActivateScratchpad: () -> Void
     let onOpenCommandPalette: () -> Void
     let onOpenDiagnostics: () -> Void
+    let onToggleWindowFloating: (WindowToken) -> Void
+    let onToggleScratchpadAssignment: (WindowToken) -> Void
+    let onCloseWindow: (WindowToken) -> Void
+    let onMoveWindowToWorkspace: (WindowToken, WorkspaceDescriptor.ID) -> Void
+    let onToggleScratchpadVisible: () -> Void
 
     var body: some View {
         WorkspaceBarContentView(
@@ -112,7 +117,12 @@ struct WorkspaceBarView: View {
             onFocusWindow: onFocusWindow,
             onActivateScratchpad: onActivateScratchpad,
             onOpenCommandPalette: onOpenCommandPalette,
-            onOpenDiagnostics: onOpenDiagnostics
+            onOpenDiagnostics: onOpenDiagnostics,
+            onToggleWindowFloating: onToggleWindowFloating,
+            onToggleScratchpadAssignment: onToggleScratchpadAssignment,
+            onCloseWindow: onCloseWindow,
+            onMoveWindowToWorkspace: onMoveWindowToWorkspace,
+            onToggleScratchpadVisible: onToggleScratchpadVisible
         )
     }
 }
@@ -129,10 +139,34 @@ struct WorkspaceBarMeasurementView: View {
             onFocusWindow: { _ in },
             onActivateScratchpad: {},
             onOpenCommandPalette: {},
-            onOpenDiagnostics: {}
+            onOpenDiagnostics: {},
+            onToggleWindowFloating: { _ in },
+            onToggleScratchpadAssignment: { _ in },
+            onCloseWindow: { _ in },
+            onMoveWindowToWorkspace: { _, _ in },
+            onToggleScratchpadVisible: {}
         )
         .fixedSize(horizontal: true, vertical: false)
     }
+}
+
+/// A target workspace offered by a window icon's *Move to Workspace ▸*
+/// submenu (the other workspaces visible on this monitor).
+struct WorkspaceBarWindowMoveTarget: Identifiable, Hashable {
+    let id: WorkspaceDescriptor.ID
+    let name: String
+}
+
+/// Bundle of right-click actions threaded from the controller through the bar
+/// to each window icon. Bundling keeps `WindowIconView` a value type without a
+/// long parameter list (plan #18).
+struct WorkspaceBarWindowActions {
+    let onToggleFloating: (WindowToken) -> Void
+    let onToggleScratchpadAssignment: (WindowToken) -> Void
+    let onClose: (WindowToken) -> Void
+    let onMoveToWorkspace: (WindowToken, WorkspaceDescriptor.ID) -> Void
+    let moveTargets: [WorkspaceBarWindowMoveTarget]
+    let scratchpadSlotOccupied: Bool
 }
 
 @MainActor
@@ -144,6 +178,11 @@ private struct WorkspaceBarContentView: View {
     let onActivateScratchpad: () -> Void
     let onOpenCommandPalette: () -> Void
     let onOpenDiagnostics: () -> Void
+    let onToggleWindowFloating: (WindowToken) -> Void
+    let onToggleScratchpadAssignment: (WindowToken) -> Void
+    let onCloseWindow: (WindowToken) -> Void
+    let onMoveWindowToWorkspace: (WindowToken, WorkspaceDescriptor.ID) -> Void
+    let onToggleScratchpadVisible: () -> Void
 
     @Environment(\.accessibilityReduceMotion) private var accessibilityReduceMotion
     @Environment(\.accessibilityReduceTransparency) private var accessibilityReduceTransparency
@@ -184,6 +223,28 @@ private struct WorkspaceBarContentView: View {
         RoundedRectangle(cornerRadius: 8, style: .continuous)
     }
 
+    /// Workspaces on this monitor offered by the *Move to Workspace ▸* submenu.
+    private var windowMoveTargets: [WorkspaceBarWindowMoveTarget] {
+        snapshot.items.map { WorkspaceBarWindowMoveTarget(id: $0.id, name: $0.name) }
+    }
+
+    /// True when the single scratchpad slot is held, so the window-icon
+    /// *Assign to Scratchpad* item is disabled (single-slot constraint, #7).
+    private var scratchpadSlotOccupied: Bool {
+        snapshot.scratchpad != nil
+    }
+
+    private var windowActions: WorkspaceBarWindowActions {
+        WorkspaceBarWindowActions(
+            onToggleFloating: onToggleWindowFloating,
+            onToggleScratchpadAssignment: onToggleScratchpadAssignment,
+            onClose: onCloseWindow,
+            onMoveToWorkspace: onMoveWindowToWorkspace,
+            moveTargets: windowMoveTargets,
+            scratchpadSlotOccupied: scratchpadSlotOccupied
+        )
+    }
+
     var body: some View {
         HStack(spacing: workspaceSpacing) {
             ForEach(snapshot.items, id: \.id) { item in
@@ -198,7 +259,8 @@ private struct WorkspaceBarContentView: View {
                     accentColor: accentColor,
                     textColor: textColor,
                     onFocusWorkspace: { onFocusWorkspace(item) },
-                    onFocusWindow: onFocusWindow
+                    onFocusWindow: onFocusWindow,
+                    windowActions: windowActions
                 )
             }
 
@@ -210,7 +272,9 @@ private struct WorkspaceBarContentView: View {
                     animationsEnabled: effectiveAnimationsEnabled,
                     accentColor: accentColor,
                     textColor: textColor,
-                    onActivateScratchpad: onActivateScratchpad
+                    onActivateScratchpad: onActivateScratchpad,
+                    onToggleScratchpadVisible: onToggleScratchpadVisible,
+                    onUnassignScratchpad: { onToggleScratchpadAssignment(scratchpad.window.id) }
                 )
             }
 
@@ -264,8 +328,23 @@ private struct WorkspaceItemView: View {
     let textColor: Color?
     let onFocusWorkspace: () -> Void
     let onFocusWindow: (WindowToken) -> Void
+    let windowActions: WorkspaceBarWindowActions
 
     @State private var isHovered = false
+
+    /// Move targets scoped to this workspace item: the other workspaces visible
+    /// on this monitor (the current one is excluded so the submenu never offers
+    /// a no-op move into the window's own workspace).
+    private var scopedWindowActions: WorkspaceBarWindowActions {
+        WorkspaceBarWindowActions(
+            onToggleFloating: windowActions.onToggleFloating,
+            onToggleScratchpadAssignment: windowActions.onToggleScratchpadAssignment,
+            onClose: windowActions.onClose,
+            onMoveToWorkspace: windowActions.onMoveToWorkspace,
+            moveTargets: windowActions.moveTargets.filter { $0.id != item.id },
+            scratchpadSlotOccupied: windowActions.scratchpadSlotOccupied
+        )
+    }
 
     var body: some View {
         HStack(spacing: windowSpacing) {
@@ -303,7 +382,8 @@ private struct WorkspaceItemView: View {
                     animationsEnabled: animationsEnabled,
                     accentColor: accentColor,
                     textColor: textColor,
-                    onFocusWindow: onFocusWindow
+                    onFocusWindow: onFocusWindow,
+                    actions: scopedWindowActions
                 )
             }
 
@@ -323,7 +403,8 @@ private struct WorkspaceItemView: View {
                     animationsEnabled: animationsEnabled,
                     accentColor: accentColor,
                     textColor: textColor,
-                    onFocusWindow: onFocusWindow
+                    onFocusWindow: onFocusWindow,
+                    actions: scopedWindowActions
                 )
             }
         }
@@ -377,9 +458,19 @@ private struct WorkspaceLabelButton: View {
                 .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
+        // Right-click workspace label: *Focus* equals left-click. The
+        // *Move Workspace to Monitor ▸* item is omitted until Nehir #62 lands
+        // (plan #18 prerequisite — not an ancestor of this branch).
+        .contextMenu {
+            Button {
+                onFocusWorkspace()
+            } label: {
+                Label("Focus", systemImage: "rectangle.center.inset.filled")
+            }
+        }
         .accessibilityLabel("Workspace \(item.name)")
         .accessibilityValue(item.isFocused ? "Focused" : "")
-        .help("Focus workspace \(item.name)")
+        .help("Focus workspace \(item.name). Right-click for more actions.")
     }
 }
 
@@ -393,6 +484,7 @@ private struct FloatingWindowsGroupView: View {
     let accentColor: Color?
     let textColor: Color?
     let onFocusWindow: (WindowToken) -> Void
+    let actions: WorkspaceBarWindowActions
 
     private var resolvedSecondaryTextColor: Color {
         textColor ?? .secondary
@@ -416,7 +508,8 @@ private struct FloatingWindowsGroupView: View {
                     animationsEnabled: animationsEnabled,
                     accentColor: accentColor,
                     textColor: textColor,
-                    onFocusWindow: onFocusWindow
+                    onFocusWindow: onFocusWindow,
+                    actions: actions
                 )
             }
         }
@@ -444,6 +537,8 @@ private struct ScratchpadPillView: View {
     let accentColor: Color?
     let textColor: Color?
     let onActivateScratchpad: () -> Void
+    let onToggleScratchpadVisible: () -> Void
+    let onUnassignScratchpad: () -> Void
 
     @State private var isHovered = false
 
@@ -492,9 +587,30 @@ private struct ScratchpadPillView: View {
         .onHover { hovering in
             isHovered = hovering
         }
+        // Right-click scratchpad pill: *Toggle Visible / Unassign / Focus*
+        // (plan #18). *Focus* mirrors the pill's left-click activation.
+        .contextMenu {
+            Button {
+                onToggleScratchpadVisible()
+            } label: {
+                Label(item.isVisible ? "Hide" : "Show", systemImage: "eye")
+            }
+            Button(role: .destructive) {
+                onUnassignScratchpad()
+            } label: {
+                Label("Unassign from Scratchpad", systemImage: "tray")
+            }
+            Button {
+                onActivateScratchpad()
+            } label: {
+                Label("Focus", systemImage: "rectangle.center.inset.filled")
+            }
+        }
         .accessibilityLabel("Scratchpad")
         .accessibilityValue(accessibilityValue)
-        .help("Scratchpad: \(item.window.appName), \(item.isVisible ? "visible" : "hidden")")
+        .help(
+            "Scratchpad: \(item.window.appName), \(item.isVisible ? "visible" : "hidden"). Right-click for more actions."
+        )
     }
 
     private var scale: CGFloat {
@@ -543,6 +659,7 @@ private struct WindowIconView: View {
     let accentColor: Color?
     let textColor: Color?
     let onFocusWindow: (WindowToken) -> Void
+    let actions: WorkspaceBarWindowActions
 
     @State private var isHovered = false
     @State private var showingWindowList = false
@@ -582,6 +699,47 @@ private struct WindowIconView: View {
         .onHover { hovering in
             isHovered = hovering
         }
+        // Right-click window icon: *Toggle Floating; Assign to Scratchpad;
+        // Move to Workspace ▸; Close; Windows…* (plan #18 v1 item set; no
+        // fullscreen — see Non-goals). Acts on this window's token, not focus.
+        .contextMenu {
+            Button {
+                actions.onToggleFloating(window.id)
+            } label: {
+                Label("Toggle Floating", systemImage: "rectangle")
+            }
+            Button {
+                actions.onToggleScratchpadAssignment(window.id)
+            } label: {
+                Label("Assign to Scratchpad", systemImage: "tray")
+            }
+            .disabled(actions.scratchpadSlotOccupied)
+            if !actions.moveTargets.isEmpty {
+                Menu {
+                    ForEach(actions.moveTargets) { target in
+                        Button(target.name) {
+                            actions.onMoveToWorkspace(window.id, target.id)
+                        }
+                    }
+                } label: {
+                    Label("Move to Workspace", systemImage: "arrow.right.square")
+                }
+            }
+            Divider()
+            Button(role: .destructive) {
+                actions.onClose(window.id)
+            } label: {
+                Label("Close", systemImage: "xmark.rectangle")
+            }
+            if window.windowCount > 1 {
+                Divider()
+                Button {
+                    showingWindowList = true
+                } label: {
+                    Label("Windows…", systemImage: "list.bullet")
+                }
+            }
+        }
         .sheet(isPresented: $showingWindowList) {
             WindowListSheet(
                 windows: window.allWindows,
@@ -596,7 +754,7 @@ private struct WindowIconView: View {
         }
         .accessibilityLabel(accessibilityLabel)
         .accessibilityValue(accessibilityValue)
-        .help(window.appName)
+        .help("\(window.appName). Right-click for more actions.")
     }
 
     private var opacity: Double {

--- a/Sources/Nehir/UI/WorkspaceBar/WorkspaceBarView.swift
+++ b/Sources/Nehir/UI/WorkspaceBar/WorkspaceBarView.swift
@@ -99,6 +99,7 @@ final class WorkspaceBarModel {
 struct WorkspaceBarView: View {
     let model: WorkspaceBarModel
     let onFocusWorkspace: (WorkspaceBarItem) -> Void
+    let onMoveFocusedWindowToWorkspace: (WorkspaceBarItem) -> Void
     let onFocusWindow: (WindowToken) -> Void
     let onActivateScratchpad: () -> Void
     let onOpenCommandPalette: () -> Void
@@ -114,6 +115,7 @@ struct WorkspaceBarView: View {
             snapshot: model.snapshot,
             animationsEnabled: true,
             onFocusWorkspace: onFocusWorkspace,
+            onMoveFocusedWindowToWorkspace: onMoveFocusedWindowToWorkspace,
             onFocusWindow: onFocusWindow,
             onActivateScratchpad: onActivateScratchpad,
             onOpenCommandPalette: onOpenCommandPalette,
@@ -136,6 +138,7 @@ struct WorkspaceBarMeasurementView: View {
             snapshot: snapshot,
             animationsEnabled: false,
             onFocusWorkspace: { _ in },
+            onMoveFocusedWindowToWorkspace: { _ in },
             onFocusWindow: { _ in },
             onActivateScratchpad: {},
             onOpenCommandPalette: {},
@@ -169,11 +172,19 @@ struct WorkspaceBarWindowActions {
     let scratchpadSlotOccupied: Bool
 }
 
+func workspaceBarMoveTargetsExcludingCurrentWorkspace(
+    _ targets: [WorkspaceBarWindowMoveTarget],
+    currentWorkspaceId: WorkspaceDescriptor.ID
+) -> [WorkspaceBarWindowMoveTarget] {
+    targets.filter { $0.id != currentWorkspaceId }
+}
+
 @MainActor
 private struct WorkspaceBarContentView: View {
     let snapshot: WorkspaceBarSnapshot
     let animationsEnabled: Bool
     let onFocusWorkspace: (WorkspaceBarItem) -> Void
+    let onMoveFocusedWindowToWorkspace: (WorkspaceBarItem) -> Void
     let onFocusWindow: (WindowToken) -> Void
     let onActivateScratchpad: () -> Void
     let onOpenCommandPalette: () -> Void
@@ -259,6 +270,7 @@ private struct WorkspaceBarContentView: View {
                     accentColor: accentColor,
                     textColor: textColor,
                     onFocusWorkspace: { onFocusWorkspace(item) },
+                    onMoveFocusedWindowToWorkspace: { onMoveFocusedWindowToWorkspace(item) },
                     onFocusWindow: onFocusWindow,
                     windowActions: windowActions
                 )
@@ -327,6 +339,7 @@ private struct WorkspaceItemView: View {
     let accentColor: Color?
     let textColor: Color?
     let onFocusWorkspace: () -> Void
+    let onMoveFocusedWindowToWorkspace: () -> Void
     let onFocusWindow: (WindowToken) -> Void
     let windowActions: WorkspaceBarWindowActions
 
@@ -341,7 +354,10 @@ private struct WorkspaceItemView: View {
             onToggleScratchpadAssignment: windowActions.onToggleScratchpadAssignment,
             onClose: windowActions.onClose,
             onMoveToWorkspace: windowActions.onMoveToWorkspace,
-            moveTargets: windowActions.moveTargets.filter { $0.id != item.id },
+            moveTargets: workspaceBarMoveTargetsExcludingCurrentWorkspace(
+                windowActions.moveTargets,
+                currentWorkspaceId: item.id
+            ),
             scratchpadSlotOccupied: windowActions.scratchpadSlotOccupied
         )
     }
@@ -353,7 +369,8 @@ private struct WorkspaceItemView: View {
                     item: item,
                     accentColor: accentColor,
                     textColor: textColor,
-                    onFocusWorkspace: onFocusWorkspace
+                    onFocusWorkspace: onFocusWorkspace,
+                    onMoveFocusedWindowToWorkspace: onMoveFocusedWindowToWorkspace
                 )
 
                 if !item.windows.isEmpty {
@@ -367,7 +384,8 @@ private struct WorkspaceItemView: View {
                     item: item,
                     accentColor: accentColor,
                     textColor: textColor,
-                    onFocusWorkspace: onFocusWorkspace
+                    onFocusWorkspace: onFocusWorkspace,
+                    onMoveFocusedWindowToWorkspace: onMoveFocusedWindowToWorkspace
                 )
             }
 
@@ -430,6 +448,20 @@ private struct WorkspaceItemView: View {
         .onHover { hovering in
             isHovered = hovering
         }
+        .contextMenu {
+            Button {
+                onFocusWorkspace()
+            } label: {
+                Label("Focus Workspace \(item.name)", systemImage: "arrow.right.square")
+            }
+            Button {
+                onMoveFocusedWindowToWorkspace()
+            } label: {
+                Label("Move Focused Window Here", systemImage: "arrowshape.turn.up.right")
+            }
+            Divider()
+            Text("Shift-click also moves one window here.")
+        }
         .accessibilityElement(children: .contain)
     }
 }
@@ -440,6 +472,7 @@ private struct WorkspaceLabelButton: View {
     let accentColor: Color?
     let textColor: Color?
     let onFocusWorkspace: () -> Void
+    let onMoveFocusedWindowToWorkspace: () -> Void
 
     private var resolvedAccentColor: Color {
         accentColor ?? .accentColor
@@ -467,10 +500,19 @@ private struct WorkspaceLabelButton: View {
             } label: {
                 Label("Focus", systemImage: "rectangle.center.inset.filled")
             }
+            Button {
+                onMoveFocusedWindowToWorkspace()
+            } label: {
+                Label("Move Focused Window Here", systemImage: "arrowshape.turn.up.right")
+            }
+            Divider()
+            Text("Shift-click also moves one window here.")
         }
         .accessibilityLabel("Workspace \(item.name)")
         .accessibilityValue(item.isFocused ? "Focused" : "")
-        .help("Focus workspace \(item.name). Right-click for more actions.")
+        .help(
+            "Focus workspace \(item.name). Shift-click or right-click to move the focused window here."
+        )
     }
 }
 

--- a/Sources/Nehir/UI/WorkspaceBarSettingsTab.swift
+++ b/Sources/Nehir/UI/WorkspaceBarSettingsTab.swift
@@ -26,6 +26,8 @@ struct WorkspaceBarSettingsTab: View {
                 }
             )
 
+            WorkspaceBarPreviewSection(configuration: previewConfiguration)
+
             if let monitorId = selectedMonitor,
                let monitor = connectedMonitors.first(where: { $0.id == monitorId })
             {
@@ -44,6 +46,152 @@ struct WorkspaceBarSettingsTab: View {
         .formStyle(.grouped)
         .onAppear {
             connectedMonitors = Monitor.current()
+        }
+    }
+
+    private var previewConfiguration: WorkspaceBarPreviewConfiguration {
+        if let monitorId = selectedMonitor,
+           let monitor = connectedMonitors.first(where: { $0.id == monitorId })
+        {
+            return WorkspaceBarPreviewConfiguration(
+                resolved: settings.resolvedBarSettings(for: monitor),
+                scopeDescription: "Preview reflects \(monitor.name)'s effective bar settings, including monitor overrides."
+            )
+        }
+
+        return WorkspaceBarPreviewConfiguration(
+            isEnabled: settings.workspaceBarEnabled,
+            showLabels: settings.workspaceBarShowLabels,
+            showFloatingWindows: settings.workspaceBarShowFloatingWindows,
+            deduplicateAppIcons: settings.workspaceBarDeduplicateAppIcons,
+            hideEmptyWorkspaces: settings.workspaceBarHideEmptyWorkspaces,
+            scopeDescription: "Preview reflects the global workspace bar defaults."
+        )
+    }
+}
+
+private struct WorkspaceBarPreviewConfiguration {
+    let isEnabled: Bool
+    let showLabels: Bool
+    let showFloatingWindows: Bool
+    let deduplicateAppIcons: Bool
+    let hideEmptyWorkspaces: Bool
+    let scopeDescription: String
+
+    init(
+        isEnabled: Bool,
+        showLabels: Bool,
+        showFloatingWindows: Bool,
+        deduplicateAppIcons: Bool,
+        hideEmptyWorkspaces: Bool,
+        scopeDescription: String
+    ) {
+        self.isEnabled = isEnabled
+        self.showLabels = showLabels
+        self.showFloatingWindows = showFloatingWindows
+        self.deduplicateAppIcons = deduplicateAppIcons
+        self.hideEmptyWorkspaces = hideEmptyWorkspaces
+        self.scopeDescription = scopeDescription
+    }
+
+    init(resolved: ResolvedBarSettings, scopeDescription: String) {
+        self.init(
+            isEnabled: resolved.enabled,
+            showLabels: resolved.showLabels,
+            showFloatingWindows: resolved.showFloatingWindows,
+            deduplicateAppIcons: resolved.deduplicateAppIcons,
+            hideEmptyWorkspaces: resolved.hideEmptyWorkspaces,
+            scopeDescription: scopeDescription
+        )
+    }
+}
+
+private struct WorkspaceBarPreviewSection: View {
+    let configuration: WorkspaceBarPreviewConfiguration
+
+    var body: some View {
+        Section("Preview & Behavior") {
+            VStack(alignment: .leading, spacing: 14) {
+                preview
+                SettingsCaption(configuration.scopeDescription)
+                behaviorList
+            }
+            .padding(.vertical, 4)
+        }
+    }
+
+    private var preview: some View {
+        ZStack {
+            HStack {
+                Spacer(minLength: 0)
+                WorkspaceBarAnimation(
+                    showLabels: configuration.showLabels,
+                    showFloatingWindows: configuration.showFloatingWindows,
+                    deduplicateAppIcons: configuration.deduplicateAppIcons,
+                    hideEmptyWorkspaces: configuration.hideEmptyWorkspaces
+                )
+                .frame(maxWidth: 360)
+                .opacity(configuration.isEnabled ? 1 : 0.35)
+                Spacer(minLength: 0)
+            }
+            .padding(.vertical, 10)
+            .frame(maxWidth: .infinity)
+
+            if !configuration.isEnabled {
+                Text("Disabled for this scope")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(.secondary)
+                    .padding(.horizontal, 10)
+                    .padding(.vertical, 5)
+                    .background(.regularMaterial, in: Capsule())
+            }
+        }
+    }
+
+    private var behaviorList: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            behaviorRow(
+                icon: "cursorarrow.click.2",
+                title: "Click a workspace",
+                text: "Focuses that workspace without warping the pointer."
+            )
+            behaviorRow(
+                icon: "list.bullet.rectangle",
+                title: "Right-click a workspace",
+                text: "Shows explicit actions to focus it or move the focused window there."
+            )
+            behaviorRow(
+                icon: "arrowshape.turn.up.right",
+                title: "Shift-click a workspace",
+                text: "Moves the focused window to that workspace as a quick shortcut."
+            )
+            behaviorRow(
+                icon: "square.stack.3d.down.right",
+                title: "Window, not column",
+                text: "Only the focused window moves; moving an entire column is a separate action."
+            )
+            behaviorRow(
+                icon: "macwindow.on.rectangle",
+                title: "Window icons and scratchpad",
+                text: "Window icons still focus windows, and the scratchpad pill opens the scratchpad."
+            )
+        }
+    }
+
+    private func behaviorRow(icon: String, title: String, text: String) -> some View {
+        HStack(alignment: .top, spacing: 8) {
+            Image(systemName: icon)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .frame(width: 16, alignment: .center)
+                .padding(.top, 1)
+            VStack(alignment: .leading, spacing: 1) {
+                Text(title)
+                    .font(.caption.weight(.semibold))
+                Text(text)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
         }
     }
 }

--- a/Sources/Nehir/UI/WorkspaceBarSettingsTab.swift
+++ b/Sources/Nehir/UI/WorkspaceBarSettingsTab.swift
@@ -70,7 +70,6 @@ private struct GlobalBarSettingsSection: View {
                     .onChange(of: settings.workspaceBarShowFloatingWindows) { _, _ in
                         controller.updateWorkspaceBarSettings()
                     }
-
                 if settings.developerModeEnabled {
                     SettingsCaption(
                         "Developer trace controls now live in the DebugBar, keeping workspace navigation separate from debugging actions."
@@ -86,6 +85,10 @@ private struct GlobalBarSettingsSection: View {
                     .onChange(of: settings.workspaceBarHideEmptyWorkspaces) { _, _ in
                         controller.updateWorkspaceBarSettings()
                     }
+
+                SettingsCaption(
+                    "Tip: right-click a window icon, the scratchpad, or a workspace for more actions."
+                )
             }
         }
 

--- a/Tests/NehirTests/WMControllerWindowActionsTests.swift
+++ b/Tests/NehirTests/WMControllerWindowActionsTests.swift
@@ -234,14 +234,18 @@ private func syncNiriWorkspaceState(
         // Focus A; close B's token. B resolves (not A's focus), and the entry
         // for B exists so the close path is reachable.
         _ = controller.workspaceManager.setManagedFocus(tokenA, in: workspaceId, onMonitor: monitor.id)
+        var closedTokens: [WindowToken] = []
+        controller.windowActionHandler.closeWindowForTests = { handle in
+            closedTokens.append(handle.id)
+        }
 
         #expect(controller.closeWindowFromBar(token: tokenB) == .executed)
-        // A remains tracked (its close path was not taken).
-        #expect(controller.workspaceManager.entry(for: tokenA) != nil)
+        #expect(closedTokens == [tokenB])
 
-        // Unknown token → notFound.
+        // Unknown token → notFound and no extra close action.
         let unknownToken = WindowToken(pid: 99_998, windowId: 99_998)
         #expect(controller.closeWindowFromBar(token: unknownToken) == .notFound)
+        #expect(closedTokens == [tokenB])
     }
 
     // MARK: - Move to Workspace

--- a/Tests/NehirTests/WMControllerWindowActionsTests.swift
+++ b/Tests/NehirTests/WMControllerWindowActionsTests.swift
@@ -1,0 +1,292 @@
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=nehir-original; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
+import CoreGraphics
+import Foundation
+@testable import Nehir
+import Testing
+
+/// Mirrors the file-private niri sync helper in WorkspaceNavigationHandlerTests:
+/// inserts each workspace's windows into the engine and reconciles selection.
+@MainActor
+private func syncNiriWorkspaceState(
+    on controller: WMController,
+    workspaceIds: Set<WorkspaceDescriptor.ID>
+) {
+    guard let engine = controller.niriEngine else { return }
+    for workspaceId in workspaceIds {
+        let handles = controller.workspaceManager.entries(in: workspaceId).map(\.handle)
+        let selectedNodeId = controller.workspaceManager.niriViewportState(for: workspaceId).selectedNodeId
+        let focusedHandle = controller.workspaceManager.lastFocusedHandle(in: workspaceId)
+        _ = engine.syncWindows(
+            handles,
+            in: workspaceId,
+            selectedNodeId: selectedNodeId,
+            focusedHandle: focusedHandle
+        )
+        let resolvedSelection = focusedHandle.flatMap { engine.findNode(for: $0)?.id }
+            ?? engine.validateSelection(selectedNodeId, in: workspaceId)
+        controller.workspaceManager.withNiriViewportState(for: workspaceId) { state in
+            state.selectedNodeId = resolvedSelection
+            state.activeColumnIndex = min(state.activeColumnIndex, max(0, engine.columns(in: workspaceId).count - 1))
+        }
+    }
+}
+
+/// Token-target semantics for the workspace-bar right-click action family
+/// (plan #18 Phase 1). These exercise the load-bearing refactor: the
+/// per-window actions must act on the *passed* token, not the focused window
+/// (the #8 defect). Mirrors the assertion style of `WMControllerScratchpadTests`.
+@Suite(.serialized) struct WMControllerWindowActionsTests {
+    // MARK: - Toggle Floating
+
+    @Test @MainActor func toggleWindowFloatingActsOnExplicitTokenNotFocus() {
+        let controller = makeLayoutPlanTestController()
+        guard let monitor = controller.workspaceManager.monitors.first,
+              let workspaceId = controller.workspaceManager.activeWorkspaceOrFirst(on: monitor.id)?.id
+        else {
+            Issue.record("Missing monitor or workspace for toggle-floating test")
+            return
+        }
+
+        let tokenA = addLayoutPlanTestWindow(on: controller, workspaceId: workspaceId, windowId: 801)
+        let tokenB = addLayoutPlanTestWindow(on: controller, workspaceId: workspaceId, windowId: 802)
+
+        // Focus window A; act on window B's token. B (not A) must toggle.
+        _ = controller.workspaceManager.setManagedFocus(tokenA, in: workspaceId, onMonitor: monitor.id)
+        #expect(controller.workspaceManager.confirmedManagedFocusToken == tokenA)
+        #expect(controller.workspaceManager.windowMode(for: tokenB) == .tiling)
+
+        let result = controller.toggleWindowFloating(token: tokenB)
+        #expect(result == .executed)
+
+        // B flipped to floating; A untouched.
+        #expect(controller.workspaceManager.windowMode(for: tokenB) == .floating)
+        #expect(controller.workspaceManager.manualLayoutOverride(for: tokenB) == .forceFloat)
+        #expect(controller.workspaceManager.windowMode(for: tokenA) == .tiling)
+        #expect(controller.workspaceManager.manualLayoutOverride(for: tokenA) == nil)
+        // Focus did not move to B.
+        #expect(controller.workspaceManager.confirmedManagedFocusToken == tokenA)
+    }
+
+    @Test @MainActor func toggleWindowFloatingReturnsNotFoundForUnknownToken() {
+        let controller = makeLayoutPlanTestController()
+        let unknownToken = WindowToken(pid: 99_999, windowId: 99_999)
+        #expect(controller.toggleWindowFloating(token: unknownToken) == .notFound)
+    }
+
+    @Test @MainActor func toggleFocusedWindowFloatingStillTargetsFocusAfterRefactor() {
+        // No-regression: the focused wrapper delegates to the same body and
+        // still targets the focused token.
+        let controller = makeLayoutPlanTestController()
+        guard let monitor = controller.workspaceManager.monitors.first,
+              let workspaceId = controller.workspaceManager.activeWorkspaceOrFirst(on: monitor.id)?.id
+        else {
+            Issue.record("Missing monitor or workspace for focused-toggle test")
+            return
+        }
+
+        let token = addLayoutPlanTestWindow(on: controller, workspaceId: workspaceId, windowId: 803)
+        _ = controller.workspaceManager.setManagedFocus(token, in: workspaceId, onMonitor: monitor.id)
+
+        #expect(controller.toggleFocusedWindowFloating() == .executed)
+        #expect(controller.workspaceManager.windowMode(for: token) == .floating)
+        #expect(controller.workspaceManager.manualLayoutOverride(for: token) == .forceFloat)
+    }
+
+    // MARK: - Assign / Unassign Scratchpad
+
+    @Test @MainActor func assignWindowToScratchpadActsOnExplicitToken() {
+        let controller = makeLayoutPlanTestController()
+        guard let monitor = controller.workspaceManager.monitors.first,
+              let workspaceId = controller.workspaceManager.activeWorkspaceOrFirst(on: monitor.id)?.id
+        else {
+            Issue.record("Missing monitor or workspace for assign test")
+            return
+        }
+
+        let tokenA = addLayoutPlanTestWindow(on: controller, workspaceId: workspaceId, windowId: 811)
+        let tokenB = addLayoutPlanTestWindow(on: controller, workspaceId: workspaceId, windowId: 812)
+        controller.axManager.applyFramesParallel([(
+            tokenB.pid,
+            tokenB.windowId,
+            CGRect(x: 140, y: 120, width: 760, height: 520)
+        )])
+
+        // Focus A; assign B. B becomes the scratchpad; A unchanged.
+        _ = controller.workspaceManager.setManagedFocus(tokenA, in: workspaceId, onMonitor: monitor.id)
+
+        #expect(controller.assignWindowToScratchpad(token: tokenB) == .executed)
+        #expect(controller.workspaceManager.scratchpadToken() == tokenB)
+        #expect(controller.workspaceManager.windowMode(for: tokenB) == .floating)
+        #expect(controller.workspaceManager.hiddenState(for: tokenB)?.isScratchpad == true)
+        // Focused window A is untouched.
+        #expect(controller.workspaceManager.windowMode(for: tokenA) == .tiling)
+        #expect(controller.workspaceManager.hiddenState(for: tokenA) == nil)
+    }
+
+    @Test @MainActor func unassignWindowFromScratchpadActsOnExplicitToken() async {
+        let controller = makeLayoutPlanTestController()
+        guard let monitor = controller.workspaceManager.monitors.first,
+              let workspaceId = controller.workspaceManager.activeWorkspaceOrFirst(on: monitor.id)?.id
+        else {
+            Issue.record("Missing monitor or workspace for unassign test")
+            return
+        }
+
+        let tokenA = addLayoutPlanTestWindow(on: controller, workspaceId: workspaceId, windowId: 821)
+        let tokenB = addLayoutPlanTestWindow(on: controller, workspaceId: workspaceId, windowId: 822)
+        controller.axManager.applyFramesParallel([(
+            tokenB.pid,
+            tokenB.windowId,
+            CGRect(x: 160, y: 130, width: 720, height: 500)
+        )])
+
+        _ = controller.assignWindowToScratchpad(token: tokenB)
+        #expect(controller.workspaceManager.scratchpadToken() == tokenB)
+
+        // Reveal the scratchpad before unassigning (matches the scratchpad-pill
+        // right-click UX: the pill is right-clicked while the app is shown).
+        controller.toggleScratchpadWindow()
+        await waitForLayoutPlanRefreshWork(on: controller)
+        #expect(controller.workspaceManager.hiddenState(for: tokenB) == nil)
+
+        // Focus A; unassign B. B is cleaned up and force-tiled; A untouched.
+        _ = controller.workspaceManager.setManagedFocus(tokenA, in: workspaceId, onMonitor: monitor.id)
+
+        #expect(controller.unassignWindowFromScratchpad(token: tokenB) == .executed)
+        #expect(controller.workspaceManager.scratchpadToken() == nil)
+        #expect(controller.workspaceManager.hiddenState(for: tokenB) == nil)
+        #expect(controller.workspaceManager.windowMode(for: tokenB) == .tiling)
+        #expect(controller.workspaceManager.manualLayoutOverride(for: tokenB) == .forceTile)
+        #expect(controller.workspaceManager.windowMode(for: tokenA) == .tiling)
+        #expect(controller.workspaceManager.manualLayoutOverride(for: tokenA) == nil)
+    }
+
+    @Test @MainActor func unassignWindowFromScratchpadReturnsNotFoundForNonScratchpadToken() {
+        let controller = makeLayoutPlanTestController()
+        guard let monitor = controller.workspaceManager.monitors.first,
+              let workspaceId = controller.workspaceManager.activeWorkspaceOrFirst(on: monitor.id)?.id
+        else {
+            Issue.record("Missing monitor or workspace for unassign-reject test")
+            return
+        }
+
+        let token = addLayoutPlanTestWindow(on: controller, workspaceId: workspaceId, windowId: 823)
+        // token is not the scratchpad → unassign is a no-op.
+        #expect(controller.unassignWindowFromScratchpad(token: token) == .notFound)
+        #expect(controller.workspaceManager.windowMode(for: token) == .tiling)
+    }
+
+    @Test @MainActor func assignWindowToScratchpadReturnsNotFoundWhenSlotOccupied() {
+        // Single-slot collision (#7): a second assignment must return .notFound
+        // so the right-click menu item disables rather than silently no-op'ing.
+        let controller = makeLayoutPlanTestController()
+        guard let monitor = controller.workspaceManager.monitors.first,
+              let workspaceId = controller.workspaceManager.activeWorkspaceOrFirst(on: monitor.id)?.id
+        else {
+            Issue.record("Missing monitor or workspace for collision test")
+            return
+        }
+
+        let tokenA = addLayoutPlanTestWindow(on: controller, workspaceId: workspaceId, windowId: 831)
+        let tokenB = addLayoutPlanTestWindow(on: controller, workspaceId: workspaceId, windowId: 832)
+        controller.axManager.applyFramesParallel([(
+            tokenA.pid,
+            tokenA.windowId,
+            CGRect(x: 140, y: 120, width: 760, height: 520)
+        )])
+        controller.axManager.applyFramesParallel([(
+            tokenB.pid,
+            tokenB.windowId,
+            CGRect(x: 980, y: 120, width: 760, height: 520)
+        )])
+
+        #expect(controller.assignWindowToScratchpad(token: tokenA) == .executed)
+        #expect(controller.workspaceManager.scratchpadToken() == tokenA)
+
+        // Slot is occupied by A → assigning B is rejected.
+        #expect(controller.assignWindowToScratchpad(token: tokenB) == .notFound)
+        #expect(controller.workspaceManager.scratchpadToken() == tokenA)
+        #expect(controller.workspaceManager.hiddenState(for: tokenB) == nil)
+        #expect(controller.workspaceManager.windowMode(for: tokenB) == .tiling)
+    }
+
+    // MARK: - Close
+
+    @Test @MainActor func closeWindowFromBarTargetsExplicitToken() {
+        // The close path resolves the passed token's entry directly (not from
+        // focus). A known token returns .executed; an unknown one .notFound.
+        // Focus is irrelevant to resolution.
+        let controller = makeLayoutPlanTestController()
+        guard let monitor = controller.workspaceManager.monitors.first,
+              let workspaceId = controller.workspaceManager.activeWorkspaceOrFirst(on: monitor.id)?.id
+        else {
+            Issue.record("Missing monitor or workspace for close test")
+            return
+        }
+
+        let tokenA = addLayoutPlanTestWindow(on: controller, workspaceId: workspaceId, windowId: 841)
+        let tokenB = addLayoutPlanTestWindow(on: controller, workspaceId: workspaceId, windowId: 842)
+
+        // Focus A; close B's token. B resolves (not A's focus), and the entry
+        // for B exists so the close path is reachable.
+        _ = controller.workspaceManager.setManagedFocus(tokenA, in: workspaceId, onMonitor: monitor.id)
+
+        #expect(controller.closeWindowFromBar(token: tokenB) == .executed)
+        // A remains tracked (its close path was not taken).
+        #expect(controller.workspaceManager.entry(for: tokenA) != nil)
+
+        // Unknown token → notFound.
+        let unknownToken = WindowToken(pid: 99_998, windowId: 99_998)
+        #expect(controller.closeWindowFromBar(token: unknownToken) == .notFound)
+    }
+
+    // MARK: - Move to Workspace
+
+    @Test @MainActor func moveWindowFromBarTargetsExplicitToken() async {
+        // The passed token is moved to the target workspace via
+        // moveWindow(handle:toWorkspaceId:), independent of focus. Requires the
+        // niri engine to be enabled and synced (same setup the navigation
+        // handler move tests use).
+        let controller = makeLayoutPlanTestController()
+        guard let monitor = controller.workspaceManager.monitors.first,
+              let workspace1 = controller.workspaceManager.workspaceId(for: "1", createIfMissing: false),
+              let workspace2 = controller.workspaceManager.workspaceId(for: "2", createIfMissing: false)
+        else {
+            Issue.record("Missing monitor or workspaces for move test")
+            return
+        }
+
+        controller.enableNiriLayout()
+        await waitForLayoutPlanRefreshWork(on: controller)
+        controller.syncMonitorsToNiriEngine()
+
+        let tokenA = addLayoutPlanTestWindow(on: controller, workspaceId: workspace1, windowId: 851)
+        let tokenB = addLayoutPlanTestWindow(on: controller, workspaceId: workspace1, windowId: 852)
+        syncNiriWorkspaceState(on: controller, workspaceIds: [workspace1, workspace2])
+
+        // Focus A; move B to workspace 2. B (not A) moves.
+        _ = controller.workspaceManager.setManagedFocus(tokenA, in: workspace1, onMonitor: monitor.id)
+        syncNiriWorkspaceState(on: controller, workspaceIds: [workspace1, workspace2])
+
+        let result = controller.moveWindowFromBar(token: tokenB, toWorkspaceId: workspace2)
+        await waitForLayoutPlanRefreshWork(on: controller)
+        #expect(result == .executed)
+        #expect(controller.workspaceManager.workspace(for: tokenB) == workspace2)
+        // A stays in workspace 1.
+        #expect(controller.workspaceManager.workspace(for: tokenA) == workspace1)
+    }
+
+    @Test @MainActor func moveWindowFromBarReturnsNotFoundForUnknownToken() {
+        let controller = makeLayoutPlanTestController()
+        guard let workspace1 = controller.workspaceManager.workspaceId(for: "1", createIfMissing: false) else {
+            Issue.record("Missing workspace for move-unknown test")
+            return
+        }
+        let unknownToken = WindowToken(pid: 99_997, windowId: 99_997)
+        #expect(controller.moveWindowFromBar(token: unknownToken, toWorkspaceId: workspace1) == .notFound)
+    }
+}

--- a/Tests/NehirTests/WorkspaceBarManagerTests.swift
+++ b/Tests/NehirTests/WorkspaceBarManagerTests.swift
@@ -534,6 +534,156 @@ private func makeRecordingPanelFactory(
     }
 }
 
+@MainActor
+private func addWorkspaceBarClickTestWindow(
+    on controller: WMController,
+    workspaceId: WorkspaceDescriptor.ID,
+    windowId: Int
+) -> WindowHandle {
+    let token = addLayoutPlanTestWindow(on: controller, workspaceId: workspaceId, windowId: windowId)
+    guard let handle = controller.workspaceManager.handle(for: token) else {
+        fatalError("Expected bridge handle for workspace bar click test window")
+    }
+    return handle
+}
+
+@MainActor
+private func syncNiriWorkspaceStateForBarClickTests(
+    on controller: WMController,
+    workspaceIds: Set<WorkspaceDescriptor.ID>
+) {
+    guard let engine = controller.niriEngine else { return }
+    for workspaceId in workspaceIds {
+        let handles = controller.workspaceManager.entries(in: workspaceId).map(\.handle)
+        let selectedNodeId = controller.workspaceManager.niriViewportState(for: workspaceId).selectedNodeId
+        let focusedHandle = controller.workspaceManager.lastFocusedHandle(in: workspaceId)
+        _ = engine.syncWindows(handles, in: workspaceId, selectedNodeId: selectedNodeId, focusedHandle: focusedHandle)
+        let resolvedSelection = focusedHandle.flatMap { engine.findNode(for: $0)?.id }
+            ?? engine.validateSelection(selectedNodeId, in: workspaceId)
+        controller.workspaceManager.withNiriViewportState(for: workspaceId) { state in
+            state.selectedNodeId = resolvedSelection
+            state.activeColumnIndex = min(state.activeColumnIndex, max(0, engine.columns(in: workspaceId).count - 1))
+        }
+    }
+}
+
+@Suite(.serialized) @MainActor struct WorkspaceBarClickIntentTests {
+    @Test func clickIntentResolveMapsShiftToMoveWindow() {
+        #expect(WorkspaceBarClickIntent.resolve(modifiers: .shift) == .moveWindow)
+        #expect(WorkspaceBarClickIntent.resolve(modifiers: NSEvent.ModifierFlags(rawValue: 0)) == .focus)
+        #expect(WorkspaceBarClickIntent.resolve(modifiers: .option) == .focus)
+        // Shift combined with other modifiers still maps to move (Shift is the move differentiator).
+        #expect(WorkspaceBarClickIntent.resolve(modifiers: [.shift, .option]) == .moveWindow)
+    }
+
+    @Test func onFocusWorkspaceDispatchesMoveOnShift() async throws {
+        let monitor = makeLayoutPlanTestMonitor(displayId: 90)
+        let controller = makeLayoutPlanTestController(monitors: [monitor])
+        controller.settings.focusFollowsWindowToMonitor = false
+
+        guard let targetWorkspaceId = controller.workspaceManager.workspaceId(for: "1", createIfMissing: false),
+              let sourceWorkspaceId = controller.workspaceManager.workspaceId(for: "2", createIfMissing: false)
+        else {
+            Issue.record("Missing single-monitor workspace fixture")
+            return
+        }
+
+        controller.enableNiriLayout()
+        await waitForLayoutPlanRefreshWork(on: controller)
+        controller.syncMonitorsToNiriEngine()
+
+        let targetFirst = addWorkspaceBarClickTestWindow(
+            on: controller,
+            workspaceId: targetWorkspaceId,
+            windowId: 20_101
+        )
+        _ = addWorkspaceBarClickTestWindow(on: controller, workspaceId: targetWorkspaceId, windowId: 20_102)
+        let movedHandle = addWorkspaceBarClickTestWindow(
+            on: controller,
+            workspaceId: sourceWorkspaceId,
+            windowId: 20_103
+        )
+
+        _ = controller.workspaceManager.rememberFocus(targetFirst, in: targetWorkspaceId)
+        _ = controller.workspaceManager.setManagedFocus(movedHandle, in: sourceWorkspaceId, onMonitor: monitor.id)
+        syncNiriWorkspaceStateForBarClickTests(on: controller, workspaceIds: [targetWorkspaceId, sourceWorkspaceId])
+        controller.workspaceManager.withNiriViewportState(for: targetWorkspaceId) { state in
+            state.activeColumnIndex = 0
+            state.viewOffsetPixels = .static(0)
+        }
+        _ = controller.workspaceManager.setActiveWorkspace(sourceWorkspaceId, on: monitor.id)
+        _ = controller.workspaceManager.setInteractionMonitor(monitor.id)
+
+        let manager = WorkspaceBarManager()
+        manager.monitorProvider = { [monitor] }
+        manager.screenProvider = { _ in nil }
+        manager.panelFactory = makeRecordingPanelFactory(store: RecordingPanelStore())
+        manager.setup(controller: controller, settings: controller.settings)
+        defer {
+            manager.clickIntentFlagProvider = { NSEvent.modifierFlags }
+            manager.cleanup()
+        }
+
+        manager.clickIntentFlagProvider = { .shift }
+        let item = WorkspaceBarItem(
+            id: targetWorkspaceId,
+            name: "1",
+            rawName: "1",
+            isFocused: false,
+            tiledWindows: [],
+            floatingWindows: []
+        )
+        manager.handleWorkspacePillClick(item)
+        await waitForLayoutPlanRefreshWork(on: controller)
+
+        #expect(controller.workspaceManager.workspace(for: movedHandle.id) == targetWorkspaceId)
+    }
+
+    @Test func onFocusWorkspaceDispatchesFocusByDefault() throws {
+        let monitor = makeLayoutPlanTestMonitor(displayId: 91)
+        let controller = makeLayoutPlanTestController(monitors: [monitor])
+
+        guard let targetWorkspaceId = controller.workspaceManager.workspaceId(for: "1", createIfMissing: false),
+              let sourceWorkspaceId = controller.workspaceManager.workspaceId(for: "2", createIfMissing: false)
+        else {
+            Issue.record("Missing single-monitor workspace fixture")
+            return
+        }
+
+        let unmovedHandle = addWorkspaceBarClickTestWindow(
+            on: controller,
+            workspaceId: sourceWorkspaceId,
+            windowId: 21_101
+        )
+        _ = controller.workspaceManager.setActiveWorkspace(sourceWorkspaceId, on: monitor.id)
+
+        let manager = WorkspaceBarManager()
+        manager.monitorProvider = { [monitor] }
+        manager.screenProvider = { _ in nil }
+        manager.panelFactory = makeRecordingPanelFactory(store: RecordingPanelStore())
+        manager.setup(controller: controller, settings: controller.settings)
+        defer {
+            manager.clickIntentFlagProvider = { NSEvent.modifierFlags }
+            manager.cleanup()
+        }
+
+        manager.clickIntentFlagProvider = { NSEvent.ModifierFlags(rawValue: 0) }
+        let item = WorkspaceBarItem(
+            id: targetWorkspaceId,
+            name: "1",
+            rawName: "1",
+            isFocused: false,
+            tiledWindows: [],
+            floatingWindows: []
+        )
+        manager.handleWorkspacePillClick(item)
+
+        // Plain-click path: focus switches to the clicked workspace, no window moves.
+        #expect(controller.workspaceManager.currentActiveWorkspace(on: monitor.id)?.id == targetWorkspaceId)
+        #expect(controller.workspaceManager.workspace(for: unmovedHandle.id) == sourceWorkspaceId)
+    }
+}
+
 @Suite struct WorkspaceBarPanelTests {
     @Test @MainActor func constrainFrameRectClampsToTargetFrameWhenScreenIsNil() {
         let panel = WorkspaceBarPanel(

--- a/Tests/NehirTests/WorkspaceBarRightClickWiringTests.swift
+++ b/Tests/NehirTests/WorkspaceBarRightClickWiringTests.swift
@@ -141,8 +141,8 @@ import Testing
 
     @Test @MainActor func moveTargetsExcludeCurrentWorkspace() throws {
         // The *Move to Workspace ▸* submenu must not offer the window's own
-        // workspace. The view scopes targets to `snapshot.items` excluding the
-        // window's item; verify the snapshot surfaces the other workspace.
+        // workspace. Verify the same helper used by the view's scoped actions
+        // removes the current workspace while preserving the other workspace.
         let monitor = makeLayoutPlanTestMonitor(displayId: 904)
         let controller = makeLayoutPlanTestController(monitors: [monitor])
         guard let workspace1 = controller.workspaceManager.workspaceId(for: "1", createIfMissing: false),
@@ -164,10 +164,17 @@ import Testing
         defer { manager.cleanup() }
 
         let snapshot = try #require(manager.snapshotForTests(on: monitor.id))
-        let workspaceIds = Set(snapshot.items.map(\.id))
-        #expect(workspaceIds.contains(workspace1))
-        #expect(workspaceIds.contains(workspace2))
-        #expect(snapshot.items.count >= 2)
+        let moveTargets = snapshot.items.map { item in
+            WorkspaceBarWindowMoveTarget(id: item.id, name: item.name)
+        }
+        let filteredTargets = workspaceBarMoveTargetsExcludingCurrentWorkspace(
+            moveTargets,
+            currentWorkspaceId: workspace1
+        )
+        let filteredIds = Set(filteredTargets.map(\.id))
+
+        #expect(!filteredIds.contains(workspace1))
+        #expect(filteredIds.contains(workspace2))
     }
 }
 

--- a/Tests/NehirTests/WorkspaceBarRightClickWiringTests.swift
+++ b/Tests/NehirTests/WorkspaceBarRightClickWiringTests.swift
@@ -1,0 +1,212 @@
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=nehir-original; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
+import AppKit
+import CoreGraphics
+import Foundation
+@testable import Nehir
+import Testing
+
+/// Bar-wiring tests for the right-click action family (plan #18 Phase 3).
+///
+/// `.contextMenu` closures live inside the SwiftUI view hierarchy and cannot be
+/// driven programmatically without simulating a real right-click gesture, so
+/// these tests verify the *contract* the closures depend on rather than the
+/// gesture itself:
+///
+/// 1. The bar snapshot exposes the window/scratchpad tokens the closures act on.
+/// 2. The controller entry points the closures wrap work end-to-end on those
+///    exact tokens (token-target, not focus — the #8/#18 seam).
+/// 3. The single-slot disable flag (`scratchpadSlotOccupied`) tracks scratchpad
+///    presence so the *Assign to Scratchpad* item disables correctly.
+@Suite(.serialized) struct WorkspaceBarRightClickWiringTests {
+    @Test @MainActor func snapshotExposesWindowTokensForEachWindowIcon() throws {
+        let monitor = makeLayoutPlanTestMonitor(displayId: 901)
+        let controller = makeLayoutPlanTestController(monitors: [monitor])
+        guard let workspaceId = controller.workspaceManager.activeWorkspaceOrFirst(on: monitor.id)?.id else {
+            Issue.record("Missing workspace for wiring fixture")
+            return
+        }
+
+        let tokenA = addLayoutPlanTestWindow(on: controller, workspaceId: workspaceId, windowId: 9010)
+        let tokenB = addLayoutPlanTestWindow(on: controller, workspaceId: workspaceId, windowId: 9011)
+
+        let manager = WorkspaceBarManager()
+        manager.monitorProvider = { [monitor] }
+        manager.screenProvider = { _ in nil }
+        manager.panelFactory = makeRightClickPanelFactory()
+
+        manager.setup(controller: controller, settings: controller.settings)
+        defer { manager.cleanup() }
+
+        let snapshot = try #require(manager.snapshotForTests(on: monitor.id))
+        let windowTokens = snapshot.items.flatMap(\.windows).map(\.id)
+        #expect(snapshot.items.contains(where: { $0.windows.contains(where: { $0.id == tokenA }) }))
+        #expect(windowTokens.contains(tokenB))
+    }
+
+    @Test @MainActor func controllerEntryPointsActOnBarSnapshotTokens() async throws {
+        // Integration: the controller methods the closures wrap
+        // (toggleWindowFloating / toggleWindowScratchpadAssignment /
+        // moveWindowFromBar / closeWindowFromBar) act on the exact tokens the
+        // bar snapshot exposes — proving the wiring is token-correct.
+        let monitor = makeLayoutPlanTestMonitor(displayId: 902)
+        let controller = makeLayoutPlanTestController(monitors: [monitor])
+        guard let workspace1 = controller.workspaceManager.workspaceId(for: "1", createIfMissing: false),
+              let workspace2 = controller.workspaceManager.workspaceId(for: "2", createIfMissing: false)
+        else {
+            Issue.record("Missing workspaces for wiring fixture")
+            return
+        }
+
+        controller.enableNiriLayout()
+        await waitForLayoutPlanRefreshWork(on: controller)
+        controller.syncMonitorsToNiriEngine()
+
+        let tokenA = addLayoutPlanTestWindow(on: controller, workspaceId: workspace1, windowId: 9020)
+        let tokenB = addLayoutPlanTestWindow(on: controller, workspaceId: workspace1, windowId: 9021)
+        syncNiriWorkspaceStateForRightClickTests(on: controller, workspaceIds: [workspace1, workspace2])
+
+        let manager = WorkspaceBarManager()
+        manager.monitorProvider = { [monitor] }
+        manager.screenProvider = { _ in nil }
+        manager.panelFactory = makeRightClickPanelFactory()
+
+        manager.setup(controller: controller, settings: controller.settings)
+        defer { manager.cleanup() }
+
+        let snapshot = try #require(manager.snapshotForTests(on: monitor.id))
+        let exposedTokens = Set(snapshot.items.flatMap(\.windows).map(\.id))
+        #expect(exposedTokens.contains(tokenA))
+        #expect(exposedTokens.contains(tokenB))
+
+        // moveWindowFromBar (window-icon *Move to Workspace ▸*) on tokenB
+        // while it is still tiled (the niri engine tracks tiled windows).
+        let moveResult = controller.moveWindowFromBar(token: tokenB, toWorkspaceId: workspace2)
+        await waitForLayoutPlanRefreshWork(on: controller)
+        #expect(moveResult == .executed)
+        #expect(controller.workspaceManager.workspace(for: tokenB) == workspace2)
+
+        // toggleWindowFloating (window-icon *Toggle Floating*) on tokenA.
+        #expect(controller.toggleWindowFloating(token: tokenA) == .executed)
+        #expect(controller.workspaceManager.windowMode(for: tokenA) == .floating)
+
+        // closeWindowFromBar (window-icon *Close*) resolves tokenA's entry.
+        #expect(controller.closeWindowFromBar(token: tokenA) == .executed)
+    }
+
+    @Test @MainActor func scratchpadPresenceDrivesAssignItemDisabledFlag() throws {
+        // The single-slot constraint (#7): the *Assign to Scratchpad* item must
+        // disable when the slot is occupied. The view derives
+        // `scratchpadSlotOccupied` from `snapshot.scratchpad != nil`; verify the
+        // snapshot tracks scratchpad presence.
+        let monitor = makeLayoutPlanTestMonitor(displayId: 903)
+        let controller = makeLayoutPlanTestController(monitors: [monitor])
+        guard let workspaceId = controller.workspaceManager.activeWorkspaceOrFirst(on: monitor.id)?.id else {
+            Issue.record("Missing workspace for scratchpad wiring fixture")
+            return
+        }
+
+        let token = addLayoutPlanTestWindow(on: controller, workspaceId: workspaceId, windowId: 9030)
+        controller.axManager.applyFramesParallel([(
+            token.pid,
+            token.windowId,
+            CGRect(x: 140, y: 120, width: 760, height: 520)
+        )])
+
+        let manager = WorkspaceBarManager()
+        manager.monitorProvider = { [monitor] }
+        manager.screenProvider = { _ in nil }
+        manager.panelFactory = makeRightClickPanelFactory()
+
+        manager.setup(controller: controller, settings: controller.settings)
+        defer { manager.cleanup() }
+
+        // No scratchpad → item enabled (slot free).
+        #expect(try #require(manager.snapshotForTests(on: monitor.id)).scratchpad == nil)
+
+        // Assigning makes the scratchpad pill appear → slot occupied → item disabled.
+        #expect(controller.assignWindowToScratchpad(token: token) == .executed)
+        manager.update()
+        let snapshot = try #require(manager.snapshotForTests(on: monitor.id))
+        #expect(snapshot.scratchpad?.window.id == token)
+
+        // A second assignment is rejected (the disable flag would have prevented
+        // the call in the UI; here we confirm the controller agrees).
+        let otherToken = addLayoutPlanTestWindow(on: controller, workspaceId: workspaceId, windowId: 9031)
+        #expect(controller.assignWindowToScratchpad(token: otherToken) == .notFound)
+    }
+
+    @Test @MainActor func moveTargetsExcludeCurrentWorkspace() throws {
+        // The *Move to Workspace ▸* submenu must not offer the window's own
+        // workspace. The view scopes targets to `snapshot.items` excluding the
+        // window's item; verify the snapshot surfaces the other workspace.
+        let monitor = makeLayoutPlanTestMonitor(displayId: 904)
+        let controller = makeLayoutPlanTestController(monitors: [monitor])
+        guard let workspace1 = controller.workspaceManager.workspaceId(for: "1", createIfMissing: false),
+              let workspace2 = controller.workspaceManager.workspaceId(for: "2", createIfMissing: false)
+        else {
+            Issue.record("Missing workspaces for move-targets fixture")
+            return
+        }
+
+        addLayoutPlanTestWindow(on: controller, workspaceId: workspace1, windowId: 9040)
+        addLayoutPlanTestWindow(on: controller, workspaceId: workspace2, windowId: 9041)
+
+        let manager = WorkspaceBarManager()
+        manager.monitorProvider = { [monitor] }
+        manager.screenProvider = { _ in nil }
+        manager.panelFactory = makeRightClickPanelFactory()
+
+        manager.setup(controller: controller, settings: controller.settings)
+        defer { manager.cleanup() }
+
+        let snapshot = try #require(manager.snapshotForTests(on: monitor.id))
+        let workspaceIds = Set(snapshot.items.map(\.id))
+        #expect(workspaceIds.contains(workspace1))
+        #expect(workspaceIds.contains(workspace2))
+        #expect(snapshot.items.count >= 2)
+    }
+}
+
+@MainActor
+private func syncNiriWorkspaceStateForRightClickTests(
+    on controller: WMController,
+    workspaceIds: Set<WorkspaceDescriptor.ID>
+) {
+    guard let engine = controller.niriEngine else { return }
+    for workspaceId in workspaceIds {
+        let handles = controller.workspaceManager.entries(in: workspaceId).map(\.handle)
+        let selectedNodeId = controller.workspaceManager.niriViewportState(for: workspaceId).selectedNodeId
+        let focusedHandle = controller.workspaceManager.lastFocusedHandle(in: workspaceId)
+        _ = engine.syncWindows(
+            handles,
+            in: workspaceId,
+            selectedNodeId: selectedNodeId,
+            focusedHandle: focusedHandle
+        )
+        let resolvedSelection = focusedHandle.flatMap { engine.findNode(for: $0)?.id }
+            ?? engine.validateSelection(selectedNodeId, in: workspaceId)
+        controller.workspaceManager.withNiriViewportState(for: workspaceId) { state in
+            state.selectedNodeId = resolvedSelection
+            state.activeColumnIndex = min(state.activeColumnIndex, max(0, engine.columns(in: workspaceId).count - 1))
+        }
+    }
+}
+
+@MainActor
+private func makeRightClickPanelFactory() -> @MainActor @Sendable () -> WorkspaceBarPanel {
+    {
+        let panel = WorkspaceBarPanel(
+            contentRect: .zero,
+            styleMask: [.borderless, .nonactivatingPanel],
+            backing: .buffered,
+            defer: false
+        )
+        panel.alphaValue = 0
+        panel.ignoresMouseEvents = true
+        return panel
+    }
+}

--- a/Tests/NehirTests/WorkspaceNavigationHandlerTests.swift
+++ b/Tests/NehirTests/WorkspaceNavigationHandlerTests.swift
@@ -165,4 +165,144 @@ private func assertMovedWindowRevealedInTargetViewport(
         )
         #expect(controller.interactionWorkspace()?.id == sourceWorkspaceId)
     }
+
+    @Test @MainActor func moveFocusedWindowFromBarMovesFocusedWindowToClickedWorkspace() async throws {
+        let controller = makeWorkspaceNavigationTestController()
+        controller.settings.focusFollowsWindowToMonitor = false
+
+        guard let monitor = controller.workspaceManager.monitors.first,
+              let targetWorkspaceId = controller.workspaceManager.workspaceId(for: "1", createIfMissing: false),
+              let sourceWorkspaceId = controller.workspaceManager.workspaceId(for: "2", createIfMissing: false)
+        else {
+            Issue.record("Missing single-monitor workspace fixture")
+            return
+        }
+
+        controller.enableNiriLayout()
+        await waitForLayoutPlanRefreshWork(on: controller)
+        controller.syncMonitorsToNiriEngine()
+
+        let targetFirst = addWorkspaceNavigationTestWindow(
+            on: controller,
+            workspaceId: targetWorkspaceId,
+            windowId: 11_101
+        )
+        _ = addWorkspaceNavigationTestWindow(on: controller, workspaceId: targetWorkspaceId, windowId: 11_102)
+        _ = addWorkspaceNavigationTestWindow(on: controller, workspaceId: targetWorkspaceId, windowId: 11_103)
+        let movedHandle = addWorkspaceNavigationTestWindow(
+            on: controller,
+            workspaceId: sourceWorkspaceId,
+            windowId: 11_104
+        )
+
+        _ = controller.workspaceManager.rememberFocus(targetFirst, in: targetWorkspaceId)
+        _ = controller.workspaceManager.setManagedFocus(movedHandle, in: sourceWorkspaceId, onMonitor: monitor.id)
+        syncNiriWorkspaceStateForWorkspaceNavigationTests(
+            on: controller,
+            workspaceIds: [targetWorkspaceId, sourceWorkspaceId]
+        )
+        controller.workspaceManager.withNiriViewportState(for: targetWorkspaceId) { state in
+            state.activeColumnIndex = 0
+            state.viewOffsetPixels = .static(0)
+        }
+        _ = controller.workspaceManager.setActiveWorkspace(sourceWorkspaceId, on: monitor.id)
+        _ = controller.workspaceManager.setInteractionMonitor(monitor.id)
+
+        controller.moveFocusedWindowFromBar(toWorkspaceId: targetWorkspaceId)
+        await waitForLayoutPlanRefreshWork(on: controller)
+
+        assertMovedWindowRevealedInTargetViewport(
+            controller: controller,
+            workspaceId: targetWorkspaceId,
+            token: movedHandle.id
+        )
+        #expect(controller.workspaceManager.workspace(for: movedHandle.id) == targetWorkspaceId)
+        #expect(controller.interactionWorkspace()?.id == sourceWorkspaceId)
+    }
+
+    @Test @MainActor func moveFocusedWindowFromBarNoopsWhenNoManagedFocus() async throws {
+        let controller = makeWorkspaceNavigationTestController()
+
+        guard let sourceWorkspaceId = controller.workspaceManager.workspaceId(for: "2", createIfMissing: false),
+              let targetWorkspaceId = controller.workspaceManager.workspaceId(for: "1", createIfMissing: false)
+        else {
+            Issue.record("Missing single-monitor workspace fixture")
+            return
+        }
+
+        // A window exists on the source workspace, but no managed focus is confirmed
+        // and the Niri engine is not enabled, so `managedCommandTargetToken()` is nil.
+        let unmovedHandle = addWorkspaceNavigationTestWindow(
+            on: controller,
+            workspaceId: sourceWorkspaceId,
+            windowId: 12_101
+        )
+        #expect(controller.managedCommandTargetToken() == nil)
+
+        controller.moveFocusedWindowFromBar(toWorkspaceId: targetWorkspaceId)
+        await waitForLayoutPlanRefreshWork(on: controller)
+
+        #expect(controller.workspaceManager.workspace(for: unmovedHandle.id) == sourceWorkspaceId)
+    }
+
+    @Test @MainActor func moveFocusedWindowFromBarResolvesCustomNamedWorkspace() async throws {
+        // Nehir workspace names are always numeric; a custom *display* name is separate
+        // from the raw numeric `name`. This verifies the bar entry point resolves via
+        // `descriptor(for:)?.name` (the raw numeric id) for a non-default-numbered
+        // workspace, and that a custom display name does not leak into the resolution.
+        let controller = makeWorkspaceNavigationTestController(
+            workspaceConfigurations: [
+                WorkspaceConfiguration(name: "1", monitorAssignment: .main),
+                WorkspaceConfiguration(name: "3", displayName: "Development", monitorAssignment: .main)
+            ]
+        )
+        controller.settings.focusFollowsWindowToMonitor = false
+
+        guard let monitor = controller.workspaceManager.monitors.first,
+              let sourceWorkspaceId = controller.workspaceManager.workspaceId(for: "1", createIfMissing: false),
+              let targetWorkspaceId = controller.workspaceManager.workspaceId(for: "3", createIfMissing: false)
+        else {
+            Issue.record("Missing custom-named workspace fixture")
+            return
+        }
+        #expect(controller.workspaceManager.descriptor(for: targetWorkspaceId)?.name == "3")
+
+        controller.enableNiriLayout()
+        await waitForLayoutPlanRefreshWork(on: controller)
+        controller.syncMonitorsToNiriEngine()
+
+        _ = addWorkspaceNavigationTestWindow(
+            on: controller,
+            workspaceId: targetWorkspaceId,
+            windowId: 13_101
+        )
+        _ = addWorkspaceNavigationTestWindow(on: controller, workspaceId: targetWorkspaceId, windowId: 13_102)
+        let movedHandle = addWorkspaceNavigationTestWindow(
+            on: controller,
+            workspaceId: sourceWorkspaceId,
+            windowId: 13_103
+        )
+
+        _ = controller.workspaceManager.setManagedFocus(movedHandle, in: sourceWorkspaceId, onMonitor: monitor.id)
+        syncNiriWorkspaceStateForWorkspaceNavigationTests(
+            on: controller,
+            workspaceIds: [sourceWorkspaceId, targetWorkspaceId]
+        )
+        controller.workspaceManager.withNiriViewportState(for: targetWorkspaceId) { state in
+            state.activeColumnIndex = 0
+            state.viewOffsetPixels = .static(0)
+        }
+        _ = controller.workspaceManager.setActiveWorkspace(sourceWorkspaceId, on: monitor.id)
+        _ = controller.workspaceManager.setInteractionMonitor(monitor.id)
+
+        controller.moveFocusedWindowFromBar(toWorkspaceId: targetWorkspaceId)
+        await waitForLayoutPlanRefreshWork(on: controller)
+
+        assertMovedWindowRevealedInTargetViewport(
+            controller: controller,
+            workspaceId: targetWorkspaceId,
+            token: movedHandle.id
+        )
+        #expect(controller.workspaceManager.workspace(for: movedHandle.id) == targetWorkspaceId)
+    }
 }


### PR DESCRIPTION
## Summary

Shift+click a workspace pill to move the focused window there (mouse analogue of Opt+Shift+N), with a right-click workspace menu and Workspace Bar settings preview that explain the click behaviors.

Add right-click context menus to the workspace bar (window icons, scratchpad, workspace labels) backed by token-parameterized window actions.

## Release notes

Choose one:

- [x] Added a `.changeset/*.md` for user-visible changes (`mise run changeset -- patch "..."`).
- [ ] No user-visible change; apply the `no release note` label to make CI skip intentional.

## Validation

<!-- Commands run, screenshots, or manual checks. -->

- [ ] Ran relevant tests/checks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added right-click context menus across workspace labels, window icons, and scratchpad controls (focus/move, toggle floating, assign/unassign, close, and “Move to Workspace”).
  * Shift+click a workspace pill now moves the currently focused window to that workspace; normal click focuses the workspace (modifier-aware).
  * Added a “Preview & Behavior” section in Workspace Bar settings describing click and right-click actions with live status.
* **Bug Fixes**
  * Improved onboarding/workspace-bar animations and “Hide Empty” behavior to match real tiled vs floating occupancy and keep focus highlighting consistent.
  * Refined window action handling to better target the selected window/icon.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->