### PR TITLE
Traces

### DIFF
--- a/.changeset/20260630004554-add-viewport-trace-verbosity-controls.md
+++ b/.changeset/20260630004554-add-viewport-trace-verbosity-controls.md
@@ -1,0 +1,6 @@
+---
+"nehir": patch
+
+---
+
+Add viewport trace verbosity controls

--- a/.changeset/20260630011228-refresh-viewport-trace-verbosity-after-settings-.md
+++ b/.changeset/20260630011228-refresh-viewport-trace-verbosity-after-settings-.md
@@ -1,0 +1,6 @@
+---
+"nehir": patch
+
+---
+
+Refresh viewport trace verbosity after settings reload

--- a/Sources/Nehir/Core/Config/CanonicalTOMLConfig.swift
+++ b/Sources/Nehir/Core/Config/CanonicalTOMLConfig.swift
@@ -41,6 +41,7 @@ struct CanonicalTOMLConfig: Codable, Equatable {
         var developerModeEnabled: Bool
         var debugBarEnabled: Bool
         var debugTraceExportCopiesFile: Bool
+        var viewportTraceVerbosity: String
         var backgroundTraceRetentionSeconds: TimeInterval
         var backgroundTraceMaxBytes: Int
         var ignoreMonitorIdentity: Bool
@@ -48,7 +49,8 @@ struct CanonicalTOMLConfig: Codable, Equatable {
 
         enum CodingKeys: String, CodingKey, CaseIterable {
             case hotkeysEnabled, preventSleepEnabled, ipcEnabled, developerModeEnabled,
-                 debugBarEnabled, debugTraceExportCopiesFile, backgroundTraceRetentionSeconds,
+                 debugBarEnabled, debugTraceExportCopiesFile, viewportTraceVerbosity,
+                 backgroundTraceRetentionSeconds,
                  backgroundTraceMaxBytes, ignoreMonitorIdentity
         }
     }
@@ -261,6 +263,7 @@ extension CanonicalTOMLConfig {
             developerModeEnabled: export.developerModeEnabled,
             debugBarEnabled: export.debugBarEnabled,
             debugTraceExportCopiesFile: export.debugTraceExportCopiesFile,
+            viewportTraceVerbosity: export.viewportTraceVerbosity,
             backgroundTraceRetentionSeconds: export.backgroundTraceRetentionSeconds,
             backgroundTraceMaxBytes: export.backgroundTraceMaxBytes,
             ignoreMonitorIdentity: export.ignoreMonitorIdentity,
@@ -442,6 +445,7 @@ extension CanonicalTOMLConfig {
             developerModeEnabled: general.developerModeEnabled,
             debugBarEnabled: general.debugBarEnabled,
             debugTraceExportCopiesFile: general.debugTraceExportCopiesFile,
+            viewportTraceVerbosity: general.viewportTraceVerbosity,
             backgroundTraceRetentionSeconds: general.backgroundTraceRetentionSeconds,
             backgroundTraceMaxBytes: general.backgroundTraceMaxBytes,
             ignoreMonitorIdentity: general.ignoreMonitorIdentity,
@@ -513,6 +517,11 @@ extension CanonicalTOMLConfig.General {
             forKey: .debugTraceExportCopiesFile,
             default: d.debugTraceExportCopiesFile
         )
+        viewportTraceVerbosity = try container.decodeWithDefault(
+            String.self,
+            forKey: .viewportTraceVerbosity,
+            default: d.viewportTraceVerbosity
+        )
         backgroundTraceRetentionSeconds = try container.decodeWithDefault(
             TimeInterval.self,
             forKey: .backgroundTraceRetentionSeconds,
@@ -539,6 +548,7 @@ extension CanonicalTOMLConfig.General {
         try container.encode(developerModeEnabled, forKey: "developerModeEnabled")
         try container.encode(debugBarEnabled, forKey: "debugBarEnabled")
         try container.encode(debugTraceExportCopiesFile, forKey: "debugTraceExportCopiesFile")
+        try container.encode(viewportTraceVerbosity, forKey: "viewportTraceVerbosity")
         try container.encode(backgroundTraceRetentionSeconds, forKey: "backgroundTraceRetentionSeconds")
         try container.encode(backgroundTraceMaxBytes, forKey: "backgroundTraceMaxBytes")
         try container.encode(ignoreMonitorIdentity, forKey: "ignoreMonitorIdentity")

--- a/Sources/Nehir/Core/Config/SettingsExport.swift
+++ b/Sources/Nehir/Core/Config/SettingsExport.swift
@@ -90,6 +90,7 @@ struct SettingsExport: Equatable, Sendable {
     var developerModeEnabled: Bool
     var debugBarEnabled: Bool
     var debugTraceExportCopiesFile: Bool
+    var viewportTraceVerbosity: String
     var backgroundTraceRetentionSeconds: TimeInterval
     var backgroundTraceMaxBytes: Int
 
@@ -176,6 +177,7 @@ extension SettingsExport {
             developerModeEnabled: false,
             debugBarEnabled: true,
             debugTraceExportCopiesFile: false,
+            viewportTraceVerbosity: ViewportTraceVerbosity.standard.rawValue,
             backgroundTraceRetentionSeconds: 0,
             backgroundTraceMaxBytes: 64 * 1024 * 1024,
             ignoreMonitorIdentity: false,

--- a/Sources/Nehir/Core/Config/SettingsStore.swift
+++ b/Sources/Nehir/Core/Config/SettingsStore.swift
@@ -276,6 +276,16 @@ final class SettingsStore {
         didSet { scheduleSave() }
     }
 
+    /// Opt-in control for how much Niri viewport trace captures record.
+    /// `standard` keeps captures lean (no per-frame gesture updates, no audit
+    /// provenance); `verbose` adds both. Only the verbose path pays the cost,
+    /// so a normal capture is cheap to ship. See `ViewportTraceVerbosity`.
+    var viewportTraceVerbosity = ViewportTraceVerbosity(
+        rawValue: SettingsStore.defaultExport.viewportTraceVerbosity
+    ) ?? .standard {
+        didSet { scheduleSave() }
+    }
+
     var backgroundTraceRetentionSeconds = SettingsStore.defaultExport.backgroundTraceRetentionSeconds {
         didSet { scheduleSave() }
     }
@@ -485,6 +495,7 @@ final class SettingsStore {
             developerModeEnabled: developerModeEnabled,
             debugBarEnabled: debugBarEnabled,
             debugTraceExportCopiesFile: debugTraceExportCopiesFile,
+            viewportTraceVerbosity: viewportTraceVerbosity.rawValue,
             backgroundTraceRetentionSeconds: backgroundTraceRetentionSeconds,
             backgroundTraceMaxBytes: backgroundTraceMaxBytes,
             ignoreMonitorIdentity: ignoreMonitorIdentity,
@@ -591,6 +602,7 @@ final class SettingsStore {
         developerModeEnabled = export.developerModeEnabled
         debugBarEnabled = export.debugBarEnabled
         debugTraceExportCopiesFile = export.debugTraceExportCopiesFile
+        viewportTraceVerbosity = ViewportTraceVerbosity(rawValue: export.viewportTraceVerbosity) ?? .standard
         backgroundTraceRetentionSeconds = max(0, export.backgroundTraceRetentionSeconds)
         backgroundTraceMaxBytes = max(1, export.backgroundTraceMaxBytes)
         ignoreMonitorIdentity = export.ignoreMonitorIdentity

--- a/Sources/Nehir/Core/Config/ViewportTraceVerbosity.swift
+++ b/Sources/Nehir/Core/Config/ViewportTraceVerbosity.swift
@@ -1,0 +1,50 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
+import Foundation
+
+/// Controls how much a Niri viewport runtime trace capture records. A single
+/// concept with three presets instead of a sprawl of independent toggles, so a
+/// user picks "how detailed" rather than reasoning about flag combinations.
+///
+/// - `lean`: viewport flow/decision events and state only. No per-line column
+///   layout dump, no per-animation-frame gesture updates, no per-mutation
+///   provenance. Smallest captures; use when you only need the event sequence.
+/// - `standard` (default): adds the per-line column layout dump, which is what
+///   most viewport/position diagnostics need to interpret snaps and offsets.
+///   Still skips the per-frame gesture-update firehose and the heavy audit.
+/// - `verbose`: adds per-animation-frame `touch_scroll_gesture_update` records
+///   and the `lastViewportMutation*` audit fields, for gesture-snap and
+///   unrecorded-mutation attribution. Largest captures.
+enum ViewportTraceVerbosity: String, CaseIterable, Codable, Identifiable {
+    case lean
+    case standard
+    case verbose
+
+    var id: String {
+        rawValue
+    }
+
+    var displayName: String {
+        switch self {
+        case .lean: "Lean"
+        case .standard: "Standard"
+        case .verbose: "Verbose"
+        }
+    }
+
+    var includesLayoutDump: Bool {
+        self != .lean
+    }
+
+    var includesGestureFrameUpdates: Bool {
+        self == .verbose
+    }
+
+    var includesMutationAudit: Bool {
+        self == .verbose
+    }
+}

--- a/Sources/Nehir/Core/Controller/MouseEventHandler.swift
+++ b/Sources/Nehir/Core/Controller/MouseEventHandler.swift
@@ -1807,15 +1807,17 @@ final class MouseEventHandler {
             controller.layoutRefreshController.stopScrollAnimation(for: monitor.displayId)
         }
         if didApply {
-            controller.recordRuntimeViewportTrace(
-                workspaceId: wsId,
-                reason: "touch_scroll_gesture_update",
-                details: [
-                    "input=trackpadTouches",
-                    String(format: "delta=%.3f", delta),
-                    "phase=committed"
-                ]
-            )
+            if controller.settings.viewportTraceVerbosity.includesGestureFrameUpdates {
+                controller.recordRuntimeViewportTrace(
+                    workspaceId: wsId,
+                    reason: "touch_scroll_gesture_update",
+                    details: [
+                        "input=trackpadTouches",
+                        String(format: "delta=%.3f", delta),
+                        "phase=committed"
+                    ]
+                )
+            }
             controller.layoutRefreshController.requestRefresh(reason: .interactiveGesture)
         }
     }

--- a/Sources/Nehir/Core/Controller/MouseEventHandler.swift
+++ b/Sources/Nehir/Core/Controller/MouseEventHandler.swift
@@ -1635,16 +1635,25 @@ final class MouseEventHandler {
             state.gestureLastAverageX = avgX
             state.gestureLastAverageY = avgY
             state.gesturePhase = .armed
+            let viewportState = controller.workspaceManager.niriViewportState(for: currentContext.wsId)
+            let armedTraceDetails = [
+                "input=trackpadTouches",
+                "requiredFingers=\(requiredFingers)",
+                "activeTouches=\(activeTouchCount)",
+                "phase=\(phase.rawValue)",
+                String(format: "startTouch=%.3f,%.3f", avgX, avgY)
+            ]
+            if !viewportState.viewOffsetPixels.isGesture, viewportState.viewOffsetPixels.isAnimating {
+                controller.recordRuntimeViewportTrace(
+                    workspaceId: currentContext.wsId,
+                    reason: "touch_scroll_gesture_armed_with_preexisting_animation",
+                    details: armedTraceDetails
+                )
+            }
             controller.recordRuntimeViewportTrace(
                 workspaceId: currentContext.wsId,
                 reason: "touch_scroll_gesture_armed",
-                details: [
-                    "input=trackpadTouches",
-                    "requiredFingers=\(requiredFingers)",
-                    "activeTouches=\(activeTouchCount)",
-                    "phase=\(phase.rawValue)",
-                    String(format: "startTouch=%.3f,%.3f", avgX, avgY)
-                ]
+                details: armedTraceDetails
             )
 
         case .armed,

--- a/Sources/Nehir/Core/Controller/NiriLayoutHandler.swift
+++ b/Sources/Nehir/Core/Controller/NiriLayoutHandler.swift
@@ -825,9 +825,11 @@ enum NiriWindowMoveResult {
         geometry: SingleWindowViewportGeometry?,
         state: inout ViewportState
     ) {
-        state.activeColumnIndex = 0
-        state.setStaticViewOffsetPixels(geometry?.centerOffset ?? 0, reason: "resetViewportForCenteredLoneWindow")
-        state.preservesUnsnappedGestureOffset = false
+        state.withRecordedViewportMutation(reason: "resetViewportForCenteredLoneWindow") { state in
+            state.activeColumnIndex = 0
+            state.viewOffsetPixels = .static(geometry?.centerOffset ?? 0)
+            state.preservesUnsnappedGestureOffset = false
+        }
         state.activatePrevColumnOnRemoval = nil
         state.viewOffsetToRestore = nil
         state.selectionProgress = 0

--- a/Sources/Nehir/Core/Controller/NiriLayoutHandler.swift
+++ b/Sources/Nehir/Core/Controller/NiriLayoutHandler.swift
@@ -545,8 +545,10 @@ enum NiriWindowMoveResult {
                 let totalInsertedWidth = insertedBeforeActive.reduce(CGFloat(0)) { total, data in
                     total + data.col.cachedWidth + pass.gap
                 }
-                state.viewOffsetPixels.offset(delta: Double(-totalInsertedWidth))
-                state.activeColumnIndex = originalActiveIdx + insertedBeforeActive.count
+                state.withRecordedViewportMutation(reason: "relayout.insertedColumnsBeforeActive") { state in
+                    state.viewOffsetPixels.offset(delta: Double(-totalInsertedWidth))
+                    state.activeColumnIndex = originalActiveIdx + insertedBeforeActive.count
+                }
             }
 
             let sortedNewColumns = newColumnData.sorted { $0.colIdx < $1.colIdx }
@@ -674,11 +676,14 @@ enum NiriWindowMoveResult {
                     abs(centeredStart - viewStart) > pixel
                 {
                     let activeIndex = state.activeColumnIndex.clamped(to: 0 ... max(0, columns.count - 1))
-                    state.viewOffsetPixels = .static(context.targetOffset(
-                        forViewportStart: centeredStart,
-                        activeColumnIndex: activeIndex,
-                        in: state
-                    ))
+                    state.setStaticViewOffsetPixels(
+                        context.targetOffset(
+                            forViewportStart: centeredStart,
+                            activeColumnIndex: activeIndex,
+                            in: state
+                        ),
+                        reason: "resolveSelection.centeredViewportCorrection"
+                    )
                     state.preservesUnsnappedGestureOffset = false
                     if abs(state.viewOffsetPixels.current() - offsetBefore) > 1 {
                         viewportNeedsRecalc = true
@@ -821,7 +826,7 @@ enum NiriWindowMoveResult {
         state: inout ViewportState
     ) {
         state.activeColumnIndex = 0
-        state.viewOffsetPixels = .static(geometry?.centerOffset ?? 0)
+        state.setStaticViewOffsetPixels(geometry?.centerOffset ?? 0, reason: "resetViewportForCenteredLoneWindow")
         state.preservesUnsnappedGestureOffset = false
         state.activatePrevColumnOnRemoval = nil
         state.viewOffsetToRestore = nil
@@ -2064,8 +2069,10 @@ enum NiriWindowMoveResult {
             gap: gap,
             sizeKeyPath: sizeKeyPath
         )
-        state.viewOffsetPixels.offset(delta: Double(previousPosition - targetPosition))
-        state.activeColumnIndex = targetIndex
+        state.withRecordedViewportMutation(reason: "adjustViewportForContainerPositionChange") { state in
+            state.viewOffsetPixels.offset(delta: Double(previousPosition - targetPosition))
+            state.activeColumnIndex = targetIndex
+        }
     }
 
     func withNiriOperationContext(

--- a/Sources/Nehir/Core/Controller/WMController.swift
+++ b/Sources/Nehir/Core/Controller/WMController.swift
@@ -285,6 +285,10 @@ final class WMController {
         settings.developerModeEnabled && isRuntimeTraceCaptureActive
     }
 
+    private func syncViewportMutationAuditFlag() {
+        workspaceManager.setViewportMutationAuditEnabled(isRuntimeTraceCaptureActive)
+    }
+
     var backgroundTraceBufferStatus: BackgroundTraceBufferStatus {
         backgroundTraceBuffer.status(isEnabled: isBackgroundTraceBufferEffectivelyEnabled)
     }
@@ -2713,6 +2717,18 @@ final class WMController {
             columns: columns,
             gap: gap
         )
+        let mutationAgeMs = state.lastViewportMutationTimestamp.map {
+            max(0, (Date().timeIntervalSince1970 - $0) * 1000.0)
+        }
+        let mutationAgeText = mutationAgeMs.map { String(format: "%.1f", $0) } ?? "nil"
+        let mutationBefore = state.lastViewportMutationBefore
+        let mutationAfter = state.lastViewportMutationAfter
+        let mutationBeforeCurrentOffsetText = mutationBefore.map { String(format: "%.1f", $0.currentOffset) } ?? "nil"
+        let mutationBeforeTargetOffsetText = mutationBefore.map { String(format: "%.1f", $0.targetOffset) } ?? "nil"
+        let mutationBeforeActiveColumnIndexText = mutationBefore.map { String($0.activeColumnIndex) } ?? "nil"
+        let mutationAfterCurrentOffsetText = mutationAfter.map { String(format: "%.1f", $0.currentOffset) } ?? "nil"
+        let mutationAfterTargetOffsetText = mutationAfter.map { String(format: "%.1f", $0.targetOffset) } ?? "nil"
+        let mutationAfterActiveColumnIndexText = mutationAfter.map { String($0.activeColumnIndex) } ?? "nil"
 
         let timestamp = Date()
         let line = ([
@@ -2730,6 +2746,17 @@ final class WMController {
             "gesture=\(state.viewOffsetPixels.isGesture)",
             "animating=\(state.viewOffsetPixels.isAnimating)",
             "preserveUnsnapped=\(state.preservesUnsnappedGestureOffset)",
+            "lastViewportMutation=\(state.lastViewportMutationReason ?? "nil")",
+            "lastViewportMutationCaller=\(state.lastViewportMutationCaller ?? "nil")",
+            "lastViewportMutationAgeMs=\(mutationAgeText)",
+            "lastViewportMutationBeforeCurrentOffset=\(mutationBeforeCurrentOffsetText)",
+            "lastViewportMutationBeforeTargetOffset=\(mutationBeforeTargetOffsetText)",
+            "lastViewportMutationBeforeKind=\(mutationBefore?.offsetKind ?? "nil")",
+            "lastViewportMutationBeforeActiveColumnIndex=\(mutationBeforeActiveColumnIndexText)",
+            "lastViewportMutationAfterCurrentOffset=\(mutationAfterCurrentOffsetText)",
+            "lastViewportMutationAfterTargetOffset=\(mutationAfterTargetOffsetText)",
+            "lastViewportMutationAfterKind=\(mutationAfter?.offsetKind ?? "nil")",
+            "lastViewportMutationAfterActiveColumnIndex=\(mutationAfterActiveColumnIndexText)",
             "selectedNode=\(selectedNode)",
             "preferredFocus=\(preferredFocus)",
             "confirmedFocus=\(confirmedFocus)",
@@ -3390,6 +3417,7 @@ final class WMController {
             backgroundTraceDrafts.removeAll(keepingCapacity: true)
             backgroundTraceDraftOrder.removeAll(keepingCapacity: true)
             syncNiriResizeTraceSink()
+            syncViewportMutationAuditFlag()
             workspaceBarManager.update()
             debugBarManager.update()
         }
@@ -3599,6 +3627,7 @@ final class WMController {
             startRuntimeStateDump: startRuntimeStateDump
         )
         syncNiriResizeTraceSink()
+        syncViewportMutationAuditFlag()
         workspaceManager.resetReconcileTraceForDebug()
         workspaceManager.resetInteractionMonitorWriteTraceForDebug()
         workspaceManager.resetFloatingBarProjectionTraceForDebug()
@@ -3706,6 +3735,7 @@ final class WMController {
         backgroundTraceDrafts.removeAll(keepingCapacity: true)
         backgroundTraceDraftOrder.removeAll(keepingCapacity: true)
         syncNiriResizeTraceSink()
+        syncViewportMutationAuditFlag()
         workspaceBarManager.update()
         debugBarManager.update()
         return .executed

--- a/Sources/Nehir/Core/Controller/WMController.swift
+++ b/Sources/Nehir/Core/Controller/WMController.swift
@@ -429,6 +429,7 @@ final class WMController {
         // an app relaunch.
         updateWorkspaceBarSettings()
         updateBackgroundTraceBufferConfiguration()
+        applyViewportTraceVerbosity()
         _ = syncMouseWarpPolicy()
 
         setEnabled(true)

--- a/Sources/Nehir/Core/Controller/WMController.swift
+++ b/Sources/Nehir/Core/Controller/WMController.swift
@@ -285,8 +285,24 @@ final class WMController {
         settings.developerModeEnabled && isRuntimeTraceCaptureActive
     }
 
+    private var viewportTraceVerbosity: ViewportTraceVerbosity {
+        settings.viewportTraceVerbosity
+    }
+
     private func syncViewportMutationAuditFlag() {
-        workspaceManager.setViewportMutationAuditEnabled(isRuntimeTraceCaptureActive)
+        // The per-mutation audit is the expensive part of the verbose path. It runs
+        // only while trace capture is active AND verbosity is `.verbose`, so a
+        // default (`.standard`) capture pays nothing for it.
+        workspaceManager.setViewportMutationAuditEnabled(
+            isRuntimeTraceCaptureActive && viewportTraceVerbosity.includesMutationAudit
+        )
+    }
+
+    /// Re-applies the viewport trace verbosity gates after the setting changes.
+    /// Called from the Diagnostics picker / debug-bar cycle.
+    func applyViewportTraceVerbosity() {
+        syncViewportMutationAuditFlag()
+        debugBarManager.update()
     }
 
     var backgroundTraceBufferStatus: BackgroundTraceBufferStatus {
@@ -2711,12 +2727,15 @@ final class WMController {
         let confirmedFocus = workspaceManager.confirmedManagedFocusToken.map(String.init(describing:)) ?? "nil"
         let currentViewStartText = currentViewStart.map { String(format: "%.1f", $0) } ?? "nil"
         let targetViewStartText = targetViewStart.map { String(format: "%.1f", $0) } ?? "nil"
-        let layoutDecisions = niriLayoutDecisionLine(
-            workspaceId: workspaceId,
-            state: state,
-            columns: columns,
-            gap: gap
-        )
+        let verbosity = viewportTraceVerbosity
+        let layoutDecisions = verbosity.includesLayoutDump
+            ? niriLayoutDecisionLine(
+                workspaceId: workspaceId,
+                state: state,
+                columns: columns,
+                gap: gap
+            )
+            : "elided"
         let mutationAgeMs = state.lastViewportMutationTimestamp.map {
             max(0, (Date().timeIntervalSince1970 - $0) * 1000.0)
         }
@@ -2729,6 +2748,22 @@ final class WMController {
         let mutationAfterCurrentOffsetText = mutationAfter.map { String(format: "%.1f", $0.currentOffset) } ?? "nil"
         let mutationAfterTargetOffsetText = mutationAfter.map { String(format: "%.1f", $0.targetOffset) } ?? "nil"
         let mutationAfterActiveColumnIndexText = mutationAfter.map { String($0.activeColumnIndex) } ?? "nil"
+
+        // The heavy `lastViewportMutation*` fields are only emitted on the
+        // `.verbose` path, so a default (`.standard`) trace capture stays lean.
+        let mutationTraceFields: [String] = verbosity.includesMutationAudit ? [
+            "lastViewportMutation=\(state.lastViewportMutationReason ?? "nil")",
+            "lastViewportMutationCaller=\(state.lastViewportMutationCaller ?? "nil")",
+            "lastViewportMutationAgeMs=\(mutationAgeText)",
+            "lastViewportMutationBeforeCurrentOffset=\(mutationBeforeCurrentOffsetText)",
+            "lastViewportMutationBeforeTargetOffset=\(mutationBeforeTargetOffsetText)",
+            "lastViewportMutationBeforeKind=\(mutationBefore?.offsetKind ?? "nil")",
+            "lastViewportMutationBeforeActiveColumnIndex=\(mutationBeforeActiveColumnIndexText)",
+            "lastViewportMutationAfterCurrentOffset=\(mutationAfterCurrentOffsetText)",
+            "lastViewportMutationAfterTargetOffset=\(mutationAfterTargetOffsetText)",
+            "lastViewportMutationAfterKind=\(mutationAfter?.offsetKind ?? "nil")",
+            "lastViewportMutationAfterActiveColumnIndex=\(mutationAfterActiveColumnIndexText)"
+        ] : []
 
         let timestamp = Date()
         let line = ([
@@ -2746,24 +2781,13 @@ final class WMController {
             "gesture=\(state.viewOffsetPixels.isGesture)",
             "animating=\(state.viewOffsetPixels.isAnimating)",
             "preserveUnsnapped=\(state.preservesUnsnappedGestureOffset)",
-            "lastViewportMutation=\(state.lastViewportMutationReason ?? "nil")",
-            "lastViewportMutationCaller=\(state.lastViewportMutationCaller ?? "nil")",
-            "lastViewportMutationAgeMs=\(mutationAgeText)",
-            "lastViewportMutationBeforeCurrentOffset=\(mutationBeforeCurrentOffsetText)",
-            "lastViewportMutationBeforeTargetOffset=\(mutationBeforeTargetOffsetText)",
-            "lastViewportMutationBeforeKind=\(mutationBefore?.offsetKind ?? "nil")",
-            "lastViewportMutationBeforeActiveColumnIndex=\(mutationBeforeActiveColumnIndexText)",
-            "lastViewportMutationAfterCurrentOffset=\(mutationAfterCurrentOffsetText)",
-            "lastViewportMutationAfterTargetOffset=\(mutationAfterTargetOffsetText)",
-            "lastViewportMutationAfterKind=\(mutationAfter?.offsetKind ?? "nil")",
-            "lastViewportMutationAfterActiveColumnIndex=\(mutationAfterActiveColumnIndexText)",
             "selectedNode=\(selectedNode)",
             "preferredFocus=\(preferredFocus)",
             "confirmedFocus=\(confirmedFocus)",
             "resizeCommandSeq=\(engine.resizeCommandGeneration)",
             "layout=\(layoutDecisions)"
-        ])
-        .joined(separator: " ")
+        ] + mutationTraceFields)
+            .joined(separator: " ")
 
         if runtimeTraceCaptureSession != nil {
             runtimeViewportTraceRecords.append(line)

--- a/Sources/Nehir/Core/Layout/Niri/NiriLayout.swift
+++ b/Sources/Nehir/Core/Layout/Niri/NiriLayout.swift
@@ -848,7 +848,7 @@ extension NiriLayoutEngine {
               !state.viewOffsetPixels.isGesture,
               abs(state.viewOffsetPixels.current()) < SingleWindowViewportGeometry.centeredOffsetEpsilon
         else { return }
-        state.viewOffsetPixels = .static(geometry.centerOffset)
+        state.setStaticViewOffsetPixels(geometry.centerOffset, reason: "seedSingleWindowCenterOffsetIfNeeded")
         state.preservesUnsnappedGestureOffset = false
     }
 

--- a/Sources/Nehir/Core/Layout/Niri/NiriLayoutEngine+Animation.swift
+++ b/Sources/Nehir/Core/Layout/Niri/NiriLayoutEngine+Animation.swift
@@ -45,8 +45,10 @@ extension NiriLayoutEngine {
         let fallback = removingNode.flatMap { fallbackSelectionOnRemoval(removing: $0.id, in: workspaceId) }
 
         if removedIdx < activeIdx {
-            state.activeColumnIndex = activeIdx - 1
-            state.viewOffsetPixels.offset(delta: Double(offset))
+            state.withRecordedViewportMutation(reason: "animateColumnsForRemoval.shiftActiveColumn") { state in
+                state.activeColumnIndex = activeIdx - 1
+                state.viewOffsetPixels.offset(delta: Double(offset))
+            }
             state.activatePrevColumnOnRemoval = nil
             return ColumnRemovalResult(
                 fallbackSelectionId: fallback,

--- a/Sources/Nehir/Core/Layout/Niri/NiriLayoutEngine+InteractiveResize.swift
+++ b/Sources/Nehir/Core/Layout/Niri/NiriLayoutEngine+InteractiveResize.swift
@@ -207,7 +207,10 @@ extension NiriLayoutEngine {
             if resize.edges.contains(.left), let origOffset = resize.originalViewOffset {
                 let widthDelta = column.cachedWidth - originalWidth
                 viewportState { state in
-                    state.setStaticViewOffsetPixels(origOffset + widthDelta, reason: "interactiveResize.leftEdgeCompensation")
+                    state.setStaticViewOffsetPixels(
+                        origOffset + widthDelta,
+                        reason: "interactiveResize.leftEdgeCompensation"
+                    )
                     state.preservesUnsnappedGestureOffset = false
                 }
             }

--- a/Sources/Nehir/Core/Layout/Niri/NiriLayoutEngine+InteractiveResize.swift
+++ b/Sources/Nehir/Core/Layout/Niri/NiriLayoutEngine+InteractiveResize.swift
@@ -207,7 +207,7 @@ extension NiriLayoutEngine {
             if resize.edges.contains(.left), let origOffset = resize.originalViewOffset {
                 let widthDelta = column.cachedWidth - originalWidth
                 viewportState { state in
-                    state.viewOffsetPixels = .static(origOffset + widthDelta)
+                    state.setStaticViewOffsetPixels(origOffset + widthDelta, reason: "interactiveResize.leftEdgeCompensation")
                     state.preservesUnsnappedGestureOffset = false
                 }
             }

--- a/Sources/Nehir/Core/Layout/Niri/NiriLayoutEngine+ViewportCommands.swift
+++ b/Sources/Nehir/Core/Layout/Niri/NiriLayoutEngine+ViewportCommands.swift
@@ -55,8 +55,10 @@ extension NiriLayoutEngine {
         if newActiveIndex != oldActiveIndex {
             let oldX = state.columnX(at: oldActiveIndex, columns: columns, gap: gaps)
             let newX = state.columnX(at: newActiveIndex, columns: columns, gap: gaps)
-            state.viewOffsetPixels.offset(delta: Double(oldX - newX))
-            state.activeColumnIndex = newActiveIndex
+            state.withRecordedViewportMutation(reason: "scrollViewport.rebaseActiveColumn") { state in
+                state.viewOffsetPixels.offset(delta: Double(oldX - newX))
+                state.activeColumnIndex = newActiveIndex
+            }
             state.viewOffsetToRestore = nil
         }
 

--- a/Sources/Nehir/Core/Layout/Niri/NiriLayoutEngine+Windows.swift
+++ b/Sources/Nehir/Core/Layout/Niri/NiriLayoutEngine+Windows.swift
@@ -487,10 +487,12 @@ extension NiriLayoutEngine {
                   let previousOffset = pendingPreviousOffset,
                   removedIdx > 0
         {
-            state.activeColumnIndex = activeIdx - 1
+            state.withRecordedViewportMutation(reason: "removeWindow.restorePreviousOffset") { state in
+                state.activeColumnIndex = activeIdx - 1
+                state.viewOffsetPixels = .static(previousOffset)
+                state.preservesUnsnappedGestureOffset = false
+            }
             state.activatePrevColumnOnRemoval = nil
-            state.setStaticViewOffsetPixels(previousOffset, reason: "removeWindow.restorePreviousOffset")
-            state.preservesUnsnappedGestureOffset = false
             viewportNeedsRecalc = true
             fallbackSelectionId = fallbackSelectionFromActiveColumn(
                 in: workspaceId,

--- a/Sources/Nehir/Core/Layout/Niri/NiriLayoutEngine+Windows.swift
+++ b/Sources/Nehir/Core/Layout/Niri/NiriLayoutEngine+Windows.swift
@@ -472,8 +472,10 @@ extension NiriLayoutEngine {
             state.activatePrevColumnOnRemoval = nil
             state.selectedNodeId = nil
         } else if removedIdx < activeIdx {
-            state.activeColumnIndex = activeIdx - 1
-            state.viewOffsetPixels.offset(delta: Double(offset))
+            state.withRecordedViewportMutation(reason: "removeWindow.shiftActiveColumn") { state in
+                state.activeColumnIndex = activeIdx - 1
+                state.viewOffsetPixels.offset(delta: Double(offset))
+            }
             state.activatePrevColumnOnRemoval = nil
             viewportNeedsRecalc = true
             fallbackSelectionId = fallbackSelectionFromActiveColumn(
@@ -487,7 +489,7 @@ extension NiriLayoutEngine {
         {
             state.activeColumnIndex = activeIdx - 1
             state.activatePrevColumnOnRemoval = nil
-            state.viewOffsetPixels = .static(previousOffset)
+            state.setStaticViewOffsetPixels(previousOffset, reason: "removeWindow.restorePreviousOffset")
             state.preservesUnsnappedGestureOffset = false
             viewportNeedsRecalc = true
             fallbackSelectionId = fallbackSelectionFromActiveColumn(

--- a/Sources/Nehir/Core/Layout/Niri/NiriNavigation.swift
+++ b/Sources/Nehir/Core/Layout/Niri/NiriNavigation.swift
@@ -217,9 +217,10 @@ extension NiriLayoutEngine {
             sizeKeyPath: sizeKeyPath
         )
         let offsetDelta = oldActivePos - newActivePos
-        state.viewOffsetPixels.offset(delta: Double(offsetDelta))
-
-        state.activeColumnIndex = targetIdx
+        state.withRecordedViewportMutation(reason: "moveSelectionToContainer.rebaseActiveColumn") { state in
+            state.viewOffsetPixels.offset(delta: Double(offsetDelta))
+            state.activeColumnIndex = targetIdx
+        }
         state.activatePrevColumnOnRemoval = nil
         state.viewOffsetToRestore = nil
 

--- a/Sources/Nehir/Core/Layout/Niri/ViewportState+Animation.swift
+++ b/Sources/Nehir/Core/Layout/Niri/ViewportState+Animation.swift
@@ -42,7 +42,7 @@ extension ViewportState {
         case let .spring(anim):
             if anim.isComplete(at: time) {
                 let finalOffset = CGFloat(anim.target)
-                viewOffsetPixels = .static(finalOffset)
+                setStaticViewOffsetPixels(finalOffset, reason: "tickAnimation.complete")
                 return false
             }
             return true
@@ -69,7 +69,7 @@ extension ViewportState {
         scale: CGFloat = 2.0
     ) {
         guard motion.animationsEnabled else {
-            viewOffsetPixels = .static(offset)
+            setStaticViewOffsetPixels(offset, reason: "animateToOffset.staticFallback")
             preservesUnsnappedGestureOffset = false
             return
         }
@@ -79,7 +79,7 @@ extension ViewportState {
 
         let toDiff = offset - viewOffsetPixels.target()
         if abs(toDiff) < pixel {
-            viewOffsetPixels.offset(delta: Double(toDiff))
+            offsetViewOffsetPixels(delta: Double(toDiff), reason: "animateToOffset.pixelSnap")
             preservesUnsnappedGestureOffset = false
             return
         }
@@ -95,23 +95,23 @@ extension ViewportState {
             config: config ?? springConfig,
             displayRefreshRate: displayRefreshRate
         )
-        viewOffsetPixels = .spring(animation)
+        setSpringViewOffsetPixels(animation, reason: "animateToOffset.spring")
         preservesUnsnappedGestureOffset = false
     }
 
     mutating func cancelAnimation() {
-        viewOffsetPixels = .static(viewOffsetPixels.target())
+        setStaticViewOffsetPixels(viewOffsetPixels.target(), reason: "cancelAnimation")
         preservesUnsnappedGestureOffset = false
     }
 
     mutating func settleAtCurrentOffset() {
-        viewOffsetPixels = .static(viewOffsetPixels.current())
+        setStaticViewOffsetPixels(viewOffsetPixels.current(), reason: "settleAtCurrentOffset")
         preservesUnsnappedGestureOffset = false
     }
 
     mutating func reset() {
         activeColumnIndex = 0
-        viewOffsetPixels = .static(0.0)
+        setStaticViewOffsetPixels(0.0, reason: "reset")
         preservesUnsnappedGestureOffset = false
         selectionProgress = 0.0
         selectedNodeId = nil
@@ -119,7 +119,7 @@ extension ViewportState {
 
     mutating func offsetViewport(by delta: CGFloat) {
         let current = viewOffsetPixels.current()
-        viewOffsetPixels = .static(current + delta)
+        setStaticViewOffsetPixels(current + delta, reason: "offsetViewport")
         preservesUnsnappedGestureOffset = false
     }
 
@@ -128,7 +128,7 @@ extension ViewportState {
     }
 
     mutating func restoreViewOffset(_ offset: CGFloat) {
-        viewOffsetPixels = .static(offset)
+        setStaticViewOffsetPixels(offset, reason: "restoreViewOffset")
         preservesUnsnappedGestureOffset = false
         viewOffsetToRestore = nil
     }
@@ -140,7 +140,7 @@ extension ViewportState {
         }
 
         guard motion.animationsEnabled else {
-            viewOffsetPixels = .static(offset)
+            setStaticViewOffsetPixels(offset, reason: "animateViewOffsetRestore.staticFallback")
             preservesUnsnappedGestureOffset = false
             viewOffsetToRestore = nil
             return
@@ -158,7 +158,7 @@ extension ViewportState {
             config: springConfig,
             displayRefreshRate: displayRefreshRate
         )
-        viewOffsetPixels = .spring(animation)
+        setSpringViewOffsetPixels(animation, reason: "animateViewOffsetRestore.spring")
         preservesUnsnappedGestureOffset = false
         viewOffsetToRestore = nil
     }

--- a/Sources/Nehir/Core/Layout/Niri/ViewportState+ColumnTransitions.swift
+++ b/Sources/Nehir/Core/Layout/Niri/ViewportState+ColumnTransitions.swift
@@ -26,7 +26,10 @@ extension ViewportState {
         let newActiveColX = columnX(at: clampedIndex, columns: columns, gap: gap)
         let offsetDelta = oldActiveColX - newActiveColX
 
-        viewOffsetPixels.offset(delta: Double(offsetDelta))
+        withRecordedViewportMutation(reason: "setActiveColumn.rebase") { state in
+            state.viewOffsetPixels.offset(delta: Double(offsetDelta))
+            state.activeColumnIndex = clampedIndex
+        }
 
         let targetOffset = computeCenteredOffset(
             columnIndex: clampedIndex,
@@ -41,11 +44,9 @@ extension ViewportState {
         if animate {
             animateToOffset(targetOffset, motion: motion)
         } else {
-            viewOffsetPixels = .static(targetOffset)
+            setStaticViewOffsetPixels(targetOffset, reason: "setActiveColumn.staticTarget")
             preservesUnsnappedGestureOffset = false
         }
-
-        activeColumnIndex = clampedIndex
         activatePrevColumnOnRemoval = nil
         viewOffsetToRestore = nil
     }
@@ -65,9 +66,11 @@ extension ViewportState {
         let clampedIndex = newIndex.clamped(to: 0 ... (columns.count - 1))
 
         let oldActiveColX = columnX(at: activeColumnIndex, columns: columns, gap: gap)
-        activeColumnIndex = clampedIndex
         let newActiveColX = columnX(at: clampedIndex, columns: columns, gap: gap)
-        viewOffsetPixels.offset(delta: Double(oldActiveColX - newActiveColX))
+        withRecordedViewportMutation(reason: "transitionToColumn.rebase") { state in
+            state.activeColumnIndex = clampedIndex
+            state.viewOffsetPixels.offset(delta: Double(oldActiveColX - newActiveColX))
+        }
 
         let context = snapContext(columns: columns, gap: gap, viewportWidth: viewportWidth)
         let currentViewStart = newActiveColX + viewOffsetPixels.target()
@@ -78,7 +81,7 @@ extension ViewportState {
         let pixel: CGFloat = 1.0 / max(scale, 1.0)
         let toDiff = targetOffset - viewOffsetPixels.target()
         if abs(toDiff) < pixel {
-            viewOffsetPixels.offset(delta: Double(toDiff))
+            offsetViewOffsetPixels(delta: Double(toDiff), reason: "transitionToColumn.pixelSnap")
             preservesUnsnappedGestureOffset = false
             activatePrevColumnOnRemoval = nil
             viewOffsetToRestore = nil
@@ -88,7 +91,7 @@ extension ViewportState {
         if animate {
             animateToOffset(targetOffset, motion: motion, scale: scale)
         } else {
-            viewOffsetPixels = .static(targetOffset)
+            setStaticViewOffsetPixels(targetOffset, reason: "transitionToColumn.staticTarget")
             preservesUnsnappedGestureOffset = false
         }
 
@@ -112,7 +115,7 @@ extension ViewportState {
             gap: gap,
             viewportWidth: viewportWidth
         )
-        viewOffsetPixels = .static(targetOffset)
+        setStaticViewOffsetPixels(targetOffset, reason: "snapToColumn")
         preservesUnsnappedGestureOffset = false
         selectionProgress = 0
     }
@@ -140,7 +143,7 @@ extension ViewportState {
             in: self
         )
 
-        viewOffsetPixels = .static(newOffset)
+        setStaticViewOffsetPixels(newOffset, reason: "scrollByPixels")
         preservesUnsnappedGestureOffset = false
 
         if changeSelection {

--- a/Sources/Nehir/Core/Layout/Niri/ViewportState+Gestures.swift
+++ b/Sources/Nehir/Core/Layout/Niri/ViewportState+Gestures.swift
@@ -14,7 +14,10 @@ extension ViewportState {
     mutating func beginGesture(isTrackpad: Bool, columns: [NiriContainer]) -> Bool {
         guard !columns.isEmpty else { return false }
         let currentOffset = viewOffsetPixels.current()
-        viewOffsetPixels = .gesture(ViewGesture(currentViewOffset: Double(currentOffset), isTrackpad: isTrackpad))
+        setGestureViewOffsetPixels(
+            ViewGesture(currentViewOffset: Double(currentOffset), isTrackpad: isTrackpad),
+            reason: "beginGesture"
+        )
         preservesUnsnappedGestureOffset = false
         selectionProgress = 0.0
         return true
@@ -136,7 +139,7 @@ extension ViewportState {
         let targetOffset = result.viewPos - Double(newColX)
 
         guard motion.animationsEnabled else {
-            viewOffsetPixels = .static(CGFloat(targetOffset))
+            setStaticViewOffsetPixels(CGFloat(targetOffset), reason: "endGesture.staticTarget")
             preservesUnsnappedGestureOffset = false
             activatePrevColumnOnRemoval = nil
             selectionProgress = 0.0
@@ -151,7 +154,7 @@ extension ViewportState {
             config: springConfig,
             displayRefreshRate: displayRefreshRate
         )
-        viewOffsetPixels = .spring(animation)
+        setSpringViewOffsetPixels(animation, reason: "endGesture.spring")
         preservesUnsnappedGestureOffset = false
 
         activatePrevColumnOnRemoval = nil
@@ -202,16 +205,19 @@ extension ViewportState {
         }
 
         if shouldAnimateBoundsCorrection, motion.animationsEnabled {
-            viewOffsetPixels = .spring(SpringAnimation(
-                from: initialOffset,
-                to: finalOffset,
-                initialVelocity: velocity,
-                startTime: timestamp,
-                config: springConfig,
-                displayRefreshRate: displayRefreshRate
-            ))
+            setSpringViewOffsetPixels(
+                SpringAnimation(
+                    from: initialOffset,
+                    to: finalOffset,
+                    initialVelocity: velocity,
+                    startTime: timestamp,
+                    config: springConfig,
+                    displayRefreshRate: displayRefreshRate
+                ),
+                reason: "endGesturePreservingCurrentOffset.spring"
+            )
         } else {
-            viewOffsetPixels = .static(CGFloat(finalOffset))
+            setStaticViewOffsetPixels(CGFloat(finalOffset), reason: "endGesturePreservingCurrentOffset.static")
         }
         preservesUnsnappedGestureOffset = true
         activatePrevColumnOnRemoval = nil
@@ -314,7 +320,7 @@ extension ViewportState {
     }
 
     private mutating func endGestureWithoutSnap(currentOffset: Double) {
-        viewOffsetPixels = .static(CGFloat(currentOffset))
+        setStaticViewOffsetPixels(CGFloat(currentOffset), reason: "endGestureWithoutSnap")
         preservesUnsnappedGestureOffset = false
         activatePrevColumnOnRemoval = nil
         viewOffsetToRestore = nil

--- a/Sources/Nehir/Core/Layout/Niri/ViewportState.swift
+++ b/Sources/Nehir/Core/Layout/Niri/ViewportState.swift
@@ -169,6 +169,14 @@ struct ViewportState {
         let currentOffset: CGFloat
         let targetOffset: CGFloat
         let offsetKind: String
+
+        static func == (lhs: ViewportMutationSnapshot, rhs: ViewportMutationSnapshot) -> Bool {
+            // Keep currentOffset in trace output, but exclude its animated,
+            // time-sensitive value from change detection.
+            lhs.activeColumnIndex == rhs.activeColumnIndex
+                && lhs.targetOffset == rhs.targetOffset
+                && lhs.offsetKind == rhs.offsetKind
+        }
     }
 
     var activeColumnIndex: Int = 0

--- a/Sources/Nehir/Core/Layout/Niri/ViewportState.swift
+++ b/Sources/Nehir/Core/Layout/Niri/ViewportState.swift
@@ -64,6 +64,17 @@ enum ViewOffset {
     case gesture(ViewGesture)
     case spring(SpringAnimation)
 
+    var mutationKind: String {
+        switch self {
+        case .static:
+            "static"
+        case .gesture:
+            "gesture"
+        case .spring:
+            "spring"
+        }
+    }
+
     func current() -> CGFloat {
         switch self {
         case let .static(offset):
@@ -153,6 +164,13 @@ enum ViewOffset {
 }
 
 struct ViewportState {
+    struct ViewportMutationSnapshot: Equatable {
+        let activeColumnIndex: Int
+        let currentOffset: CGFloat
+        let targetOffset: CGFloat
+        let offsetKind: String
+    }
+
     var activeColumnIndex: Int = 0
 
     var viewOffsetPixels: ViewOffset = .static(0.0)
@@ -172,9 +190,105 @@ struct ViewportState {
     var recentFFMFocusToken: WindowToken?
     var recentFFMFocusTimestamp: Date?
 
+    var isViewportMutationAuditEnabled = false
+    var lastViewportMutationReason: String?
+    var lastViewportMutationCaller: String?
+    var lastViewportMutationTimestamp: TimeInterval?
+    var lastViewportMutationBefore: ViewportMutationSnapshot?
+    var lastViewportMutationAfter: ViewportMutationSnapshot?
+
     let springConfig: SpringConfig = .niriHorizontalViewMovement
 
     var animationClock: AnimationClock?
 
     var displayRefreshRate: Double = 60.0
+
+    func viewportMutationSnapshot() -> ViewportMutationSnapshot {
+        ViewportMutationSnapshot(
+            activeColumnIndex: activeColumnIndex,
+            currentOffset: viewOffsetPixels.current(),
+            targetOffset: viewOffsetPixels.target(),
+            offsetKind: viewOffsetPixels.mutationKind
+        )
+    }
+
+    mutating func clearViewportMutationAudit() {
+        lastViewportMutationReason = nil
+        lastViewportMutationCaller = nil
+        lastViewportMutationTimestamp = nil
+        lastViewportMutationBefore = nil
+        lastViewportMutationAfter = nil
+    }
+
+    mutating func withRecordedViewportMutation(
+        reason: String,
+        caller: String = #function,
+        fileID: StaticString = #fileID,
+        line: UInt = #line,
+        _ mutate: (inout ViewportState) -> Void
+    ) {
+        guard isViewportMutationAuditEnabled else {
+            mutate(&self)
+            return
+        }
+
+        let before = viewportMutationSnapshot()
+        mutate(&self)
+        let after = viewportMutationSnapshot()
+        guard before != after else { return }
+
+        lastViewportMutationReason = reason
+        lastViewportMutationCaller = "\(fileID):\(line) \(caller)"
+        lastViewportMutationTimestamp = Date().timeIntervalSince1970
+        lastViewportMutationBefore = before
+        lastViewportMutationAfter = after
+    }
+
+    mutating func offsetViewOffsetPixels(
+        delta: Double,
+        reason: String,
+        caller: String = #function,
+        fileID: StaticString = #fileID,
+        line: UInt = #line
+    ) {
+        withRecordedViewportMutation(reason: reason, caller: caller, fileID: fileID, line: line) { state in
+            state.viewOffsetPixels.offset(delta: delta)
+        }
+    }
+
+    mutating func setStaticViewOffsetPixels(
+        _ offset: CGFloat,
+        reason: String,
+        caller: String = #function,
+        fileID: StaticString = #fileID,
+        line: UInt = #line
+    ) {
+        withRecordedViewportMutation(reason: reason, caller: caller, fileID: fileID, line: line) { state in
+            state.viewOffsetPixels = .static(offset)
+        }
+    }
+
+    mutating func setGestureViewOffsetPixels(
+        _ gesture: ViewGesture,
+        reason: String,
+        caller: String = #function,
+        fileID: StaticString = #fileID,
+        line: UInt = #line
+    ) {
+        withRecordedViewportMutation(reason: reason, caller: caller, fileID: fileID, line: line) { state in
+            state.viewOffsetPixels = .gesture(gesture)
+        }
+    }
+
+    mutating func setSpringViewOffsetPixels(
+        _ animation: SpringAnimation,
+        reason: String,
+        caller: String = #function,
+        fileID: StaticString = #fileID,
+        line: UInt = #line
+    ) {
+        withRecordedViewportMutation(reason: reason, caller: caller, fileID: fileID, line: line) { state in
+            state.viewOffsetPixels = .spring(animation)
+        }
+    }
 }

--- a/Sources/Nehir/Core/Workspace/WorkspaceManager.swift
+++ b/Sources/Nehir/Core/Workspace/WorkspaceManager.swift
@@ -3515,19 +3515,36 @@ final class WorkspaceManager {
         }
     }
 
+    private var isViewportMutationAuditEnabled = false
+
+    func setViewportMutationAuditEnabled(_ enabled: Bool) {
+        isViewportMutationAuditEnabled = enabled
+        for workspaceId in sessionState.workspaceSessions.keys {
+            guard var viewportState = sessionState.workspaceSessions[workspaceId]?.niriViewportState else { continue }
+            viewportState.isViewportMutationAuditEnabled = enabled
+            viewportState.clearViewportMutationAudit()
+            sessionState.workspaceSessions[workspaceId]?.niriViewportState = viewportState
+        }
+    }
+
     func niriViewportState(for workspaceId: WorkspaceDescriptor.ID) -> ViewportState {
-        if let state = sessionState.workspaceSessions[workspaceId]?.niriViewportState {
+        if var state = sessionState.workspaceSessions[workspaceId]?.niriViewportState {
+            state.isViewportMutationAuditEnabled = isViewportMutationAuditEnabled
             return state
         }
         var newState = ViewportState()
         newState.animationClock = animationClock
+        newState.isViewportMutationAuditEnabled = isViewportMutationAuditEnabled
         return newState
     }
 
     func updateNiriViewportState(_ state: ViewportState, for workspaceId: WorkspaceDescriptor.ID) {
         var workspaceSession = sessionState.workspaceSessions[workspaceId] ?? SessionState.WorkspaceSession()
         let previousViewportState = workspaceSession.niriViewportState
-        workspaceSession.niriViewportState = state
+        var normalizedState = state
+        normalizedState.animationClock = animationClock
+        normalizedState.isViewportMutationAuditEnabled = isViewportMutationAuditEnabled
+        workspaceSession.niriViewportState = normalizedState
 
         // Bump the per-workspace revision whenever a LIVE selection field
         // changes. This is the single chokepoint for ALL live ViewportState
@@ -3548,9 +3565,9 @@ final class WorkspaceManager {
         // `niriViewportState(for:)` hands the plan-builder, so the comparison is
         // consistent, and a first write that is itself empty does not bump.
         let previousSelection = previousViewportState ?? ViewportState()
-        if previousSelection.selectedNodeId != state.selectedNodeId
-            || previousSelection.activeColumnIndex != state.activeColumnIndex
-            || previousSelection.selectionProgress != state.selectionProgress
+        if previousSelection.selectedNodeId != normalizedState.selectedNodeId
+            || previousSelection.activeColumnIndex != normalizedState.activeColumnIndex
+            || previousSelection.selectionProgress != normalizedState.selectionProgress
         {
             workspaceSession.selectionRevision &+= 1
             // Reactive lens: the workspace bar (and any other viewport-derived UI)

--- a/Sources/Nehir/UI/DebugBar/DebugBarManager.swift
+++ b/Sources/Nehir/UI/DebugBar/DebugBarManager.swift
@@ -11,6 +11,7 @@ struct DebugBarSnapshot: Equatable {
     var backgroundTraceStatus: BackgroundTraceBufferStatus
     var retentionSeconds: TimeInterval
     var exportCopiesFile: Bool
+    var viewportTraceVerbosity: ViewportTraceVerbosity
 }
 
 @MainActor
@@ -39,7 +40,8 @@ final class DebugBarManager {
             traceCaptureStatus: controller.runtimeTraceCaptureStatus,
             backgroundTraceStatus: controller.backgroundTraceBufferStatus,
             retentionSeconds: settings.backgroundTraceRetentionSeconds,
-            exportCopiesFile: settings.debugTraceExportCopiesFile
+            exportCopiesFile: settings.debugTraceExportCopiesFile,
+            viewportTraceVerbosity: settings.viewportTraceVerbosity
         )
         let view = DebugBarView(
             snapshot: snapshot,
@@ -61,6 +63,13 @@ final class DebugBarManager {
             onToggleCopyMode: { [weak settings, weak self] in
                 guard let settings else { return }
                 settings.debugTraceExportCopiesFile.toggle()
+                self?.update()
+            },
+            onCycleViewportTraceVerbosity: { [weak controller, weak settings, weak self] in
+                guard let settings else { return }
+                settings.viewportTraceVerbosity = Self
+                    .nextViewportVerbosity(after: settings.viewportTraceVerbosity)
+                controller?.applyViewportTraceVerbosity()
                 self?.update()
             }
         )
@@ -174,6 +183,12 @@ final class DebugBarManager {
         guard let index = presets.firstIndex(of: value) else { return 0 }
         return presets[(index + 1) % presets.count]
     }
+
+    private static func nextViewportVerbosity(after value: ViewportTraceVerbosity) -> ViewportTraceVerbosity {
+        let order: [ViewportTraceVerbosity] = [.standard, .lean, .verbose]
+        guard let index = order.firstIndex(of: value) else { return .standard }
+        return order[(index + 1) % order.count]
+    }
 }
 
 struct DebugBarView: View {
@@ -182,6 +197,7 @@ struct DebugBarView: View {
     let onResetBuffer: () -> Void
     let onCycleRetention: () -> Void
     let onToggleCopyMode: () -> Void
+    let onCycleViewportTraceVerbosity: () -> Void
 
     var body: some View {
         HStack(spacing: 4) {
@@ -205,6 +221,16 @@ struct DebugBarView: View {
             .help("Reset trace buffer without stopping capture")
 
             DebugBarDivider()
+
+            Button(action: onCycleViewportTraceVerbosity) {
+                Label(snapshot.viewportTraceVerbosity.displayName, systemImage: "chart.bar.doc.horizontal")
+                    .labelStyle(.titleAndIcon)
+                    .foregroundStyle(snapshot.viewportTraceVerbosity == .verbose ? .yellow : .primary)
+            }
+            .buttonStyle(DebugBarInlineControlStyle())
+            .help(
+                "Viewport trace verbosity (Lean / Standard / Verbose). Verbose adds per-frame gesture updates and per-mutation provenance."
+            )
 
             Button(action: onCycleRetention) {
                 Label(retentionLabel, systemImage: "timer")

--- a/Sources/Nehir/UI/DisplayDiagnosticsSettingsTab.swift
+++ b/Sources/Nehir/UI/DisplayDiagnosticsSettingsTab.swift
@@ -308,6 +308,20 @@ struct DisplayDiagnosticsSettingsTab: View {
                 }
             )
 
+            Picker("Viewport Trace Verbosity", selection: $settings.viewportTraceVerbosity) {
+                ForEach(ViewportTraceVerbosity.allCases) { verbosity in
+                    Text(verbosity.displayName).tag(verbosity)
+                }
+            }
+            .onChange(of: settings.viewportTraceVerbosity) { _, _ in
+                controller.applyViewportTraceVerbosity()
+            }
+            SettingsCaption(
+                "Controls how much viewport trace captures record. "
+                    + "Lean omits the per-line layout dump; Standard (default) adds it; "
+                    + "Verbose also records per-frame gesture updates and per-mutation provenance."
+            )
+
             DebugCommandRow(
                 title: "Reset Runtime State",
                 hotkey: hotkey(for: "debug.resetRuntimeState"),

--- a/Tests/NehirTests/Fixtures/canonical-settings.toml
+++ b/Tests/NehirTests/Fixtures/canonical-settings.toml
@@ -36,6 +36,7 @@ hotkeysEnabled = true
 ignoreMonitorIdentity = false
 ipcEnabled = false
 preventSleepEnabled = false
+viewportTraceVerbosity = "standard"
 
 [gestures]
 fingerCount = 3


### PR DESCRIPTION
## Summary

<!-- What changed and why? -->

## Release notes

Choose one:

- [x] Added a `.changeset/*.md` for user-visible changes (`mise run changeset -- patch "..."`).
- [ ] No user-visible change; apply the `no release note` label to make CI skip intentional.

## Validation

<!-- Commands run, screenshots, or manual checks. -->

- [ ] Ran relevant tests/checks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a viewport trace verbosity setting with three levels (lean, standard, verbose).
  * Added UI controls to view and cycle verbosity from the debug bar, and a developer diagnostics picker to change it.
* **Bug Fixes**
  * Trace capture now respects the selected verbosity, including omitting layout and mutation-audit details when not enabled.
  * Viewport trace behavior updates correctly after settings are reloaded.
  * Improved consistency of viewport state mutation tracking to better match captured diagnostics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->