### PR TITLE
Keep inactive monitor overrides visible

### DIFF
--- a/.changeset/20260630112906-keep-disconnected-monitor-overrides-inactive-and.md
+++ b/.changeset/20260630112906-keep-disconnected-monitor-overrides-inactive-and.md
@@ -1,0 +1,6 @@
+---
+"nehir": patch
+
+---
+
+Keep disconnected monitor overrides inactive and visible in Niri settings

--- a/Sources/Nehir/Core/Config/MonitorSettingsType.swift
+++ b/Sources/Nehir/Core/Config/MonitorSettingsType.swift
@@ -15,18 +15,213 @@ protocol MonitorSettingsType: Codable, Identifiable, Equatable {
     var monitorAnchorPoint: CGPoint? { get set }
 }
 
+enum MonitorSettingsResolver {
+    static func activeSetting<T: MonitorSettingsType>(
+        for monitor: Monitor,
+        in settings: [T],
+        connectedMonitors: [Monitor],
+        ignoreIdentity: Bool
+    ) -> T? {
+        let monitors = connectedMonitors.isEmpty ? [monitor] : connectedMonitors
+        guard let index = activeAssignmentIndices(
+            settings: settings,
+            connectedMonitors: monitors,
+            ignoreIdentity: ignoreIdentity
+        )[monitor.id] else {
+            return nil
+        }
+        return settings[index]
+    }
+
+    static func activeAssignments<T: MonitorSettingsType>(
+        settings: [T],
+        connectedMonitors: [Monitor],
+        ignoreIdentity: Bool
+    ) -> [T.ID: Monitor.ID] {
+        activeAssignmentIndices(
+            settings: settings,
+            connectedMonitors: connectedMonitors,
+            ignoreIdentity: ignoreIdentity
+        )
+        .reduce(into: [:]) { result, assignment in
+            result[settings[assignment.value].id] = assignment.key
+        }
+    }
+
+    static func inactiveSettings<T: MonitorSettingsType>(
+        _ settings: [T],
+        connectedMonitors: [Monitor],
+        ignoreIdentity: Bool
+    ) -> [T] {
+        let activeIndices = Set(activeAssignmentIndices(
+            settings: settings,
+            connectedMonitors: connectedMonitors,
+            ignoreIdentity: ignoreIdentity
+        ).values)
+        return settings.enumerated().compactMap { index, setting in
+            activeIndices.contains(index) ? nil : setting
+        }
+    }
+
+    private static func activeAssignmentIndices<T: MonitorSettingsType>(
+        settings: [T],
+        connectedMonitors: [Monitor],
+        ignoreIdentity: Bool
+    ) -> [Monitor.ID: Int] {
+        guard !settings.isEmpty, !connectedMonitors.isEmpty else { return [:] }
+        if ignoreIdentity {
+            return positionAssignmentIndices(settings: settings, connectedMonitors: connectedMonitors)
+        }
+        return identityAssignmentIndices(settings: settings, connectedMonitors: connectedMonitors)
+    }
+
+    private static func identityAssignmentIndices<T: MonitorSettingsType>(
+        settings: [T],
+        connectedMonitors: [Monitor]
+    ) -> [Monitor.ID: Int] {
+        var assignments: [Monitor.ID: Int] = [:]
+
+        for monitor in connectedMonitors {
+            let candidates = settings.indices.filter {
+                settings[$0].monitorName.caseInsensitiveCompare(monitor.name) == .orderedSame
+            }
+            guard !candidates.isEmpty else { continue }
+            if candidates.count == 1 {
+                let candidate = candidates[0]
+                if let displayId = settings[candidate].monitorDisplayId,
+                   displayId != monitor.displayId
+                {
+                    if let closest = uniqueClosestAnchorIndex(
+                        among: candidates,
+                        settings: settings,
+                        monitor: monitor
+                    ) {
+                        assignments[monitor.id] = closest
+                    }
+                    continue
+                }
+                assignments[monitor.id] = candidate
+                continue
+            }
+
+            let displayIdMatches = candidates.filter { settings[$0].monitorDisplayId == monitor.displayId }
+            if displayIdMatches.count == 1 {
+                assignments[monitor.id] = displayIdMatches[0]
+                continue
+            }
+            if displayIdMatches.count > 1 {
+                if let closest = uniqueClosestAnchorIndex(
+                    among: displayIdMatches,
+                    settings: settings,
+                    monitor: monitor
+                ) {
+                    assignments[monitor.id] = closest
+                }
+                continue
+            }
+
+            if let closest = uniqueClosestAnchorIndex(among: candidates, settings: settings, monitor: monitor) {
+                assignments[monitor.id] = closest
+            }
+        }
+
+        return assignments
+    }
+
+    private static func positionAssignmentIndices<T: MonitorSettingsType>(
+        settings: [T],
+        connectedMonitors: [Monitor]
+    ) -> [Monitor.ID: Int] {
+        var assignments: [Monitor.ID: Int] = [:]
+        var usedSettingIndices = Set<Int>()
+        var usedMonitorIds = Set<Monitor.ID>()
+
+        let anchorMatches = settings.indices.flatMap { index -> [MonitorSettingsAnchorMatch] in
+            guard let anchor = settings[index].monitorAnchorPoint else { return [] }
+            return connectedMonitors.map {
+                MonitorSettingsAnchorMatch(
+                    settingIndex: index,
+                    monitor: $0,
+                    distance: anchor.distanceSquared(to: $0.workspaceAnchorPoint)
+                )
+            }
+        }
+        .sorted { lhs, rhs in
+            if lhs.distance != rhs.distance { return lhs.distance < rhs.distance }
+            if lhs.settingIndex != rhs.settingIndex { return lhs.settingIndex < rhs.settingIndex }
+            return monitorSortKey(lhs.monitor) < monitorSortKey(rhs.monitor)
+        }
+
+        for match in anchorMatches {
+            guard !usedSettingIndices.contains(match.settingIndex),
+                  !usedMonitorIds.contains(match.monitor.id)
+            else { continue }
+            assignments[match.monitor.id] = match.settingIndex
+            usedSettingIndices.insert(match.settingIndex)
+            usedMonitorIds.insert(match.monitor.id)
+        }
+
+        let remainingNoAnchorIndices = settings.indices.filter {
+            settings[$0].monitorAnchorPoint == nil && !usedSettingIndices.contains($0)
+        }
+        let remainingMonitors = connectedMonitors.filter { !usedMonitorIds.contains($0.id) }
+        let monitorIndicesByName = Dictionary(grouping: remainingMonitors.indices) { index in
+            remainingMonitors[index].name.lowercased()
+        }
+        let settingIndicesByName = Dictionary(grouping: remainingNoAnchorIndices) { index in
+            settings[index].monitorName.lowercased()
+        }
+
+        for (name, settingIndices) in settingIndicesByName {
+            guard settingIndices.count == 1,
+                  let settingIndex = settingIndices.first,
+                  let monitorIndices = monitorIndicesByName[name],
+                  monitorIndices.count == 1,
+                  let monitorIndex = monitorIndices.first
+            else { continue }
+            let monitor = remainingMonitors[monitorIndex]
+            assignments[monitor.id] = settingIndex
+        }
+
+        return assignments
+    }
+
+    private static func uniqueClosestAnchorIndex<T: MonitorSettingsType>(
+        among indices: [Int],
+        settings: [T],
+        monitor: Monitor
+    ) -> Int? {
+        let scored = indices.compactMap { index -> (index: Int, distance: CGFloat)? in
+            guard let anchor = settings[index].monitorAnchorPoint else { return nil }
+            return (index, anchor.distanceSquared(to: monitor.workspaceAnchorPoint))
+        }
+        guard let best = scored.min(by: { $0.distance < $1.distance }) else { return nil }
+        let ties = scored.filter { $0.distance == best.distance }
+        return ties.count == 1 ? best.index : nil
+    }
+
+    private static func monitorSortKey(_ monitor: Monitor) -> (CGFloat, CGFloat, UInt32) {
+        (monitor.frame.minX, -monitor.frame.maxY, monitor.displayId)
+    }
+}
+
+private struct MonitorSettingsAnchorMatch {
+    let settingIndex: Int
+    let monitor: Monitor
+    let distance: CGFloat
+}
+
 enum MonitorSettingsStore {
     static func get<T: MonitorSettingsType>(
         for monitor: Monitor,
         in settings: [T]
     ) -> T? {
-        if let exact = settings.first(where: { $0.monitorDisplayId == monitor.displayId }) {
-            return exact
-        }
-
-        return settings.first {
-            $0.monitorDisplayId == nil && $0.monitorName == monitor.name
-        }
+        MonitorSettingsResolver.activeSetting(
+            for: monitor,
+            in: settings,
+            connectedMonitors: [monitor],
+            ignoreIdentity: false
+        )
     }
 
     static func get<T: MonitorSettingsType>(for monitorName: String, in settings: [T]) -> T? {
@@ -61,15 +256,19 @@ enum MonitorSettingsStore {
     }
 
     static func remove<T: MonitorSettingsType>(for monitor: Monitor, from settings: inout [T]) {
-        settings.removeAll { item in
-            if let itemDisplayId = item.monitorDisplayId {
-                return itemDisplayId == monitor.displayId
-            }
-            return item.monitorName == monitor.name
-        }
+        guard let active = get(for: monitor, in: settings) else { return }
+        settings.removeAll { $0.id == active.id }
     }
 
     static func remove<T: MonitorSettingsType>(for monitorName: String, from settings: inout [T]) {
         settings.removeAll { $0.monitorName == monitorName }
+    }
+}
+
+private extension CGPoint {
+    func distanceSquared(to point: CGPoint) -> CGFloat {
+        let dx = x - point.x
+        let dy = y - point.y
+        return dx * dx + dy * dy
     }
 }

--- a/Sources/Nehir/Core/Config/SettingsStore.swift
+++ b/Sources/Nehir/Core/Config/SettingsStore.swift
@@ -563,28 +563,12 @@ final class SettingsStore {
         workspaceBarYOffset = export.workspaceBarYOffset
         workspaceBarAccentColor = export.workspaceBarAccentColor
         workspaceBarTextColor = export.workspaceBarTextColor
-        monitorBarSettings = SettingsStore.reboundMonitorSettings(
-            export.monitorBarSettings,
-            monitors: monitors,
-            ignoreIdentity: export.ignoreMonitorIdentity
-        )
+        monitorBarSettings = export.monitorBarSettings
 
         appRules = export.appRules
-        monitorGapSettings = SettingsStore.reboundMonitorSettings(
-            export.monitorGapSettings,
-            monitors: monitors,
-            ignoreIdentity: export.ignoreMonitorIdentity
-        )
-        monitorOrientationSettings = SettingsStore.reboundMonitorSettings(
-            export.monitorOrientationSettings,
-            monitors: monitors,
-            ignoreIdentity: export.ignoreMonitorIdentity
-        )
-        monitorNiriSettings = SettingsStore.reboundMonitorSettings(
-            export.monitorNiriSettings,
-            monitors: monitors,
-            ignoreIdentity: export.ignoreMonitorIdentity
-        )
+        monitorGapSettings = export.monitorGapSettings
+        monitorOrientationSettings = export.monitorOrientationSettings
+        monitorNiriSettings = export.monitorNiriSettings
 
         preventSleepEnabled = export.preventSleepEnabled
         ipcEnabled = export.ipcEnabled
@@ -720,151 +704,97 @@ final class SettingsStore {
         return normalized
     }
 
-    private static func reboundMonitorSettings<T: MonitorSettingsType>(
-        _ settings: [T],
-        monitors: [Monitor],
-        ignoreIdentity: Bool = false
-    ) -> [T] {
-        if ignoreIdentity {
-            return reboundMonitorSettingsByPosition(settings, monitors: monitors)
-        }
-
-        return settings.map { setting in
-            var rebound = setting
-            let resolvedMonitor = reboundMonitor(
-                displayId: rebound.monitorDisplayId,
-                monitorName: rebound.monitorName,
-                anchorPoint: nil,
-                monitors: monitors,
-                ignoreIdentity: false
-            )
-            applyResolvedMonitor(resolvedMonitor, to: &rebound)
-            return rebound
-        }
+    private func connectedMonitorPeers(_ connectedMonitors: [Monitor], fallback monitor: Monitor) -> [Monitor] {
+        connectedMonitors.isEmpty ? [monitor] : connectedMonitors
     }
 
-    private static func reboundMonitorSettingsByPosition<T: MonitorSettingsType>(
-        _ settings: [T],
-        monitors: [Monitor]
-    ) -> [T] {
-        var rebound = settings
-        var resolvedMonitorByIndex: [Int: Monitor] = [:]
-        var usedMonitorIds = Set<Monitor.ID>()
-
-        for index in rebound.indices {
-            guard let displayId = rebound[index].monitorDisplayId,
-                  let exact = monitors.first(where: { $0.displayId == displayId }),
-                  usedMonitorIds.insert(exact.id).inserted
-            else { continue }
-            resolvedMonitorByIndex[index] = exact
-        }
-
-        let anchorMatches = rebound.indices.flatMap { index -> [(index: Int, monitor: Monitor, distance: CGFloat)] in
-            guard resolvedMonitorByIndex[index] == nil,
-                  let anchor = rebound[index].monitorAnchorPoint
-            else { return [] }
-            return monitors
-                .filter { !usedMonitorIds.contains($0.id) }
-                .map { (index: index, monitor: $0, distance: anchor.distanceSquared(to: $0.workspaceAnchorPoint)) }
-        }
-        .sorted { lhs, rhs in
-            if lhs.distance != rhs.distance { return lhs.distance < rhs.distance }
-            if lhs.index != rhs.index { return lhs.index < rhs.index }
-            return monitorSortKey(lhs.monitor) < monitorSortKey(rhs.monitor)
-        }
-
-        var usedSettingIndices = Set(resolvedMonitorByIndex.keys)
-        for match in anchorMatches {
-            guard !usedSettingIndices.contains(match.index),
-                  usedMonitorIds.insert(match.monitor.id).inserted
-            else { continue }
-            resolvedMonitorByIndex[match.index] = match.monitor
-            usedSettingIndices.insert(match.index)
-        }
-
-        for index in rebound.indices where resolvedMonitorByIndex[index] == nil {
-            let matches = monitors.filter {
-                !usedMonitorIds.contains($0.id) && $0.name
-                    .caseInsensitiveCompare(rebound[index].monitorName) == .orderedSame
-            }
-            guard matches.count == 1, let match = matches.first else { continue }
-            resolvedMonitorByIndex[index] = match
-            usedMonitorIds.insert(match.id)
-        }
-
-        for index in rebound.indices {
-            applyResolvedMonitor(resolvedMonitorByIndex[index], to: &rebound[index])
-        }
-        return rebound
+    private func activeMonitorSetting<T: MonitorSettingsType>(
+        for monitor: Monitor,
+        in settings: [T],
+        connectedMonitors: [Monitor] = []
+    ) -> T? {
+        MonitorSettingsResolver.activeSetting(
+            for: monitor,
+            in: settings,
+            connectedMonitors: connectedMonitorPeers(connectedMonitors, fallback: monitor),
+            ignoreIdentity: ignoreMonitorIdentity
+        )
     }
 
-    private static func applyResolvedMonitor<T: MonitorSettingsType>(_ monitor: Monitor?, to setting: inout T) {
-        setting.monitorDisplayId = monitor?.displayId
-        // Refresh the saved anchor whenever the monitor is currently connected, so a later
-        // reconnect can match this override by layout position. When the monitor is absent,
-        // keep the previously stored anchor.
-        if let monitor {
-            setting.monitorAnchorPoint = monitor.workspaceAnchorPoint
+    private func upsertMonitorSetting<T: MonitorSettingsType>(_ item: T, in settings: inout [T]) {
+        if let index = settings.firstIndex(where: { $0.id == item.id }) {
+            settings[index] = item
+            return
         }
+
+        if let index = settings.firstIndex(where: {
+            $0.monitorName.caseInsensitiveCompare(item.monitorName) == .orderedSame &&
+                $0.monitorDisplayId == item.monitorDisplayId
+        }) {
+            settings[index] = item
+            return
+        }
+
+        if item.monitorDisplayId != nil,
+           let index = settings.firstIndex(where: {
+               $0.monitorName.caseInsensitiveCompare(item.monitorName) == .orderedSame &&
+                   $0.monitorDisplayId == nil
+           })
+        {
+            settings[index] = item
+            return
+        }
+
+        settings.append(item)
     }
 
-    private static func reboundMonitorDisplayId(
-        _ displayId: CGDirectDisplayID?,
-        monitorName: String,
-        monitors: [Monitor]
-    ) -> CGDirectDisplayID? {
-        reboundMonitor(
-            displayId: displayId,
-            monitorName: monitorName,
-            anchorPoint: nil,
-            monitors: monitors,
-            ignoreIdentity: false
-        )?.displayId
+    private func removeActiveMonitorSetting<T: MonitorSettingsType>(
+        for monitor: Monitor,
+        from settings: inout [T],
+        connectedMonitors: [Monitor] = []
+    ) {
+        guard let active = activeMonitorSetting(
+            for: monitor,
+            in: settings,
+            connectedMonitors: connectedMonitors
+        ) else { return }
+        settings.removeAll { $0.id == active.id }
     }
 
-    private static func reboundMonitor(
-        displayId: CGDirectDisplayID?,
-        monitorName: String,
-        anchorPoint: CGPoint?,
-        monitors: [Monitor],
-        ignoreIdentity: Bool
-    ) -> Monitor? {
-        if let displayId, let exact = monitors.first(where: { $0.displayId == displayId }) {
-            return exact
-        }
-        if ignoreIdentity, let anchorPoint {
-            return monitors.min {
-                $0.workspaceAnchorPoint.distanceSquared(to: anchorPoint)
-                    < $1.workspaceAnchorPoint.distanceSquared(to: anchorPoint)
-            }
-        }
-        let matches = monitors.filter { $0.name.caseInsensitiveCompare(monitorName) == .orderedSame }
-        guard matches.count == 1 else { return nil }
-        return matches[0]
-    }
-
-    func barSettings(for monitor: Monitor) -> MonitorBarSettings? {
-        MonitorSettingsStore.get(for: monitor, in: monitorBarSettings)
+    func barSettings(for monitor: Monitor, connectedMonitors: [Monitor] = []) -> MonitorBarSettings? {
+        activeMonitorSetting(for: monitor, in: monitorBarSettings, connectedMonitors: connectedMonitors)
     }
 
     func barSettings(for monitorName: String) -> MonitorBarSettings? {
         MonitorSettingsStore.get(for: monitorName, in: monitorBarSettings)
     }
 
-    func updateBarSettings(_ settings: MonitorBarSettings) {
-        MonitorSettingsStore.update(settings, in: &monitorBarSettings)
+    func inactiveBarSettings(connectedMonitors: [Monitor]) -> [MonitorBarSettings] {
+        MonitorSettingsResolver.inactiveSettings(
+            monitorBarSettings,
+            connectedMonitors: connectedMonitors,
+            ignoreIdentity: ignoreMonitorIdentity
+        )
     }
 
-    func removeBarSettings(for monitor: Monitor) {
-        MonitorSettingsStore.remove(for: monitor, from: &monitorBarSettings)
+    func updateBarSettings(_ settings: MonitorBarSettings) {
+        upsertMonitorSetting(settings, in: &monitorBarSettings)
+    }
+
+    func removeBarSettings(for monitor: Monitor, connectedMonitors: [Monitor] = []) {
+        removeActiveMonitorSetting(for: monitor, from: &monitorBarSettings, connectedMonitors: connectedMonitors)
     }
 
     func removeBarSettings(for monitorName: String) {
         MonitorSettingsStore.remove(for: monitorName, from: &monitorBarSettings)
     }
 
-    func resolvedBarSettings(for monitor: Monitor) -> ResolvedBarSettings {
-        resolvedBarSettings(override: barSettings(for: monitor))
+    func removeBarSettings(id: MonitorBarSettings.ID) {
+        monitorBarSettings.removeAll { $0.id == id }
+    }
+
+    func resolvedBarSettings(for monitor: Monitor, connectedMonitors: [Monitor] = []) -> ResolvedBarSettings {
+        resolvedBarSettings(override: barSettings(for: monitor, connectedMonitors: connectedMonitors))
     }
 
     func resolvedBarSettings(for monitorName: String) -> ResolvedBarSettings {
@@ -896,28 +826,40 @@ final class SettingsStore {
         appRules.first { $0.bundleId == bundleId }
     }
 
-    func gapSettings(for monitor: Monitor) -> MonitorGapSettings? {
-        MonitorSettingsStore.get(for: monitor, in: monitorGapSettings)
+    func gapSettings(for monitor: Monitor, connectedMonitors: [Monitor] = []) -> MonitorGapSettings? {
+        activeMonitorSetting(for: monitor, in: monitorGapSettings, connectedMonitors: connectedMonitors)
     }
 
     func gapSettings(for monitorName: String) -> MonitorGapSettings? {
         MonitorSettingsStore.get(for: monitorName, in: monitorGapSettings)
     }
 
-    func updateGapSettings(_ settings: MonitorGapSettings) {
-        MonitorSettingsStore.update(settings, in: &monitorGapSettings)
+    func inactiveGapSettings(connectedMonitors: [Monitor]) -> [MonitorGapSettings] {
+        MonitorSettingsResolver.inactiveSettings(
+            monitorGapSettings,
+            connectedMonitors: connectedMonitors,
+            ignoreIdentity: ignoreMonitorIdentity
+        )
     }
 
-    func removeGapSettings(for monitor: Monitor) {
-        MonitorSettingsStore.remove(for: monitor, from: &monitorGapSettings)
+    func updateGapSettings(_ settings: MonitorGapSettings) {
+        upsertMonitorSetting(settings, in: &monitorGapSettings)
+    }
+
+    func removeGapSettings(for monitor: Monitor, connectedMonitors: [Monitor] = []) {
+        removeActiveMonitorSetting(for: monitor, from: &monitorGapSettings, connectedMonitors: connectedMonitors)
     }
 
     func removeGapSettings(for monitorName: String) {
         MonitorSettingsStore.remove(for: monitorName, from: &monitorGapSettings)
     }
 
-    func resolvedGapSettings(for monitor: Monitor) -> ResolvedGapSettings {
-        let override = gapSettings(for: monitor)
+    func removeGapSettings(id: MonitorGapSettings.ID) {
+        monitorGapSettings.removeAll { $0.id == id }
+    }
+
+    func resolvedGapSettings(for monitor: Monitor, connectedMonitors: [Monitor] = []) -> ResolvedGapSettings {
+        let override = gapSettings(for: monitor, connectedMonitors: connectedMonitors)
         return ResolvedGapSettings(
             gapSize: (override?.gapSize ?? gapSize).clamped(to: 0 ... 64),
             outerGapLeft: (override?.outerGapLeft ?? outerGapLeft).clamped(to: 0 ... 64),
@@ -927,16 +869,16 @@ final class SettingsStore {
         )
     }
 
-    func orientationSettings(for monitor: Monitor) -> MonitorOrientationSettings? {
-        MonitorSettingsStore.get(for: monitor, in: monitorOrientationSettings)
+    func orientationSettings(for monitor: Monitor, connectedMonitors: [Monitor] = []) -> MonitorOrientationSettings? {
+        activeMonitorSetting(for: monitor, in: monitorOrientationSettings, connectedMonitors: connectedMonitors)
     }
 
     func orientationSettings(for monitorName: String) -> MonitorOrientationSettings? {
         MonitorSettingsStore.get(for: monitorName, in: monitorOrientationSettings)
     }
 
-    func effectiveOrientation(for monitor: Monitor) -> Monitor.Orientation {
-        if let override = orientationSettings(for: monitor),
+    func effectiveOrientation(for monitor: Monitor, connectedMonitors: [Monitor] = []) -> Monitor.Orientation {
+        if let override = orientationSettings(for: monitor, connectedMonitors: connectedMonitors),
            let orientation = override.orientation
         {
             return orientation
@@ -945,39 +887,55 @@ final class SettingsStore {
     }
 
     func updateOrientationSettings(_ settings: MonitorOrientationSettings) {
-        MonitorSettingsStore.update(settings, in: &monitorOrientationSettings)
+        upsertMonitorSetting(settings, in: &monitorOrientationSettings)
     }
 
-    func removeOrientationSettings(for monitor: Monitor) {
-        MonitorSettingsStore.remove(for: monitor, from: &monitorOrientationSettings)
+    func removeOrientationSettings(for monitor: Monitor, connectedMonitors: [Monitor] = []) {
+        removeActiveMonitorSetting(
+            for: monitor,
+            from: &monitorOrientationSettings,
+            connectedMonitors: connectedMonitors
+        )
     }
 
     func removeOrientationSettings(for monitorName: String) {
         MonitorSettingsStore.remove(for: monitorName, from: &monitorOrientationSettings)
     }
 
-    func niriSettings(for monitor: Monitor) -> MonitorNiriSettings? {
-        MonitorSettingsStore.get(for: monitor, in: monitorNiriSettings)
+    func niriSettings(for monitor: Monitor, connectedMonitors: [Monitor] = []) -> MonitorNiriSettings? {
+        activeMonitorSetting(for: monitor, in: monitorNiriSettings, connectedMonitors: connectedMonitors)
     }
 
     func niriSettings(for monitorName: String) -> MonitorNiriSettings? {
         MonitorSettingsStore.get(for: monitorName, in: monitorNiriSettings)
     }
 
-    func updateNiriSettings(_ settings: MonitorNiriSettings) {
-        MonitorSettingsStore.update(settings, in: &monitorNiriSettings)
+    func inactiveNiriSettings(connectedMonitors: [Monitor]) -> [MonitorNiriSettings] {
+        MonitorSettingsResolver.inactiveSettings(
+            monitorNiriSettings,
+            connectedMonitors: connectedMonitors,
+            ignoreIdentity: ignoreMonitorIdentity
+        )
     }
 
-    func removeNiriSettings(for monitor: Monitor) {
-        MonitorSettingsStore.remove(for: monitor, from: &monitorNiriSettings)
+    func updateNiriSettings(_ settings: MonitorNiriSettings) {
+        upsertMonitorSetting(settings, in: &monitorNiriSettings)
+    }
+
+    func removeNiriSettings(for monitor: Monitor, connectedMonitors: [Monitor] = []) {
+        removeActiveMonitorSetting(for: monitor, from: &monitorNiriSettings, connectedMonitors: connectedMonitors)
     }
 
     func removeNiriSettings(for monitorName: String) {
         MonitorSettingsStore.remove(for: monitorName, from: &monitorNiriSettings)
     }
 
-    func resolvedNiriSettings(for monitor: Monitor) -> ResolvedNiriSettings {
-        resolvedNiriSettings(override: niriSettings(for: monitor))
+    func removeNiriSettings(id: MonitorNiriSettings.ID) {
+        monitorNiriSettings.removeAll { $0.id == id }
+    }
+
+    func resolvedNiriSettings(for monitor: Monitor, connectedMonitors: [Monitor] = []) -> ResolvedNiriSettings {
+        resolvedNiriSettings(override: niriSettings(for: monitor, connectedMonitors: connectedMonitors))
     }
 
     func resolvedNiriSettings(for monitorName: String) -> ResolvedNiriSettings {
@@ -1029,17 +987,5 @@ final class SettingsStore {
     static func validatedLoneWindowMaxWidth(_ width: Double?) -> Double? {
         guard let width else { return nil }
         return min(1.0, max(0.10, width))
-    }
-
-    private static func monitorSortKey(_ monitor: Monitor) -> (CGFloat, CGFloat, UInt32) {
-        (monitor.frame.minX, -monitor.frame.maxY, monitor.displayId)
-    }
-}
-
-private extension CGPoint {
-    func distanceSquared(to point: CGPoint) -> CGFloat {
-        let dx = x - point.x
-        let dy = y - point.y
-        return dx * dx + dy * dy
     }
 }

--- a/Sources/Nehir/Core/Controller/NiriLayoutHandler.swift
+++ b/Sources/Nehir/Core/Controller/NiriLayoutHandler.swift
@@ -1891,8 +1891,12 @@ enum NiriWindowMoveResult {
     func refreshResolvedMonitorSettings() {
         guard let controller, let engine = controller.niriEngine else { return }
 
-        for monitor in controller.workspaceManager.monitors {
-            let resolved = controller.settings.resolvedNiriSettings(for: monitor)
+        let connectedMonitors = controller.workspaceManager.monitors
+        for monitor in connectedMonitors {
+            let resolved = controller.settings.resolvedNiriSettings(
+                for: monitor,
+                connectedMonitors: connectedMonitors
+            )
             engine.updateMonitorSettings(resolved, for: monitor.id)
         }
     }

--- a/Sources/Nehir/Core/Controller/WMController.swift
+++ b/Sources/Nehir/Core/Controller/WMController.swift
@@ -518,7 +518,7 @@ final class WMController {
     }
 
     func resolvedGapSettings(for monitor: Monitor) -> ResolvedGapSettings {
-        settings.resolvedGapSettings(for: monitor)
+        settings.resolvedGapSettings(for: monitor, connectedMonitors: workspaceManager.monitors)
     }
 
     func gapSize(for monitor: Monitor) -> CGFloat {

--- a/Sources/Nehir/UI/LayoutSettingsTab.swift
+++ b/Sources/Nehir/UI/LayoutSettingsTab.swift
@@ -9,7 +9,7 @@ struct LayoutSettingsTab: View {
     @Bindable var settings: SettingsStore
     @Bindable var controller: WMController
 
-    @State private var selectedMonitor: Monitor.ID?
+    @State private var selectedScope: LayoutSettingsScope = .global
     @State private var connectedMonitors: [Monitor] = Monitor.current()
     @State private var draftGapSize: Double?
     @State private var draftOuterGapLeft: Double?
@@ -37,48 +37,135 @@ struct LayoutSettingsTab: View {
         draftOuterGapBottom ?? settings.outerGapBottom
     }
 
+    private var inactiveNiriOverrides: [MonitorNiriSettings] {
+        settings.inactiveNiriSettings(connectedMonitors: connectedMonitors)
+    }
+
+    private var inactiveGapOverrides: [MonitorGapSettings] {
+        settings.inactiveGapSettings(connectedMonitors: connectedMonitors)
+    }
+
     var body: some View {
         Form {
-            MonitorScopeSection(
-                selectedMonitor: $selectedMonitor,
-                monitors: connectedMonitors,
+            LayoutScopeSection(
+                selectedScope: $selectedScope,
+                connectedMonitors: connectedMonitors,
+                inactiveGapOverrides: inactiveGapOverrides,
+                inactiveNiriOverrides: inactiveNiriOverrides,
                 hasOverrides: {
-                    settings.niriSettings(for: $0) != nil || settings.gapSettings(for: $0)?.hasOverrides == true
+                    settings.niriSettings(for: $0, connectedMonitors: connectedMonitors) != nil ||
+                        settings.gapSettings(for: $0, connectedMonitors: connectedMonitors)?.hasOverrides == true
                 },
-                reset: { monitor in
-                    settings.removeGapSettings(for: monitor)
-                    settings.removeNiriSettings(for: monitor)
+                resetConnected: { monitor in
+                    settings.removeGapSettings(for: monitor, connectedMonitors: connectedMonitors)
+                    settings.removeNiriSettings(for: monitor, connectedMonitors: connectedMonitors)
                     controller.updateMonitorGapSettings()
+                    controller.updateMonitorNiriSettings()
+                },
+                deleteInactiveGap: { id in
+                    settings.removeGapSettings(id: id)
+                    selectedScope = .global
+                    controller.updateMonitorGapSettings()
+                },
+                deleteInactiveNiri: { id in
+                    settings.removeNiriSettings(id: id)
+                    selectedScope = .global
                     controller.updateMonitorNiriSettings()
                 }
             )
 
-            if let monitorId = selectedMonitor,
-               let monitor = connectedMonitors.first(where: { $0.id == monitorId })
-            {
-                MonitorGapSettingsSection(
-                    settings: settings,
-                    controller: controller,
-                    monitor: monitor
-                )
-
-                MonitorNiriSettingsSection(
-                    settings: settings,
-                    controller: controller,
-                    monitor: monitor
-                )
-            } else {
+            switch selectedScope {
+            case .global:
                 globalSpacingSections
 
                 GlobalNiriSettingsSection(
                     settings: settings,
                     controller: controller
                 )
+            case let .connected(monitorId):
+                if let monitor = connectedMonitors.first(where: { $0.id == monitorId }) {
+                    MonitorGapSettingsSection(
+                        settings: settings,
+                        controller: controller,
+                        monitor: monitor,
+                        connectedMonitors: connectedMonitors
+                    )
+
+                    MonitorNiriSettingsSection(
+                        settings: settings,
+                        controller: controller,
+                        monitor: monitor,
+                        connectedMonitors: connectedMonitors
+                    )
+                } else {
+                    globalSpacingSections
+
+                    GlobalNiriSettingsSection(
+                        settings: settings,
+                        controller: controller
+                    )
+                }
+            case let .inactiveGapOverride(id):
+                if let override = inactiveGapOverrides.first(where: { $0.id == id }) {
+                    SavedMonitorGapOverrideSection(
+                        override: override,
+                        deleteOverride: {
+                            settings.removeGapSettings(id: id)
+                            selectedScope = .global
+                            controller.updateMonitorGapSettings()
+                        }
+                    )
+                } else {
+                    globalSpacingSections
+
+                    GlobalNiriSettingsSection(
+                        settings: settings,
+                        controller: controller
+                    )
+                }
+            case let .inactiveNiriOverride(id):
+                if let override = inactiveNiriOverrides.first(where: { $0.id == id }) {
+                    SavedMonitorNiriOverrideSection(
+                        override: override,
+                        deleteOverride: {
+                            settings.removeNiriSettings(id: id)
+                            selectedScope = .global
+                            controller.updateMonitorNiriSettings()
+                        }
+                    )
+                } else {
+                    globalSpacingSections
+
+                    GlobalNiriSettingsSection(
+                        settings: settings,
+                        controller: controller
+                    )
+                }
             }
         }
         .formStyle(.grouped)
         .onAppear {
-            connectedMonitors = Monitor.current()
+            refreshConnectedMonitors()
+        }
+    }
+
+    private func refreshConnectedMonitors() {
+        connectedMonitors = Monitor.current()
+        switch selectedScope {
+        case .global:
+            break
+        case let .connected(monitorId):
+            if !connectedMonitors.contains(where: { $0.id == monitorId }) {
+                selectedScope = .global
+            }
+        case let .inactiveGapOverride(id):
+            if !inactiveGapOverrides.contains(where: { $0.id == id }) {
+                selectedScope = .global
+            }
+        case let .inactiveNiriOverride(id):
+            if !inactiveNiriOverrides.contains(where: { $0.id == id }) {
+                selectedScope = .global
+            }
         }
     }
 
@@ -207,15 +294,167 @@ struct LayoutSettingsTab: View {
     }
 }
 
+private enum LayoutSettingsScope: Hashable {
+    case global
+    case connected(Monitor.ID)
+    case inactiveGapOverride(MonitorGapSettings.ID)
+    case inactiveNiriOverride(MonitorNiriSettings.ID)
+}
+
+private struct LayoutScopeSection: View {
+    @Binding var selectedScope: LayoutSettingsScope
+    let connectedMonitors: [Monitor]
+    let inactiveGapOverrides: [MonitorGapSettings]
+    let inactiveNiriOverrides: [MonitorNiriSettings]
+    let hasOverrides: (Monitor) -> Bool
+    let resetConnected: (Monitor) -> Void
+    let deleteInactiveGap: (MonitorGapSettings.ID) -> Void
+    let deleteInactiveNiri: (MonitorNiriSettings.ID) -> Void
+
+    var body: some View {
+        Section("Configuration Scope") {
+            Picker("Configure", selection: $selectedScope) {
+                Text("Global Defaults").tag(LayoutSettingsScope.global)
+                if !connectedMonitors.isEmpty {
+                    Divider()
+                    ForEach(connectedMonitors, id: \.id) { monitor in
+                        HStack {
+                            Text(monitor.name)
+                            if monitor.isMain {
+                                Text("(Main)")
+                                    .foregroundStyle(.secondary)
+                            }
+                        }
+                        .tag(LayoutSettingsScope.connected(monitor.id))
+                    }
+                }
+                if !inactiveGapOverrides.isEmpty || !inactiveNiriOverrides.isEmpty {
+                    Divider()
+                    ForEach(inactiveGapOverrides) { override in
+                        Text("\(override.monitorName) — Inactive Spacing")
+                            .tag(LayoutSettingsScope.inactiveGapOverride(override.id))
+                    }
+                    ForEach(inactiveNiriOverrides) { override in
+                        Text("\(override.monitorName) — Inactive Columns")
+                            .tag(LayoutSettingsScope.inactiveNiriOverride(override.id))
+                    }
+                }
+            }
+
+            statusRow
+        }
+    }
+
+    @ViewBuilder
+    private var statusRow: some View {
+        switch selectedScope {
+        case .global:
+            EmptyView()
+        case let .connected(monitorId):
+            if let monitor = connectedMonitors.first(where: { $0.id == monitorId }) {
+                LabeledContent("Overrides") {
+                    HStack {
+                        Text(hasOverrides(monitor) ? "Custom" : "Using global defaults")
+                            .foregroundStyle(.secondary)
+                        Button("Reset to Global") {
+                            resetConnected(monitor)
+                        }
+                        .disabled(!hasOverrides(monitor))
+                    }
+                }
+            }
+        case let .inactiveGapOverride(id):
+            LabeledContent("Status") {
+                HStack {
+                    Text("Inactive / disconnected")
+                        .foregroundStyle(.secondary)
+                    Button("Delete Override") {
+                        deleteInactiveGap(id)
+                    }
+                }
+            }
+        case let .inactiveNiriOverride(id):
+            LabeledContent("Status") {
+                HStack {
+                    Text("Inactive / disconnected")
+                        .foregroundStyle(.secondary)
+                    Button("Delete Override") {
+                        deleteInactiveNiri(id)
+                    }
+                }
+            }
+        }
+    }
+}
+
+private struct SavedMonitorGapOverrideSection: View {
+    let override: MonitorGapSettings
+    let deleteOverride: () -> Void
+
+    var body: some View {
+        Section("Saved Display Override") {
+            LabeledContent("Display") {
+                Text(override.monitorName)
+            }
+            LabeledContent("Status") {
+                Text("Inactive / disconnected")
+                    .foregroundStyle(.secondary)
+            }
+            if let displayId = override.monitorDisplayId {
+                LabeledContent("Runtime Display ID") {
+                    Text("\(displayId) (advisory)")
+                        .foregroundStyle(.secondary)
+                }
+            }
+            if let anchor = override.monitorAnchorPoint {
+                LabeledContent("Saved Position") {
+                    Text("x \(formatCoordinate(anchor.x)), y \(formatCoordinate(anchor.y))")
+                        .foregroundStyle(.secondary)
+                }
+            }
+            Button("Delete Override", role: .destructive) {
+                deleteOverride()
+            }
+            SettingsCaption(
+                "This saved layout override is not active for any connected monitor. It is kept on disk until you delete it."
+            )
+        }
+
+        Section("Saved Spacing Values") {
+            savedValue("Inner Gap", override.gapSize.map { "\(Int($0)) px" })
+            savedValue("Left Margin", override.outerGapLeft.map { "\(Int($0)) px" })
+            savedValue("Right Margin", override.outerGapRight.map { "\(Int($0)) px" })
+            savedValue("Top Margin", override.outerGapTop.map { "\(Int($0)) px" })
+            savedValue("Bottom Margin", override.outerGapBottom.map { "\(Int($0)) px" })
+            SettingsCaption(
+                "Inactive overrides are read-only here; reconnect the display to edit them as an active monitor."
+            )
+        }
+    }
+
+    private func savedValue(_ label: String, _ value: String?) -> some View {
+        LabeledContent(label) {
+            Text(value ?? "Uses global default")
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    private func formatCoordinate(_ coordinate: CGFloat) -> String {
+        coordinate == coordinate.rounded() ? String(Int(coordinate)) : String(Double(coordinate))
+    }
+}
+
 struct MonitorGapSettingsSection: View {
     @Bindable var settings: SettingsStore
     @Bindable var controller: WMController
     let monitor: Monitor
+    var connectedMonitors: [Monitor] = []
 
     private var monitorSettings: MonitorGapSettings {
-        settings.gapSettings(for: monitor) ?? MonitorGapSettings(
+        settings.gapSettings(for: monitor, connectedMonitors: connectedMonitors) ?? MonitorGapSettings(
             monitorName: monitor.name,
-            monitorDisplayId: monitor.displayId
+            monitorDisplayId: monitor.displayId,
+            monitorAnchorPoint: monitor.workspaceAnchorPoint
         )
     }
 
@@ -223,11 +462,12 @@ struct MonitorGapSettingsSection: View {
         var ms = monitorSettings
         ms.monitorName = monitor.name
         ms.monitorDisplayId = monitor.displayId
+        ms.monitorAnchorPoint = monitor.workspaceAnchorPoint
         update(&ms)
         if ms.hasOverrides {
             settings.updateGapSettings(ms)
         } else {
-            settings.removeGapSettings(for: monitor)
+            settings.removeGapSettings(for: monitor, connectedMonitors: connectedMonitors)
         }
         controller.updateMonitorGapSettings()
     }

--- a/Sources/Nehir/UI/MonitorSettingsTab.swift
+++ b/Sources/Nehir/UI/MonitorSettingsTab.swift
@@ -379,6 +379,7 @@ private struct SelectedMonitorDetails: View {
         let newSettings = MonitorOrientationSettings(
             monitorName: monitor.name,
             monitorDisplayId: monitor.displayId,
+            monitorAnchorPoint: monitor.workspaceAnchorPoint,
             orientation: orientation
         )
 

--- a/Sources/Nehir/UI/SettingsView.swift
+++ b/Sources/Nehir/UI/SettingsView.swift
@@ -237,40 +237,229 @@ struct NiriSettingsTab: View {
     @Bindable var settings: SettingsStore
     @Bindable var controller: WMController
 
-    @State private var selectedMonitor: Monitor.ID?
+    @State private var selectedScope: NiriSettingsScope = .global
     @State private var connectedMonitors: [Monitor] = Monitor.current()
+
+    private var inactiveOverrides: [MonitorNiriSettings] {
+        settings.inactiveNiriSettings(connectedMonitors: connectedMonitors)
+    }
 
     var body: some View {
         Form {
-            MonitorScopeSection(
-                selectedMonitor: $selectedMonitor,
-                monitors: connectedMonitors,
-                hasOverrides: { settings.niriSettings(for: $0) != nil },
-                reset: { monitor in
-                    settings.removeNiriSettings(for: monitor)
+            NiriScopeSection(
+                selectedScope: $selectedScope,
+                connectedMonitors: connectedMonitors,
+                inactiveOverrides: inactiveOverrides,
+                hasOverrides: { settings.niriSettings(for: $0, connectedMonitors: connectedMonitors) != nil },
+                resetConnected: { monitor in
+                    settings.removeNiriSettings(for: monitor, connectedMonitors: connectedMonitors)
+                    controller.updateMonitorNiriSettings()
+                },
+                deleteInactive: { id in
+                    settings.removeNiriSettings(id: id)
+                    selectedScope = .global
                     controller.updateMonitorNiriSettings()
                 }
             )
 
-            if let monitorId = selectedMonitor,
-               let monitor = connectedMonitors.first(where: { $0.id == monitorId })
-            {
-                MonitorNiriSettingsSection(
-                    settings: settings,
-                    controller: controller,
-                    monitor: monitor
-                )
-            } else {
+            switch selectedScope {
+            case .global:
                 GlobalNiriSettingsSection(
                     settings: settings,
                     controller: controller
                 )
+            case let .connected(monitorId):
+                if let monitor = connectedMonitors.first(where: { $0.id == monitorId }) {
+                    MonitorNiriSettingsSection(
+                        settings: settings,
+                        controller: controller,
+                        monitor: monitor,
+                        connectedMonitors: connectedMonitors
+                    )
+                } else {
+                    GlobalNiriSettingsSection(
+                        settings: settings,
+                        controller: controller
+                    )
+                }
+            case let .inactiveOverride(id):
+                if let override = inactiveOverrides.first(where: { $0.id == id }) {
+                    SavedMonitorNiriOverrideSection(
+                        override: override,
+                        deleteOverride: {
+                            settings.removeNiriSettings(id: id)
+                            selectedScope = .global
+                            controller.updateMonitorNiriSettings()
+                        }
+                    )
+                } else {
+                    GlobalNiriSettingsSection(
+                        settings: settings,
+                        controller: controller
+                    )
+                }
             }
         }
         .formStyle(.grouped)
         .onAppear {
-            connectedMonitors = Monitor.current()
+            refreshConnectedMonitors()
         }
+    }
+
+    private func refreshConnectedMonitors() {
+        connectedMonitors = Monitor.current()
+        switch selectedScope {
+        case .global:
+            break
+        case let .connected(monitorId):
+            if !connectedMonitors.contains(where: { $0.id == monitorId }) {
+                selectedScope = .global
+            }
+        case let .inactiveOverride(id):
+            if !inactiveOverrides.contains(where: { $0.id == id }) {
+                selectedScope = .global
+            }
+        }
+    }
+}
+
+enum NiriSettingsScope: Hashable {
+    case global
+    case connected(Monitor.ID)
+    case inactiveOverride(MonitorNiriSettings.ID)
+}
+
+struct NiriScopeSection: View {
+    @Binding var selectedScope: NiriSettingsScope
+    let connectedMonitors: [Monitor]
+    let inactiveOverrides: [MonitorNiriSettings]
+    let hasOverrides: (Monitor) -> Bool
+    let resetConnected: (Monitor) -> Void
+    let deleteInactive: (MonitorNiriSettings.ID) -> Void
+
+    var body: some View {
+        Section("Configuration Scope") {
+            Picker("Configure", selection: $selectedScope) {
+                Text("Global Defaults").tag(NiriSettingsScope.global)
+                if !connectedMonitors.isEmpty {
+                    Divider()
+                    ForEach(connectedMonitors, id: \.id) { monitor in
+                        HStack {
+                            Text(monitor.name)
+                            if monitor.isMain {
+                                Text("(Main)")
+                                    .foregroundStyle(.secondary)
+                            }
+                        }
+                        .tag(NiriSettingsScope.connected(monitor.id))
+                    }
+                }
+                if !inactiveOverrides.isEmpty {
+                    Divider()
+                    ForEach(inactiveOverrides) { override in
+                        Text("\(override.monitorName) — Inactive")
+                            .tag(NiriSettingsScope.inactiveOverride(override.id))
+                    }
+                }
+            }
+
+            statusRow
+        }
+    }
+
+    @ViewBuilder
+    private var statusRow: some View {
+        switch selectedScope {
+        case .global:
+            EmptyView()
+        case let .connected(monitorId):
+            if let monitor = connectedMonitors.first(where: { $0.id == monitorId }) {
+                LabeledContent("Overrides") {
+                    HStack {
+                        Text(hasOverrides(monitor) ? "Custom" : "Using global defaults")
+                            .foregroundStyle(.secondary)
+                        Button("Reset to Global") {
+                            resetConnected(monitor)
+                        }
+                        .disabled(!hasOverrides(monitor))
+                    }
+                }
+            }
+        case let .inactiveOverride(id):
+            LabeledContent("Status") {
+                HStack {
+                    Text("Inactive / disconnected")
+                        .foregroundStyle(.secondary)
+                    Button("Delete Override") {
+                        deleteInactive(id)
+                    }
+                }
+            }
+        }
+    }
+}
+
+struct SavedMonitorNiriOverrideSection: View {
+    let override: MonitorNiriSettings
+    let deleteOverride: () -> Void
+
+    var body: some View {
+        Section("Saved Display Override") {
+            LabeledContent("Display") {
+                Text(override.monitorName)
+            }
+            LabeledContent("Status") {
+                Text("Inactive / disconnected")
+                    .foregroundStyle(.secondary)
+            }
+            if let displayId = override.monitorDisplayId {
+                LabeledContent("Runtime Display ID") {
+                    Text("\(displayId) (advisory)")
+                        .foregroundStyle(.secondary)
+                }
+            }
+            if let anchor = override.monitorAnchorPoint {
+                LabeledContent("Saved Position") {
+                    Text("x \(formatCoordinate(anchor.x)), y \(formatCoordinate(anchor.y))")
+                        .foregroundStyle(.secondary)
+                }
+            }
+            Button("Delete Override", role: .destructive) {
+                deleteOverride()
+            }
+            SettingsCaption(
+                "This saved display override is not active for any connected monitor. It is kept on disk until you delete it."
+            )
+        }
+
+        Section("Saved Niri Values") {
+            LabeledContent("Columns to Fit") {
+                Text(override.balancedColumnCount.map(String.init) ?? "Uses global default")
+                    .foregroundStyle(.secondary)
+            }
+            LabeledContent("Single-Window Default") {
+                Text(loneWindowPolicyDescription)
+                    .foregroundStyle(.secondary)
+            }
+            SettingsCaption(
+                "Inactive overrides are read-only here; reconnect the display to edit them as an active monitor."
+            )
+        }
+    }
+
+    private var loneWindowPolicyDescription: String {
+        switch override.loneWindowPolicy {
+        case .fill:
+            return "Fill"
+        case let .centered(maxWidthFraction):
+            return "Centered (\(Int((maxWidthFraction * 100).rounded()))%)"
+        case .none:
+            return "Uses global default"
+        }
+    }
+
+    private func formatCoordinate(_ coordinate: CGFloat) -> String {
+        coordinate == coordinate.rounded() ? String(Int(coordinate)) : String(Double(coordinate))
     }
 }
 
@@ -523,11 +712,13 @@ struct MonitorNiriSettingsSection: View {
     @Bindable var settings: SettingsStore
     @Bindable var controller: WMController
     let monitor: Monitor
+    var connectedMonitors: [Monitor] = []
 
     private var monitorSettings: MonitorNiriSettings {
-        settings.niriSettings(for: monitor) ?? MonitorNiriSettings(
+        settings.niriSettings(for: monitor, connectedMonitors: connectedMonitors) ?? MonitorNiriSettings(
             monitorName: monitor.name,
-            monitorDisplayId: monitor.displayId
+            monitorDisplayId: monitor.displayId,
+            monitorAnchorPoint: monitor.workspaceAnchorPoint
         )
     }
 
@@ -535,6 +726,7 @@ struct MonitorNiriSettingsSection: View {
         var ms = monitorSettings
         ms.monitorName = monitor.name
         ms.monitorDisplayId = monitor.displayId
+        ms.monitorAnchorPoint = monitor.workspaceAnchorPoint
         update(&ms)
         settings.updateNiriSettings(ms)
         controller.updateMonitorNiriSettings()

--- a/Sources/Nehir/UI/WorkspaceBarSettingsTab.swift
+++ b/Sources/Nehir/UI/WorkspaceBarSettingsTab.swift
@@ -11,62 +11,198 @@ struct WorkspaceBarSettingsTab: View {
     @Bindable var settings: SettingsStore
     @Bindable var controller: WMController
 
-    @State private var selectedMonitor: Monitor.ID?
+    @State private var selectedScope: BarSettingsScope = .global
     @State private var connectedMonitors: [Monitor] = Monitor.current()
+
+    private var inactiveOverrides: [MonitorBarSettings] {
+        settings.inactiveBarSettings(connectedMonitors: connectedMonitors)
+    }
 
     var body: some View {
         Form {
-            MonitorScopeSection(
-                selectedMonitor: $selectedMonitor,
-                monitors: connectedMonitors,
-                hasOverrides: { settings.barSettings(for: $0) != nil },
-                reset: { monitor in
-                    settings.removeBarSettings(for: monitor)
+            BarScopeSection(
+                selectedScope: $selectedScope,
+                connectedMonitors: connectedMonitors,
+                inactiveOverrides: inactiveOverrides,
+                hasOverrides: { settings.barSettings(for: $0, connectedMonitors: connectedMonitors) != nil },
+                resetConnected: { monitor in
+                    settings.removeBarSettings(for: monitor, connectedMonitors: connectedMonitors)
+                    controller.updateWorkspaceBarSettings()
+                },
+                deleteInactive: { id in
+                    settings.removeBarSettings(id: id)
+                    selectedScope = .global
                     controller.updateWorkspaceBarSettings()
                 }
             )
 
             WorkspaceBarPreviewSection(configuration: previewConfiguration)
 
-            if let monitorId = selectedMonitor,
-               let monitor = connectedMonitors.first(where: { $0.id == monitorId })
-            {
-                MonitorBarSettingsSection(
-                    settings: settings,
-                    controller: controller,
-                    monitor: monitor
-                )
-            } else {
+            switch selectedScope {
+            case .global:
                 GlobalBarSettingsSection(
                     settings: settings,
                     controller: controller
                 )
+            case let .connected(monitorId):
+                if let monitor = connectedMonitors.first(where: { $0.id == monitorId }) {
+                    MonitorBarSettingsSection(
+                        settings: settings,
+                        controller: controller,
+                        monitor: monitor,
+                        connectedMonitors: connectedMonitors
+                    )
+                } else {
+                    GlobalBarSettingsSection(
+                        settings: settings,
+                        controller: controller
+                    )
+                }
+            case let .inactiveOverride(id):
+                if let override = inactiveOverrides.first(where: { $0.id == id }) {
+                    SavedMonitorBarOverrideSection(
+                        override: override,
+                        deleteOverride: {
+                            settings.removeBarSettings(id: id)
+                            selectedScope = .global
+                            controller.updateWorkspaceBarSettings()
+                        }
+                    )
+                } else {
+                    GlobalBarSettingsSection(
+                        settings: settings,
+                        controller: controller
+                    )
+                }
             }
         }
         .formStyle(.grouped)
         .onAppear {
-            connectedMonitors = Monitor.current()
+            refreshConnectedMonitors()
         }
     }
 
     private var previewConfiguration: WorkspaceBarPreviewConfiguration {
-        if let monitorId = selectedMonitor,
-           let monitor = connectedMonitors.first(where: { $0.id == monitorId })
-        {
+        switch selectedScope {
+        case .global:
             return WorkspaceBarPreviewConfiguration(
-                resolved: settings.resolvedBarSettings(for: monitor),
+                isEnabled: settings.workspaceBarEnabled,
+                showLabels: settings.workspaceBarShowLabels,
+                showFloatingWindows: settings.workspaceBarShowFloatingWindows,
+                deduplicateAppIcons: settings.workspaceBarDeduplicateAppIcons,
+                hideEmptyWorkspaces: settings.workspaceBarHideEmptyWorkspaces,
+                scopeDescription: "Preview reflects the global workspace bar defaults."
+            )
+        case let .connected(monitorId):
+            guard let monitor = connectedMonitors.first(where: { $0.id == monitorId }) else {
+                return WorkspaceBarPreviewConfiguration.global(settings: settings)
+            }
+            return WorkspaceBarPreviewConfiguration(
+                resolved: settings.resolvedBarSettings(for: monitor, connectedMonitors: connectedMonitors),
                 scopeDescription: "Preview reflects \(monitor.name)'s effective bar settings, including monitor overrides."
             )
+        case let .inactiveOverride(id):
+            guard let override = inactiveOverrides.first(where: { $0.id == id }) else {
+                return WorkspaceBarPreviewConfiguration.global(settings: settings)
+            }
+            return WorkspaceBarPreviewConfiguration(
+                override: override,
+                settings: settings,
+                scopeDescription: "Preview reflects the saved inactive override for \(override.monitorName)."
+            )
         }
+    }
 
-        return WorkspaceBarPreviewConfiguration(
-            isEnabled: settings.workspaceBarEnabled,
-            showLabels: settings.workspaceBarShowLabels,
-            showFloatingWindows: settings.workspaceBarShowFloatingWindows,
-            deduplicateAppIcons: settings.workspaceBarDeduplicateAppIcons,
-            hideEmptyWorkspaces: settings.workspaceBarHideEmptyWorkspaces,
-            scopeDescription: "Preview reflects the global workspace bar defaults."
-        )
+    private func refreshConnectedMonitors() {
+        connectedMonitors = Monitor.current()
+        switch selectedScope {
+        case .global:
+            break
+        case let .connected(monitorId):
+            if !connectedMonitors.contains(where: { $0.id == monitorId }) {
+                selectedScope = .global
+            }
+        case let .inactiveOverride(id):
+            if !inactiveOverrides.contains(where: { $0.id == id }) {
+                selectedScope = .global
+            }
+        }
+    }
+}
+
+private enum BarSettingsScope: Hashable {
+    case global
+    case connected(Monitor.ID)
+    case inactiveOverride(MonitorBarSettings.ID)
+}
+
+private struct BarScopeSection: View {
+    @Binding var selectedScope: BarSettingsScope
+    let connectedMonitors: [Monitor]
+    let inactiveOverrides: [MonitorBarSettings]
+    let hasOverrides: (Monitor) -> Bool
+    let resetConnected: (Monitor) -> Void
+    let deleteInactive: (MonitorBarSettings.ID) -> Void
+
+    var body: some View {
+        Section("Configuration Scope") {
+            Picker("Configure", selection: $selectedScope) {
+                Text("Global Defaults").tag(BarSettingsScope.global)
+                if !connectedMonitors.isEmpty {
+                    Divider()
+                    ForEach(connectedMonitors, id: \.id) { monitor in
+                        HStack {
+                            Text(monitor.name)
+                            if monitor.isMain {
+                                Text("(Main)")
+                                    .foregroundStyle(.secondary)
+                            }
+                        }
+                        .tag(BarSettingsScope.connected(monitor.id))
+                    }
+                }
+                if !inactiveOverrides.isEmpty {
+                    Divider()
+                    ForEach(inactiveOverrides) { override in
+                        Text("\(override.monitorName) — Inactive")
+                            .tag(BarSettingsScope.inactiveOverride(override.id))
+                    }
+                }
+            }
+
+            statusRow
+        }
+    }
+
+    @ViewBuilder
+    private var statusRow: some View {
+        switch selectedScope {
+        case .global:
+            EmptyView()
+        case let .connected(monitorId):
+            if let monitor = connectedMonitors.first(where: { $0.id == monitorId }) {
+                LabeledContent("Overrides") {
+                    HStack {
+                        Text(hasOverrides(monitor) ? "Custom" : "Using global defaults")
+                            .foregroundStyle(.secondary)
+                        Button("Reset to Global") {
+                            resetConnected(monitor)
+                        }
+                        .disabled(!hasOverrides(monitor))
+                    }
+                }
+            }
+        case let .inactiveOverride(id):
+            LabeledContent("Status") {
+                HStack {
+                    Text("Inactive / disconnected")
+                        .foregroundStyle(.secondary)
+                    Button("Delete Override") {
+                        deleteInactive(id)
+                    }
+                }
+            }
+        }
     }
 }
 
@@ -102,6 +238,28 @@ private struct WorkspaceBarPreviewConfiguration {
             deduplicateAppIcons: resolved.deduplicateAppIcons,
             hideEmptyWorkspaces: resolved.hideEmptyWorkspaces,
             scopeDescription: scopeDescription
+        )
+    }
+
+    @MainActor init(override: MonitorBarSettings, settings: SettingsStore, scopeDescription: String) {
+        self.init(
+            isEnabled: override.enabled ?? settings.workspaceBarEnabled,
+            showLabels: override.showLabels ?? settings.workspaceBarShowLabels,
+            showFloatingWindows: override.showFloatingWindows ?? settings.workspaceBarShowFloatingWindows,
+            deduplicateAppIcons: override.deduplicateAppIcons ?? settings.workspaceBarDeduplicateAppIcons,
+            hideEmptyWorkspaces: override.hideEmptyWorkspaces ?? settings.workspaceBarHideEmptyWorkspaces,
+            scopeDescription: scopeDescription
+        )
+    }
+
+    @MainActor static func global(settings: SettingsStore) -> WorkspaceBarPreviewConfiguration {
+        WorkspaceBarPreviewConfiguration(
+            isEnabled: settings.workspaceBarEnabled,
+            showLabels: settings.workspaceBarShowLabels,
+            showFloatingWindows: settings.workspaceBarShowFloatingWindows,
+            deduplicateAppIcons: settings.workspaceBarDeduplicateAppIcons,
+            hideEmptyWorkspaces: settings.workspaceBarHideEmptyWorkspaces,
+            scopeDescription: "Preview reflects the global workspace bar defaults."
         )
     }
 }
@@ -404,15 +562,83 @@ private struct GlobalBarSettingsSection: View {
     }
 }
 
+private struct SavedMonitorBarOverrideSection: View {
+    let override: MonitorBarSettings
+    let deleteOverride: () -> Void
+
+    var body: some View {
+        Section("Saved Display Override") {
+            LabeledContent("Display") {
+                Text(override.monitorName)
+            }
+            LabeledContent("Status") {
+                Text("Inactive / disconnected")
+                    .foregroundStyle(.secondary)
+            }
+            if let displayId = override.monitorDisplayId {
+                LabeledContent("Runtime Display ID") {
+                    Text("\(displayId) (advisory)")
+                        .foregroundStyle(.secondary)
+                }
+            }
+            if let anchor = override.monitorAnchorPoint {
+                LabeledContent("Saved Position") {
+                    Text("x \(formatCoordinate(anchor.x)), y \(formatCoordinate(anchor.y))")
+                        .foregroundStyle(.secondary)
+                }
+            }
+            Button("Delete Override", role: .destructive) {
+                deleteOverride()
+            }
+            SettingsCaption(
+                "This saved workspace-bar override is not active for any connected monitor. It is kept on disk until you delete it."
+            )
+        }
+
+        Section("Saved Workspace Bar Values") {
+            savedValue("Enabled", override.enabled.map { $0 ? "On" : "Off" })
+            savedValue("Show Workspace Labels", override.showLabels.map { $0 ? "On" : "Off" })
+            savedValue("Show Floating Windows", override.showFloatingWindows.map { $0 ? "On" : "Off" })
+            savedValue("Group Windows by App", override.deduplicateAppIcons.map { $0 ? "On" : "Off" })
+            savedValue("Hide Empty Workspaces", override.hideEmptyWorkspaces.map { $0 ? "On" : "Off" })
+            savedValue("Show Trace Capture Button", override.showTraceButton.map { $0 ? "On" : "Off" })
+            savedValue("Position", override.position?.displayName)
+            savedValue("Window Level", override.windowLevel?.displayName)
+            savedValue("Notch-Aware Positioning", override.notchAware.map { $0 ? "On" : "Off" })
+            savedValue("Reserve Space", override.reserveLayoutSpace.map { $0 ? "On" : "Off" })
+            savedValue("X Offset", override.xOffset.map { "\(Int($0)) px" })
+            savedValue("Y Offset", override.yOffset.map { "\(Int($0)) px" })
+            savedValue("Bar Height", override.height.map { "\(Int($0)) px" })
+            savedValue("Background Opacity", override.backgroundOpacity.map { "\(Int($0 * 100))%" })
+            SettingsCaption(
+                "Inactive overrides are read-only here; reconnect the display to edit them as an active monitor."
+            )
+        }
+    }
+
+    private func savedValue(_ label: String, _ value: String?) -> some View {
+        LabeledContent(label) {
+            Text(value ?? "Uses global default")
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    private func formatCoordinate(_ coordinate: CGFloat) -> String {
+        coordinate == coordinate.rounded() ? String(Int(coordinate)) : String(Double(coordinate))
+    }
+}
+
 private struct MonitorBarSettingsSection: View {
     @Bindable var settings: SettingsStore
     @Bindable var controller: WMController
     let monitor: Monitor
+    var connectedMonitors: [Monitor] = []
 
     private var monitorSettings: MonitorBarSettings {
-        settings.barSettings(for: monitor) ?? MonitorBarSettings(
+        settings.barSettings(for: monitor, connectedMonitors: connectedMonitors) ?? MonitorBarSettings(
             monitorName: monitor.name,
-            monitorDisplayId: monitor.displayId
+            monitorDisplayId: monitor.displayId,
+            monitorAnchorPoint: monitor.workspaceAnchorPoint
         )
     }
 
@@ -420,6 +646,7 @@ private struct MonitorBarSettingsSection: View {
         var ms = monitorSettings
         ms.monitorName = monitor.name
         ms.monitorDisplayId = monitor.displayId
+        ms.monitorAnchorPoint = monitor.workspaceAnchorPoint
         update(&ms)
         settings.updateBarSettings(ms)
         controller.updateWorkspaceBarSettings()

--- a/Tests/NehirTests/MonitorIdentityMatchingTests.swift
+++ b/Tests/NehirTests/MonitorIdentityMatchingTests.swift
@@ -83,7 +83,7 @@ private func makeIdentityTestMonitor(
 
     // MARK: - MonitorSettingsStore
 
-    @Test func monitorSettingsStoreUsesReboundDisplayIdentityOnly() {
+    @Test func monitorSettingsStoreRejectsCrossNameDisplayIdMatches() {
         let setting = MonitorBarSettings(
             monitorName: "Right",
             monitorAnchorPoint: CGPoint(x: 1920, y: 1080),
@@ -98,7 +98,19 @@ private func makeIdentityTestMonitor(
         )
 
         #expect(MonitorSettingsStore.get(for: rightMonitor, in: [setting]) == nil)
-        #expect(MonitorSettingsStore.get(for: rightMonitor, in: [rebound])?.id == rebound.id)
+        #expect(MonitorSettingsStore.get(for: rightMonitor, in: [rebound]) == nil)
+    }
+
+    @Test func monitorSettingsStoreFallsBackToAnchorWhenDisplayIdDoesNotMatch() {
+        let setting = MonitorBarSettings(
+            monitorName: "Shared",
+            monitorDisplayId: 111,
+            monitorAnchorPoint: CGPoint(x: 1920, y: 1080),
+            enabled: false
+        )
+        let monitor = makeIdentityTestMonitor(displayId: 900, name: "Shared", x: 1920)
+
+        #expect(MonitorSettingsStore.get(for: monitor, in: [setting])?.id == setting.id)
     }
 
     // MARK: - WorkspacesTOMLCodec anchor persistence

--- a/Tests/NehirTests/SettingsStoreTests.swift
+++ b/Tests/NehirTests/SettingsStoreTests.swift
@@ -707,7 +707,7 @@ struct HotkeySurfaceTests {
         #expect(reloaded.ignoreMonitorIdentity == true)
     }
 
-    @Test func tomlApplyClearsStaleMonitorDisplayIdWhenNameCannotBeResolved() {
+    @Test func tomlApplyPreservesDisconnectedMonitorDisplayIdWhenNameCannotBeResolved() {
         let settings = SettingsStore(defaults: makeTestDefaults())
         let currentMonitor = makeSettingsTestMonitor(displayId: 202, name: "Studio Display")
         var export = SettingsExport.defaults()
@@ -717,11 +717,11 @@ struct HotkeySurfaceTests {
 
         settings.applyExport(export, monitors: [currentMonitor])
 
-        #expect(settings.monitorBarSettings.first?.monitorDisplayId == nil)
+        #expect(settings.monitorBarSettings.first?.monitorDisplayId == 101)
         #expect(settings.barSettings(for: currentMonitor) == nil)
     }
 
-    @Test func tomlApplyRebindsMonitorSettingsByPositionWhenIdentityIgnored() {
+    @Test func tomlApplyPreservesMonitorSettingsWhenIdentityIgnored() {
         let settings = SettingsStore(defaults: makeTestDefaults())
         let leftMonitor = makeSettingsTestMonitor(displayId: 201, name: "Left Office", x: 0)
         let rightMonitor = makeSettingsTestMonitor(displayId: 202, name: "Right Office", x: 1920)
@@ -738,11 +738,14 @@ struct HotkeySurfaceTests {
 
         settings.applyExport(export, monitors: [leftMonitor, rightMonitor])
 
-        #expect(settings.monitorBarSettings.first?.monitorDisplayId == rightMonitor.displayId)
-        #expect(settings.monitorBarSettings.first?.monitorAnchorPoint == rightMonitor.workspaceAnchorPoint)
+        #expect(settings.monitorBarSettings.first?.monitorDisplayId == 101)
+        #expect(settings.monitorBarSettings.first?.monitorAnchorPoint == CGPoint(x: 1910, y: 1080))
+        #expect(settings.barSettings(for: leftMonitor, connectedMonitors: [leftMonitor, rightMonitor]) == nil)
+        #expect(settings.barSettings(for: rightMonitor, connectedMonitors: [leftMonitor, rightMonitor])?
+            .monitorName == "Home")
     }
 
-    @Test func tomlApplyRebindsMonitorSettingsByPositionOneToOne() {
+    @Test func tomlApplyPreservesMonitorSettingsByPositionWhenIdentityIgnored() {
         let settings = SettingsStore(defaults: makeTestDefaults())
         let leftMonitor = makeSettingsTestMonitor(displayId: 201, name: "Left Office", x: 0)
         let rightMonitor = makeSettingsTestMonitor(displayId: 202, name: "Right Office", x: 1920)
@@ -755,8 +758,12 @@ struct HotkeySurfaceTests {
 
         settings.applyExport(export, monitors: [leftMonitor, rightMonitor])
 
-        let displayIds = settings.monitorBarSettings.compactMap(\.monitorDisplayId)
-        #expect(Set(displayIds) == [leftMonitor.displayId, rightMonitor.displayId])
+        #expect(settings.monitorBarSettings[0].monitorAnchorPoint == CGPoint(x: 0, y: 1080))
+        #expect(settings.monitorBarSettings[1].monitorAnchorPoint == CGPoint(x: 1920, y: 1080))
+        #expect(settings.barSettings(for: leftMonitor, connectedMonitors: [leftMonitor, rightMonitor])?
+            .monitorName == "Home Left")
+        #expect(settings.barSettings(for: rightMonitor, connectedMonitors: [leftMonitor, rightMonitor])?
+            .monitorName == "Home Right")
     }
 }
 


### PR DESCRIPTION
## Summary

Keep disconnected monitor overrides inactive and visible in Niri settings
## Release notes

Choose one:

- [x] Added a `.changeset/*.md` for user-visible changes (`mise run changeset -- patch "..."`).
- [ ] No user-visible change; apply the `no release note` label to make CI skip intentional.

## Validation

<!-- Commands run, screenshots, or manual checks. -->

- [ ] Ran relevant tests/checks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Settings screens now support a multi-scope view: global defaults, overrides for connected monitors, and saved inactive/disconnected overrides.
  * Added read-only sections for inactive overrides (with delete actions) across layout, workspace bar, and Niri settings.

* **Bug Fixes**
  * Per-monitor bar, gap, orientation, and Niri settings now resolve more accurately when multiple monitors are connected.
  * Removing a monitor setting now removes only the currently active match rather than broader stored entries.
  * Inactive monitor overrides remain inactive and visible in Niri settings.

* **Chores**
  * Updated release metadata for an upcoming patch release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->