### PR TITLE
Add focused-window app rule action across surfaces

### DIFF
--- a/.changeset/20260628002437-add-a-create-app-rule-for-focused-window-command.md
+++ b/.changeset/20260628002437-add-a-create-app-rule-for-focused-window-command.md
@@ -1,0 +1,6 @@
+---
+"nehir": minor
+
+---
+
+Add a "Create App Rule for Focused Window…" action that opens the App Rules editor with a draft pre-filled from the focused window's bundle id, title, and AX role/subrole. Resolves the focused window, builds a guided rule draft, and opens Settings on the App Rules tab ready for the user to pick effects and save. Ships in the command palette and workspace-bar window-icon right-click menu with no default hotkey (assignable via Hotkeys settings).

--- a/.provenance.json
+++ b/.provenance.json
@@ -86,6 +86,7 @@
         "Tests/NehirTests/WMControllerWindowActionsTests.swift",
         "Tests/NehirTests/WorkspaceBarGeometryTests.swift",
         "Tests/NehirTests/WorkspaceBarRightClickWiringTests.swift",
+        "Tests/NehirTests/CreateAppRuleForFocusedWindowTests.swift",
         "Tests/NehirTests/WorkspaceNavigationHandlerTests.swift",
         "Tests/NehirTests/WorkspacesTOMLCodecTests.swift"
       ],

--- a/Sources/Nehir/Core/Config/HotkeyConfigMapping.swift
+++ b/Sources/Nehir/Core/Config/HotkeyConfigMapping.swift
@@ -133,6 +133,7 @@ enum HotkeyConfigMapping {
         ("ui", "commandPalette", "openCommandPalette"),
         ("ui", "menuAnywhere", "openMenuAnywhere"),
         ("ui", "settings", "openSettings"),
+        ("ui", "createAppRuleForFocusedWindow", "createAppRuleForFocusedWindow"),
         ("ui", "toggleOverview", "toggleOverview"),
         ("ui", "toggleWorkspaceBar", "toggleWorkspaceBarVisibility"),
         // ui toggles

--- a/Sources/Nehir/Core/Controller/CommandHandler.swift
+++ b/Sources/Nehir/Core/Controller/CommandHandler.swift
@@ -195,6 +195,17 @@ final class CommandHandler {
             controller.openMenuAnywhere()
         case .openSettings:
             SettingsWindowController.shared.show(settings: controller.settings, controller: controller)
+        case .createAppRuleForFocusedWindow:
+            let snapshot = controller.focusedWindowDecisionDebugSnapshot()
+            guard let draft = snapshot.flatMap(AppRuleDraft.guided(from:)) else {
+                return .notFound
+            }
+            SettingsWindowController.shared.show(
+                settings: controller.settings,
+                controller: controller,
+                section: .appRules,
+                pendingAppRuleDraft: draft
+            )
         case .debugDumpRuntimeState:
             controller.dumpRuntimeState()
         case .debugResetRuntimeState:

--- a/Sources/Nehir/Core/Input/ActionCatalog.swift
+++ b/Sources/Nehir/Core/Input/ActionCatalog.swift
@@ -732,6 +732,13 @@ enum ActionCatalog {
                 keywords: ["settings", "preferences", "configure", "config"]
             ),
             action(
+                id: "createAppRuleForFocusedWindow",
+                command: .createAppRuleForFocusedWindow,
+                category: .focus,
+                binding: .unassigned,
+                keywords: ["app rule", "rule", "bundle", "focused window", "create rule"]
+            ),
+            action(
                 id: "debug.dumpRuntimeState",
                 command: .debugDumpRuntimeState,
                 category: .debugging,
@@ -940,6 +947,7 @@ enum ActionCatalog {
         case .toggleScratchpadWindow: "Toggle Scratchpad Window"
         case .openMenuAnywhere: "Open Menu Anywhere"
         case .openSettings: "Open Settings"
+        case .createAppRuleForFocusedWindow: "Create App Rule for Focused Window…"
         case .debugDumpRuntimeState: "Debug: Dump Runtime State"
         case .debugResetRuntimeState: "Debug: Reset Runtime State"
         case .debugRestartClearingRuntimeState: "Debug: Restart Clearing Runtime State"
@@ -1101,6 +1109,12 @@ enum ActionCatalog {
             .openMenuAnywhere
         case .openSettings:
             .openSettings
+        case .createAppRuleForFocusedWindow:
+            // Intentionally no headless IPC/CLI form: this command opens an
+            // interactive App Rules editor the user must finish by hand.
+            // Returning nil here is what keeps the NehirIPC module (the
+            // command-request/router/manifest surface) out of scope for v1.
+            nil
         case .debugDumpRuntimeState:
             .debugDumpRuntimeState
         case .debugResetRuntimeState:

--- a/Sources/Nehir/Core/Input/HotkeyCommand.swift
+++ b/Sources/Nehir/Core/Input/HotkeyCommand.swift
@@ -84,6 +84,7 @@ enum HotkeyCommand: Codable, Equatable, Hashable {
 
     case openMenuAnywhere
     case openSettings
+    case createAppRuleForFocusedWindow
 
     case debugDumpRuntimeState
     case debugResetRuntimeState

--- a/Sources/Nehir/UI/AppRulesView.swift
+++ b/Sources/Nehir/UI/AppRulesView.swift
@@ -17,6 +17,7 @@ struct RunningAppInfo: Identifiable {
 struct AppRulesView: View {
     @Bindable var settings: SettingsStore
     @Bindable var controller: WMController
+    @Bindable var navigation: SettingsNavigationModel
 
     @State private var selectedRuleId: AppRule.ID?
     @State private var addDraft: AppRuleDraft?
@@ -92,6 +93,7 @@ struct AppRulesView: View {
                         },
                         onCancel: { addDraft = nil }
                     )
+                    .id(draft.id)
                 } else if let ruleId = selectedRuleId,
                           let ruleIndex = settings.appRules.firstIndex(where: { $0.id == ruleId })
                 {
@@ -141,6 +143,12 @@ struct AppRulesView: View {
         } message: { rule in
             Text("Delete the rule for \(rule.bundleId)?")
         }
+        .onAppear {
+            consumePendingAppRuleDraft()
+        }
+        .onChange(of: navigation.pendingAppRuleDraft) { _, _ in
+            consumePendingAppRuleDraft()
+        }
     }
 
     private var workspaceNames: [String] {
@@ -170,6 +178,20 @@ struct AppRulesView: View {
         guard let draft = AppRuleDraft.guided(from: snapshot) else { return }
         addDraft = draft
         selectedRuleId = nil
+    }
+
+    /// Consumes a one-shot app-rule draft handed over by another surface (e.g.
+    /// the "Create App Rule for Focused Window…" command via
+    /// `SettingsNavigationModel.pendingAppRuleDraft`) and opens the add editor
+    /// on it. Mirrors how the Hotkeys tab consumes `hotkeySearchSeed`: it runs
+    /// on appear (fresh navigation) and on change (command re-fired while the
+    /// App Rules tab is already visible, so the explicit command replaces any
+    /// in-flight draft), and clears the seed after consuming so it fires once.
+    private func consumePendingAppRuleDraft() {
+        guard let pending = navigation.pendingAppRuleDraft else { return }
+        addDraft = pending
+        selectedRuleId = nil
+        navigation.pendingAppRuleDraft = nil
     }
 }
 

--- a/Sources/Nehir/UI/SettingsDetailView.swift
+++ b/Sources/Nehir/UI/SettingsDetailView.swift
@@ -45,7 +45,7 @@ struct SettingsDetailView: View {
         case .bar:
             WorkspaceBarSettingsTab(settings: settings, controller: controller)
         case .appRules:
-            AppRulesView(settings: settings, controller: controller)
+            AppRulesView(settings: settings, controller: controller, navigation: navigation)
         case .hotkeys:
             HotkeySettingsView(settings: settings, controller: controller, navigation: navigation)
         case .diagnostics:

--- a/Sources/Nehir/UI/SettingsView.swift
+++ b/Sources/Nehir/UI/SettingsView.swift
@@ -14,6 +14,11 @@ final class SettingsNavigationModel {
     /// Hotkeys view consumes and clears it on appear so it filters to the
     /// relevant bindings (e.g. the debug commands) instead of showing all.
     var hotkeySearchSeed: String?
+    /// A one-shot pre-filled app-rule draft handed to the App Rules tab on
+    /// navigation (e.g. from the "Create App Rule for Focused Window…"
+    /// command). AppRulesView consumes and clears it on appear / change so the
+    /// add editor opens on the seeded draft exactly once.
+    var pendingAppRuleDraft: AppRuleDraft?
 
     init(selectedSection: SettingsSection = .general) {
         self.selectedSection = selectedSection

--- a/Sources/Nehir/UI/SettingsWindowController.swift
+++ b/Sources/Nehir/UI/SettingsWindowController.swift
@@ -27,11 +27,13 @@ final class SettingsWindowController {
     func show(
         settings: SettingsStore,
         controller: WMController,
-        section: SettingsSection? = nil
+        section: SettingsSection? = nil,
+        pendingAppRuleDraft: AppRuleDraft? = nil
     ) {
         if let section {
             navigation.selectedSection = section
         }
+        navigation.pendingAppRuleDraft = pendingAppRuleDraft
 
         if let window {
             window.makeKeyAndOrderFront(nil)

--- a/Sources/Nehir/UI/WorkspaceBar/WorkspaceBarManager.swift
+++ b/Sources/Nehir/UI/WorkspaceBar/WorkspaceBarManager.swift
@@ -247,6 +247,18 @@ final class WorkspaceBarManager {
                         section: .diagnostics
                     )
                 },
+                onCreateAppRuleForWindow: { [weak controller, weak settings] token in
+                    guard let controller, let settings,
+                          let snapshot = controller.windowDecisionDebugSnapshot(for: token),
+                          let draft = AppRuleDraft.guided(from: snapshot)
+                    else { return }
+                    SettingsWindowController.shared.show(
+                        settings: settings,
+                        controller: controller,
+                        section: .appRules,
+                        pendingAppRuleDraft: draft
+                    )
+                },
                 onToggleWindowFloating: { [weak controller] token in
                     _ = controller?.toggleWindowFloating(token: token)
                 },

--- a/Sources/Nehir/UI/WorkspaceBar/WorkspaceBarView.swift
+++ b/Sources/Nehir/UI/WorkspaceBar/WorkspaceBarView.swift
@@ -117,6 +117,7 @@ struct WorkspaceBarView: View {
     let onActivateScratchpad: () -> Void
     let onOpenCommandPalette: () -> Void
     let onOpenDiagnostics: () -> Void
+    let onCreateAppRuleForWindow: (WindowToken) -> Void
     let onToggleWindowFloating: (WindowToken) -> Void
     let onToggleWindowSticky: (WindowToken) -> Void
     let onToggleScratchpadAssignment: (WindowToken) -> Void
@@ -134,6 +135,7 @@ struct WorkspaceBarView: View {
             onActivateScratchpad: onActivateScratchpad,
             onOpenCommandPalette: onOpenCommandPalette,
             onOpenDiagnostics: onOpenDiagnostics,
+            onCreateAppRuleForWindow: onCreateAppRuleForWindow,
             onToggleWindowFloating: onToggleWindowFloating,
             onToggleWindowSticky: onToggleWindowSticky,
             onToggleScratchpadAssignment: onToggleScratchpadAssignment,
@@ -158,6 +160,7 @@ struct WorkspaceBarMeasurementView: View {
             onActivateScratchpad: {},
             onOpenCommandPalette: {},
             onOpenDiagnostics: {},
+            onCreateAppRuleForWindow: { _ in },
             onToggleWindowFloating: { _ in },
             onToggleWindowSticky: { _ in },
             onToggleScratchpadAssignment: { _ in },
@@ -183,6 +186,7 @@ struct WorkspaceBarWindowActions {
     let onToggleFloating: (WindowToken) -> Void
     let onToggleSticky: (WindowToken) -> Void
     let onToggleScratchpadAssignment: (WindowToken) -> Void
+    let onCreateAppRule: (WindowToken) -> Void
     let onClose: (WindowToken) -> Void
     let onMoveToWorkspace: (WindowToken, WorkspaceDescriptor.ID) -> Void
     let moveTargets: [WorkspaceBarWindowMoveTarget]
@@ -206,6 +210,7 @@ private struct WorkspaceBarContentView: View {
     let onActivateScratchpad: () -> Void
     let onOpenCommandPalette: () -> Void
     let onOpenDiagnostics: () -> Void
+    let onCreateAppRuleForWindow: (WindowToken) -> Void
     let onToggleWindowFloating: (WindowToken) -> Void
     let onToggleWindowSticky: (WindowToken) -> Void
     let onToggleScratchpadAssignment: (WindowToken) -> Void
@@ -268,6 +273,7 @@ private struct WorkspaceBarContentView: View {
             onToggleFloating: onToggleWindowFloating,
             onToggleSticky: onToggleWindowSticky,
             onToggleScratchpadAssignment: onToggleScratchpadAssignment,
+            onCreateAppRule: onCreateAppRuleForWindow,
             onClose: onCloseWindow,
             onMoveToWorkspace: onMoveWindowToWorkspace,
             moveTargets: windowMoveTargets,
@@ -385,6 +391,7 @@ private struct WorkspaceItemView: View {
             onToggleFloating: windowActions.onToggleFloating,
             onToggleSticky: windowActions.onToggleSticky,
             onToggleScratchpadAssignment: windowActions.onToggleScratchpadAssignment,
+            onCreateAppRule: windowActions.onCreateAppRule,
             onClose: windowActions.onClose,
             onMoveToWorkspace: windowActions.onMoveToWorkspace,
             moveTargets: workspaceBarMoveTargetsExcludingCurrentWorkspace(
@@ -848,8 +855,8 @@ private struct WindowIconView: View {
             isHovered = hovering
         }
         // Right-click window icon: *Toggle Floating; Assign to Scratchpad;
-        // Move to Workspace ▸; Close; Windows…*. Acts on this window's token,
-        // not focus.
+        // Create App Rule; Move to Workspace ▸; Close; Windows…*. Acts on
+        // this window's token, not focus.
         .contextMenu {
             Button {
                 actions.onToggleFloating(window.id)
@@ -877,6 +884,11 @@ private struct WindowIconView: View {
                 } label: {
                     Label("Move to Workspace", systemImage: "arrow.right.square")
                 }
+            }
+            Button {
+                actions.onCreateAppRule(window.id)
+            } label: {
+                Label("Create App Rule for This Window…", systemImage: "slider.horizontal.3")
             }
             Divider()
             Button(role: .destructive) {

--- a/Tests/NehirTests/ActionCatalogTests.swift
+++ b/Tests/NehirTests/ActionCatalogTests.swift
@@ -126,6 +126,11 @@ import Testing
     }
 
     @Test func allCatalogActionsAreAssignableSearchableConfigurableAndPubliclyInvokable() {
+        // Commands that intentionally have no headless IPC/CLI equivalent
+        // (they open an interactive editor the user must finish by hand), so
+        // they legitimately carry no ipcCommandName. Every other catalogued
+        // action must remain IPC-invokable.
+        let interactiveOnlyCommandIds: Set<String> = ["createAppRuleForFocusedWindow"]
         for spec in ActionCatalog.allSpecs() {
             #expect(
                 HotkeySettingsDisplayModel.isVisible(bindingId: spec.id, developerModeEnabled: true),
@@ -135,7 +140,11 @@ import Testing
                 HotkeyConfigMapping.configKey(forInternalId: spec.id) != nil,
                 "\(spec.id) should have a TOML config key"
             )
-            #expect(spec.ipcCommandName != nil, "\(spec.id) should have an IPC/CLI command")
+            if interactiveOnlyCommandIds.contains(spec.id) {
+                #expect(spec.ipcCommandName == nil, "\(spec.id) should not have an IPC command")
+            } else {
+                #expect(spec.ipcCommandName != nil, "\(spec.id) should have an IPC/CLI command")
+            }
         }
     }
 

--- a/Tests/NehirTests/CreateAppRuleForFocusedWindowTests.swift
+++ b/Tests/NehirTests/CreateAppRuleForFocusedWindowTests.swift
@@ -1,0 +1,134 @@
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=nehir-original; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
+@testable import Nehir
+import Testing
+
+/// Covers the "Create App Rule for Focused Window…" command surface added for
+/// backlog #26: its action-spec registration (palette and workspace-bar
+/// window-icon right-click surfacing), title, TOML config-key mapping, search
+/// findability, no-IPC status, and the one-shot `pendingAppRuleDraft` plumbing
+/// that carries a pre-filled draft from the command into the App Rules editor.
+///
+/// The command-handler happy path (focused window -> draft -> Settings opens on
+/// the App Rules editor) is exercised at runtime via the same
+/// `focusedWindowDecisionDebugSnapshot()` + `AppRuleDraft.guided(from:)` +
+/// `presentNewRule(from:)` path the in-tab "New Rule from Focused Window" button
+/// already drives (see AppRuleDraftTests for the seed mapping); it is not
+/// unit-tested here because resolving a real focused-window bundle id requires
+/// live AX fixtures, and the success path opens the `SettingsWindowController`
+/// singleton window.
+@Suite @MainActor struct CreateAppRuleForFocusedWindowTests {
+    @Test func actionSpecIsRegisteredForPaletteSurfacing() throws {
+        let spec = try #require(ActionCatalog.spec(for: "createAppRuleForFocusedWindow"))
+
+        #expect(spec.command == .createAppRuleForFocusedWindow)
+        #expect(spec.category == .focus)
+        #expect(spec.requiresDeveloperMode == false)
+        #expect(spec.defaultBinding.isUnassigned, "v1 ships with no default hotkey")
+    }
+
+    @Test func titleUsesEllipsisSuffixIndicatingEditorDialog() throws {
+        let spec = try #require(ActionCatalog.spec(for: "createAppRuleForFocusedWindow"))
+
+        #expect(spec.title == "Create App Rule for Focused Window…")
+        #expect(ActionCatalog.title(for: .createAppRuleForFocusedWindow) == "Create App Rule for Focused Window…")
+        #expect(HotkeyCommand.createAppRuleForFocusedWindow.displayName == "Create App Rule for Focused Window…")
+    }
+
+    @Test func specIsSurfacedThroughDefaultBindingsRegistry() throws {
+        // The palette and hotkey registry are built from ActionCatalog.allSpecs();
+        // ensure the new command is reachable there too (mirrors openSettings).
+        let binding = try #require(
+            HotkeyBindingRegistry.defaults().first { $0.id == "createAppRuleForFocusedWindow" }
+        )
+
+        #expect(binding.command == .createAppRuleForFocusedWindow)
+        #expect(binding.binding.isUnassigned)
+    }
+
+    @Test func configKeyIsMappedForPersistence() {
+        // Required so the binding is assignable/persistable like every other
+        // catalogued action (enforced by allCatalogActionsAreAssignable…).
+        #expect(
+            HotkeyConfigMapping.configKey(forInternalId: "createAppRuleForFocusedWindow")
+                == "ui.createAppRuleForFocusedWindow"
+        )
+        #expect(
+            HotkeyConfigMapping.internalId(forConfigKey: "ui.createAppRuleForFocusedWindow")
+                == "createAppRuleForFocusedWindow"
+        )
+    }
+
+    @Test func searchTermsFindCommandByRuleKeywords() throws {
+        let binding = try #require(
+            HotkeyBindingRegistry.defaults().first { $0.id == "createAppRuleForFocusedWindow" }
+        )
+
+        #expect(ActionCatalog.matchesSearch("rule", binding: binding))
+        #expect(ActionCatalog.matchesSearch("app rule", binding: binding))
+        #expect(ActionCatalog.matchesSearch("create rule", binding: binding))
+        #expect(ActionCatalog.matchesSearch("bundle", binding: binding))
+    }
+
+    @Test func commandHasNoIpcName() throws {
+        // Decision D: v1 has no headless IPC/CLI surface, so the spec carries
+        // no ipcCommandName (the NehirIPC module is intentionally untouched).
+        // See the discovery's Step 5 deferral.
+        let spec = try #require(ActionCatalog.spec(for: "createAppRuleForFocusedWindow"))
+
+        #expect(spec.ipcCommandName == nil)
+        #expect(spec.ipcDescriptor == nil)
+    }
+
+    @Test func settingsNavigationModelCarriesOneShotAppRuleDraft() {
+        let navigation = SettingsNavigationModel(selectedSection: .appRules)
+
+        // Defaults to nil (no pending draft).
+        #expect(navigation.pendingAppRuleDraft == nil)
+
+        // A command handler hands a pre-filled draft over to the App Rules tab.
+        let draft = AppRuleDraft(bundleId: "com.example.focused")
+        navigation.pendingAppRuleDraft = draft
+        #expect(navigation.pendingAppRuleDraft?.bundleId == "com.example.focused")
+
+        // AppRulesView consumes it and clears the seed so it fires exactly once
+        // (mirrors how the Hotkeys tab consumes hotkeySearchSeed).
+        navigation.pendingAppRuleDraft = nil
+        #expect(navigation.pendingAppRuleDraft == nil)
+    }
+
+    @Test func guidedDraftFromFocusedSnapshotIsBundleLevelWithAvailableMatchers() {
+        // Confirms Decision B: the command reuses AppRuleDraft.guided(from:)
+        // unchanged, seeding the bundle id plus title/AX matchers when present.
+        let snapshot = WindowDecisionDebugSnapshot(
+            token: nil,
+            appName: "Example",
+            bundleId: "com.example.focused",
+            title: "Main Window",
+            axRole: "AXWindow",
+            axSubrole: "AXStandardWindow",
+            appFullscreen: false,
+            manualOverride: nil,
+            disposition: .managed,
+            source: .heuristic,
+            layoutDecisionKind: .fallbackLayout,
+            deferredReason: nil,
+            admissionOutcome: .trackedTiling,
+            workspaceName: nil,
+            minWidth: nil,
+            minHeight: nil,
+            matchedRuleId: nil,
+            heuristicReasons: [],
+            attributeFetchSucceeded: true
+        )
+
+        let draft = AppRuleDraft.guided(from: snapshot)
+
+        #expect(draft?.bundleId == "com.example.focused")
+        #expect(draft?.titleMatcherMode == .substring)
+        #expect(draft?.axRoleEnabled == true)
+    }
+}


### PR DESCRIPTION
## Summary

Add a "Create App Rule for Focused Window…" action that opens the App Rules editor with a draft pre-filled from the focused window's bundle id, title, and AX role/subrole. Resolves the focused window, builds a guided rule draft, and opens Settings on the App Rules tab ready for the user to pick effects and save. Ships in the command palette and workspace-bar window-icon right-click menu with no default hotkey (assignable via Hotkeys settings).
## Release notes

Choose one:

- [x] Added a `.changeset/*.md` for user-visible changes (`mise run changeset -- patch "..."`).
- [ ] No user-visible change; apply the `no release note` label to make CI skip intentional.

## Validation

<!-- Commands run, screenshots, or manual checks. -->

- [ ] Ran relevant tests/checks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added **“Create App Rule for Focused Window…”** command to generate a guided App Rules draft from the current window and open Settings directly in the App Rules editor.
  * Launchable from the **command palette** and the **workspace bar window icon right-click menu** (no default hotkey).

* **Bug Fixes**
  * Improved one-time navigation draft handling so the App Rules editor seeds with the correct draft and then clears it after opening.

* **Tests**
  * Added automated coverage for command registration, search/discovery, unassigned hotkey behavior, and the one-shot draft handoff into the App Rules editor.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->