### PR TITLE
Do not recenter viewport on activation of fully visible windows

### DIFF
--- a/.changeset/20260625235955-only-apply-reveal-partial-when-activating-partia.md
+++ b/.changeset/20260625235955-only-apply-reveal-partial-when-activating-partia.md
@@ -1,0 +1,6 @@
+---
+"nehir": patch
+
+---
+
+Only apply Reveal Partial when activating partially visible windows

--- a/Sources/Nehir/Core/Controller/AXEventHandler.swift
+++ b/Sources/Nehir/Core/Controller/AXEventHandler.swift
@@ -2510,7 +2510,7 @@ final class AXEventHandler: CGSEventDelegate {
                         "snapCount=\(columnSnaps.count)"
                     ]
                 )
-                let didReveal = engine.scrollToReveal(
+                let didReveal = engine.revealForFocusActivation(
                     columnIndex: columnIndex,
                     isFFM: isFFM,
                     state: &state,

--- a/Sources/Nehir/Core/Layout/Niri/NiriLayoutEngine+ViewportCommands.swift
+++ b/Sources/Nehir/Core/Layout/Niri/NiriLayoutEngine+ViewportCommands.swift
@@ -147,6 +147,66 @@ extension NiriLayoutEngine {
         return true
     }
 
+    /// Reveals a column in response to a focus activation (e.g. clicking or
+    /// focusing a window). Unlike the layout-driven `scrollToReveal`:
+    /// - Activating an already fully visible column never moves the viewport.
+    /// - Parked (fully hidden) columns are revealed with the fixed default snap,
+    ///   independent of `revealPartial`; that policy is for clipped/partially
+    ///   visible content only.
+    /// - Clipped columns delegate to `scrollToReveal`, where `revealPartial` applies.
+    @discardableResult
+    func revealForFocusActivation(
+        columnIndex: Int,
+        isFFM: Bool,
+        state: inout ViewportState,
+        context: ViewportSnapContext,
+        motion: MotionSnapshot,
+        scale: CGFloat = 2.0,
+        animationConfig: SpringConfig? = nil
+    ) -> Bool {
+        guard !isFFM else { return false }
+        guard context.columns.indices.contains(columnIndex), !context.snapPoints.isEmpty else { return false }
+
+        let viewStart = context.currentViewStart(in: state)
+        let visibility = context.visibility(of: columnIndex, viewportOffset: viewStart, in: state)
+        switch visibility {
+        case .fullyVisible:
+            return false
+        case .parked:
+            // Parked columns are fully hidden offscreen; reveal them with the
+            // fixed default snap, independent of `revealPartial` (a policy for
+            // clipped content). Mirrors `defaultSnap()` in `scrollToReveal`:
+            // closest snap when it fills the viewport, otherwise the center snap.
+            let targetSnaps = context.snapCandidates(for: columnIndex, in: state)
+            let closest = targetSnaps.closest(to: viewStart)
+            let fixedSnap: SnapPoint
+            if let closest, context.fillsViewport(at: closest.offset, in: state) {
+                fixedSnap = closest
+            } else if let center = targetSnaps.first(where: { $0.kind == .center }) {
+                fixedSnap = center
+            } else if let closest {
+                fixedSnap = closest
+            } else {
+                return false
+            }
+            let pixel = 1.0 / max(scale, 1.0)
+            let targetOffset = context.targetOffset(for: fixedSnap, in: state)
+            guard abs(targetOffset - state.viewOffsetPixels.target()) > pixel else { return false }
+            state.animateToOffset(targetOffset, motion: motion, config: animationConfig, scale: scale)
+            return true
+        case .clipped:
+            return scrollToReveal(
+                columnIndex: columnIndex,
+                isFFM: isFFM,
+                state: &state,
+                context: context,
+                motion: motion,
+                scale: scale,
+                animationConfig: animationConfig
+            )
+        }
+    }
+
     func syncViewportSelectionToActiveColumn(columns: [NiriContainer], state: inout ViewportState) -> NiriWindow? {
         guard columns.indices.contains(state.activeColumnIndex) else { return nil }
         let activeColumn = columns[state.activeColumnIndex]

--- a/Sources/Nehir/UI/BehaviorSettingsTab.swift
+++ b/Sources/Nehir/UI/BehaviorSettingsTab.swift
@@ -56,7 +56,7 @@ struct BehaviorSettingsTab: View {
                     controller.updateNiriConfig(revealPartial: newValue)
                 }
                 SettingsCaption(
-                    "Default uses closest snap only when that snap aligns both viewport edges and visible columns fill the viewport; otherwise it centers."
+                    "Controls how activating a partially visible window reveals it. Fully visible windows do not move the viewport."
                 )
             }
 


### PR DESCRIPTION
## Summary

<!-- What changed and why? -->

## Release notes

Choose one:

- [ ] Added a `.changeset/*.md` for user-visible changes (`mise run changeset -- patch "..."`).
- [ ] No user-visible change; apply the `no release note` label to make CI skip intentional.

## Validation

<!-- Commands run, screenshots, or manual checks. -->

- [ ] Ran relevant tests/checks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved “Reveal Partial” behavior during window activation: the viewport now adjusts only for partially visible windows, leaving fully visible windows unchanged.
  * Updated activation handling to use a dedicated reveal flow for more consistent focus behavior.
* **Documentation**
  * Refined the “Reveal Partial” setting text to clarify how partially visible vs fully visible windows affect viewport movement.
* **Chores**
  * Added a patch release note for the `nehir` package.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->