### PR TITLE
Add sticky PiP defaults and ignore app rules

### DIFF
--- a/.changeset/20260626014016-add-sticky-and-ignore-app-rule-plumbing.md
+++ b/.changeset/20260626014016-add-sticky-and-ignore-app-rule-plumbing.md
@@ -1,0 +1,6 @@
+---
+"nehir": patch
+
+---
+
+Add sticky app rules, commands, and workspace-bar projection so classifiable Picture-in-Picture-style windows stay visible across workspace switches while remaining manually unstickable; document native/helper PiP limitations for Safari, Dia, Arc, and Atlas-like surfaces that are indistinguishable from menus or dialogs; add `manage = "ignore"` app rules for unmanaged windows; and allow lone-window Niri workspaces to use far-overscroll boundary snaps.

--- a/Sources/Nehir/Core/Ax/AXWindow.swift
+++ b/Sources/Nehir/Core/Ax/AXWindow.swift
@@ -900,15 +900,7 @@ enum AXWindowService {
             unpinAXElement(for: windowId)
         }
 
-        let appElement = AXUIElementCreateApplication(pid)
-        var windowsRef: CFTypeRef?
-        let result = AXUIElementCopyAttributeValue(
-            appElement,
-            kAXWindowsAttribute as CFString,
-            &windowsRef
-        )
-
-        guard result == .success, let windows = windowsRef as? [AXUIElement] else {
+        guard let windows = axWindows(for: pid) else {
             return nil
         }
 
@@ -920,6 +912,68 @@ enum AXWindowService {
         }
 
         return nil
+    }
+
+    static func axWindowRef(
+        for windowId: UInt32,
+        pid: pid_t,
+        matching windowInfo: WindowServerInfo?
+    ) -> AXWindowRef? {
+        if let exact = axWindowRef(for: windowId, pid: pid) {
+            return exact
+        }
+        guard let windowInfo,
+              pid_t(windowInfo.pid) == pid,
+              let windows = axWindows(for: pid)
+        else {
+            return nil
+        }
+
+        let targetFrame = ScreenCoordinateSpace.toAppKit(rect: windowInfo.frame).standardized
+        guard targetFrame.width >= 120, targetFrame.height >= 90 else {
+            return nil
+        }
+
+        for window in windows {
+            var resolvedWindowId: CGWindowID = 0
+            if _AXUIElementGetWindow(window, &resolvedWindowId) == .success,
+               resolvedWindowId != 0,
+               resolvedWindowId != windowId
+            {
+                continue
+            }
+
+            let ref = AXWindowRef(element: window, windowId: Int(windowId))
+            guard shouldTreatAsTopLevelWindow(
+                role: role(ref),
+                subrole: subrole(ref)
+            ) else {
+                continue
+            }
+            guard let frame = try? frame(ref),
+                  frame.approximatelyEqual(to: targetFrame, tolerance: 3.0)
+            else {
+                continue
+            }
+            return ref
+        }
+
+        return nil
+    }
+
+    private static func axWindows(for pid: pid_t) -> [AXUIElement]? {
+        let appElement = AXUIElementCreateApplication(pid)
+        var windowsRef: CFTypeRef?
+        let result = AXUIElementCopyAttributeValue(
+            appElement,
+            kAXWindowsAttribute as CFString,
+            &windowsRef
+        )
+
+        guard result == .success, let windows = windowsRef as? [AXUIElement] else {
+            return nil
+        }
+        return windows
     }
 
     private enum FrameWriteAttribute {

--- a/Sources/Nehir/Core/Config/AppRule.swift
+++ b/Sources/Nehir/Core/Config/AppRule.swift
@@ -8,6 +8,7 @@ import Foundation
 
 enum WindowRuleManageAction: String, Codable, CaseIterable, Identifiable {
     case auto
+    case ignore
 
     var id: String {
         rawValue
@@ -16,6 +17,7 @@ enum WindowRuleManageAction: String, Codable, CaseIterable, Identifiable {
     var displayName: String {
         switch self {
         case .auto: "Automatic"
+        case .ignore: "Ignore"
         }
     }
 }
@@ -52,6 +54,7 @@ struct AppRule: Codable, Identifiable, Equatable {
         case assignToWorkspace
         case minWidth
         case minHeight
+        case sticky
     }
 
     let id: UUID
@@ -66,6 +69,7 @@ struct AppRule: Codable, Identifiable, Equatable {
     var assignToWorkspace: String?
     var minWidth: Double?
     var minHeight: Double?
+    var sticky: Bool?
 
     init(
         id: UUID = UUID(),
@@ -79,7 +83,8 @@ struct AppRule: Codable, Identifiable, Equatable {
         layout: WindowRuleLayoutAction? = nil,
         assignToWorkspace: String? = nil,
         minWidth: Double? = nil,
-        minHeight: Double? = nil
+        minHeight: Double? = nil,
+        sticky: Bool? = nil
     ) {
         self.id = id
         self.bundleId = bundleId
@@ -93,6 +98,7 @@ struct AppRule: Codable, Identifiable, Equatable {
         self.assignToWorkspace = assignToWorkspace
         self.minWidth = minWidth
         self.minHeight = minHeight
+        self.sticky = sticky
     }
 
     var effectiveManageAction: WindowRuleManageAction {
@@ -129,6 +135,7 @@ struct AppRule: Codable, Identifiable, Equatable {
         effectiveManageAction != .auto || effectiveLayoutAction != .auto ||
             assignToWorkspace != nil ||
             minWidth != nil || minHeight != nil ||
+            sticky != nil ||
             hasAdvancedMatchers
     }
 
@@ -146,5 +153,6 @@ struct AppRule: Codable, Identifiable, Equatable {
         assignToWorkspace = try container.decodeIfPresent(String.self, forKey: .assignToWorkspace)
         minWidth = try container.decodeIfPresent(Double.self, forKey: .minWidth)
         minHeight = try container.decodeIfPresent(Double.self, forKey: .minHeight)
+        sticky = try container.decodeIfPresent(Bool.self, forKey: .sticky)
     }
 }

--- a/Sources/Nehir/Core/Config/AppRuleFileStore.swift
+++ b/Sources/Nehir/Core/Config/AppRuleFileStore.swift
@@ -58,7 +58,9 @@ enum AppRuleFileStore {
         if let v = rule.axSubrole { lines.append("axSubrole = \(quoted(v))") }
 
         var effectLines: [String] = []
+        if let manage = rule.manage { effectLines.append("manage = \(quoted(manage.rawValue))") }
         if let layout = rule.layout { effectLines.append("layout = \(quoted(layout.rawValue))") }
+        if let sticky = rule.sticky { effectLines.append("sticky = \(sticky ? "true" : "false")") }
         if let w = rule.minWidth { effectLines.append("minWidth = \(formatNumber(w))") }
         if let h = rule.minHeight { effectLines.append("minHeight = \(formatNumber(h))") }
         if let ws = rule.assignToWorkspace { effectLines.append("assignToWorkspace = \(quoted(ws))") }
@@ -148,10 +150,12 @@ enum AppRuleFileStore {
             titleRegex: extractString(matchFields["titleRegex"]),
             axRole: extractString(matchFields["axRole"]),
             axSubrole: extractString(matchFields["axSubrole"]),
+            manage: extractString(effectFields["manage"]).flatMap(WindowRuleManageAction.init(rawValue:)),
             layout: extractString(effectFields["layout"]).flatMap(WindowRuleLayoutAction.init(rawValue:)),
             assignToWorkspace: extractString(effectFields["assignToWorkspace"]),
             minWidth: extractDouble(effectFields["minWidth"]),
-            minHeight: extractDouble(effectFields["minHeight"])
+            minHeight: extractDouble(effectFields["minHeight"]),
+            sticky: extractBool(effectFields["sticky"])
         )
         return (documentFields["order"].flatMap(extractInt), rule)
     }
@@ -171,6 +175,7 @@ enum AppRuleFileStore {
 
                 [effect]
                 layout = "float"
+                sticky = true
                 minWidth = 320
                 minHeight = 180
                 """
@@ -280,6 +285,15 @@ enum AppRuleFileStore {
     private static func extractDouble(_ raw: String?) -> Double? {
         guard let raw else { return nil }
         return Double(raw.trimmingCharacters(in: .whitespaces))
+    }
+
+    private static func extractBool(_ raw: String?) -> Bool? {
+        guard let raw else { return nil }
+        switch raw.trimmingCharacters(in: .whitespaces).lowercased() {
+        case "true": return true
+        case "false": return false
+        default: return nil
+        }
     }
 
     private static func extractInt(_ raw: String) -> Int? {

--- a/Sources/Nehir/Core/Config/HotkeyConfigMapping.swift
+++ b/Sources/Nehir/Core/Config/HotkeyConfigMapping.swift
@@ -119,6 +119,7 @@ enum HotkeyConfigMapping {
         ("layout", "scrollViewportLeft", "scrollViewport.left"),
         ("layout", "scrollViewportRight", "scrollViewport.right"),
         ("layout", "toggleFocusedFloating", "toggleFocusedWindowFloating"),
+        ("layout", "toggleFocusedSticky", "toggleFocusedWindowSticky"),
         ("layout", "assignScratchpad", "assignFocusedWindowToScratchpad"),
         ("layout", "toggleScratchpad", "toggleScratchpadWindow"),
         ("layout", "raiseAllFloating", "raiseAllFloatingWindows"),

--- a/Sources/Nehir/Core/Controller/AXEventHandler.swift
+++ b/Sources/Nehir/Core/Controller/AXEventHandler.swift
@@ -89,6 +89,11 @@ struct NiriCreateFocusTraceEvent: Equatable {
             reason: PrepareCreateCandidateRejectionReason,
             hasWindowInfo: Bool,
             windowInfoPid: pid_t?,
+            windowInfoLevel: Int32?,
+            windowInfoParentId: UInt32?,
+            windowInfoHasFloatingTag: Bool?,
+            windowInfoHasDocumentTag: Bool?,
+            windowInfoFrame: CGRect?,
             fallbackToken: WindowToken?,
             hasFallbackAXRef: Bool,
             createContextSource: String?
@@ -215,11 +220,16 @@ extension NiriCreateFocusTraceEvent: CustomStringConvertible {
             reason,
             hasWindowInfo,
             windowInfoPid,
+            windowInfoLevel,
+            windowInfoParentId,
+            windowInfoHasFloatingTag,
+            windowInfoHasDocumentTag,
+            windowInfoFrame,
             fallbackToken,
             hasFallbackAXRef,
             createContextSource
         ):
-            "prepare_create_rejected window=\(windowId) token=\(String(describing: token)) context=\(context) reason=\(reason.rawValue) has_window_info=\(hasWindowInfo) window_info_pid=\(windowInfoPid.map(String.init) ?? "nil") fallback_token=\(String(describing: fallbackToken)) has_fallback_ax_ref=\(hasFallbackAXRef) create_context_source=\(createContextSource ?? "nil")"
+            "prepare_create_rejected window=\(windowId) token=\(String(describing: token)) context=\(context) reason=\(reason.rawValue) has_window_info=\(hasWindowInfo) window_info_pid=\(windowInfoPid.map(String.init) ?? "nil") window_info_level=\(windowInfoLevel.map(String.init) ?? "nil") window_info_parent=\(windowInfoParentId.map(String.init) ?? "nil") ws_float=\(windowInfoHasFloatingTag.map(String.init) ?? "nil") ws_doc=\(windowInfoHasDocumentTag.map(String.init) ?? "nil") ws_frame=\(windowInfoFrame.map { LayoutTrace.rect($0) } ?? "nil") fallback_token=\(String(describing: fallbackToken)) has_fallback_ax_ref=\(hasFallbackAXRef) create_context_source=\(createContextSource ?? "nil")"
         case let .unrequestedAdmissionDuringNonManagedFocusDecision(
             token,
             suppressed,
@@ -1578,13 +1588,18 @@ final class AXEventHandler: CGSEventDelegate {
               let controller,
               controller.workspaceManager.confirmedManagedFocusToken == token,
               let workspaceId = controller.workspaceManager.workspace(for: token),
-              let monitorId = controller.workspaceManager.monitorId(for: workspaceId),
-              controller.workspaceManager.activeWorkspace(on: monitorId)?.id == workspaceId
+              let monitorId = controller.workspaceManager.monitorId(for: workspaceId)
         else {
             return
         }
 
-        beginWindowCloseFocusRecovery(in: workspaceId)
+        if controller.workspaceManager.activeWorkspace(on: monitorId)?.id == workspaceId {
+            beginWindowCloseFocusRecovery(in: workspaceId)
+        } else {
+            clearManagedFocusState(matching: token, workspaceId: workspaceId)
+            _ = controller.workspaceManager.enterNonManagedFocus(appFullscreen: false)
+            controller.focusBorderController.clear()
+        }
     }
 
     private func shouldSuppressObservedActivationDuringWindowCloseRecovery(
@@ -1745,6 +1760,33 @@ final class AXEventHandler: CGSEventDelegate {
         return true
     }
 
+    private func shouldSuppressHiddenInactiveStickyActivation(
+        entry observedEntry: WindowModel.Entry,
+        isWorkspaceActive: Bool,
+        requestDisposition: ActivationRequestDisposition,
+        source: ActivationEventSource
+    ) -> Bool {
+        guard !isWorkspaceActive,
+              case .unrelatedNoRequest = requestDisposition,
+              source == .workspaceDidActivateApplication || source == .focusedWindowChanged,
+              observedEntry.visibility == .hiddenWorkspaceInactive,
+              let controller,
+              controller.workspaceManager.hasStickyWindowSource(observedEntry.token),
+              !controller.workspaceManager.isStickyWindow(observedEntry.token)
+        else {
+            return false
+        }
+
+        // A manually unstuck PiP keeps its automatic sticky source so commands
+        // can still target/toggle it, but it should behave like a normal
+        // inactive-workspace window while unstuck. Some native PiP surfaces
+        // report app activation/focus again immediately after Nehir parks them;
+        // accepting that unrelated activation switches back to the PiP's
+        // workspace and reveals the window. Suppress that app-internal churn
+        // unless there is an explicit managed focus request.
+        return true
+    }
+
     private func shouldSuppressSameAppInactiveWorkspaceActivationBeforeCloseRecovery(
         entry observedEntry: WindowModel.Entry,
         isWorkspaceActive: Bool,
@@ -1888,6 +1930,15 @@ final class AXEventHandler: CGSEventDelegate {
             let isWorkspaceActive = targetMonitor.map { monitor in
                 controller.workspaceManager.activeWorkspace(on: monitor.id)?.id == wsId
             } ?? false
+
+            if shouldSuppressHiddenInactiveStickyActivation(
+                entry: entry,
+                isWorkspaceActive: isWorkspaceActive,
+                requestDisposition: requestDisposition,
+                source: source
+            ) {
+                return
+            }
 
             if shouldSuppressSameAppInactiveWorkspaceActivationBeforeCloseRecovery(
                 entry: entry,
@@ -3070,10 +3121,21 @@ final class AXEventHandler: CGSEventDelegate {
             return nil
         }
 
-        guard let axRef = fallbackAXRef?.windowId == Int(windowId)
-            ? fallbackAXRef
-            : resolveAXWindowRef(windowId: windowId, pid: token.pid)
-        else {
+        let resolvedAXRef = if fallbackAXRef?.windowId == Int(windowId) {
+            fallbackAXRef
+        } else {
+            resolveAXWindowRef(windowId: windowId, pid: token.pid, matching: windowInfo)
+                ?? resolveFocusedAXWindowRef(pid: token.pid).flatMap { $0.windowId == Int(windowId) ? $0 : nil }
+        }
+        guard let axRef = resolvedAXRef else {
+            if let windowServerOnlyCandidate = prepareWindowServerOnlyStickyCreate(
+                windowId: windowId,
+                token: token,
+                windowInfo: windowInfo,
+                createPlacementContext: createPlacementContext
+            ) {
+                return windowServerOnlyCandidate
+            }
             recordPrepareCreateRejection(
                 windowId: windowId,
                 token: token,
@@ -3180,6 +3242,93 @@ final class AXEventHandler: CGSEventDelegate {
         )
     }
 
+    private func prepareWindowServerOnlyStickyCreate(
+        windowId: UInt32,
+        token: WindowToken,
+        windowInfo: WindowServerInfo?,
+        createPlacementContext: WindowCreatePlacementContext?
+    ) -> PreparedCreate? {
+        guard let controller,
+              let windowInfo,
+              isWindowServerOnlyStickyCreateCandidate(windowInfo, token: token)
+        else {
+            return nil
+        }
+
+        let axRef = AXWindowRef(element: AXUIElementCreateSystemWide(), windowId: Int(windowId))
+        let bundleId = resolveBundleId(token.pid)
+        let isParented = windowInfo.parentId != 0
+        let workspaceId = controller.resolveWorkspaceForNewWindow(
+            workspaceName: nil,
+            axRef: axRef,
+            pid: token.pid,
+            parentWindowId: isParented ? windowInfo.parentId : nil,
+            inheritTrackedParentWorkspace: isParented,
+            preferSameAppSiblingWorkspace: false,
+            structuralReplacementWorkspaceId: nil,
+            restrictWorkspaceRuleToPlacementMonitor: false,
+            createPlacementContext: createPlacementContext,
+            windowFrame: windowInfo.frame,
+            fallbackWorkspaceId: controller.interactionWorkspace()?.id
+        )
+        recordCreatePlacementTrace(
+            token: token,
+            workspaceId: workspaceId,
+            createPlacementContext: createPlacementContext,
+            windowFrame: windowInfo.frame,
+            controller: controller
+        )
+        subscribeToWindows([windowId])
+
+        return PreparedCreate(
+            windowId: windowId,
+            token: token,
+            axRef: axRef,
+            ruleEffects: ManagedWindowRuleEffects(sticky: true),
+            replacementMetadata: ManagedReplacementMetadata(
+                bundleId: bundleId,
+                workspaceId: workspaceId,
+                mode: .floating,
+                role: kAXWindowRole as String,
+                subrole: kAXStandardWindowSubrole as String,
+                title: windowInfo.title,
+                windowLevel: windowInfo.level,
+                parentWindowId: windowInfo.parentId == 0 ? nil : windowInfo.parentId,
+                frame: windowInfo.frame,
+                transientWindowServerEvidence: true,
+                degradedWindowServerChildEvidence: false,
+                userAddressableTransientWindowServerSurface: true
+            ),
+            hasStructuralReplacementWorkspaceMatch: false,
+            hasExplicitWorkspaceAssignment: false,
+            requiresPostCreateLifecycleVerification: false
+        )
+    }
+
+    private func isWindowServerOnlyStickyCreateCandidate(
+        _ windowInfo: WindowServerInfo,
+        token: WindowToken
+    ) -> Bool {
+        guard pid_t(windowInfo.pid) == token.pid,
+              windowInfo.id == UInt32(token.windowId),
+              !windowInfo.hasDocumentTag
+        else {
+            return false
+        }
+
+        // Top-level floating media surface (Helium/Chrome/Vivaldi/Zen style PiP):
+        // a level-3, parentless, floating-tagged window with a media-like frame.
+        if windowInfo.parentId == 0,
+           windowInfo.level == 3,
+           windowInfo.hasFloatingTag,
+           isTopLevelResizableMediaLikeSurfaceFrame(windowInfo.frame)
+        {
+            return true
+        }
+
+        return false
+    }
+
     private func recordPrepareCreateRejection(
         windowId: UInt32,
         token: WindowToken?,
@@ -3199,6 +3348,11 @@ final class AXEventHandler: CGSEventDelegate {
                     reason: reason,
                     hasWindowInfo: windowInfo != nil,
                     windowInfoPid: windowInfo.map { pid_t($0.pid) },
+                    windowInfoLevel: windowInfo.map { $0.level },
+                    windowInfoParentId: windowInfo.map { $0.parentId },
+                    windowInfoHasFloatingTag: windowInfo.map { $0.hasFloatingTag },
+                    windowInfoHasDocumentTag: windowInfo.map { $0.hasDocumentTag },
+                    windowInfoFrame: windowInfo.map { $0.frame },
                     fallbackToken: fallbackToken,
                     hasFallbackAXRef: fallbackAXRef != nil,
                     createContextSource: createPlacementContext?.source
@@ -4672,6 +4826,17 @@ final class AXEventHandler: CGSEventDelegate {
 
     private func resolveAXWindowRef(windowId: UInt32, pid: pid_t) -> AXWindowRef? {
         axWindowRefProvider?(windowId, pid) ?? AXWindowService.axWindowRef(for: windowId, pid: pid)
+    }
+
+    private func resolveAXWindowRef(
+        windowId: UInt32,
+        pid: pid_t,
+        matching windowInfo: WindowServerInfo?
+    ) -> AXWindowRef? {
+        if let provided = axWindowRefProvider?(windowId, pid) {
+            return provided
+        }
+        return AXWindowService.axWindowRef(for: windowId, pid: pid, matching: windowInfo)
     }
 
     private func subscribeToWindows(_ windowIds: [UInt32]) {

--- a/Sources/Nehir/Core/Controller/CommandHandler.swift
+++ b/Sources/Nehir/Core/Controller/CommandHandler.swift
@@ -185,6 +185,8 @@ final class CommandHandler {
             _ = controller.rescueOffscreenWindows()
         case .toggleFocusedWindowFloating:
             return controller.toggleFocusedWindowFloating()
+        case .toggleFocusedWindowSticky:
+            return controller.toggleFocusedWindowSticky()
         case .assignFocusedWindowToScratchpad:
             return controller.assignFocusedWindowToScratchpad()
         case .toggleScratchpadWindow:

--- a/Sources/Nehir/Core/Controller/LayoutRefreshController.swift
+++ b/Sources/Nehir/Core/Controller/LayoutRefreshController.swift
@@ -1383,6 +1383,11 @@ import QuartzCore
             }
 
             let wsForWindow: WorkspaceDescriptor.ID
+            let evaluatedRuleEffects = ruleEffectsPreservingExistingAutomaticStickySource(
+                decision.ruleEffects,
+                existingEntry: existingEntry,
+                facts: evaluation.facts
+            )
             let ruleEffects: ManagedWindowRuleEffects
             if let existingEntry {
                 if shouldPreservePreFullscreenState {
@@ -1393,14 +1398,14 @@ import QuartzCore
                 } else if appFullscreen {
                     _ = controller.workspaceManager.markNativeFullscreenSuspended(existingEntry.token)
                     wsForWindow = existingAssignment ?? defaultWorkspace
-                    ruleEffects = decision.ruleEffects
+                    ruleEffects = evaluatedRuleEffects
                 } else {
                     wsForWindow = existingAssignment ?? defaultWorkspace
-                    ruleEffects = decision.ruleEffects
+                    ruleEffects = evaluatedRuleEffects
                 }
             } else {
                 wsForWindow = existingAssignment ?? defaultWorkspace
-                ruleEffects = decision.ruleEffects
+                ruleEffects = evaluatedRuleEffects
             }
             let oldMode = existingEntry?.mode
             let admittedMode = oldMode ?? trackedMode
@@ -1409,6 +1414,10 @@ import QuartzCore
             } else {
                 existingEntry?.managedReplacementMetadata?.parentWindowId
             }
+            let transientFlags = mergedManagedReplacementTransientFlags(
+                existingMetadata: existingEntry?.managedReplacementMetadata,
+                facts: evaluation.facts
+            )
             let managedReplacementMetadata = ManagedReplacementMetadata(
                 bundleId: evaluation.facts.ax.bundleId ?? bundleId ?? existingEntry?.managedReplacementMetadata?
                     .bundleId,
@@ -1421,15 +1430,9 @@ import QuartzCore
                     .windowLevel,
                 parentWindowId: parentWindowId,
                 frame: evaluation.facts.windowServer?.frame ?? existingEntry?.managedReplacementMetadata?.frame,
-                transientWindowServerEvidence: existingEntry?.managedReplacementMetadata?
-                    .transientWindowServerEvidence == true
-                    || evaluation.facts.windowServer?.hasTransientSurfaceEvidence == true,
-                degradedWindowServerChildEvidence: existingEntry?.managedReplacementMetadata?
-                    .degradedWindowServerChildEvidence == true
-                    || evaluation.facts.degradedWindowServerChildEvidence,
-                userAddressableTransientWindowServerSurface: existingEntry?.managedReplacementMetadata?
-                    .userAddressableTransientWindowServerSurface == true
-                    || evaluation.facts.userAddressableTransientWindowServerSurface
+                transientWindowServerEvidence: transientFlags.transientWindowServerEvidence,
+                degradedWindowServerChildEvidence: transientFlags.degradedWindowServerChildEvidence,
+                userAddressableTransientWindowServerSurface: transientFlags.userAddressableTransientWindowServerSurface
             )
 
             _ = controller.workspaceManager.addWindow(
@@ -2271,15 +2274,11 @@ import QuartzCore
 
     func hideInactiveWorkspaces(activeWorkspaceIds: Set<WorkspaceDescriptor.ID>) {
         guard let controller else { return }
-        // Before taking the visibility snapshot, re-anchor any window macOS reports as
-        // global (present on every known Space, e.g. a browser Picture-in-Picture) to
-        // the active workspace on the monitor it is actually displayed on. Such a window
-        // is shown by macOS on every Space, so parking it offscreen when its original
-        // Nehir workspace goes inactive is exactly the #108 "disappears" symptom, and
-        // leaving its workspaceId pointing at the now-inactive workspace would leave it
-        // logically inactive-while-visible (the bleed/drift family). Re-anchoring here
-        // keeps the snapshot, the frame-suppression set, and the hide loop all coherent.
-        reanchorGlobalWindowsToActiveWorkspaces(activeWorkspaceIds: activeWorkspaceIds)
+        // Before taking the visibility snapshot, re-anchor sticky windows to the active
+        // workspace on the monitor they are actually displayed on. This keeps the
+        // snapshot, frame-suppression set, and hide loop coherent for native global,
+        // manually sticky, and rule-sticky windows.
+        reanchorStickyWindowsToActiveWorkspaces(activeWorkspaceIds: activeWorkspaceIds)
         let workspaceEntries = workspaceEntriesSnapshot(on: controller)
 
         // Rebuild the workspace-level frame suppression set (live check in applyFramesParallel).
@@ -2336,28 +2335,19 @@ import QuartzCore
         }
     }
 
-    /// Re-anchors windows macOS reports as global (present on every known Space) to
-    /// the active workspace on the monitor they are actually displayed on.
+    /// Re-anchors effective sticky windows to the active workspace on the monitor
+    /// they are actually displayed on.
     ///
-    /// A global window (e.g. a browser Picture-in-Picture with
-    /// `collectionBehavior = .canJoinAllSpaces`) is kept on-screen by macOS across
-    /// every Space. Nehir must not fight that: it must never park such a window when
-    /// its original Nehir workspace goes inactive, and it must keep the model coherent
-    /// so the window is never logically inactive-while-visible.
+    /// Native global windows are discovered from `SpaceTopology`, then published to
+    /// `WorkspaceManager` before sticky membership is resolved through the canonical
+    /// sticky predicate. Manual- and rule-sticky windows are re-anchored regardless of
+    /// the number of known Spaces; manual unsticky vetoes the effective sticky state.
     ///
-    /// This recomputes `SpaceTopology`, and for every entry that is present on all
-    /// known Spaces it (1) re-binds its `workspaceId` to the active workspace on the
-    /// monitor its live frame is on (so it belongs to an active workspace), (2)
-    /// refreshes its floating geometry to that live frame (so the floating resolver
-    /// keeps it on that monitor instead of snapping it back), (3) clears any stale
-    /// hide state, and (4) marks it active so its frame writes are not suppressed.
-    /// It also publishes the resulting global-token set to `WorkspaceManager` so the
-    /// floating-resolution path can treat these windows specially (Lever 2).
-    ///
-    /// Only discriminates when `knownSpaceIds.count > 1` (multi-display "Displays have
-    /// separate Spaces"). On a single display every window reports the one active
-    /// Space, so this is a no-op there.
-    private func reanchorGlobalWindowsToActiveWorkspaces(
+    /// For each effective sticky entry this (1) re-binds its `workspaceId` to the
+    /// active workspace on the monitor its live frame is on, (2) refreshes floating
+    /// geometry to that live frame, (3) clears stale hide state, and (4) marks it active
+    /// so frame writes are not suppressed as inactive-workspace.
+    private func reanchorStickyWindowsToActiveWorkspaces(
         activeWorkspaceIds: Set<WorkspaceDescriptor.ID>
     ) {
         guard let controller else { return }
@@ -2372,19 +2362,22 @@ import QuartzCore
             from: trackedEntries,
             spaceTopology: spaceTopology
         )
+        controller.workspaceManager.setGlobalStickyWindowTokens(globalTokens)
+        let stickyTokens = Set<WindowToken>(trackedEntries.compactMap { entry in
+            controller.workspaceManager.isStickyWindow(entry.token) ? entry.token : nil
+        })
         let nativeInactiveTokens = nativeInactiveWindowTokens(
             from: trackedEntries,
             spaceTopology: spaceTopology
         )
         lastSpaceTopologyDebugSummary = spaceTopology.debugSummary
-            + " globalSticky=\(globalTokens.count) nativeInactive=\(nativeInactiveTokens.count)"
+            + " globalSticky=\(globalTokens.count) sticky=\(stickyTokens.count) nativeInactive=\(nativeInactiveTokens.count)"
         if !nativeInactiveTokens.isEmpty {
             lastSpaceTopologyDebugSummary += " exempted=\(nativeInactiveTokens.count)"
         }
-        controller.workspaceManager.setGlobalStickyWindowTokens(globalTokens)
         controller.workspaceManager.setNativeInactiveWindowTokens(nativeInactiveTokens)
 
-        for entry in trackedEntries where globalTokens.contains(entry.token) {
+        for entry in trackedEntries where stickyTokens.contains(entry.token) {
             let liveFrame = fastFrame(for: entry.token, axRef: entry.axRef)
             let physicalMonitor = liveFrame?.center.monitorApproximation(in: monitors)
                 ?? controller.workspaceManager.monitor(for: entry.workspaceId)
@@ -2400,7 +2393,7 @@ import QuartzCore
                     for: entry.token
                 )
             }
-            // A global window is never parked offscreen; clear any stale hide state
+            // A sticky window is never parked offscreen; clear any stale hide state
             // and make sure its frame writes are not suppressed as inactive-workspace.
             controller.workspaceManager.setHiddenState(nil, for: entry.token)
             controller.axManager.unsuppressFrameWrites([(entry.pid, entry.windowId)])
@@ -2434,14 +2427,12 @@ import QuartzCore
             guard controller.workspaceManager.layoutReason(for: entry.token) != .nativeFullscreen else {
                 continue
             }
-            // Lever 1: a window macOS reports as present on every known Space (e.g. a
-            // browser Picture-in-Picture) must never be parked offscreen when a Nehir
-            // workspace goes inactive — macOS is deliberately showing it on every
-            // Space. `reanchorGlobalWindowsToActiveWorkspaces` normally moves such a
-            // window into the active workspace before this point, so this guard is the
-            // defensive backstop that keeps the window visible and active if it reaches
-            // the hide path bound to an inactive workspace.
-            if controller.workspaceManager.isGlobalStickyWindow(entry.token) {
+            // Lever 1: an effective sticky window must never be parked offscreen when a
+            // Nehir workspace goes inactive. `reanchorStickyWindowsToActiveWorkspaces`
+            // normally moves it into the active workspace before this point, so this
+            // guard is the defensive backstop that keeps the window visible and active
+            // if it reaches the hide path bound to an inactive workspace.
+            if controller.workspaceManager.isStickyWindow(entry.token) {
                 controller.workspaceManager.setHiddenState(nil, for: entry.token)
                 controller.axManager.unsuppressFrameWrites([(entry.pid, entry.windowId)])
                 controller.axManager.markWindowActive(entry.windowId)
@@ -2757,39 +2748,50 @@ import QuartzCore
             var fallbackAttempted = false
             var fallbackResult: AXFrameWriteResult?
 
+            let shouldFallback: Bool
             if let observedOrigin = observedFrame?.origin {
                 let dx = abs(observedOrigin.x - plan.origin.x)
                 let dy = abs(observedOrigin.y - plan.origin.y)
+                shouldFallback = dx > verifyEpsilon || dy > verifyEpsilon
                 // Diagnostic: log SkyLight result vs requested
                 controller.axManager
                     .recordFrameApplyTrace(
-                        "hidePlan.verify id=\(plan.entry.windowId) requested=\(LayoutTrace.point(plan.origin)) observed=\(LayoutTrace.point(observedOrigin)) dx=\(String(format: "%.1f", dx)) dy=\(String(format: "%.1f", dy)) fallback=\(dx > verifyEpsilon || dy > verifyEpsilon ? "YES" : "no")"
+                        "hidePlan.verify id=\(plan.entry.windowId) requested=\(LayoutTrace.point(plan.origin)) observed=\(LayoutTrace.point(observedOrigin)) dx=\(String(format: "%.1f", dx)) dy=\(String(format: "%.1f", dy)) fallback=\(shouldFallback ? "YES" : "no")"
                     )
-                if dx > verifyEpsilon || dy > verifyEpsilon {
-                    fallbackAttempted = true
-                    let axResult = AXWindowService.setFrame(plan.entry.axRef, frame: requestedFrame)
-                    fallbackResult = axResult
-                    observedFrame = axResult.observedFrame
-                        ?? AXWindowService.framePreferFast(plan.entry.axRef)
-                        ?? controller.axManager.lastAppliedFrame(for: plan.entry.windowId)
-                    // Diagnostic: log AX fallback result
-                    if let afterFallback = observedFrame?.origin {
-                        controller.axManager
-                            .recordFrameApplyTrace(
-                                "hidePlan.axFallback id=\(plan.entry.windowId) axResult=\(axResult) requested=\(LayoutTrace.point(plan.origin)) afterFallback=\(LayoutTrace.point(afterFallback))"
-                            )
-                    } else {
-                        controller.axManager
-                            .recordFrameApplyTrace(
-                                "hidePlan.axFallback id=\(plan.entry.windowId) axResult=\(axResult) afterFallback=nil"
-                            )
-                    }
-                }
             } else {
+                shouldFallback = true
                 controller.axManager
                     .recordFrameApplyTrace(
-                        "hidePlan.verify id=\(plan.entry.windowId) requested=\(LayoutTrace.point(plan.origin)) observed=nil"
+                        "hidePlan.verify id=\(plan.entry.windowId) requested=\(LayoutTrace.point(plan.origin)) observed=nil fallback=YES"
                     )
+            }
+
+            if shouldFallback {
+                fallbackAttempted = true
+                let fallbackAXRef = AXWindowService.axWindowRef(
+                    for: UInt32(plan.entry.windowId),
+                    pid: plan.entry.pid
+                ) ?? plan.entry.axRef
+                let axResult = AXWindowService.setFrame(fallbackAXRef, frame: requestedFrame)
+                if axResult.failureReason == nil, fallbackAXRef != plan.entry.axRef {
+                    plan.entry.axRef = fallbackAXRef
+                }
+                fallbackResult = axResult
+                observedFrame = axResult.observedFrame
+                    ?? AXWindowService.framePreferFast(fallbackAXRef)
+                    ?? controller.axManager.lastAppliedFrame(for: plan.entry.windowId)
+                // Diagnostic: log AX fallback result
+                if let afterFallback = observedFrame?.origin {
+                    controller.axManager
+                        .recordFrameApplyTrace(
+                            "hidePlan.axFallback id=\(plan.entry.windowId) axResult=\(axResult) requested=\(LayoutTrace.point(plan.origin)) afterFallback=\(LayoutTrace.point(afterFallback))"
+                        )
+                } else {
+                    controller.axManager
+                        .recordFrameApplyTrace(
+                            "hidePlan.axFallback id=\(plan.entry.windowId) axResult=\(axResult) afterFallback=nil"
+                        )
+                }
             }
 
             let verified = positionPlanPlacementVerified(

--- a/Sources/Nehir/Core/Controller/WMCommandTarget.swift
+++ b/Sources/Nehir/Core/Controller/WMCommandTarget.swift
@@ -10,6 +10,7 @@ struct WMCommandTarget: Equatable {
         case layoutSelection
         case confirmedManagedFocus
         case frontmostManagedFallback
+        case samePidFloatingFallback
     }
 
     let token: WindowToken

--- a/Sources/Nehir/Core/Controller/WMController.swift
+++ b/Sources/Nehir/Core/Controller/WMController.swift
@@ -1270,8 +1270,8 @@ final class WMController {
         // currently-viewed workspace, otherwise it "leaks" onto whatever workspace the
         // user happens to be viewing and can then anchor managed focus there, dragging
         // later siblings across. User-addressable transient standard windows (e.g.
-        // Zoom's full call window) keep normal placement; global canJoinAllSpaces
-        // surfaces are reanchored separately by reanchorGlobalWindowsToActiveWorkspaces.
+        // Zoom's full call window) keep normal placement; sticky/global surfaces are
+        // reanchored separately by LayoutRefreshController.
         if context == .automatic,
            existingEntry == nil,
            bindTransientFloatingToAppWorkspace,
@@ -1350,7 +1350,7 @@ final class WMController {
 
     private func isNonUserAddressableNonGlobalTransientFloatingSurface(_ entry: WindowModel.Entry) -> Bool {
         guard entry.managedReplacementMetadata?.transientWindowServerEvidence == true,
-              !workspaceManager.isGlobalStickyWindow(entry.token)
+              !workspaceManager.hasStickyWindowSource(entry.token)
         else {
             return false
         }
@@ -1730,7 +1730,12 @@ final class WMController {
         _ decision: WindowDecision,
         manualOverride: ManualWindowOverride?
     ) -> WindowDecision {
-        guard let manualOverride, decision.disposition != .unmanaged else {
+        guard let manualOverride else {
+            return decision
+        }
+        if decision.disposition == .unmanaged,
+           case .userRule = decision.source
+        {
             return decision
         }
 
@@ -1884,6 +1889,74 @@ final class WMController {
     }
 
     func managedCommandTarget() -> WMCommandTarget? {
+        let frontmostPid = commandHandler.frontmostAppPidProvider?()
+            ?? NSWorkspace.shared.frontmostApplication?.processIdentifier
+        let frontmostToken = commandHandler.frontmostFocusedWindowTokenProvider?()
+            ?? frontmostPid.flatMap { axEventHandler.focusedWindowToken(for: $0) }
+
+        let frontmostTokenIsUntracked = frontmostToken.map { workspaceManager.entry(for: $0) == nil } == true
+        let frontmostTokenIsSelfProcess = frontmostPid == getpid() && frontmostTokenIsUntracked
+
+        if workspaceManager.recentlyLeftNonManagedFocus(within: 1.0) {
+            if let target = managedCommandTarget(forFrontmostToken: frontmostToken),
+               workspaceManager.hasStickyWindowSource(target.token)
+            {
+                return target
+            }
+            if frontmostToken != nil, !frontmostTokenIsSelfProcess {
+                return nil
+            }
+        }
+
+        if workspaceManager.isNonManagedFocusActive {
+            let preservedManagedFocus = workspaceManager.confirmedManagedFocusToken
+            if let frontmostToken,
+               workspaceManager.entry(for: frontmostToken) != nil
+            {
+                return nil
+            }
+            if let frontmostPid {
+                axEventHandler.handleAppActivation(
+                    pid: frontmostPid,
+                    source: .focusedWindowChanged,
+                    origin: .probe
+                )
+                let resolvedFrontmostToken = commandHandler.frontmostFocusedWindowTokenProvider?()
+                    ?? axEventHandler.focusedWindowToken(for: frontmostPid)
+                if let target = managedCommandTarget(forFrontmostToken: resolvedFrontmostToken),
+                   target.token != preservedManagedFocus || workspaceManager.hasStickyWindowSource(target.token)
+                {
+                    return target
+                }
+            }
+            return nil
+        }
+
+        if let frontmostPid,
+           frontmostTokenIsUntracked,
+           !frontmostTokenIsSelfProcess
+        {
+            axEventHandler.handleAppActivation(
+                pid: frontmostPid,
+                source: .focusedWindowChanged,
+                origin: .probe
+            )
+            let resolvedFrontmostToken = commandHandler.frontmostFocusedWindowTokenProvider?()
+                ?? axEventHandler.focusedWindowToken(for: frontmostPid)
+            if let target = managedCommandTarget(forFrontmostToken: resolvedFrontmostToken) {
+                return target
+            }
+            if resolvedFrontmostToken != nil {
+                // The frontmost app has an untracked window, but the focus layer
+                // has not entered non-managed focus. Keep evaluating confirmed
+                // managed focus/layout targets instead of dropping focused
+                // commands on unrelated frontmost app noise (notably tests and
+                // Nehir-owned UI). Stale non-managed focus is handled by the
+                // `isNonManagedFocusActive` and `recentlyLeftNonManagedFocus`
+                // guards above.
+            }
+        }
+
         if let token = workspaceManager.confirmedManagedFocusToken,
            let workspaceId = workspaceManager.workspace(for: token),
            let entry = workspaceManager.entry(for: token),
@@ -1896,20 +1969,14 @@ final class WMController {
             )
         }
 
-        let frontmostPid = commandHandler.frontmostAppPidProvider?()
-            ?? NSWorkspace.shared.frontmostApplication?.processIdentifier
-        let frontmostToken = commandHandler.frontmostFocusedWindowTokenProvider?()
-            ?? frontmostPid.flatMap { axEventHandler.focusedWindowToken(for: $0) }
-        if let frontmostToken,
-           let workspaceId = workspaceManager.workspace(for: frontmostToken),
-           let entry = workspaceManager.entry(for: frontmostToken),
-           entry.mode == .floating
+        if let target = managedCommandTarget(forFrontmostToken: frontmostToken, requireFloating: true) {
+            return target
+        }
+
+        if let frontmostPid,
+           let target = samePidFloatingCommandTarget(pid: frontmostPid, excluding: frontmostToken)
         {
-            return WMCommandTarget(
-                token: frontmostToken,
-                workspaceId: workspaceId,
-                source: .frontmostManagedFallback
-            )
+            return target
         }
 
         if let target = layoutSelectionCommandTarget() {
@@ -1927,9 +1994,17 @@ final class WMController {
             )
         }
 
+        return managedCommandTarget(forFrontmostToken: frontmostToken)
+    }
+
+    private func managedCommandTarget(
+        forFrontmostToken frontmostToken: WindowToken?,
+        requireFloating: Bool = false
+    ) -> WMCommandTarget? {
         guard let frontmostToken,
               let workspaceId = workspaceManager.workspace(for: frontmostToken),
-              workspaceManager.entry(for: frontmostToken) != nil
+              let entry = workspaceManager.entry(for: frontmostToken),
+              !requireFloating || entry.mode == .floating
         else {
             return nil
         }
@@ -1937,6 +2012,28 @@ final class WMController {
             token: frontmostToken,
             workspaceId: workspaceId,
             source: .frontmostManagedFallback
+        )
+    }
+
+    private func samePidFloatingCommandTarget(pid: pid_t, excluding excludedToken: WindowToken?) -> WMCommandTarget? {
+        let candidates = workspaceManager.entries(forPid: pid)
+            .filter { entry in
+                entry.token != excludedToken
+                    && entry.mode == .floating
+                    && entry.visibility == .visible
+                    && !isNonUserAddressableNonGlobalTransientFloatingSurface(entry)
+            }
+            .sorted { lhs, rhs in
+                if lhs.observedState.isFocused != rhs.observedState.isFocused {
+                    return lhs.observedState.isFocused && !rhs.observedState.isFocused
+                }
+                return lhs.windowId > rhs.windowId
+            }
+        guard let entry = candidates.first else { return nil }
+        return WMCommandTarget(
+            token: entry.token,
+            workspaceId: entry.workspaceId,
+            source: .samePidFloatingFallback
         )
     }
 
@@ -2248,6 +2345,16 @@ final class WMController {
         existingEntry: WindowModel.Entry?,
         context: WindowRuleReevaluationContext
     ) -> TrackedWindowMode? {
+        if context == .automatic,
+           let existingEntry,
+           decision.disposition == .unmanaged,
+           case .builtInRule("transientSystemDialogSurface") = decision.source,
+           existingEntry.mode == .floating,
+           existingEntry.managedReplacementMetadata?.transientWindowServerEvidence == true
+        {
+            return .floating
+        }
+
         guard let trackedMode = trackedModeForLifecycle(
             decision: decision,
             existingEntry: existingEntry
@@ -2260,6 +2367,10 @@ final class WMController {
               decision.layoutDecisionKind == .fallbackLayout
         else {
             return trackedMode
+        }
+
+        if workspaceManager.isStickyWindow(existingEntry.token) {
+            return .floating
         }
 
         if existingEntry.mode == .floating,
@@ -3777,6 +3888,11 @@ final class WMController {
             }
 
             let oldEffects = existingEntry?.ruleEffects ?? .none
+            let effectiveRuleEffects = ruleEffectsPreservingExistingAutomaticStickySource(
+                evaluation.decision.ruleEffects,
+                existingEntry: existingEntry,
+                facts: evaluation.facts
+            )
             let oldMode = existingEntry?.mode
             let oldWorkspaceId = existingEntry?.workspaceId
             let hasExplicitWorkspaceAssignment = workspaceAssignment(pid: token.pid, windowId: token.windowId) != nil
@@ -3833,7 +3949,7 @@ final class WMController {
                 windowId: token.windowId,
                 to: workspaceId,
                 mode: oldMode ?? effectiveTrackedMode,
-                ruleEffects: evaluation.decision.ruleEffects
+                ruleEffects: effectiveRuleEffects
             )
             if existingEntry == nil {
                 axEventHandler.discardCreatePlacementContext(for: token.windowId)
@@ -3858,6 +3974,10 @@ final class WMController {
                 } else {
                     updatedEntry.managedReplacementMetadata?.parentWindowId
                 }
+                let transientFlags = mergedManagedReplacementTransientFlags(
+                    existingMetadata: updatedEntry.managedReplacementMetadata,
+                    facts: evaluation.facts
+                )
                 _ = workspaceManager.setManagedReplacementMetadata(
                     ManagedReplacementMetadata(
                         bundleId: evaluation.facts.ax.bundleId ?? updatedEntry.managedReplacementMetadata?.bundleId,
@@ -3870,22 +3990,17 @@ final class WMController {
                             .windowLevel,
                         parentWindowId: parentWindowId,
                         frame: evaluation.facts.windowServer?.frame ?? updatedEntry.managedReplacementMetadata?.frame,
-                        transientWindowServerEvidence: updatedEntry.managedReplacementMetadata?
-                            .transientWindowServerEvidence == true
-                            || evaluation.facts.windowServer?.hasTransientSurfaceEvidence == true,
-                        degradedWindowServerChildEvidence: updatedEntry.managedReplacementMetadata?
-                            .degradedWindowServerChildEvidence == true
-                            || evaluation.facts.degradedWindowServerChildEvidence,
-                        userAddressableTransientWindowServerSurface: updatedEntry.managedReplacementMetadata?
-                            .userAddressableTransientWindowServerSurface == true
-                            || evaluation.facts.userAddressableTransientWindowServerSurface
+                        transientWindowServerEvidence: transientFlags.transientWindowServerEvidence,
+                        degradedWindowServerChildEvidence: transientFlags.degradedWindowServerChildEvidence,
+                        userAddressableTransientWindowServerSurface: transientFlags
+                            .userAddressableTransientWindowServerSurface
                     ),
                     for: token
                 )
             }
 
             if existingEntry == nil
-                || oldEffects != evaluation.decision.ruleEffects
+                || oldEffects != effectiveRuleEffects
                 || oldWorkspaceId != workspaceId
                 || oldMode != effectiveTrackedMode
             {
@@ -3929,11 +4044,26 @@ final class WMController {
             return .notFound
         }
 
+        let currentOverride = workspaceManager.manualLayoutOverride(for: token)
+        let metadata = entry.managedReplacementMetadata
+        let isStandardSurface = metadata == nil
+            || (metadata?.role == kAXWindowRole as String
+                && (metadata?.subrole == nil || metadata?.subrole == kAXStandardWindowSubrole as String))
+        let togglesExplicitTransientState = workspaceManager.isManualUnstickyWindow(token) || !isStandardSurface
         let nextOverride: ManualWindowOverride?
-        if workspaceManager.manualLayoutOverride(for: token) != nil {
+        if currentOverride == .forceTile, entry.mode == .tiling, togglesExplicitTransientState {
+            nextOverride = .forceFloat
+        } else if currentOverride == .forceFloat, entry.mode == .floating, togglesExplicitTransientState {
+            nextOverride = .forceTile
+        } else if currentOverride != nil {
             nextOverride = nil
         } else {
             nextOverride = entry.mode == .tiling ? .forceFloat : .forceTile
+        }
+
+        if nextOverride == .forceTile, workspaceManager.isStickyWindow(token) {
+            _ = workspaceManager.setManualStickyWindow(false, for: token)
+            _ = workspaceManager.setStickyFloatingPromotion(false, for: token)
         }
 
         applyManagedWindowOverride(nextOverride, for: token, entry: entry)
@@ -3945,6 +4075,70 @@ final class WMController {
             return .notFound
         }
         return toggleWindowFloating(token: token)
+    }
+
+    @discardableResult
+    func toggleWindowSticky(token: WindowToken) -> ExternalCommandResult {
+        guard let entry = workspaceManager.entry(for: token),
+              !isManagedWindowSuspendedForNativeFullscreen(token),
+              !isNonUserAddressableNonGlobalTransientFloatingSurface(entry)
+        else {
+            return .notFound
+        }
+
+        let shouldStick = !workspaceManager.isStickyWindow(token)
+        let manualOverride = workspaceManager.manualLayoutOverride(for: token)
+        let wasManualSticky = workspaceManager.isManualStickyWindow(token)
+        let wasStickyPromotion = workspaceManager.isStickyFloatingPromotion(token)
+        _ = workspaceManager.setManualStickyWindow(shouldStick, for: token)
+
+        if shouldStick {
+            if manualOverride == .forceTile {
+                workspaceManager.setManualLayoutOverride(nil, for: token)
+            }
+            if entry.mode == .tiling {
+                _ = workspaceManager.setStickyFloatingPromotion(true, for: token)
+                _ = transitionWindowMode(
+                    for: token,
+                    to: .floating,
+                    preferredMonitor: monitorForInteraction(),
+                    applyFloatingFrame: true
+                )
+            }
+            layoutRefreshController.requestRefresh(reason: .layoutCommand)
+        } else {
+            _ = workspaceManager.setStickyFloatingPromotion(false, for: token)
+            let shouldRestoreTiling = wasStickyPromotion || (wasManualSticky && manualOverride == .forceFloat)
+            if shouldRestoreTiling {
+                let updatedEntry = workspaceManager.entry(for: token) ?? entry
+                if manualOverride == .forceFloat {
+                    workspaceManager.setManualLayoutOverride(nil, for: token)
+                }
+                _ = transitionWindowMode(
+                    for: token,
+                    to: .tiling,
+                    preferredMonitor: monitorForInteraction(),
+                    applyFloatingFrame: true
+                )
+                layoutRefreshController.requestRefresh(
+                    reason: .layoutCommand,
+                    affectedWorkspaceIds: [updatedEntry.workspaceId]
+                )
+            } else {
+                if manualOverride == .forceFloat, entry.ruleEffects.sticky == true {
+                    workspaceManager.setManualLayoutOverride(nil, for: token)
+                }
+                layoutRefreshController.requestRefresh(reason: .layoutCommand)
+            }
+        }
+        return .executed
+    }
+
+    func toggleFocusedWindowSticky() -> ExternalCommandResult {
+        guard let token = focusedManagedTokenForCommand() else {
+            return .notFound
+        }
+        return toggleWindowSticky(token: token)
     }
 
     /// Assigns an explicit token to the single scratchpad slot, honoring the

--- a/Sources/Nehir/Core/Input/ActionCatalog.swift
+++ b/Sources/Nehir/Core/Input/ActionCatalog.swift
@@ -697,6 +697,13 @@ enum ActionCatalog {
                 keywords: ["float", "floating"]
             ),
             action(
+                id: "toggleFocusedWindowSticky",
+                command: .toggleFocusedWindowSticky,
+                category: .layout,
+                binding: .unassigned,
+                keywords: ["sticky", "pin", "all workspaces", "picture in picture", "pip"]
+            ),
+            action(
                 id: "assignFocusedWindowToScratchpad",
                 command: .assignFocusedWindowToScratchpad,
                 category: .layout,
@@ -928,6 +935,7 @@ enum ActionCatalog {
         case .raiseAllFloatingWindows: "Raise All Floating Windows"
         case .rescueOffscreenWindows: "Rescue Off-Screen Floating Windows"
         case .toggleFocusedWindowFloating: "Toggle Focused Window Floating"
+        case .toggleFocusedWindowSticky: "Toggle Focused Window Sticky"
         case .assignFocusedWindowToScratchpad: "Assign Focused Window to Scratchpad"
         case .toggleScratchpadWindow: "Toggle Scratchpad Window"
         case .openMenuAnywhere: "Open Menu Anywhere"
@@ -1083,6 +1091,8 @@ enum ActionCatalog {
             .toggleWorkspaceBar
         case .toggleFocusedWindowFloating:
             .toggleFocusedWindowFloating
+        case .toggleFocusedWindowSticky:
+            .toggleFocusedWindowSticky
         case .assignFocusedWindowToScratchpad:
             .scratchpadAssign
         case .toggleScratchpadWindow:

--- a/Sources/Nehir/Core/Input/HotkeyCommand.swift
+++ b/Sources/Nehir/Core/Input/HotkeyCommand.swift
@@ -78,6 +78,7 @@ enum HotkeyCommand: Codable, Equatable, Hashable {
     case raiseAllFloatingWindows
     case rescueOffscreenWindows
     case toggleFocusedWindowFloating
+    case toggleFocusedWindowSticky
     case assignFocusedWindowToScratchpad
     case toggleScratchpadWindow
 

--- a/Sources/Nehir/Core/Layout/Niri/ViewportState+Geometry.swift
+++ b/Sources/Nehir/Core/Layout/Niri/ViewportState+Geometry.swift
@@ -102,18 +102,6 @@ struct ViewportSnapContext {
         let width = max(0, column.effectiveViewportWidth)
         guard width > 0 else { return [] }
 
-        if columns.count == 1,
-           columnIndex == 0,
-           column.loneWindowLayoutWidthOverride != nil
-        {
-            let edgeOffset = width - viewportWidth
-            return [
-                SnapPoint(offset: 0, columnIndex: 0, kind: .leftEdge),
-                SnapPoint(offset: edgeOffset, columnIndex: 0, kind: .rightEdge),
-                SnapPoint(offset: edgeOffset / 2, columnIndex: 0, kind: .center)
-            ].sortedAndDeduped(pixelTolerance: pixelTolerance)
-        }
-
         var candidates: [SnapPoint] = [
             SnapPoint(
                 offset: state.boundedViewportStart(
@@ -617,13 +605,6 @@ extension ViewportState {
     ) -> ClosedRange<CGFloat> {
         guard !columns.isEmpty, viewportWidth > 0 else { return 0 ... 0 }
 
-        if columns.count == 1,
-           let overrideWidth = columns.first?.loneWindowLayoutWidthOverride
-        {
-            let edgeOffset = overrideWidth - viewportWidth
-            return min(0, edgeOffset) ... max(0, edgeOffset)
-        }
-
         let fraction = edgeVisibleFraction.clamped(to: 0 ... 1)
         let firstWidth = max(0, columns.first?.effectiveViewportWidth ?? 0)
         let lastWidth = max(0, columns.last?.effectiveViewportWidth ?? 0)
@@ -694,17 +675,6 @@ extension ViewportState {
 
         func bounded(_ offset: CGFloat) -> CGFloat {
             boundedViewportStart(offset, columns: columns, gap: gap, viewportWidth: viewportWidth)
-        }
-
-        if columns.count == 1,
-           let overrideWidth = columns.first?.loneWindowLayoutWidthOverride
-        {
-            let edgeOffset = overrideWidth - viewportWidth
-            return [
-                SnapPoint(offset: 0, columnIndex: 0, kind: .leftEdge),
-                SnapPoint(offset: edgeOffset, columnIndex: 0, kind: .rightEdge),
-                SnapPoint(offset: edgeOffset / 2, columnIndex: 0, kind: .center)
-            ].sortedAndDeduped(pixelTolerance: pixelTolerance)
         }
 
         var points: [SnapPoint] = []

--- a/Sources/Nehir/Core/Rules/WindowRuleEngine.swift
+++ b/Sources/Nehir/Core/Rules/WindowRuleEngine.swift
@@ -47,6 +47,7 @@ struct ManagedWindowRuleEffects: Equatable, Sendable {
     var minWidth: Double?
     var minHeight: Double?
     var matchedRuleId: UUID?
+    var sticky: Bool?
 
     static let none = ManagedWindowRuleEffects()
 }
@@ -98,6 +99,19 @@ struct WindowDecision: Equatable, Sendable {
     }
 }
 
+func isTopLevelResizableMediaLikeSurfaceFrame(_ frame: CGRect) -> Bool {
+    let frame = frame.standardized
+    guard frame.width >= 240,
+          frame.height >= 135,
+          frame.width * frame.height <= 1_600_000
+    else {
+        return false
+    }
+
+    let aspectRatio = frame.width / frame.height
+    return aspectRatio >= 1.2 && aspectRatio <= 2.4
+}
+
 struct WindowRuleFacts: Equatable, Sendable {
     let appName: String?
     let ax: AXWindowFacts
@@ -108,6 +122,9 @@ struct WindowRuleFacts: Equatable, Sendable {
         guard !ax.attributeFetchSucceeded,
               let windowServer
         else {
+            return false
+        }
+        if windowServer.parentId == 0, isTopLevelResizableMediaLikeSurface(windowServer) {
             return false
         }
         return windowServer.hasModalTag || (windowServer.hasFloatingTag && !windowServer.hasDocumentTag)
@@ -126,6 +143,89 @@ struct WindowRuleFacts: Equatable, Sendable {
         }
         return true
     }
+
+    var pipDefaultStickyCandidate: Bool {
+        guard ax.attributeFetchSucceeded,
+              ax.role == kAXWindowRole as String,
+              ax.hasCloseButton,
+              let windowServer,
+              windowServer.parentId == 0,
+              windowServer.level > 0,
+              windowServer.level < 20
+        else {
+            return false
+        }
+
+        if ax.subrole == kAXStandardWindowSubrole as String {
+            return userAddressableTransientWindowServerSurface ||
+                (!windowServer.hasModalTag && !windowServer.hasFloatingTag)
+        }
+
+        if ax.subrole == kAXSystemDialogSubrole as String {
+            return isTopLevelResizableMediaLikeSurface(windowServer)
+                && !windowServer.hasModalTag
+                && !windowServer.hasFloatingTag
+                && !ax.hasFullscreenButton
+                && ax.hasZoomButton
+                && ax.hasMinimizeButton
+        }
+
+        return false
+    }
+
+    private func isTopLevelResizableMediaLikeSurface(_ windowServer: WindowServerInfo) -> Bool {
+        isTopLevelResizableMediaLikeSurfaceFrame(windowServer.frame)
+    }
+}
+
+func ruleEffectsPreservingExistingAutomaticStickySource(
+    _ effects: ManagedWindowRuleEffects,
+    existingEntry: WindowModel.Entry?,
+    facts: WindowRuleFacts
+) -> ManagedWindowRuleEffects {
+    guard effects.sticky == nil,
+          existingEntry?.ruleEffects.sticky == true
+    else {
+        return effects
+    }
+
+    let metadata = existingEntry?.managedReplacementMetadata
+    let hasSameTransientSurfaceEvidence = metadata?.transientWindowServerEvidence == true
+        || metadata?.userAddressableTransientWindowServerSurface == true
+        || facts.windowServer?.hasTransientSurfaceEvidence == true
+        || facts.userAddressableTransientWindowServerSurface
+        || facts.pipDefaultStickyCandidate
+        || facts.degradedWindowServerChildEvidence
+    guard hasSameTransientSurfaceEvidence else { return effects }
+
+    var preserved = effects
+    preserved.sticky = true
+    return preserved
+}
+
+func mergedManagedReplacementTransientFlags(
+    existingMetadata: ManagedReplacementMetadata?,
+    facts: WindowRuleFacts
+) -> (
+    transientWindowServerEvidence: Bool,
+    degradedWindowServerChildEvidence: Bool,
+    userAddressableTransientWindowServerSurface: Bool
+) {
+    let userAddressableTransientWindowServerSurface = existingMetadata?
+        .userAddressableTransientWindowServerSurface == true
+        || facts.userAddressableTransientWindowServerSurface
+        || facts.pipDefaultStickyCandidate
+    let degradedWindowServerChildEvidence = !userAddressableTransientWindowServerSurface
+        && (existingMetadata?.degradedWindowServerChildEvidence == true || facts.degradedWindowServerChildEvidence)
+    let transientWindowServerEvidence = existingMetadata?.transientWindowServerEvidence == true
+        || facts.windowServer?.hasTransientSurfaceEvidence == true
+        || userAddressableTransientWindowServerSurface
+
+    return (
+        transientWindowServerEvidence,
+        degradedWindowServerChildEvidence,
+        userAddressableTransientWindowServerSurface
+    )
 }
 
 enum WindowRuleReevaluationTarget: Hashable, Sendable {
@@ -374,8 +474,20 @@ final class WindowRuleEngine {
         let effects = ManagedWindowRuleEffects(
             minWidth: userRule?.rule.minWidth,
             minHeight: userRule?.rule.minHeight,
-            matchedRuleId: userRule?.rule.id
+            matchedRuleId: userRule?.rule.id,
+            sticky: userRule?.rule.sticky ?? (facts.pipDefaultStickyCandidate ? true : nil)
         )
+
+        if let userRule,
+           userRule.rule.effectiveManageAction == .ignore,
+           let userDecision = explicitDecision(
+               userRule,
+               workspaceName: workspaceName,
+               effects: effects
+           )
+        {
+            return userDecision
+        }
 
         if let parentedSurfaceDecision = parentedWindowServerSurfaceDecision(
             for: facts,
@@ -451,7 +563,7 @@ final class WindowRuleEngine {
 
         if appFullscreen {
             return WindowDecision(
-                disposition: .managed,
+                disposition: stickyAdjustedDisposition(.managed, effects: effects),
                 source: userRule.map { .userRule($0.rule.id) }
                     ?? builtInRule.map { builtInRuleSource(for: $0) }
                     ?? .heuristic,
@@ -489,7 +601,7 @@ final class WindowRuleEngine {
         )
 
         return WindowDecision(
-            disposition: heuristic.disposition,
+            disposition: stickyAdjustedDisposition(heuristic.disposition, effects: effects),
             source: userRule.map { .userRule($0.rule.id) } ?? .heuristic,
             layoutDecisionKind: .fallbackLayout,
             workspaceName: workspaceName,
@@ -514,7 +626,7 @@ final class WindowRuleEngine {
         }
 
         return WindowDecision(
-            disposition: disposition,
+            disposition: stickyAdjustedDisposition(disposition, effects: effects),
             source: .userRule(compiled.rule.id),
             layoutDecisionKind: .fallbackLayout,
             workspaceName: workspaceName,
@@ -550,6 +662,7 @@ final class WindowRuleEngine {
         guard facts.ax.attributeFetchSucceeded,
               facts.ax.role == kAXWindowRole as String,
               facts.ax.subrole == kAXSystemDialogSubrole as String,
+              !facts.pipDefaultStickyCandidate,
               facts.windowServer?.parentId == nil || facts.windowServer?.parentId == 0
         else {
             return nil
@@ -621,24 +734,37 @@ final class WindowRuleEngine {
         }
 
         let disposition: WindowDecisionDisposition
-        switch compiled.rule.effectiveLayoutAction {
-        case .float:
-            disposition = .floating
-        case .tile:
-            disposition = .managed
-        case .auto:
-            return nil
+        if compiled.rule.effectiveManageAction == .ignore {
+            disposition = .unmanaged
+        } else {
+            switch compiled.rule.effectiveLayoutAction {
+            case .float:
+                disposition = .floating
+            case .tile:
+                disposition = .managed
+            case .auto:
+                return nil
+            }
         }
 
+        let effectiveDisposition = stickyAdjustedDisposition(disposition, effects: effects)
         return WindowDecision(
-            disposition: disposition,
+            disposition: effectiveDisposition,
             source: source,
             layoutDecisionKind: .explicitLayout,
-            workspaceName: workspaceName,
-            ruleEffects: effects,
+            workspaceName: effectiveDisposition == .unmanaged ? nil : workspaceName,
+            ruleEffects: effectiveDisposition == .unmanaged ? .none : effects,
             heuristicReasons: [],
             deferredReason: nil
         )
+    }
+
+    private func stickyAdjustedDisposition(
+        _ disposition: WindowDecisionDisposition,
+        effects: ManagedWindowRuleEffects
+    ) -> WindowDecisionDisposition {
+        guard effects.sticky == true, disposition == .managed else { return disposition }
+        return .floating
     }
 
     private func builtInRuleSource(for compiled: CompiledRule) -> WindowDecisionSource {

--- a/Sources/Nehir/Core/Workspace/WorkspaceManager.swift
+++ b/Sources/Nehir/Core/Workspace/WorkspaceManager.swift
@@ -210,6 +210,7 @@ final class WorkspaceManager {
     private let reconcileTrace = ReconcileTraceRecorder()
     private let interactionMonitorWriteTrace = InteractionMonitorWriteRecorder()
     private var recentFloatingBarProjectionTraceRecords: [String] = []
+    private var lastNonManagedFocusExitAt: Date?
     private lazy var runtimeStore = RuntimeStore(traceRecorder: reconcileTrace)
     private let restorePlanner = RestorePlanner()
     private var bootPersistedWindowRestoreCatalog: PersistedWindowRestoreCatalog
@@ -221,6 +222,9 @@ final class WorkspaceManager {
     /// `SpaceTopology`. Such windows are never parked on workspace switch and must
     /// not be clamped back to a stale reference monitor on a cross-monitor drag.
     private var globalStickyWindowTokens: Set<WindowToken> = []
+    private var manualStickyWindowTokens: Set<WindowToken> = []
+    private var manualUnstickyWindowTokens: Set<WindowToken> = []
+    private var stickyFloatingPromotionTokens: Set<WindowToken> = []
     /// Last native macOS Space ID observed from CGS create notifications, keyed by
     /// WindowServer window ID. This mirrors upstream OmniWM's native-space tracking
     /// and complements `SLSCopySpacesForWindows`: a window may have multiple candidate
@@ -514,6 +518,9 @@ final class WorkspaceManager {
         nativeFullscreenRecordsByOriginalToken.removeAll()
         nativeFullscreenOriginalTokenByCurrentToken.removeAll()
         globalStickyWindowTokens.removeAll()
+        manualStickyWindowTokens.removeAll()
+        manualUnstickyWindowTokens.removeAll()
+        stickyFloatingPromotionTokens.removeAll()
         nativeSpaceIdByWindowId.removeAll()
         nativeInactiveWindowTokens.removeAll()
         consumedBootPersistedWindowRestoreEntries.removeAll()
@@ -710,6 +717,13 @@ final class WorkspaceManager {
     }
 
     private func applyReconciledFocusSession(_ focusSession: FocusSessionSnapshot) {
+        let wasNonManagedFocusActive = sessionState.focus.isNonManagedFocusActive
+        if wasNonManagedFocusActive, !focusSession.isNonManagedFocusActive {
+            lastNonManagedFocusExitAt = Date()
+        } else if !wasNonManagedFocusActive, focusSession.isNonManagedFocusActive {
+            lastNonManagedFocusExitAt = nil
+        }
+
         sessionState.focus.focusedToken = focusSession.focusedToken
         sessionState.focus.pendingManagedFocus = .init(
             token: focusSession.pendingManagedFocus.token,
@@ -1146,6 +1160,11 @@ final class WorkspaceManager {
 
     var isNonManagedFocusActive: Bool {
         sessionState.focus.isNonManagedFocusActive
+    }
+
+    func recentlyLeftNonManagedFocus(within interval: TimeInterval) -> Bool {
+        guard let lastNonManagedFocusExitAt else { return false }
+        return Date().timeIntervalSince(lastNonManagedFocusExitAt) <= interval
     }
 
     var isAppFullscreenActive: Bool {
@@ -2598,6 +2617,15 @@ final class WorkspaceManager {
         if globalStickyWindowTokens.remove(oldToken) != nil {
             globalStickyWindowTokens.insert(newToken)
         }
+        if manualStickyWindowTokens.remove(oldToken) != nil {
+            manualStickyWindowTokens.insert(newToken)
+        }
+        if manualUnstickyWindowTokens.remove(oldToken) != nil {
+            manualUnstickyWindowTokens.insert(newToken)
+        }
+        if stickyFloatingPromotionTokens.remove(oldToken) != nil {
+            stickyFloatingPromotionTokens.insert(newToken)
+        }
         if nativeInactiveWindowTokens.remove(oldToken) != nil {
             nativeInactiveWindowTokens.insert(newToken)
         }
@@ -2694,7 +2722,9 @@ final class WorkspaceManager {
         }
 
         let isGlobalSticky = isGlobalStickyWindow(entry.token)
-        if entry.layoutReason != .standard, !isGlobalSticky {
+        let isSticky = isStickyWindow(entry.token)
+        let hasStickySource = hasStickyWindowSource(entry.token)
+        if entry.layoutReason != .standard, !isSticky {
             return .rejected(reason: "layoutReason=\(String(describing: entry.layoutReason))")
         }
 
@@ -2704,8 +2734,16 @@ final class WorkspaceManager {
         let hasChildEvidence = metadata?.parentWindowId != nil
             || metadata?.degradedWindowServerChildEvidence == true
 
-        if isGlobalSticky {
-            return .accepted(reason: "globalSticky")
+        if isSticky {
+            return .accepted(reason: isGlobalSticky ? "globalSticky" : "sticky")
+        }
+
+        if manualLayoutOverride(for: entry.token) != nil {
+            return .accepted(reason: "manualOverride")
+        }
+
+        if hasStickySource, !isStandardAXWindowSurface(metadata) {
+            return .accepted(reason: "stickySource")
         }
 
         if !isStandardAXWindowSurface(metadata) {
@@ -2765,7 +2803,7 @@ final class WorkspaceManager {
         let bundleId = metadata?.bundleId ?? "nil"
         let parentWindowId = metadata?.parentWindowId.map(String.init) ?? "nil"
         let isScratchpad = isScratchpadToken(entry.token) || hiddenState(for: entry.token)?.isScratchpad == true
-        let record = "\(Date().ISO8601Format()) workspace=\(workspace.uuidString) token=\(entry.token) bundleId=\(bundleId) \(outcome) frame=\(runtimeDebugFrame(floatingBarProjectionFrame(for: entry))) layoutReason=\(String(describing: entry.layoutReason)) transientWindowServerEvidence=\(metadata?.transientWindowServerEvidence == true) degradedWindowServerChildEvidence=\(metadata?.degradedWindowServerChildEvidence == true) parentWindowId=\(parentWindowId) globalSticky=\(isGlobalStickyWindow(entry.token)) scratchpad=\(isScratchpad)"
+        let record = "\(Date().ISO8601Format()) workspace=\(workspace.uuidString) token=\(entry.token) bundleId=\(bundleId) \(outcome) frame=\(runtimeDebugFrame(floatingBarProjectionFrame(for: entry))) layoutReason=\(String(describing: entry.layoutReason)) transientWindowServerEvidence=\(metadata?.transientWindowServerEvidence == true) degradedWindowServerChildEvidence=\(metadata?.degradedWindowServerChildEvidence == true) parentWindowId=\(parentWindowId) globalSticky=\(isGlobalStickyWindow(entry.token)) sticky=\(isStickyWindow(entry.token)) scratchpad=\(isScratchpad)"
         recentFloatingBarProjectionTraceRecords.append(record)
         if recentFloatingBarProjectionTraceRecords.count > 120 {
             recentFloatingBarProjectionTraceRecords.removeFirst(recentFloatingBarProjectionTraceRecords.count - 120)
@@ -2981,6 +3019,60 @@ final class WorkspaceManager {
         globalStickyWindowTokens.contains(token)
     }
 
+    func isStickyWindow(_ token: WindowToken) -> Bool {
+        guard !isManualUnstickyWindow(token) else { return false }
+        return hasStickyWindowSource(token)
+    }
+
+    func hasStickyWindowSource(_ token: WindowToken) -> Bool {
+        isGlobalStickyWindow(token) || isManualStickyWindow(token) || windows.entry(for: token)?.ruleEffects
+            .sticky == true
+    }
+
+    func isManualStickyWindow(_ token: WindowToken) -> Bool {
+        manualStickyWindowTokens.contains(token)
+    }
+
+    func isManualUnstickyWindow(_ token: WindowToken) -> Bool {
+        manualUnstickyWindowTokens.contains(token)
+    }
+
+    func isStickyFloatingPromotion(_ token: WindowToken) -> Bool {
+        stickyFloatingPromotionTokens.contains(token)
+    }
+
+    @discardableResult
+    func setStickyFloatingPromotion(_ promoted: Bool, for token: WindowToken) -> Bool {
+        let changed: Bool
+        if promoted {
+            changed = stickyFloatingPromotionTokens.insert(token).inserted
+        } else {
+            changed = stickyFloatingPromotionTokens.remove(token) != nil
+        }
+        if changed {
+            invalidateWorkspaceProjection(reason: "stickyFloatingPromotionChanged")
+        }
+        return changed
+    }
+
+    @discardableResult
+    func setManualStickyWindow(_ sticky: Bool, for token: WindowToken) -> Bool {
+        let changed: Bool
+        if sticky {
+            let inserted = manualStickyWindowTokens.insert(token).inserted
+            let removed = manualUnstickyWindowTokens.remove(token) != nil
+            changed = inserted || removed
+        } else {
+            let removed = manualStickyWindowTokens.remove(token) != nil
+            let inserted = manualUnstickyWindowTokens.insert(token).inserted
+            changed = removed || inserted
+        }
+        if changed {
+            invalidateWorkspaceProjection(reason: "manualStickyWindowChanged")
+        }
+        return changed
+    }
+
     func noteNativeSpace(windowId: UInt32, spaceId: UInt64) {
         guard spaceId != 0 else { return }
         nativeSpaceIdByWindowId[Int(windowId)] = spaceId
@@ -3140,6 +3232,9 @@ final class WorkspaceManager {
         _ = removeNativeFullscreenRecord(containing: entry.token)
         nativeSpaceIdByWindowId.removeValue(forKey: entry.windowId)
         globalStickyWindowTokens.remove(entry.token)
+        manualStickyWindowTokens.remove(entry.token)
+        manualUnstickyWindowTokens.remove(entry.token)
+        stickyFloatingPromotionTokens.remove(entry.token)
         nativeInactiveWindowTokens.remove(entry.token)
         handleWindowRemoved(entry.token, in: entry.workspaceId)
         _ = windows.removeWindow(key: entry.token)

--- a/Sources/Nehir/IPC/IPCCommandRouter.swift
+++ b/Sources/Nehir/IPC/IPCCommandRouter.swift
@@ -180,6 +180,8 @@ final class IPCCommandRouter {
             return controller.commandHandler.performCommand(.toggleWorkspaceBarVisibility)
         case .toggleFocusedWindowFloating:
             return toggleFocusedWindowFloating()
+        case .toggleFocusedWindowSticky:
+            return toggleFocusedWindowSticky()
         case .scratchpadAssign:
             return assignFocusedWindowToScratchpad()
         case .scratchpadToggle:
@@ -370,6 +372,10 @@ final class IPCCommandRouter {
 
     private func toggleFocusedWindowFloating() -> ExternalCommandResult {
         controller.commandHandler.performCommand(.toggleFocusedWindowFloating)
+    }
+
+    private func toggleFocusedWindowSticky() -> ExternalCommandResult {
+        controller.commandHandler.performCommand(.toggleFocusedWindowSticky)
     }
 
     private func assignFocusedWindowToScratchpad() -> ExternalCommandResult {

--- a/Sources/Nehir/IPC/IPCQueryRouter.swift
+++ b/Sources/Nehir/IPC/IPCQueryRouter.swift
@@ -361,6 +361,7 @@ final class IPCQueryRouter {
             isFocused: include("is-focused", in: fields) ? (entry.token == focusedToken) : nil,
             isVisible: include("is-visible", in: fields) ? isVisible : nil,
             isScratchpad: include("is-scratchpad", in: fields) ? isScratchpad : nil,
+            isSticky: include("is-sticky", in: fields) ? controller.workspaceManager.isStickyWindow(entry.token) : nil,
             hiddenReason: include("hidden-reason", in: fields) ? hiddenState.map(ipcHiddenReason(from:)) : nil
         )
     }

--- a/Sources/Nehir/IPC/IPCRuleProjection.swift
+++ b/Sources/Nehir/IPC/IPCRuleProjection.swift
@@ -42,10 +42,12 @@ enum IPCRuleProjection {
             titleRegex: definition.titleRegex,
             axRole: definition.axRole,
             axSubrole: definition.axSubrole,
+            manage: definition.manage,
             layout: definition.layout,
             assignToWorkspace: definition.assignToWorkspace,
             minWidth: definition.minWidth,
             minHeight: definition.minHeight,
+            sticky: definition.sticky,
             specificity: rule.specificity,
             isValid: isValid,
             invalidRegexMessage: invalidRegexMessage
@@ -61,10 +63,12 @@ enum IPCRuleProjection {
                 titleRegex: rule.titleRegex,
                 axRole: rule.axRole,
                 axSubrole: rule.axSubrole,
+                manage: ipcRuleManage(from: rule.effectiveManageAction),
                 layout: ipcRuleLayout(from: rule.effectiveLayoutAction),
                 assignToWorkspace: rule.assignToWorkspace,
                 minWidth: rule.minWidth,
-                minHeight: rule.minHeight
+                minHeight: rule.minHeight,
+                sticky: rule.sticky
             )
         )
     }
@@ -79,10 +83,12 @@ enum IPCRuleProjection {
             titleRegex: normalized.titleRegex,
             axRole: normalized.axRole,
             axSubrole: normalized.axSubrole,
+            manage: windowRuleManage(from: normalized.manage),
             layout: windowRuleLayout(from: normalized.layout),
             assignToWorkspace: normalized.assignToWorkspace,
             minWidth: normalized.minWidth,
-            minHeight: normalized.minHeight
+            minHeight: normalized.minHeight,
+            sticky: normalized.sticky
         )
     }
 
@@ -94,11 +100,31 @@ enum IPCRuleProjection {
             titleRegex: definition.titleRegex?.trimmedNonEmpty,
             axRole: definition.axRole?.trimmedNonEmpty,
             axSubrole: definition.axSubrole?.trimmedNonEmpty,
+            manage: definition.manage,
             layout: definition.layout,
             assignToWorkspace: definition.assignToWorkspace?.trimmedNonEmpty,
             minWidth: definition.minWidth,
-            minHeight: definition.minHeight
+            minHeight: definition.minHeight,
+            sticky: definition.sticky
         )
+    }
+
+    private static func ipcRuleManage(from action: WindowRuleManageAction) -> IPCRuleManage {
+        switch action {
+        case .auto:
+            .auto
+        case .ignore:
+            .ignore
+        }
+    }
+
+    private static func windowRuleManage(from manage: IPCRuleManage?) -> WindowRuleManageAction? {
+        switch manage ?? .auto {
+        case .auto:
+            nil
+        case .ignore:
+            .ignore
+        }
     }
 
     private static func ipcRuleLayout(from action: WindowRuleLayoutAction) -> IPCRuleLayout {

--- a/Sources/Nehir/UI/AppRuleDraft.swift
+++ b/Sources/Nehir/UI/AppRuleDraft.swift
@@ -28,7 +28,10 @@ enum TitleMatcherMode: String, CaseIterable, Identifiable {
 struct AppRuleDraft: Identifiable, Equatable {
     let id: UUID
     var bundleId: String
+    var manageAction: WindowRuleManageAction
     var layoutAction: WindowRuleLayoutAction
+    var stickyEnabled: Bool
+    var sticky: Bool
     var assignToWorkspaceEnabled: Bool
     var assignToWorkspace: String
     var minWidthEnabled: Bool
@@ -48,7 +51,10 @@ struct AppRuleDraft: Identifiable, Equatable {
     init(id: UUID = UUID(), bundleId: String = "") {
         self.id = id
         self.bundleId = bundleId
+        manageAction = .auto
         layoutAction = .auto
+        stickyEnabled = false
+        sticky = true
         assignToWorkspaceEnabled = false
         assignToWorkspace = ""
         minWidthEnabled = false
@@ -69,7 +75,10 @@ struct AppRuleDraft: Identifiable, Equatable {
     init(rule: AppRule) {
         id = rule.id
         bundleId = rule.bundleId
+        manageAction = rule.effectiveManageAction
         layoutAction = rule.effectiveLayoutAction
+        stickyEnabled = rule.sticky != nil
+        sticky = rule.sticky ?? true
         assignToWorkspaceEnabled = rule.assignToWorkspace != nil
         assignToWorkspace = rule.assignToWorkspace ?? ""
         minWidthEnabled = rule.minWidth != nil
@@ -129,10 +138,12 @@ struct AppRuleDraft: Identifiable, Equatable {
             titleRegex: titleMatcherMode == .regex ? titleRegex.trimmedNonEmpty : nil,
             axRole: axRoleEnabled ? axRole.trimmedNonEmpty : nil,
             axSubrole: axSubroleEnabled ? axSubrole.trimmedNonEmpty : nil,
+            manage: manageAction == .auto ? nil : manageAction,
             layout: layoutAction == .auto ? nil : layoutAction,
             assignToWorkspace: assignToWorkspaceEnabled ? assignToWorkspace.trimmedNonEmpty : nil,
             minWidth: minWidthEnabled ? minWidth : nil,
-            minHeight: minHeightEnabled ? minHeight : nil
+            minHeight: minHeightEnabled ? minHeight : nil,
+            sticky: stickyEnabled ? sticky : nil
         )
     }
 }

--- a/Sources/Nehir/UI/AppRulesView.swift
+++ b/Sources/Nehir/UI/AppRulesView.swift
@@ -218,19 +218,27 @@ struct AppRuleSidebarRow: View {
                 .lineLimit(1)
 
             HStack(spacing: 4) {
-                switch rule.effectiveLayoutAction {
-                case .float:
-                    RuleBadge(text: "Float", color: .blue)
-                case .tile:
-                    RuleBadge(text: "Tile", color: .teal)
-                case .auto:
-                    EmptyView()
+                if rule.effectiveManageAction == .ignore {
+                    RuleBadge(text: "Ignore", color: .red)
                 }
-                if rule.assignToWorkspace != nil {
-                    RuleBadge(text: "WS", color: .green)
-                }
-                if rule.minWidth != nil || rule.minHeight != nil {
-                    RuleBadge(text: "Size", color: .orange)
+                if rule.effectiveManageAction != .ignore {
+                    if rule.sticky == true {
+                        RuleBadge(text: "Sticky", color: .yellow)
+                    }
+                    switch rule.effectiveLayoutAction {
+                    case .float:
+                        RuleBadge(text: "Float", color: .blue)
+                    case .tile:
+                        RuleBadge(text: "Tile", color: .teal)
+                    case .auto:
+                        EmptyView()
+                    }
+                    if rule.assignToWorkspace != nil {
+                        RuleBadge(text: "WS", color: .green)
+                    }
+                    if rule.minWidth != nil || rule.minHeight != nil {
+                        RuleBadge(text: "Size", color: .orange)
+                    }
                 }
                 if rule.hasAdvancedMatchers {
                     RuleBadge(text: "Advanced", color: .purple)
@@ -312,13 +320,30 @@ struct AppRuleDetailView: View {
             }
 
             Section("Window Behavior") {
+                Picker("Manage", selection: $draft.manageAction) {
+                    ForEach(WindowRuleManageAction.allCases) { action in
+                        Text(action.displayName).tag(action)
+                    }
+                }
+
+                if ignoresWindows {
+                    SettingsCaption(
+                        "Ignored windows are left out of Nehir's managed model. Layout, Sticky, workspace, and size effects will not apply."
+                    )
+                }
+
                 Picker("Layout", selection: $draft.layoutAction) {
                     ForEach(WindowRuleLayoutAction.allCases) { action in
                         Text(action.displayName).tag(action)
                     }
                 }
+                .disabled(ignoresWindows)
+
+                Toggle("Sticky", isOn: $draft.stickyEnabled)
+                    .disabled(ignoresWindows)
 
                 Toggle("Assign to Workspace", isOn: $draft.assignToWorkspaceEnabled)
+                    .disabled(ignoresWindows)
                     .onChange(of: draft.assignToWorkspaceEnabled) { _, enabled in
                         guard enabled else { return }
                         seedWorkspaceIfNeeded()
@@ -330,7 +355,7 @@ struct AppRuleDetailView: View {
                             Text(name).tag(name)
                         }
                     }
-                    .disabled(workspaceNames.isEmpty)
+                    .disabled(workspaceNames.isEmpty || ignoresWindows)
 
                     if workspaceNames.isEmpty {
                         SettingsCaption("No workspaces configured. Add workspaces in Settings.")
@@ -388,6 +413,10 @@ struct AppRuleDetailView: View {
             rule = newValue.makeRule(id: rule.id)
             controller.updateAppRules()
         }
+    }
+
+    private var ignoresWindows: Bool {
+        draft.manageAction == .ignore
     }
 
     private var titleRegexError: String? {
@@ -488,13 +517,32 @@ struct AppRuleAddPane: View {
                 }
 
                 Section("Window Behavior") {
+                    Picker("Manage", selection: $draft.manageAction) {
+                        ForEach(WindowRuleManageAction.allCases) { action in
+                            Text(action.displayName).tag(action)
+                        }
+                    }
+
+                    if ignoresWindows {
+                        Text(
+                            "Ignored windows are left out of Nehir's managed model. Layout, Sticky, workspace, and size effects will not apply."
+                        )
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                    }
+
                     Picker("Layout", selection: $draft.layoutAction) {
                         ForEach(WindowRuleLayoutAction.allCases) { action in
                             Text(action.displayName).tag(action)
                         }
                     }
+                    .disabled(ignoresWindows)
+
+                    Toggle("Sticky", isOn: $draft.stickyEnabled)
+                        .disabled(ignoresWindows)
 
                     Toggle("Assign to Workspace", isOn: $draft.assignToWorkspaceEnabled)
+                        .disabled(ignoresWindows)
                         .onChange(of: draft.assignToWorkspaceEnabled) { _, enabled in
                             guard enabled else { return }
                             seedWorkspaceIfNeeded()
@@ -506,7 +554,7 @@ struct AppRuleAddPane: View {
                                 Text(name).tag(name)
                             }
                         }
-                        .disabled(workspaceNames.isEmpty)
+                        .disabled(workspaceNames.isEmpty || ignoresWindows)
 
                         if workspaceNames.isEmpty {
                             Text("No workspaces configured. Add workspaces in Settings.")
@@ -582,6 +630,10 @@ struct AppRuleAddPane: View {
     private var titleRegexError: String? {
         guard draft.titleMatcherMode == .regex else { return nil }
         return AppRuleDraftValidation.titleRegexError(for: draft.titleRegex)
+    }
+
+    private var ignoresWindows: Bool {
+        draft.manageAction == .ignore
     }
 
     private var isValid: Bool {

--- a/Sources/Nehir/UI/WorkspaceBar/WorkspaceBarDataSource.swift
+++ b/Sources/Nehir/UI/WorkspaceBar/WorkspaceBarDataSource.swift
@@ -59,6 +59,13 @@ enum WorkspaceBarDataSource {
                 viewportSelectedToken: viewportSelectedToken,
                 settings: settings
             ),
+            sticky: stickyItem(
+                for: monitor,
+                workspaceManager: workspaceManager,
+                appInfoCache: appInfoCache,
+                focusedToken: focusedToken,
+                viewportSelectedToken: viewportSelectedToken
+            ),
             scratchpad: scratchpadItem(
                 workspaceManager: workspaceManager,
                 appInfoCache: appInfoCache,
@@ -83,15 +90,12 @@ enum WorkspaceBarDataSource {
             let projectedEntries = workspaceManager.barVisibleEntries(
                 in: workspace.id,
                 showFloatingWindows: options.showFloatingWindows
-            )
+            ).filter { !workspaceManager.isStickyWindow($0.token) }
             return WorkspaceSnapshot(
                 workspace: workspace,
                 tiledEntries: projectedEntries.filter { $0.mode == .tiling },
                 floatingEntries: projectedEntries.filter { $0.mode == .floating },
-                hasBarOccupancy: workspaceManager.hasBarVisibleOccupancy(
-                    in: workspace.id,
-                    showFloatingWindows: options.showFloatingWindows
-                )
+                hasBarOccupancy: !projectedEntries.isEmpty
             )
         }
 
@@ -139,6 +143,35 @@ enum WorkspaceBarDataSource {
                 floatingWindows: floatingWindows
             )
         }
+    }
+
+    private static func stickyItem(
+        for monitor: Monitor,
+        workspaceManager: WorkspaceManager,
+        appInfoCache: AppInfoCache,
+        focusedToken: WindowToken?,
+        viewportSelectedToken: WindowToken?
+    ) -> WorkspaceBarStickyItem? {
+        var seen: Set<WindowToken> = []
+        let entries = workspaceManager.workspaces(on: monitor.id).flatMap { workspace in
+            workspaceManager.barVisibleEntries(
+                in: workspace.id,
+                showFloatingWindows: true
+            )
+        }.filter { entry in
+            workspaceManager.isStickyWindow(entry.token) && seen.insert(entry.token).inserted
+        }
+
+        let windows = createWindowItems(
+            entries: entries,
+            deduplicate: false,
+            useLayoutOrder: false,
+            appInfoCache: appInfoCache,
+            focusedToken: focusedToken,
+            viewportSelectedToken: viewportSelectedToken
+        )
+        guard !windows.isEmpty else { return nil }
+        return WorkspaceBarStickyItem(windows: windows)
     }
 
     private static func scratchpadItem(

--- a/Sources/Nehir/UI/WorkspaceBar/WorkspaceBarManager.swift
+++ b/Sources/Nehir/UI/WorkspaceBar/WorkspaceBarManager.swift
@@ -250,6 +250,9 @@ final class WorkspaceBarManager {
                 onToggleWindowFloating: { [weak controller] token in
                     _ = controller?.toggleWindowFloating(token: token)
                 },
+                onToggleWindowSticky: { [weak controller] token in
+                    _ = controller?.toggleWindowSticky(token: token)
+                },
                 onToggleScratchpadAssignment: { [weak controller] token in
                     _ = controller?.toggleWindowScratchpadAssignment(token: token)
                 },
@@ -450,7 +453,7 @@ final class WorkspaceBarManager {
         let projection = controller?.workspaceBarProjection(
             for: monitor,
             projection: resolved.projectionOptions
-        ) ?? WorkspaceBarProjection(items: [], scratchpad: nil)
+        ) ?? WorkspaceBarProjection(items: [], sticky: nil, scratchpad: nil)
 
         return WorkspaceBarSnapshot(
             projection: projection,

--- a/Sources/Nehir/UI/WorkspaceBar/WorkspaceBarView.swift
+++ b/Sources/Nehir/UI/WorkspaceBar/WorkspaceBarView.swift
@@ -23,6 +23,7 @@ struct WorkspaceBarItem: Identifiable, Equatable {
 
 struct WorkspaceBarProjection: Equatable {
     let items: [WorkspaceBarItem]
+    let sticky: WorkspaceBarStickyItem?
     let scratchpad: WorkspaceBarScratchpadItem?
 }
 
@@ -56,6 +57,14 @@ struct WorkspaceBarWindowInfo: Identifiable, Equatable {
     let isSelected: Bool
 }
 
+struct WorkspaceBarStickyItem: Identifiable, Equatable {
+    let windows: [WorkspaceBarWindowItem]
+
+    var id: String {
+        "sticky"
+    }
+}
+
 struct WorkspaceBarScratchpadItem: Identifiable, Equatable {
     let window: WorkspaceBarWindowItem
     let isVisible: Bool
@@ -79,6 +88,10 @@ struct WorkspaceBarSnapshot: Equatable {
 
     var items: [WorkspaceBarItem] {
         projection.items
+    }
+
+    var sticky: WorkspaceBarStickyItem? {
+        projection.sticky
     }
 
     var scratchpad: WorkspaceBarScratchpadItem? {
@@ -105,6 +118,7 @@ struct WorkspaceBarView: View {
     let onOpenCommandPalette: () -> Void
     let onOpenDiagnostics: () -> Void
     let onToggleWindowFloating: (WindowToken) -> Void
+    let onToggleWindowSticky: (WindowToken) -> Void
     let onToggleScratchpadAssignment: (WindowToken) -> Void
     let onCloseWindow: (WindowToken) -> Void
     let onMoveWindowToWorkspace: (WindowToken, WorkspaceDescriptor.ID) -> Void
@@ -121,6 +135,7 @@ struct WorkspaceBarView: View {
             onOpenCommandPalette: onOpenCommandPalette,
             onOpenDiagnostics: onOpenDiagnostics,
             onToggleWindowFloating: onToggleWindowFloating,
+            onToggleWindowSticky: onToggleWindowSticky,
             onToggleScratchpadAssignment: onToggleScratchpadAssignment,
             onCloseWindow: onCloseWindow,
             onMoveWindowToWorkspace: onMoveWindowToWorkspace,
@@ -144,6 +159,7 @@ struct WorkspaceBarMeasurementView: View {
             onOpenCommandPalette: {},
             onOpenDiagnostics: {},
             onToggleWindowFloating: { _ in },
+            onToggleWindowSticky: { _ in },
             onToggleScratchpadAssignment: { _ in },
             onCloseWindow: { _ in },
             onMoveWindowToWorkspace: { _, _ in },
@@ -165,6 +181,7 @@ struct WorkspaceBarWindowMoveTarget: Identifiable, Hashable {
 /// long parameter list (plan #18).
 struct WorkspaceBarWindowActions {
     let onToggleFloating: (WindowToken) -> Void
+    let onToggleSticky: (WindowToken) -> Void
     let onToggleScratchpadAssignment: (WindowToken) -> Void
     let onClose: (WindowToken) -> Void
     let onMoveToWorkspace: (WindowToken, WorkspaceDescriptor.ID) -> Void
@@ -190,6 +207,7 @@ private struct WorkspaceBarContentView: View {
     let onOpenCommandPalette: () -> Void
     let onOpenDiagnostics: () -> Void
     let onToggleWindowFloating: (WindowToken) -> Void
+    let onToggleWindowSticky: (WindowToken) -> Void
     let onToggleScratchpadAssignment: (WindowToken) -> Void
     let onCloseWindow: (WindowToken) -> Void
     let onMoveWindowToWorkspace: (WindowToken, WorkspaceDescriptor.ID) -> Void
@@ -248,6 +266,7 @@ private struct WorkspaceBarContentView: View {
     private var windowActions: WorkspaceBarWindowActions {
         WorkspaceBarWindowActions(
             onToggleFloating: onToggleWindowFloating,
+            onToggleSticky: onToggleWindowSticky,
             onToggleScratchpadAssignment: onToggleScratchpadAssignment,
             onClose: onCloseWindow,
             onMoveToWorkspace: onMoveWindowToWorkspace,
@@ -273,6 +292,19 @@ private struct WorkspaceBarContentView: View {
                     onMoveFocusedWindowToWorkspace: { onMoveFocusedWindowToWorkspace(item) },
                     onFocusWindow: onFocusWindow,
                     windowActions: windowActions
+                )
+            }
+
+            if let sticky = snapshot.sticky {
+                StickyPillView(
+                    item: sticky,
+                    iconSize: iconSize,
+                    itemHeight: itemHeight,
+                    animationsEnabled: effectiveAnimationsEnabled,
+                    accentColor: accentColor,
+                    textColor: textColor,
+                    onFocusWindow: onFocusWindow,
+                    actions: windowActions
                 )
             }
 
@@ -351,6 +383,7 @@ private struct WorkspaceItemView: View {
     private var scopedWindowActions: WorkspaceBarWindowActions {
         WorkspaceBarWindowActions(
             onToggleFloating: windowActions.onToggleFloating,
+            onToggleSticky: windowActions.onToggleSticky,
             onToggleScratchpadAssignment: windowActions.onToggleScratchpadAssignment,
             onClose: windowActions.onClose,
             onMoveToWorkspace: windowActions.onMoveToWorkspace,
@@ -571,6 +604,80 @@ private struct FloatingWindowsGroupView: View {
 }
 
 @MainActor
+private struct StickyPillView: View {
+    let item: WorkspaceBarStickyItem
+    let iconSize: CGFloat
+    let itemHeight: CGFloat
+    let animationsEnabled: Bool
+    let accentColor: Color?
+    let textColor: Color?
+    let onFocusWindow: (WindowToken) -> Void
+    let actions: WorkspaceBarWindowActions
+
+    @State private var isHovered = false
+
+    private var resolvedAccentColor: Color {
+        accentColor ?? .accentColor
+    }
+
+    private var resolvedSecondaryTextColor: Color {
+        textColor ?? .secondary
+    }
+
+    private var isFocused: Bool {
+        item.windows.contains(where: \.isFocused)
+    }
+
+    var body: some View {
+        HStack(spacing: 5) {
+            Image(systemName: "pin.fill")
+                .font(.system(size: max(10, iconSize * 0.64), weight: .semibold))
+                .foregroundColor(isFocused ? resolvedAccentColor : resolvedSecondaryTextColor)
+                .accessibilityHidden(true)
+
+            ForEach(item.windows, id: \.id) { window in
+                WindowIconView(
+                    window: window,
+                    iconSize: iconSize,
+                    isFocused: window.isFocused,
+                    isSelected: window.isSelected,
+                    isInFocusedWorkspace: true,
+                    context: .floating,
+                    animationsEnabled: animationsEnabled,
+                    accentColor: accentColor,
+                    textColor: textColor,
+                    onFocusWindow: onFocusWindow,
+                    actions: actions
+                )
+            }
+        }
+        .padding(.horizontal, 8)
+        .frame(height: itemHeight)
+        .contentShape(Capsule(style: .continuous))
+        .background {
+            Capsule(style: .continuous)
+                .fill(isFocused ? resolvedAccentColor.opacity(0.18) : Color.secondary.opacity(0.08))
+                .background(.regularMaterial, in: Capsule(style: .continuous))
+                .overlay {
+                    Capsule(style: .continuous)
+                        .strokeBorder(
+                            isFocused ? resolvedAccentColor : Color.secondary.opacity(0.36),
+                            lineWidth: isFocused ? 1.2 : 0.8
+                        )
+                }
+        }
+        .scaleEffect(isHovered ? 1.03 : 1)
+        .animation(animationsEnabled ? .easeInOut(duration: 0.12) : nil, value: isHovered)
+        .onHover { hovering in
+            isHovered = hovering
+        }
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel("Sticky windows")
+        .help("Sticky windows stay visible across workspace changes. Right-click a window for actions.")
+    }
+}
+
+@MainActor
 private struct ScratchpadPillView: View {
     let item: WorkspaceBarScratchpadItem
     let iconSize: CGFloat
@@ -749,6 +856,11 @@ private struct WindowIconView: View {
                 actions.onToggleFloating(window.id)
             } label: {
                 Label("Toggle Floating", systemImage: "rectangle")
+            }
+            Button {
+                actions.onToggleSticky(window.id)
+            } label: {
+                Label("Toggle Sticky", systemImage: "pin")
             }
             Button {
                 actions.onToggleScratchpadAssignment(window.id)

--- a/Sources/NehirCtl/CLIParser.swift
+++ b/Sources/NehirCtl/CLIParser.swift
@@ -357,10 +357,12 @@ enum CLIParser {
         var titleRegex: String?
         var axRole: String?
         var axSubrole: String?
+        var manage: IPCRuleManage = .auto
         var layout: IPCRuleLayout = .auto
         var assignToWorkspace: String?
         var minWidth: Double?
         var minHeight: Double?
+        var sticky: Bool?
         var seenFlags: Set<String> = []
         var index = 0
 
@@ -388,6 +390,11 @@ enum CLIParser {
                 axRole = value
             case "--ax-subrole":
                 axSubrole = value
+            case "--manage":
+                guard let parsedManage = IPCRuleManage(rawValue: value) else {
+                    throw CLIParseError.usage(usageText)
+                }
+                manage = parsedManage
             case "--layout":
                 guard let parsedLayout = IPCRuleLayout(rawValue: value) else {
                     throw CLIParseError.usage(usageText)
@@ -399,6 +406,8 @@ enum CLIParser {
                 minWidth = try parsePositiveDouble(value)
             case "--min-height":
                 minHeight = try parsePositiveDouble(value)
+            case "--sticky":
+                sticky = try parseBool(value)
             default:
                 throw CLIParseError.usage(usageText)
             }
@@ -417,10 +426,12 @@ enum CLIParser {
             titleRegex: titleRegex,
             axRole: axRole,
             axSubrole: axSubrole,
+            manage: manage,
             layout: layout,
             assignToWorkspace: assignToWorkspace,
             minWidth: minWidth,
-            minHeight: minHeight
+            minHeight: minHeight,
+            sticky: sticky
         )
 
         guard IPCRuleValidator.validate(definition).isValid else {
@@ -642,6 +653,18 @@ enum CLIParser {
             throw CLIParseError.usage(usageText)
         }
         return value
+    }
+
+    private static func parseBool(_ rawValue: String) throws -> Bool {
+        switch rawValue.lowercased() {
+        case "true",
+             "yes",
+             "1": true
+        case "false",
+             "no",
+             "0": false
+        default: throw CLIParseError.usage(usageText)
+        }
     }
 
     private static func parsePID(_ rawValue: String) throws -> Int32 {

--- a/Sources/NehirCtl/CLIRenderer.swift
+++ b/Sources/NehirCtl/CLIRenderer.swift
@@ -353,7 +353,9 @@ enum CLIRenderer {
                 String(rule.position),
                 rule.id,
                 rule.bundleId,
+                rule.manage?.rawValue ?? "auto",
                 rule.layout.rawValue,
+                rule.sticky.map(boolDescription) ?? "-",
                 rule.assignToWorkspace ?? "-",
                 rule.titleRegex ?? "-",
                 String(rule.specificity),
@@ -362,7 +364,18 @@ enum CLIRenderer {
         }
 
         return formatRows(
-            headers: ["POS", "ID", "BUNDLE ID", "LAYOUT", "WORKSPACE", "TITLE REGEX", "SPECIFICITY", "VALID"],
+            headers: [
+                "POS",
+                "ID",
+                "BUNDLE ID",
+                "MANAGE",
+                "LAYOUT",
+                "STICKY",
+                "WORKSPACE",
+                "TITLE REGEX",
+                "SPECIFICITY",
+                "VALID"
+            ],
             rows: rows,
             format: format
         )

--- a/Sources/NehirIPC/IPCAutomationManifest.swift
+++ b/Sources/NehirIPC/IPCAutomationManifest.swift
@@ -293,6 +293,7 @@ public enum IPCAutomationManifest {
         "is-focused",
         "is-visible",
         "is-scratchpad",
+        "is-sticky",
         "hidden-reason"
     ]
 
@@ -733,6 +734,11 @@ public enum IPCAutomationManifest {
             summary: "Toggle the focused managed window between tiled and floating."
         ),
         command(
+            ["toggle-focused-window-sticky"],
+            name: .toggleFocusedWindowSticky,
+            summary: "Toggle the sticky visibility effect for the focused managed window."
+        ),
+        command(
             ["scratchpad", "assign"],
             name: .scratchpadAssign,
             summary: "Assign the focused managed window to the scratchpad."
@@ -869,6 +875,11 @@ public enum IPCAutomationManifest {
             valuePlaceholder: "<subrole>"
         ),
         .init(
+            flag: "--manage",
+            summary: "Set whether Nehir manages matching windows.",
+            valuePlaceholder: "<auto|ignore>"
+        ),
+        .init(
             flag: "--layout",
             summary: "Set the rule layout action.",
             valuePlaceholder: "<auto|tile|float>"
@@ -887,6 +898,11 @@ public enum IPCAutomationManifest {
             flag: "--min-height",
             summary: "Set the minimum floating height in points.",
             valuePlaceholder: "<points>"
+        ),
+        .init(
+            flag: "--sticky",
+            summary: "Set the sticky visibility effect for matching windows.",
+            valuePlaceholder: "<true|false>"
         )
     ]
 

--- a/Sources/NehirIPC/IPCModels.swift
+++ b/Sources/NehirIPC/IPCModels.swift
@@ -127,6 +127,11 @@ public enum IPCDisplayOrientation: String, Codable, Equatable, Sendable {
     case vertical
 }
 
+public enum IPCRuleManage: String, Codable, Equatable, Sendable {
+    case auto
+    case ignore
+}
+
 public enum IPCRuleLayout: String, Codable, Equatable, Sendable {
     case auto
     case tile
@@ -280,6 +285,7 @@ public enum IPCCommandName: String, Codable, CaseIterable, Equatable, Sendable {
     case toggleOverview = "toggle-overview"
     case toggleWorkspaceBar = "toggle-workspace-bar"
     case toggleFocusedWindowFloating = "toggle-focused-window-floating"
+    case toggleFocusedWindowSticky = "toggle-focused-window-sticky"
     case scratchpadAssign = "scratchpad-assign"
     case scratchpadToggle = "scratchpad-toggle"
     case openMenuAnywhere = "open-menu-anywhere"
@@ -416,6 +422,7 @@ public enum IPCCommandRequest: Equatable, Sendable {
     case toggleOverview
     case toggleWorkspaceBar
     case toggleFocusedWindowFloating
+    case toggleFocusedWindowSticky
     case scratchpadAssign
     case scratchpadToggle
     case openMenuAnywhere
@@ -568,6 +575,8 @@ public enum IPCCommandRequest: Equatable, Sendable {
             .toggleWorkspaceBar
         case .toggleFocusedWindowFloating:
             .toggleFocusedWindowFloating
+        case .toggleFocusedWindowSticky:
+            .toggleFocusedWindowSticky
         case .scratchpadAssign:
             .scratchpadAssign
         case .scratchpadToggle:
@@ -840,6 +849,9 @@ public enum IPCCommandRequest: Equatable, Sendable {
         case .toggleFocusedWindowFloating:
             try requireNoArguments()
             self = .toggleFocusedWindowFloating
+        case .toggleFocusedWindowSticky:
+            try requireNoArguments()
+            self = .toggleFocusedWindowSticky
         case .scratchpadAssign:
             try requireNoArguments()
             self = .scratchpadAssign
@@ -1088,6 +1100,8 @@ extension IPCCommandRequest: Codable {
             self = .toggleWorkspaceBar
         case .toggleFocusedWindowFloating:
             self = .toggleFocusedWindowFloating
+        case .toggleFocusedWindowSticky:
+            self = .toggleFocusedWindowSticky
         case .scratchpadAssign:
             self = .scratchpadAssign
         case .scratchpadToggle:
@@ -1267,6 +1281,8 @@ extension IPCCommandRequest: Codable {
         case .toggleWorkspaceBar:
             break
         case .toggleFocusedWindowFloating:
+            break
+        case .toggleFocusedWindowSticky:
             break
         case .scratchpadAssign:
             break
@@ -1561,10 +1577,12 @@ public struct IPCRuleDefinition: Codable, Equatable, Sendable {
     public let titleRegex: String?
     public let axRole: String?
     public let axSubrole: String?
+    public let manage: IPCRuleManage?
     public let layout: IPCRuleLayout
     public let assignToWorkspace: String?
     public let minWidth: Double?
     public let minHeight: Double?
+    public let sticky: Bool?
 
     public init(
         bundleId: String,
@@ -1573,10 +1591,12 @@ public struct IPCRuleDefinition: Codable, Equatable, Sendable {
         titleRegex: String? = nil,
         axRole: String? = nil,
         axSubrole: String? = nil,
+        manage: IPCRuleManage? = nil,
         layout: IPCRuleLayout = .auto,
         assignToWorkspace: String? = nil,
         minWidth: Double? = nil,
-        minHeight: Double? = nil
+        minHeight: Double? = nil,
+        sticky: Bool? = nil
     ) {
         self.bundleId = bundleId
         self.appNameSubstring = appNameSubstring
@@ -1584,10 +1604,12 @@ public struct IPCRuleDefinition: Codable, Equatable, Sendable {
         self.titleRegex = titleRegex
         self.axRole = axRole
         self.axSubrole = axSubrole
+        self.manage = manage
         self.layout = layout
         self.assignToWorkspace = assignToWorkspace
         self.minWidth = minWidth
         self.minHeight = minHeight
+        self.sticky = sticky
     }
 }
 
@@ -2226,6 +2248,7 @@ public struct IPCWindowQuerySnapshot: Codable, Equatable, Sendable {
     public let isFocused: Bool?
     public let isVisible: Bool?
     public let isScratchpad: Bool?
+    public let isSticky: Bool?
     public let hiddenReason: IPCHiddenReason?
 
     public init(
@@ -2242,6 +2265,7 @@ public struct IPCWindowQuerySnapshot: Codable, Equatable, Sendable {
         isFocused: Bool? = nil,
         isVisible: Bool? = nil,
         isScratchpad: Bool? = nil,
+        isSticky: Bool? = nil,
         hiddenReason: IPCHiddenReason? = nil
     ) {
         self.id = id
@@ -2257,6 +2281,7 @@ public struct IPCWindowQuerySnapshot: Codable, Equatable, Sendable {
         self.isFocused = isFocused
         self.isVisible = isVisible
         self.isScratchpad = isScratchpad
+        self.isSticky = isSticky
         self.hiddenReason = hiddenReason
     }
 }
@@ -2381,10 +2406,12 @@ public struct IPCRuleSnapshot: Codable, Equatable, Sendable {
     public let titleRegex: String?
     public let axRole: String?
     public let axSubrole: String?
+    public let manage: IPCRuleManage?
     public let layout: IPCRuleLayout
     public let assignToWorkspace: String?
     public let minWidth: Double?
     public let minHeight: Double?
+    public let sticky: Bool?
     public let specificity: Int
     public let isValid: Bool
     public let invalidRegexMessage: String?
@@ -2398,10 +2425,12 @@ public struct IPCRuleSnapshot: Codable, Equatable, Sendable {
         titleRegex: String? = nil,
         axRole: String? = nil,
         axSubrole: String? = nil,
+        manage: IPCRuleManage? = nil,
         layout: IPCRuleLayout,
         assignToWorkspace: String? = nil,
         minWidth: Double? = nil,
         minHeight: Double? = nil,
+        sticky: Bool? = nil,
         specificity: Int,
         isValid: Bool,
         invalidRegexMessage: String? = nil
@@ -2414,10 +2443,12 @@ public struct IPCRuleSnapshot: Codable, Equatable, Sendable {
         self.titleRegex = titleRegex
         self.axRole = axRole
         self.axSubrole = axSubrole
+        self.manage = manage
         self.layout = layout
         self.assignToWorkspace = assignToWorkspace
         self.minWidth = minWidth
         self.minHeight = minHeight
+        self.sticky = sticky
         self.specificity = specificity
         self.isValid = isValid
         self.invalidRegexMessage = invalidRegexMessage

--- a/Tests/NehirTests/CLIParserTests.swift
+++ b/Tests/NehirTests/CLIParserTests.swift
@@ -61,8 +61,12 @@ private func sampleRuleOptionValue(for flag: String) -> String {
         "AXWindow"
     case "--ax-subrole":
         "AXStandardWindow"
+    case "--manage":
+        "ignore"
     case "--layout":
         "float"
+    case "--sticky":
+        "true"
     case "--assign-to-workspace":
         "2"
     case "--min-width":

--- a/Tests/NehirTests/IPCModelsTests.swift
+++ b/Tests/NehirTests/IPCModelsTests.swift
@@ -442,10 +442,12 @@ private func assertRoundTrip<T: Codable & Equatable>(_ value: T) throws {
             "--title-regex",
             "--ax-role",
             "--ax-subrole",
+            "--manage",
             "--layout",
             "--assign-to-workspace",
             "--min-width",
-            "--min-height"
+            "--min-height",
+            "--sticky"
         ]
         let addDescriptor = IPCAutomationManifest.ruleActionDescriptor(for: .add)
         let replaceDescriptor = IPCAutomationManifest.ruleActionDescriptor(for: .replace)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -307,10 +307,11 @@ From creation to destruction, a window passes through these stages:
 3. `WindowRuleEngine.evaluate()` produces a `WindowDecision`:
    - `.managed` — tiled in the layout engine
    - `.floating` — tracked but positioned independently
-   - `.unmanaged` — ignored entirely (e.g., system UI, panels)
-4. `WMController.resolveWorkspaceForNewWindow(...)` chooses the workspace from placement inputs. Current frame/interaction monitor evidence beats stale confirmed focus; recent same-pid workspace is only a fallback for focus-cleared AX-first admission.
-5. If tracked: `WindowModel` creates an `Entry`, layout engine inserts a node.
-6. `LayoutRefreshController` schedules a refresh to compute and apply frames.
+   - `.unmanaged` — ignored entirely (e.g., system UI, panels, or user `manage = "ignore"` rules)
+4. Rule effects (`ManagedWindowRuleEffects`) are attached to tracked windows. Effects include sizing constraints and sticky visibility; sticky is an overlay/source, not a separate window mode.
+5. `WMController.resolveWorkspaceForNewWindow(...)` chooses the workspace from placement inputs. Current frame/interaction monitor evidence beats stale confirmed focus; recent same-pid workspace is only a fallback for focus-cleared AX-first admission.
+6. If tracked: `WindowModel` creates an `Entry`, layout engine inserts a node.
+7. `LayoutRefreshController` schedules a refresh to compute and apply frames.
 
 **Destruction:**
 1. `CGSEventObserver` receives `.destroyed(windowId, spaceId)`
@@ -319,7 +320,7 @@ From creation to destruction, a window passes through these stages:
 4. `LayoutRefreshController` schedules a `windowRemoval` refresh
 5. Focus recovery runs if the destroyed window was focused
 
-Nehir also guards the native activation race around close/collapse. macOS may focus another window before Nehir receives the destroy, hide, or AX focus-loss signal for the disappearing surface. `AXEventHandler` arms a short `windowCloseFocusRecovery` lease from tracked destroys, untracked auxiliary same-pid destroys, focused-window loss, and the confirmed managed window becoming hidden. While the lease is active, unrelated native activations away from the recovery workspace are suppressed; duplicate confirmations of the already-focused token preserve the active viewport instead of revealing parked columns. If an inactive-workspace `workspaceDidActivateApplication` arrives just before the close signal, Nehir briefly defers and retries it so recovery can arm first; if no recovery appears, the retry is allowed as a real native activation. Explicit Nehir focus requests still bypass this guard.
+Nehir also guards the native activation race around close/collapse and manually-unstuck sticky surfaces. macOS may focus another window before Nehir receives the destroy, hide, or AX focus-loss signal for the disappearing surface. `AXEventHandler` arms a short `windowCloseFocusRecovery` lease from tracked destroys, untracked auxiliary same-pid destroys, focused-window loss, and the confirmed managed window becoming hidden. While the lease is active, unrelated native activations away from the recovery workspace are suppressed; duplicate confirmations of the already-focused token preserve the active viewport instead of revealing parked columns. If an inactive-workspace `workspaceDidActivateApplication` arrives just before the close signal, Nehir briefly defers and retries it so recovery can arm first; if no recovery appears, the retry is allowed as a real native activation. Hidden, inactive manually-unstuck PiP/sticky-source windows also suppress unrelated activation churn so native PiP focus reports do not immediately reveal the window again. Explicit Nehir focus requests still bypass these guards.
 
 **Managed Replacement:**
 Some apps (browsers, terminals) destroy and recreate windows during internal operations. `AXEventHandler` detects these patterns via `ManagedReplacementMetadata` correlation — matching a destroy+create pair within a 150ms grace period to preserve the window's workspace assignment and position.
@@ -444,6 +445,10 @@ WorkspaceManager
 ├── reconcileTrace / runtimeStore           Replayed runtime snapshot and trace state
 ├── restorePlanner                          Restore and rescue planning
 ├── bootPersistedWindowRestoreCatalog       Relaunch restore intents loaded from settings
+├── globalStickyWindowTokens                Native cross-Space sticky tokens from topology
+├── manualStickyWindowTokens                User-pinned sticky tokens
+├── manualUnstickyWindowTokens              User opt-outs that beat automatic sticky sources
+├── stickyFloatingPromotionTokens           Tiled sticky windows promoted to floating while sticky
 ├── session: SessionState                   Ephemeral runtime state
 │   ├── monitorSessions: [MonitorID: MonitorSession]
 │   │   ├── visibleWorkspaceId
@@ -477,7 +482,7 @@ struct Entry {
     let axRef: AXWindowRef
     var workspaceId: WorkspaceDescriptor.ID
     var mode: TrackedWindowMode          // .tiling or .floating
-    var ruleEffects: ManagedWindowRuleEffects
+    var ruleEffects: ManagedWindowRuleEffects  // min sizes, sticky source
     var floatingState: FloatingState?    // Last frame, normalized position
     var hiddenReason: HiddenReason?      // .workspaceInactive, .layoutTransient, .scratchpad
     var manualLayoutOverride: ManualWindowOverride?
@@ -485,7 +490,7 @@ struct Entry {
 }
 ```
 
-Entries are indexed by both `WindowToken` and raw `windowId` for fast lookup from different event sources.
+Entries are indexed by both `WindowToken` and raw `windowId` for fast lookup from different event sources. Sticky is intentionally modeled outside `TrackedWindowMode`: `WorkspaceManager.hasStickyWindowSource(_:)` answers whether a token has any native/rule/manual automatic source, while `isStickyWindow(_:)` applies the manual unsticky override to produce the effective visibility behavior used by layout and workspace-bar projection.
 
 ### 4.3 Niri Layout Engine (Scrolling Columns)
 
@@ -532,7 +537,7 @@ All three types inherit from `NiriNode` (base class with `id: NodeId`, `parent`,
 | Proportional width gap accounting | `ProportionalSize.resolveProportionalSpan(...)` | Do not duplicate `(availableSpace - gap) * proportion - gap`; Reveal Partial `.default` depends on the same `2 * gap` fit tolerance so 50% + 50% columns remain viewport-fitting. |
 | Stacked/tiled secondary-axis sizing | `NiriAxisSolver` and the tabbed/shared-frame layout helpers | Inner gaps are between adjacent stacked tiles only (`count - 1` gaps). Top/bottom monitor-edge padding comes from outer gaps, not inner gap. |
 | Snap points, viewport bounds, and full-width-column snap exceptions | `ViewportState+Geometry.swift` (`computeSnapGrid`, `viewportStartBounds`, `boundedViewportStart(...)`) and `ViewportSnapContext` | Gesture release, scroll commands, reveal, resize adjustment, and column transitions must share this geometry. Do not add ad-hoc `±gap` snaps elsewhere; columns that approximately fill the viewport intentionally omit synthetic edge snaps that would only lose margins, while over-wide columns keep theirs so clipped content stays reachable. Lone-window snap/bounds math must use `NiriContainer.effectiveViewportWidth`, not raw `cachedWidth`, so transient fill/centered render width and canonical multi-column width stay separated. |
-| Lone-window viewport rect and render offset | `SingleWindowViewportGeometry` plus `singleWindowViewportGeometry(...)`, `resolvedSingleWindowViewportRect(...)`, `prepareSingleWindowViewport(...)`, and `prepareAndSeedSingleWindowViewport(...)` in `NiriLayout.swift` | Controllers may prepare/seed geometry, but must not re-derive centered width, center offset, rendered frame offset, or lone-window scrollable span. Lone-window rendering follows the raw viewport offset; the shared snap grid decides where it settles. Default fill/centered width goes into `loneWindowLayoutWidthOverride`; manual width remains canonical `cachedWidth`. |
+| Lone-window viewport rect and render offset | `SingleWindowViewportGeometry` plus `singleWindowViewportGeometry(...)`, `resolvedSingleWindowViewportRect(...)`, `prepareSingleWindowViewport(...)`, and `prepareAndSeedSingleWindowViewport(...)` in `NiriLayout.swift` | Controllers may prepare/seed geometry, but must not re-derive centered width, center offset, rendered frame offset, or lone-window scrollable span. Lone-window rendering follows the raw viewport offset; the shared snap grid decides where it settles. Single-column workspaces use the same far-overscroll boundary points as multi-column strips, so strong swipes can settle with only an edge sliver visible. Default fill/centered width goes into `loneWindowLayoutWidthOverride`; manual width remains canonical `cachedWidth`. |
 | Monitor-aware gap resolution | `SettingsStore.resolvedGapSettings(for:)`, exposed at runtime through `WMController.gapSize(for:)` and `WMController.outerGaps(for:)` | Use these helpers when a monitor is known. Direct `workspaceManager.gaps` / `workspaceManager.outerGaps` access should be limited to no-monitor fallback paths. |
 | Monitor-aware Niri settings and lone-window override resolution | `SettingsStore.resolvedNiriSettings(for:)` and `MonitorNiriSettings.loneWindowPolicy` | `nil` means inherit global policy; `.fill` and `.centered(maxWidthFraction:)` are explicit per-monitor overrides. Do not infer override mode from nullable centered width. |
 
@@ -655,10 +660,11 @@ Events are buffered in a lock-protected `PendingCGSEventState` and drained on th
 
 Evaluates windows against rules to produce a `WindowDecision`. Evaluation order (first match wins):
 
-1. **Manual overrides** — user has explicitly toggled float/tile on this window
-2. **User-defined rules** — configured in settings, matching on bundle ID, app name, title (literal or regex), AX role/subrole
-3. **Built-in rules** — hardcoded rules for known system UI
-4. **Heuristics** — size constraints, window role/subrole analysis
+1. **User manage-ignore rules** — `manage = "ignore"` is a management decision and wins over manual layout overrides and all other effects.
+2. **Manual overrides** — user has explicitly toggled float/tile on this window; manual overrides can beat built-in unmanaged decisions for user-addressable non-standard surfaces.
+3. **User-defined rules** — configured in settings, matching on bundle ID, app name, title (literal or regex), AX role/subrole
+4. **Built-in rules** — hardcoded rules for known system UI and PiP/default-sticky candidates
+5. **Heuristics** — size constraints, window role/subrole analysis
 
 **Key types:**
 
@@ -667,7 +673,7 @@ struct WindowDecision {
     let disposition: WindowDecisionDisposition  // .managed, .floating, .unmanaged, .undecided
     let source: WindowDecisionSource            // .manualOverride, .userRule(UUID), .builtInRule, .heuristic
     let workspaceName: String?                  // Target workspace (if rule specifies)
-    let ruleEffects: ManagedWindowRuleEffects   // minWidth, minHeight constraints
+    let ruleEffects: ManagedWindowRuleEffects   // minWidth, minHeight, sticky
 }
 
 struct WindowRuleFacts {
@@ -1008,7 +1014,8 @@ Nehir uses SkyLight (private macOS framework) for low-latency window operations.
 | `WindowToken` | Value type (`pid` + `windowId`) identifying a window. Used as dictionary keys throughout. |
 | `WindowHandle` | Reference-type wrapper around `WindowToken`. Identity-compared (`===`). Used in layout trees. |
 | `AXWindowRef` | Accessibility bridge (`AXUIElement` + `windowId`) for reading/writing window properties. |
-| `TrackedWindowMode` | `.tiling` or `.floating` — whether a window is managed by the layout engine. |
+| `TrackedWindowMode` | `.tiling` or `.floating` — whether a tracked window participates in tiling or independent floating placement. Sticky is not a third mode. |
+| `ManagedWindowRuleEffects` | Rule/effective overlays attached to a tracked window, including minimum size constraints and sticky visibility. |
 | `WorkspaceDescriptor` | A workspace definition: `id` (UUID), `name`, optional `assignedMonitorPoint`. |
 | `SessionState` | Ephemeral runtime state in `WorkspaceManager`: focused window, visible workspace per monitor, viewport states. |
 | `NiriRoot` / `NiriContainer` / `NiriWindow` | The three-level Niri layout tree: root → columns → windows. |
@@ -1027,5 +1034,6 @@ Nehir uses SkyLight (private macOS framework) for low-latency window operations.
 | `NodeId` | UUID-based identifier for Niri layout tree nodes. |
 | `SpringConfig` | Spring parameters: `dampingRatio` controls oscillation damping (`1.0` is critically damped), `stiffness` controls how aggressively the spring accelerates toward its target, `epsilon` is the completion displacement threshold, and `velocityEpsilon` is the completion velocity threshold. Niri presets: `niriHorizontalViewMovement` controls viewport/column scrolling, `niriWindowMovement` controls window/column movement springs, and `niriWindowResize` controls column width resize springs. |
 | `WindowDecision` | Result of rule evaluation: `disposition`, `source`, `workspaceName`, `ruleEffects`. |
-| `WindowRuleFacts` | Input for rule evaluation: app name, AX facts (role, subrole, title), size constraints. |
+| `WindowRuleFacts` | Input for rule evaluation: app name, AX facts (role, subrole, title), size constraints, and WindowServer evidence used for PiP/default-sticky classification. |
+| `Sticky window` | A managed window with an effective cross-workspace visibility effect from native sticky state, rules, PiP defaults, or manual toggles. Manual unsticky wins for effective behavior. |
 | `Scratchpad` | A special slot for a single transient window that can be toggled in/out of view. |

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -173,6 +173,7 @@ Move column left/right        Hyper+Left/Right
 
 Toggle fullscreen             Option+Command+Return
 Toggle native fullscreen      Option+Shift+Command+Return
+Toggle focused window sticky  Unassigned
 Toggle column tabbed          Option+Shift+Command+T
 Toggle column full width      Option+Shift+Command+F
 Balance sizes                 Option+Shift+Command+B
@@ -216,6 +217,40 @@ bundleId = "com.google.Chrome"
 minWidth = 500
 minHeight = 375
 ```
+
+Rule effects are explicit and composable:
+
+```toml
+# Leave a helper overlay alone entirely.
+[match]
+bundleId = "com.example.Helper"
+titleSubstring = "Overlay"
+
+[effect]
+manage = "ignore"
+
+# Keep a media-style window visible across workspace switches.
+[match]
+bundleId = "org.mozilla.firefox"
+titleSubstring = "Picture-in-Picture"
+
+[effect]
+layout = "float"
+sticky = true
+```
+
+Supported effect values:
+
+- `manage = "auto" | "ignore"` — `ignore` makes matching windows unmanaged. It wins over layout, sticky, sizing, and workspace effects.
+- `layout = "auto" | "tile" | "float"` — chooses the tracked layout mode for managed matches.
+- `sticky = true | false` — sets the sticky visibility effect for managed matches. `true` pins the window across workspaces; `false` opts matching windows out of sticky defaults such as Picture-in-Picture classification.
+- `assignToWorkspace = "<raw workspace name>"`, `minWidth`, `minHeight` — existing placement and size effects.
+
+Picture-in-Picture-like media windows are sticky by default when Nehir can classify them from AX/WindowServer facts. This is not a special window mode: PiP surfaces are still normal managed floating/tiling windows with an automatic sticky source, and the manual sticky toggle can unstick/restick them.
+
+Classification is intentionally conservative. Some Chromium/Helium-style PiP windows expose reliable AX facts only after the PiP receives focus or a click, so Nehir may start tracking them after that first interaction rather than at the instant the surface appears.
+
+Some browsers expose PiP as native macOS helper UI rather than a normal addressable media window. Safari, Dia, Arc, and Atlas/ChatGPT can create parented popup-level WindowServer children or generic `AXDialog` surfaces whose AX/WindowServer facts are indistinguishable from context menus or ordinary dialogs. Nehir intentionally does not auto-manage those surfaces as sticky PiP because doing so can pin context menus. When such an app provides stable AX facts, use an explicit app rule (for example matching bundle ID plus `axSubrole = "AXDialog"` or a title pattern) to opt that surface into `layout = "float"` and `sticky = true`.
 
 Monitor overrides use `[match]` / `[niri]` / `[bar]` / `[orientation]` sections:
 

--- a/docs/IPC-CLI.md
+++ b/docs/IPC-CLI.md
@@ -338,12 +338,13 @@ Workspace IDs are positive numeric strings. Direct hotkeys stay limited to `1-9`
 | Command | Arguments | Surface | Description |
 |---------|-----------|---------|-------------|
 | `command toggle-focused-window-floating` | — | command | Toggle focused window between tiled and floating |
+| `command toggle-focused-window-sticky` | — | command | Toggle the focused managed window's sticky visibility effect |
 | `command raise-all-floating-windows` | — | command | Raise all visible floating windows |
 | `command rescue-offscreen-windows` | — | command | Clamp tracked floating windows back onto their visible monitors |
 | `command scratchpad assign` | — | command | Assign the focused window to the scratchpad |
 | `command scratchpad toggle` | — | command | Show or hide the scratchpad window |
 
-When a managed floating window has keyboard focus, focused-window commands target that floating window even if the Niri viewport selection still points at a tiled window underneath it.
+When a managed floating window has keyboard focus, focused-window commands target that floating window even if the Niri viewport selection still points at a tiled window underneath it. Sticky command targeting also accepts windows with a sticky source (for example a manually-unstuck PiP) so the user can toggle them back even when the effective sticky state is currently off.
 
 ### UI Toggles
 
@@ -428,7 +429,7 @@ Use `--fields` with a comma-separated list to limit returned fields.
 
 Field tokens are part of the CLI contract. Returned JSON still uses the payload schema's field names, so the selected token may not be byte-for-byte identical to the JSON key. For example, `window-counts` selects the workspace payload's `counts` field.
 
-**Window fields:** `id`, `pid`, `workspace`, `display`, `app`, `title`, `frame`, `mode`, `layout-reason`, `manual-override`, `is-focused`, `is-visible`, `is-scratchpad`, `hidden-reason`
+**Window fields:** `id`, `pid`, `workspace`, `display`, `app`, `title`, `frame`, `mode`, `layout-reason`, `manual-override`, `is-focused`, `is-visible`, `is-scratchpad`, `is-sticky`, `hidden-reason`
 
 **Workspace fields:** `id`, `raw-name`, `display-name`, `number`, `display`, `is-focused`, `is-visible`, `is-current`, `window-counts`, `focused-window-id`
 
@@ -518,7 +519,7 @@ Numeric inputs are resolved as raw workspace IDs first. Display-name lookup is a
 
 ## Rules
 
-Manage persisted window rules that control layout behavior and default workspace placement for matching windows.
+Manage persisted window rules that control whether matching windows are managed, their layout behavior, sticky visibility, and default workspace placement.
 Rule add, replace, and config reload update initial placement defaults; existing managed windows stay on their current workspace unless `rule apply` is used.
 
 ```
@@ -535,7 +536,9 @@ nehirctl rule <action> [arguments...] [options...]
 | `--title-regex` | `<pattern>` | Match window title against this regex |
 | `--ax-role` | `<role>` | Match accessibility role |
 | `--ax-subrole` | `<subrole>` | Match accessibility subrole |
+| `--manage` | `<auto\|ignore>` | Management action; `ignore` leaves matching windows unmanaged and wins over layout/sticky effects |
 | `--layout` | `<auto\|tile\|float>` | Layout action (`auto` = default behavior) |
+| `--sticky` | `<true\|false>` | Sticky visibility effect for managed matches; `false` opts out of sticky defaults |
 | `--assign-to-workspace` | `<raw-name>` | Open first matching app windows on this workspace raw name |
 | `--min-width` | `<points>` | Minimum window width in points |
 | `--min-height` | `<points>` | Minimum window height in points |
@@ -601,6 +604,13 @@ nehirctl rule add --bundle-id com.apple.Safari --layout tile --assign-to-workspa
 
 # Float windows with "Preferences" in the title
 nehirctl rule add --bundle-id com.apple.Safari --title-substring Preferences --layout float
+
+# Ignore a helper overlay entirely
+nehirctl rule add --bundle-id com.example.Helper --title-substring Overlay --manage ignore
+
+# Force matching media windows sticky, or opt them out of PiP default sticky
+nehirctl rule add --bundle-id org.mozilla.firefox --title-substring Picture-in-Picture --layout float --sticky true
+nehirctl rule add --bundle-id app.zen-browser.zen --title-substring Picture-in-Picture --sticky false
 
 # Remove a rule
 nehirctl rule remove 550e8400-e29b-41d4-a716-446655440000

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -57,6 +57,16 @@ See also: [active column](#active-column).
 
 ---
 
+## managed window
+
+A window admitted into Nehir's tracked model. Managed windows have a `WindowModel.Entry`, appear in IPC window queries, and have a `TrackedWindowMode` of either `.tiling` or `.floating`.
+
+Sticky, scratchpad, rule effects, hidden state, and focus metadata are overlays on top of managed windows; they are not extra tracked modes.
+
+See also: [unmanaged window](#unmanaged-window), [sticky window](#sticky-window).
+
+---
+
 ## inner gap
 
 The spacing between adjacent tiled surfaces inside the layout. In stacked/tiled columns, inner gap applies only between neighboring tiles on the secondary axis (`count - 1` gaps). It is not monitor-edge padding.
@@ -110,11 +120,25 @@ Outer gap is distinct from [inner gap](#inner-gap): top/bottom edge padding must
 
 ## parked window
 
-A window the layout engine has moved to an offscreen resting position. Parked windows are not visible to the user. Due to a macOS limitation, exactly 1px of the window remains on-screen to prevent the system from reclaiming its display connection.
+A window Nehir has moved to an offscreen or edge resting position because it should not currently be visible. Due to macOS WindowServer limitations, this is not a true hide for external app windows: Nehir can usually reduce the visible remnant to a tiny edge/corner strip, but the system may clamp the requested position.
 
-Represented internally as `ContainerVisibilityState.hidden(AxisHideEdge)` with a `layoutTransient` hidden reason. The edge (`.left` / `.right`) records which side the window is parked on.
+For Niri viewport scrolling, represented internally as `ContainerVisibilityState.hidden(AxisHideEdge)` with a `layoutTransient` hidden reason. The edge (`.left` / `.right`) records which side the window is parked on. Workspace-inactive and scratchpad hiding use the same hidden-state model with different hidden reasons (`workspaceInactive`, `scratchpad`) and may use physical-edge parking rather than a viewport side.
 
 In the [layout notation](viewport-navigation-spec.md#layout-notation), columns that are fully outside the viewport and have been parked appear as plain numbers outside `[]`, e.g. `30 [...]` — the `30` is a parked column on the left. A [clipped column](#clipped-column) (partially visible) is distinct and uses the split notation.
+
+See also: [sticky window](#sticky-window), [single-window viewport geometry](#single-window-viewport-geometry).
+
+---
+
+## picture-in-picture default sticky
+
+A built-in window-rule effect for PiP-like media surfaces. Nehir classifies common Picture-in-Picture windows from AX and WindowServer facts and marks them sticky by default so they remain visible across workspace switches.
+
+This is an automatic sticky **source**, not a special PiP mode. The window is still tracked as either `.floating` or `.tiling`. Users can manually unstick it; the automatic source remains recorded so commands can target/toggle the same surface, but the effective sticky state becomes false until sticky is re-enabled.
+
+PiP classification is conservative. Some PiP windows expose reliable AX facts only after the PiP receives focus or a click, so Nehir may begin tracking them after that first interaction. Browser PiP implementations that expose only parented popup-level WindowServer children or generic dialog surfaces may remain unmanaged/native-sticky because the same facts are also used by context menus and ordinary dialogs. Use explicit app rules for stable app-specific surfaces.
+
+See also: [sticky window](#sticky-window), [managed window](#managed-window).
 
 ---
 
@@ -153,7 +177,7 @@ The centralized geometry model for a workspace containing exactly one normal non
 
 Callers should use `singleWindowViewportGeometry(...)`, `resolvedSingleWindowViewportRect(...)`, `prepareSingleWindowViewport(...)`, or `prepareAndSeedSingleWindowViewport(...)` instead of re-deriving centered width, center offset, or frame offset rules in controllers. Viewport positions, bounds, and snap widths should use `NiriContainer.effectiveViewportWidth`, which selects the transient lone-window render width when present and falls back to canonical `cachedWidth` otherwise.
 
-Lone-window rendering follows the raw viewport offset so gestures are visibly responsive. The shared [snap grid](#snap-grid), not a render-time clamp, decides where the window settles. `cachedWidth` remains canonical; the lone-window render width must not leak into multi-column layout state.
+Lone-window rendering follows the raw viewport offset so gestures are visibly responsive. The shared [snap grid](#snap-grid), not a render-time clamp, decides where the window settles. A single tiled window still participates in the same far-overscroll boundary math as multi-column layouts, so a sufficiently strong swipe can settle at a boundary with only a sliver of the lone column visible. `cachedWidth` remains canonical; the lone-window render width must not leak into multi-column layout state.
 
 ---
 
@@ -179,13 +203,27 @@ In the [layout notation](viewport-navigation-spec.md#effective-snap-point-annota
 
 ---
 
-## viewport
+## sticky window
 
-The visible portion of the column strip on a given monitor. Its horizontal position is described by `ViewportState.viewOffsetPixels`. The viewport does not resize; it scrolls over the column strip.
+A managed window whose effective visibility spans workspaces on the same monitor. Sticky windows are projected separately in the workspace bar and are not hidden merely because their assigned workspace is inactive.
+
+Sticky state is an effect/source overlay, not a third `TrackedWindowMode`. Sources include native global sticky detection, built-in Picture-in-Picture classification, app rules (`sticky = true`), and the manual sticky toggle. A manual unsticky override wins over automatic sources; such a window remains command-addressable as having a sticky source, but `isStickyWindow` is false until sticky is toggled back on.
+
+See also: [picture-in-picture default sticky](#picture-in-picture-default-sticky), [managed window](#managed-window), [parked window](#parked-window).
 
 ---
 
-## viewport offset
+## unmanaged window
+
+A window Nehir deliberately does not track or lay out. Built-in rules ignore system UI and panels, and user app rules can request this with `manage = "ignore"`.
+
+Unmanaged windows do not get a `WindowModel.Entry`, do not appear in managed-window IPC queries, and are not moved by layout refresh. Focus on unmanaged windows is represented as non-managed focus so Nehir does not accidentally mutate a stale managed command target.
+
+See also: [managed window](#managed-window).
+
+---
+
+## viewport
 
 The current scroll position of the viewport, stored as `ViewportState.viewOffsetPixels`. A `ViewOffset` enum with three states: `.static` (settled), `.gesture` (in motion), `.spring` (animating to target).
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,7 +5,9 @@ title: Nehir Documentation
 # Nehir Documentation
 
 - [Architecture Guide](ARCHITECTURE.md) — internals for contributors
-- [Configuration Principles](CONFIGURATION.md) — split config layout, design rationale, file reference
+- [Glossary](glossary.md) — shared terminology for windows, sticky behavior, parking, and viewport concepts
+- [Viewport Navigation Spec](viewport-navigation-spec.md) — snap, reveal, parked-window, and lone-window viewport behavior
+- [Configuration Principles](CONFIGURATION.md) — split config layout, app rules, design rationale, file reference
 - [Settings Migrations](SETTINGS_MIGRATIONS.md) — gradual config migration policy and registry
 - [IPC & CLI Reference](IPC-CLI.md) — `nehirctl` commands and socket protocol
 - [Recipes](recipes/README.md) — companion setup snippets

--- a/docs/offscreen-clamp-fix.md
+++ b/docs/offscreen-clamp-fix.md
@@ -123,6 +123,10 @@ Useful confirmed findings:
   Zoom call window) clamp to a larger visible strip if requested exactly at the edge,
   so workspace-inactive parking uses the same 1pt reveal limitation as transient
   parking rather than an app-specific special case.
+- Picture-in-Picture surfaces can report fresh app activation/focus after Nehir parks
+  them. For manually-unstuck PiP/default-sticky windows, the focus layer must suppress
+  unrelated hidden-inactive activation churn; otherwise native activation can reveal the
+  parked PiP again even though the hide plan itself requested the correct edge position.
 - Using that same right-edge parking for transient left-hidden windows removes the parked
   left corner but causes a visible left-to-right fly during the hide transition.
 - **Unconfirmed hypotheses are not fixes.** A proposed hide strategy may be implemented

--- a/docs/viewport-navigation-spec.md
+++ b/docs/viewport-navigation-spec.md
@@ -118,6 +118,8 @@ Columns whose effective width approximately fills the viewport (within pixel tol
 
 For a lone-window workspace, effective viewport width is the transient lone-window render width (`loneWindowLayoutWidthOverride`) when present, not the canonical column `cachedWidth`. This lets fill/centered lone windows scroll and snap against the real rendered span while preserving the canonical width used when a second column appears.
 
+A single tiled column uses the same far overscroll boundary points as a multi-column strip. A trackpad gesture can therefore settle at a far boundary when the projected release position is closer to that boundary than to the center/resting snap, leaving only the configured edge sliver of the lone column visible.
+
 ### Gesture release
 
 On gesture release, the viewport snaps to the nearest snap point. The focused column updates to the column at the target snap position.
@@ -143,7 +145,11 @@ Per-monitor overrides are tri-state through `MonitorNiriSettings.loneWindowPolic
 
 `SingleWindowViewportGeometry` is the source of truth for the resolved lone-window rect, center offset, and render offset. `NiriContainer.effectiveViewportWidth` is the source of truth for viewport positions, bounds, and snap width when that rect is wider or narrower than the canonical column width. Controllers and gesture handlers should call `singleWindowViewportGeometry(...)`, `resolvedSingleWindowViewportRect(...)`, `prepareSingleWindowViewport(...)`, or `prepareAndSeedSingleWindowViewport(...)` rather than re-deriving the math.
 
-Lone-window rendering follows the raw viewport offset so scroll gestures are visible. The snap grid decides where the viewport settles. This keeps fill windows responsive during a gesture while preventing them from parking at bogus `±gap` edge snaps after release. `cachedWidth` remains the canonical column width for later multi-column layout; the fill/centered render span is transient and must not leak back into canonical width state.
+Lone-window rendering follows the raw viewport offset so scroll gestures are visible. The snap grid decides where the viewport settles. This keeps fill windows responsive during a gesture while preserving the same far-overscroll affordance available in multi-column layouts. `cachedWidth` remains the canonical column width for later multi-column layout; the fill/centered render span is transient and must not leak back into canonical width state.
+
+### Single-window snap bounds
+
+A single tiled window is the selected column and participates in far overscroll. `viewportStartBounds(...)` applies the same edge-visible-fraction rule used for the first and last columns of a multi-column strip. Gesture release chooses the closest projected snap, with far-boundary snaps available even when there is only one column.
 
 ---
 


### PR DESCRIPTION
## Summary

Add sticky app-rule effects, a focused-window sticky command, sticky workspace-bar projection, and default sticky classification for PiP-like windows while keeping manual unsticky overrides effective.

Add manage = ignore app rules for unmanaged windows and keep lone-window Niri workspaces eligible for far-overscroll boundary snaps.

solves #108 

## Release notes

Choose one:

- [x] Added a `.changeset/*.md` for user-visible changes (`mise run changeset -- patch "..."`).
- [ ] No user-visible change; apply the `no release note` label to make CI skip intentional.

## Validation

<!-- Commands run, screenshots, or manual checks. -->

- [ ] Ran relevant tests/checks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added “Toggle Focused Window Sticky” hotkey, command-line/IPC support, and `is-sticky` window query field.
  * App rules now support `sticky` effects and `manage = ignore` to keep matching windows unmanaged.
  * Workspace bars now project sticky windows and provide a UI action to toggle sticky state.
* **Bug Fixes**
  * Improved sticky/projection behavior for PiP-like windows, reducing hidden inactive activation churn.
  * Refined lone-window snapping so far-boundary settling behaves consistently.
* **Documentation**
  * Updated configuration, IPC/CLI, and glossary/architecture docs for sticky and ignore behavior.
* **Tests**
  * Updated CLI/IPC model tests for new manage/sticky options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->