### PR TITLE
Stop inactive-workspace layout frame writes from leaking windows onscreen

### DIFF
--- a/.changeset/20260625194857-stop-inactive-workspace-layout-frame-writes-from.md
+++ b/.changeset/20260625194857-stop-inactive-workspace-layout-frame-writes-from.md
@@ -1,0 +1,6 @@
+---
+"nehir": patch
+
+---
+
+Stop inactive-workspace layout frame writes from leaking windows back onscreen

--- a/Sources/Nehir/Core/Controller/LayoutRefreshController.swift
+++ b/Sources/Nehir/Core/Controller/LayoutRefreshController.swift
@@ -2609,10 +2609,20 @@ import QuartzCore
         guard let liveFrame = AXWindowService.framePreferFast(entry.axRef)
             ?? (try? AXWindowService.frame(entry.axRef))
         else { return nil }
-        guard let activeWorkspaceId = controller.interactionWorkspace()?.id,
-              let activeMonitor = controller.workspaceManager.monitor(for: activeWorkspaceId)
-        else { return nil }
-        guard liveFrame.intersects(activeMonitor.frame) else { return nil }
+        // A workspace-inactive window must be parked offscreen on every monitor, so a
+        // leak is detected when the live frame intersects ANY active monitor — not only
+        // the single interaction monitor. Otherwise a window bleeding onto a different
+        // monitor's active workspace (a multi-monitor leak) is missed and never repaired.
+        let activeMonitors = controller.workspaceManager.monitors.filter {
+            controller.workspaceManager.activeWorkspace(on: $0.id) != nil
+        }
+        guard let activeMonitor = activeMonitors.first(where: { liveFrame.intersects($0.frame) }) else {
+            return nil
+        }
+        let interactionWorkspaceId = controller.interactionWorkspace()?.id
+        let activeWorkspaceId = interactionWorkspaceId
+            ?? controller.workspaceManager.activeWorkspace(on: activeMonitor.id)?.id
+        guard let activeWorkspaceId else { return nil }
 
         let hiddenPlacementMonitor = HiddenPlacementMonitorContext(monitor)
         let resolvedHiddenPlacementMonitors = hiddenPlacementMonitors
@@ -4068,6 +4078,18 @@ final class LayoutDiffExecutor {
 
         for (entry, hiddenState) in shownEntries {
             guard let hiddenState else { continue }
+            // An inactive workspace's `.show` means "visible inside this workspace's
+            // layout," not "reveal on the active monitor." Route such entries away
+            // from the entire reveal/visible-frame application flow — the pending
+            // reveal transaction, the visibleJobs activation (markWindowActive), and
+            // the frame write — by marking the token blocked. Otherwise the frame is
+            // pulled onscreen while the model still reports workspaceInactive. Tokens
+            // that also carry an explicit restoreChange are owned by the restore path
+            // above and are left untouched here.
+            if !isPlanWorkspaceActive, !restoreTokens.contains(entry.token) {
+                blockedRevealTokens.insert(entry.token)
+                continue
+            }
             guard let targetFrame = frameChangeByToken[entry.token] else {
                 if refreshController.hasPendingRevealTransaction(for: entry.windowId) {
                     blockedRevealTokens.insert(entry.token)

--- a/Sources/Nehir/Core/Controller/LayoutRefreshController.swift
+++ b/Sources/Nehir/Core/Controller/LayoutRefreshController.swift
@@ -2458,6 +2458,29 @@ import QuartzCore
             // Skip moving windows already hidden offscreen by the layout engine.
             // They're already parked — no need to shuffle them to the other side.
             if let hiddenState = controller.workspaceManager.hiddenState(for: entry.token) {
+                // Second-line repair: the model says this inactive-workspace window is
+                // parked, but its live frame is visibly onscreen (for example, a layout
+                // frame write leaked it onto the active monitor). Re-apply
+                // workspace-inactive parking instead of only logging the drift.
+                // `hideWindow` preserves the existing proportionalPosition so a later
+                // reveal still restores the user's original on-screen position.
+                if hiddenState.workspaceInactive,
+                   isWorkspaceInactiveWindowVisiblyDrifting(
+                       entry,
+                       monitor: monitor,
+                       preferredSide: preferredSide,
+                       hiddenState: hiddenState,
+                       hiddenPlacementMonitors: hiddenPlacementMonitors
+                   )
+                {
+                    hideWindow(
+                        entry,
+                        monitor: monitor,
+                        side: preferredSide,
+                        reason: .workspaceInactive,
+                        hiddenPlacementMonitors: hiddenPlacementMonitors
+                    )
+                }
                 traceWorkspaceInactiveVisibleDriftIfNeeded(
                     entry,
                     monitor: monitor,
@@ -2541,6 +2564,29 @@ import QuartzCore
             return rightLine
         }
         return lines.isEmpty ? "none" : lines.joined(separator: "\n")
+    }
+
+    /// Returns whether a window that the model reports as workspace-inactive-hidden
+    /// is in fact visibly onscreen on the active monitor and not parked at a screen
+    /// edge. Unlike `workspaceInactiveVisibleDriftLine`, this is evaluated regardless
+    /// of whether runtime trace capture is active, so it can drive a corrective
+    /// repair rather than only a diagnostic trace.
+    private func isWorkspaceInactiveWindowVisiblyDrifting(
+        _ entry: WindowModel.Entry,
+        monitor: Monitor,
+        preferredSide: HideSide,
+        hiddenState: WindowModel.HiddenState,
+        hiddenPlacementMonitors: [HiddenPlacementMonitorContext]? = nil
+    ) -> Bool {
+        workspaceInactiveVisibleDriftLine(
+            entry,
+            monitor: monitor,
+            preferredSide: preferredSide,
+            hiddenState: hiddenState,
+            hiddenPlacementMonitors: hiddenPlacementMonitors,
+            trigger: "hideWorkspace.driftRepair",
+            requireTraceCapture: false
+        ) != nil
     }
 
     private func workspaceInactiveVisibleDriftLine(
@@ -3912,6 +3958,14 @@ final class LayoutDiffExecutor {
 
         let diff = plan.diff
 
+        // Whether this plan targets the workspace that is currently active on its own
+        // monitor. Frame writes for an inactive workspace are the layout engine
+        // computing where a window *would* sit if the workspace were visible; they
+        // must not be treated as active/onscreen jobs (see inactive-workspace frame
+        // leak fix).
+        let isPlanWorkspaceActive = controller.workspaceManager
+            .activeWorkspace(on: monitor.id)?.id == plan.workspaceId
+
         var resolvedEntries: [WindowToken: WindowModel.Entry] = [:]
         var hiddenEntries: [(entry: WindowModel.Entry, side: HideSide)] = []
         var hiddenTokens: Set<WindowToken> = []
@@ -4145,6 +4199,12 @@ final class LayoutDiffExecutor {
                 && !pendingRevealTokens.contains(entry.token)
                 && !blockedRevealTokens.contains(entry.token)
             {
+                // A `.show` diff means "visible inside this workspace's layout," not
+                // "visible on the active monitor." For an inactive workspace, clearing
+                // the workspace-inactive hidden state here would mark the window as
+                // un-hidden in the model while it is still parked offscreen, so leave
+                // the state intact and let `hideInactiveWorkspaces` own the reveal.
+                guard isPlanWorkspaceActive else { continue }
                 controller.workspaceManager.setHiddenState(nil, for: entry.token)
             }
         }
@@ -4219,12 +4279,27 @@ final class LayoutDiffExecutor {
             }
         }
 
-        let visibleFrameJobs = (frameUpdates + resizeMinimumProbeFrameUpdates + revealFrameUpdates)
+        // Only mark windows active / unsuppress frame writes for jobs that are truly
+        // meant to appear on the active monitor: explicit reveal/restore visible jobs,
+        // pending reveal transactions, and ordinary frame changes only when this plan's
+        // workspace is the active one on its monitor.
+        //
+        // A frame change for an INACTIVE workspace is just the layout engine computing
+        // where the window would sit if the workspace were visible. Activating or
+        // unsuppressing it here removes the window from the inactive set right before
+        // the guarded `applyFramesParallel` write, leaking the visible frame onscreen
+        // while its model still reports `workspaceInactive`. Leaving inactive ordinary
+        // jobs classified as inactive lets `applyFramesParallel` record `skip-inactive`,
+        // and `hideInactiveWorkspaces` owns offscreen parking for them.
+        let activatableOrdinaryFrameUpdates: [(pid: pid_t, windowId: Int, frame: CGRect)] = isPlanWorkspaceActive
+            ? (frameUpdates + resizeMinimumProbeFrameUpdates)
+            : []
+        let activatableFrameJobs = (activatableOrdinaryFrameUpdates + revealFrameUpdates)
             .map { (pid: $0.pid, windowId: $0.windowId) }
         var activeFrameJobs: [(pid: pid_t, windowId: Int)] = []
-        activeFrameJobs.reserveCapacity(visibleJobs.count + visibleFrameJobs.count)
+        activeFrameJobs.reserveCapacity(visibleJobs.count + activatableFrameJobs.count)
         var seenActiveWindowIds: Set<Int> = []
-        for job in visibleJobs + visibleFrameJobs where seenActiveWindowIds.insert(job.windowId).inserted {
+        for job in visibleJobs + activatableFrameJobs where seenActiveWindowIds.insert(job.windowId).inserted {
             activeFrameJobs.append(job)
         }
         if !activeFrameJobs.isEmpty {

--- a/Tests/NehirTests/LayoutRefreshControllerTests.swift
+++ b/Tests/NehirTests/LayoutRefreshControllerTests.swift
@@ -980,6 +980,160 @@ private func makeUnavailableLayoutPlanTestWindow(windowId: Int) -> AXWindowRef {
         #expect(controller.workspaceManager.hiddenState(for: token)?.workspaceInactive == true)
     }
 
+    @Test @MainActor func executeInactiveWorkspaceLayoutPlanDoesNotLeakVisibleFrameWrite() {
+        let controller = makeLayoutPlanTestController()
+        guard let monitor = controller.workspaceManager.monitors.first,
+              let inactiveWorkspaceId = controller.workspaceManager.workspaceId(for: "1", createIfMissing: false),
+              let activeWorkspaceId = controller.workspaceManager.workspaceId(for: "2", createIfMissing: false)
+        else {
+            Issue.record("Missing monitor or workspaces for inactive frame-leak regression test")
+            return
+        }
+        _ = controller.workspaceManager.setActiveWorkspace(activeWorkspaceId, on: monitor.id)
+        // Workspace 1 is now inactive while workspace 2 is active on the same monitor.
+        #expect(controller.workspaceManager.activeWorkspace(on: monitor.id)?.id == activeWorkspaceId)
+
+        let token = addLayoutPlanTestWindow(on: controller, workspaceId: inactiveWorkspaceId, windowId: 21476)
+        setWorkspaceInactiveHiddenStateForLayoutPlanTests(on: controller, token: token, monitor: monitor)
+
+        // Mirror executeRefreshExecutionPlan: classify the workspace-1 window as inactive
+        // before layout application so applyFramesParallel's skip-inactive guard can fire.
+        controller.axManager.updateInactiveWorkspaceWindows(
+            allEntries: [(workspaceId: inactiveWorkspaceId, windowId: token.windowId)],
+            activeWorkspaceIds: [activeWorkspaceId]
+        )
+        #expect(controller.axManager.inactiveWorkspaceWindowIds.contains(token.windowId))
+
+        let leakedFrame = CGRect(x: 160, y: 110, width: 820, height: 540)
+        var diff = WorkspaceLayoutDiff()
+        diff.frameChanges = [LayoutFrameChange(token: token, frame: leakedFrame, forceApply: false)]
+
+        controller.layoutRefreshController.executeLayoutPlan(
+            WorkspaceLayoutPlan(
+                workspaceId: inactiveWorkspaceId,
+                monitor: controller.layoutRefreshController.buildMonitorSnapshot(for: monitor),
+                sessionPatch: WorkspaceSessionPatch(workspaceId: inactiveWorkspaceId),
+                diff: diff
+            )
+        )
+
+        // The inactive workspace's ordinary frame change must not be activated/unsuppressed,
+        // so applyFramesParallel skips it (skip-inactive) instead of writing the visible
+        // frame onscreen while the model still reports workspaceInactive.
+        #expect(controller.axManager.inactiveWorkspaceWindowIds.contains(token.windowId))
+        #expect(controller.axManager.lastAppliedFrame(for: token.windowId) == nil)
+        #expect(controller.workspaceManager.hiddenState(for: token)?.workspaceInactive == true)
+    }
+
+    @Test @MainActor func executeActiveWorkspaceLayoutPlanRevealStillRestoresHiddenWindow() {
+        let controller = makeLayoutPlanTestController()
+        guard let monitor = controller.workspaceManager.monitors.first,
+              let activeWorkspaceId = controller.workspaceManager.activeWorkspaceOrFirst(on: monitor.id)?.id
+        else {
+            Issue.record("Missing monitor or active workspace for active reveal regression test")
+            return
+        }
+
+        let token = addLayoutPlanTestWindow(on: controller, workspaceId: activeWorkspaceId, windowId: 21477)
+        setWorkspaceInactiveHiddenStateForLayoutPlanTests(on: controller, token: token, monitor: monitor)
+
+        let frame = CGRect(x: 160, y: 110, width: 820, height: 540)
+        var diff = WorkspaceLayoutDiff()
+        diff.frameChanges = [LayoutFrameChange(token: token, frame: frame, forceApply: false)]
+        diff.restoreChanges = [
+            LayoutRestoreChange(
+                token: token,
+                hiddenState: WindowModel.HiddenState(
+                    proportionalPosition: CGPoint(x: 0.5, y: 0.5),
+                    referenceMonitorId: monitor.id,
+                    workspaceInactive: true
+                )
+            )
+        ]
+
+        controller.layoutRefreshController.executeLayoutPlan(
+            WorkspaceLayoutPlan(
+                workspaceId: activeWorkspaceId,
+                monitor: controller.layoutRefreshController.buildMonitorSnapshot(for: monitor),
+                sessionPatch: WorkspaceSessionPatch(workspaceId: activeWorkspaceId),
+                diff: diff
+            )
+        )
+
+        // Active-workspace reveal must still clear the workspace-inactive hidden state,
+        // apply the restore frame, and leave the window classified active.
+        #expect(controller.workspaceManager.hiddenState(for: token) == nil)
+        #expect(controller.axManager.lastAppliedFrame(for: token.windowId) == frame)
+        #expect(!controller.axManager.inactiveWorkspaceWindowIds.contains(token.windowId))
+    }
+
+    @Test @MainActor func hideInactiveWorkspacesRepairsWorkspaceInactiveVisibleDrift() async {
+        await withAXFrameProviderIsolationForTests {
+            let controller = makeLayoutPlanTestController()
+            guard let monitor = controller.workspaceManager.monitors.first,
+                  let activeWorkspaceId = controller.workspaceManager.workspaceId(for: "1", createIfMissing: false),
+                  let inactiveWorkspaceId = controller.workspaceManager.workspaceId(for: "2", createIfMissing: false),
+                  controller.interactionWorkspace()?.id == activeWorkspaceId
+            else {
+                Issue.record("Missing monitor or workspaces for drift repair regression test")
+                return
+            }
+
+            let token = addLayoutPlanTestWindow(on: controller, workspaceId: inactiveWorkspaceId, windowId: 21478)
+            setWorkspaceInactiveHiddenStateForLayoutPlanTests(on: controller, token: token, monitor: monitor)
+
+            // The window is modelled inactive-hidden, but its live frame is visibly on the
+            // active monitor (simulating a leaked frame write), well away from any screen
+            // edge park position.
+            let leakedFrame = CGRect(x: 300, y: 200, width: 800, height: 600)
+            let previousFastFrameProvider = AXWindowService.fastFrameProviderForTests
+            let previousSetFrameProvider = AXWindowService.setFrameResultProviderForTests
+            var repairedFrameWrites: [CGRect] = []
+            AXWindowService.fastFrameProviderForTests = { window in
+                if window.windowId == token.windowId {
+                    return leakedFrame
+                }
+                return previousFastFrameProvider?(window)
+            }
+            AXWindowService.setFrameResultProviderForTests = { window, frame, currentFrameHint in
+                if window.windowId == token.windowId {
+                    repairedFrameWrites.append(frame)
+                }
+                return previousSetFrameProvider?(window, frame, currentFrameHint)
+                    ?? AXFrameWriteResult(
+                        targetFrame: frame,
+                        observedFrame: frame,
+                        writeOrder: AXWindowService.frameWriteOrder(
+                            currentFrame: currentFrameHint,
+                            targetFrame: frame
+                        ),
+                        sizeError: .success,
+                        positionError: .success,
+                        failureReason: nil
+                    )
+            }
+            defer {
+                AXWindowService.fastFrameProviderForTests = previousFastFrameProvider
+                AXWindowService.setFrameResultProviderForTests = previousSetFrameProvider
+            }
+
+            controller.layoutRefreshController.hideInactiveWorkspaces(activeWorkspaceIds: [activeWorkspaceId])
+
+            // The drift repair re-parks the leaked window offscreen instead of only
+            // logging workspaceInactiveVisibleDrift and skipping (hideWorkspace.skipAlreadyHidden).
+            // Without the repair this collection is empty; the window would stay visibly leaked.
+            guard let parkedFrame = repairedFrameWrites.first else {
+                Issue.record("Expected a drift-repair frame write to re-park the leaked window")
+                return
+            }
+            let parkedRect = CGRect(origin: parkedFrame.origin, size: leakedFrame.size)
+            let parkedOffscreen = parkedRect.origin.x <= monitor.frame.minX
+                || parkedRect.maxX >= monitor.frame.maxX
+            #expect(parkedOffscreen)
+            #expect(controller.workspaceManager.hiddenState(for: token)?.workspaceInactive == true)
+        }
+    }
+
     @Test @MainActor func executeLayoutPlanRestoresSecondaryWorkspaceWindowOnVisibleMonitor() {
         let fixture = makeTwoMonitorLayoutPlanTestController()
         let controller = fixture.controller

--- a/Tests/NehirTests/LayoutRefreshControllerTests.swift
+++ b/Tests/NehirTests/LayoutRefreshControllerTests.swift
@@ -1025,6 +1025,46 @@ private func makeUnavailableLayoutPlanTestWindow(windowId: Int) -> AXWindowRef {
         #expect(controller.workspaceManager.hiddenState(for: token)?.workspaceInactive == true)
     }
 
+    @Test @MainActor func executeInactiveWorkspaceLayoutPlanDoesNotRevealViaShowDiff() {
+        let controller = makeLayoutPlanTestController()
+        guard let monitor = controller.workspaceManager.monitors.first,
+              let inactiveWorkspaceId = controller.workspaceManager.workspaceId(for: "1", createIfMissing: false),
+              let activeWorkspaceId = controller.workspaceManager.workspaceId(for: "2", createIfMissing: false)
+        else {
+            Issue.record("Missing monitor or workspaces for inactive .show reveal regression test")
+            return
+        }
+        _ = controller.workspaceManager.setActiveWorkspace(activeWorkspaceId, on: monitor.id)
+
+        let token = addLayoutPlanTestWindow(on: controller, workspaceId: inactiveWorkspaceId, windowId: 21479)
+        setWorkspaceInactiveHiddenStateForLayoutPlanTests(on: controller, token: token, monitor: monitor)
+        controller.axManager.updateInactiveWorkspaceWindows(
+            allEntries: [(workspaceId: inactiveWorkspaceId, windowId: token.windowId)],
+            activeWorkspaceIds: [activeWorkspaceId]
+        )
+
+        // A `.show` visibility change on an inactive workspace plan must not enter the
+        // pending reveal transaction flow, which would otherwise route the frame through
+        // the unconditional reveal path and leak it onscreen.
+        let leakedFrame = CGRect(x: 160, y: 110, width: 820, height: 540)
+        var diff = WorkspaceLayoutDiff()
+        diff.frameChanges = [LayoutFrameChange(token: token, frame: leakedFrame, forceApply: false)]
+        diff.visibilityChanges = [.show(token)]
+
+        controller.layoutRefreshController.executeLayoutPlan(
+            WorkspaceLayoutPlan(
+                workspaceId: inactiveWorkspaceId,
+                monitor: controller.layoutRefreshController.buildMonitorSnapshot(for: monitor),
+                sessionPatch: WorkspaceSessionPatch(workspaceId: inactiveWorkspaceId),
+                diff: diff
+            )
+        )
+
+        #expect(controller.axManager.inactiveWorkspaceWindowIds.contains(token.windowId))
+        #expect(controller.axManager.lastAppliedFrame(for: token.windowId) == nil)
+        #expect(controller.workspaceManager.hiddenState(for: token)?.workspaceInactive == true)
+    }
+
     @Test @MainActor func executeActiveWorkspaceLayoutPlanRevealStillRestoresHiddenWindow() {
         let controller = makeLayoutPlanTestController()
         guard let monitor = controller.workspaceManager.monitors.first,
@@ -1129,6 +1169,87 @@ private func makeUnavailableLayoutPlanTestWindow(windowId: Int) -> AXWindowRef {
             let parkedRect = CGRect(origin: parkedFrame.origin, size: leakedFrame.size)
             let parkedOffscreen = parkedRect.origin.x <= monitor.frame.minX
                 || parkedRect.maxX >= monitor.frame.maxX
+            #expect(parkedOffscreen)
+            #expect(controller.workspaceManager.hiddenState(for: token)?.workspaceInactive == true)
+        }
+    }
+
+    @Test @MainActor func hideInactiveWorkspacesRepairsMultiMonitorDriftAwayFromInteractionMonitor() async {
+        await withAXFrameProviderIsolationForTests {
+            let primaryMonitor = makeLayoutPlanPrimaryTestMonitor(name: "Primary")
+            let secondaryMonitor = makeLayoutPlanSecondaryTestMonitor(name: "Secondary", x: 1920)
+            let controller = makeLayoutPlanTestController(
+                monitors: [primaryMonitor, secondaryMonitor],
+                workspaceConfigurations: [
+                    WorkspaceConfiguration(name: "1", monitorAssignment: .main),
+                    WorkspaceConfiguration(name: "2", monitorAssignment: .secondary),
+                    WorkspaceConfiguration(name: "3", monitorAssignment: .secondary)
+                ]
+            )
+            guard let primaryWorkspaceId = controller.workspaceManager.workspaceId(for: "1", createIfMissing: false),
+                  let secondaryWorkspaceId = controller.workspaceManager.workspaceId(for: "2", createIfMissing: false),
+                  let inactiveWorkspaceId = controller.workspaceManager.workspaceId(for: "3", createIfMissing: false),
+                  controller.workspaceManager.setActiveWorkspace(primaryWorkspaceId, on: primaryMonitor.id),
+                  controller.workspaceManager.setActiveWorkspace(secondaryWorkspaceId, on: secondaryMonitor.id),
+                  controller.workspaceManager.setInteractionMonitor(primaryMonitor.id)
+            else {
+                Issue.record("Missing monitors or workspaces for multi-monitor drift repair test")
+                return
+            }
+            // Interaction is on the primary monitor, so its active workspace is workspace 1.
+            #expect(controller.interactionWorkspace()?.id == primaryWorkspaceId)
+
+            // Workspace 3 is inactive; its monitor (secondary) now shows the active workspace 2.
+            let token = addLayoutPlanTestWindow(on: controller, workspaceId: inactiveWorkspaceId, windowId: 21480)
+            setWorkspaceInactiveHiddenStateForLayoutPlanTests(on: controller, token: token, monitor: secondaryMonitor)
+
+            // The window is modelled inactive-hidden, but its live frame is visibly leaked onto
+            // the SECONDARY monitor, which is not the interaction (primary) monitor.
+            let leakedFrame = CGRect(x: 2100, y: 200, width: 800, height: 600)
+            let previousFastFrameProvider = AXWindowService.fastFrameProviderForTests
+            let previousSetFrameProvider = AXWindowService.setFrameResultProviderForTests
+            var repairedFrameWrites: [CGRect] = []
+            AXWindowService.fastFrameProviderForTests = { window in
+                if window.windowId == token.windowId {
+                    return leakedFrame
+                }
+                return previousFastFrameProvider?(window)
+            }
+            AXWindowService.setFrameResultProviderForTests = { window, frame, currentFrameHint in
+                if window.windowId == token.windowId {
+                    repairedFrameWrites.append(frame)
+                }
+                return previousSetFrameProvider?(window, frame, currentFrameHint)
+                    ?? AXFrameWriteResult(
+                        targetFrame: frame,
+                        observedFrame: frame,
+                        writeOrder: AXWindowService.frameWriteOrder(
+                            currentFrame: currentFrameHint,
+                            targetFrame: frame
+                        ),
+                        sizeError: .success,
+                        positionError: .success,
+                        failureReason: nil
+                    )
+            }
+            defer {
+                AXWindowService.fastFrameProviderForTests = previousFastFrameProvider
+                AXWindowService.setFrameResultProviderForTests = previousSetFrameProvider
+            }
+
+            controller.layoutRefreshController.hideInactiveWorkspaces(
+                activeWorkspaceIds: [primaryWorkspaceId, secondaryWorkspaceId]
+            )
+
+            // The drift check now scans every active monitor, so the leak on the secondary
+            // (non-interaction) monitor is still detected and re-parked offscreen.
+            guard let parkedFrame = repairedFrameWrites.first else {
+                Issue.record("Expected a multi-monitor drift-repair frame write to re-park the leaked window")
+                return
+            }
+            let parkedRect = CGRect(origin: parkedFrame.origin, size: leakedFrame.size)
+            let parkedOffscreen = parkedRect.origin.x <= secondaryMonitor.frame.minX
+                || parkedRect.maxX >= secondaryMonitor.frame.maxX
             #expect(parkedOffscreen)
             #expect(controller.workspaceManager.hiddenState(for: token)?.workspaceInactive == true)
         }


### PR DESCRIPTION
## Summary

A frame change emitted for an inactive workspace's layout plan was treated as an active/onscreen job by the layout diff executor: it called AXManager.markWindowActive and unsuppressFrameWrites on every frame job before applyFramesParallel. That removed the window from inactiveWorkspaceWindowIds right before the guarded write, so the visible frame was applied onscreen while its model still reported hiddenState.workspaceInactive. hideInactiveWorkspaces then skipped the corrective hide because the stale hidden state implied the window was already parked, leaving it leaked.

Teach the diff executor whether its plan workspace is currently active on its monitor (isPlanWorkspaceActive) and gate ordinary frameUpdate / resizeMinimumProbe jobs (and .show hidden-state clears) behind that flag. Only explicit reveal/restore visible jobs and pending reveal transactions remain unconditional active jobs. Inactive ordinary frame writes now stay classified inactive so applyFramesParallel records skip-inactive, and hideInactiveWorkspaces owns offscreen parking.

Also add a second-line repair in hideWorkspace: when a workspace-inactive window is visibly drifting on the active monitor (the model says parked but the live frame is onscreen), re-apply workspace-inactive parking via hideWindow instead of only logging the drift.

Adds three regression tests in LayoutRefreshControllerTests covering the inactive-plan skip, the active-workspace reveal, and the drift repair.

## Release notes

Choose one:

- [x] Added a `.changeset/*.md` for user-visible changes (`mise run changeset -- patch "..."`).
- [ ] No user-visible change; apply the `no release note` label to make CI skip intentional.

## Validation

<!-- Commands run, screenshots, or manual checks. -->

- [ ] Ran relevant tests/checks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Inactive-workspace windows no longer leak back onscreen; drift is now repaired when a hidden inactive window is still visibly present.
  * Improved detection of “active workspace” context, preventing unintended visible frame writes during inactive layout plan updates.
  * Refined show/reveal handling so inactive plans avoid the reveal path unless restoring state.

* **Tests**
  * Added regression tests covering inactive parking (including show changes), active reveal behavior, and async drift-repair scenarios (single- and multi-monitor).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->