### PR TITLE
Confirm pid window list after partial ax enumeration

### DIFF
--- a/.changeset/20260701055054-fixed-multi-window-apps-like-vs-code-insiders-an.md
+++ b/.changeset/20260701055054-fixed-multi-window-apps-like-vs-code-insiders-an.md
@@ -1,0 +1,6 @@
+---
+"nehir": patch
+
+---
+
+Fixed multi-window apps like VS Code Insiders and Helium losing windows to unmanaged state at startup.

--- a/.provenance.json
+++ b/.provenance.json
@@ -19,6 +19,7 @@
     {
       "name": "Nehir-original files (no prior existence in OmniWM; provenance audit)",
       "paths": [
+        "Sources/Nehir/Core/Ax/AXWindowsQueryTrace.swift",
         "Sources/Nehir/Core/Ax/RawAXNotificationTrace.swift",
         "Sources/Nehir/Core/Config/AppRuleFileStore.swift",
         "Sources/Nehir/Core/Config/ConfigAssistancePrompt.swift",

--- a/Sources/Nehir/Core/Ax/AXManager.swift
+++ b/Sources/Nehir/Core/Ax/AXManager.swift
@@ -460,6 +460,17 @@ final class AXManager {
         let visibleWindows = SkyLight.shared.queryAllVisibleWindows()
         var pidsWithWindows = Set(visibleWindows.map { $0.pid })
 
+        // Diagnostic only: per-pid on-screen window counts, used below to
+        // cross-check against each app's AX-reported window count and trace
+        // a mismatch (the AX query returning fewer windows than the pid
+        // actually has on screen). Takes the max of the two WindowServer
+        // sources since neither alone is guaranteed complete (see the
+        // CGWindowList comment below).
+        var windowServerCountsByPid: [pid_t: Int] = [:]
+        for window in visibleWindows {
+            windowServerCountsByPid[window.pid, default: 0] += 1
+        }
+
         // Some Electron apps are missed by the broad SLS enumeration but are
         // visible through CGWindowList. Add regular rendered windows from the
         // public API without changing apps already discovered through SLS.
@@ -467,6 +478,7 @@ final class AXManager {
             [.optionOnScreenOnly, .excludeDesktopElements],
             kCGNullWindowID
         ) as? [[String: Any]] {
+            var cgWindowCountsByPid: [pid_t: Int] = [:]
             for window in cgWindows {
                 guard let pidNumber = window[kCGWindowOwnerPID as String] as? Int,
                       let layer = window[kCGWindowLayer as String] as? Int,
@@ -474,13 +486,19 @@ final class AXManager {
                       let alpha = window[kCGWindowAlpha as String] as? Double,
                       alpha > 0
                 else { continue }
-                pidsWithWindows.insert(pid_t(pidNumber))
+                let pid = pid_t(pidNumber)
+                pidsWithWindows.insert(pid)
+                cgWindowCountsByPid[pid, default: 0] += 1
+            }
+            for (pid, count) in cgWindowCountsByPid {
+                windowServerCountsByPid[pid] = max(windowServerCountsByPid[pid] ?? 0, count)
             }
         }
 
         let apps = NSWorkspace.shared.runningApplications.filter {
             shouldTrack($0) && pidsWithWindows.contains($0.processIdentifier)
         }
+        let windowServerCounts = windowServerCountsByPid
 
         return await withTaskGroup(
             of: (pid: pid_t, windows: [(AXWindowRef, pid_t, Int)], failed: Bool).self
@@ -497,6 +515,15 @@ final class AXManager {
                         }
 
                         if let windows = appWindows {
+                            if let windowServerCount = windowServerCounts[app.processIdentifier],
+                               windows.count < windowServerCount
+                            {
+                                await AppAXContext.recordAXWindowCountMismatch(
+                                    pid: app.processIdentifier,
+                                    axCount: windows.count,
+                                    windowServerCount: windowServerCount
+                                )
+                            }
                             return (
                                 app.processIdentifier,
                                 windows.map { ($0.0, app.processIdentifier, $0.1) },

--- a/Sources/Nehir/Core/Ax/AXWindowsQueryTrace.swift
+++ b/Sources/Nehir/Core/Ax/AXWindowsQueryTrace.swift
@@ -43,36 +43,60 @@ extension AXWindowsQueryRecord: CustomStringConvertible {
 
 /// Bounded ring of AX windows-query trace records, mirroring
 /// `RawAXNotificationRecorder`.
+///
+/// `queryResult` entries are logged on every `getWindowsAsync()` call and can
+/// be frequent (e.g. during a `pid_reevaluation`/focus-driven churn burst),
+/// while `countMismatch` entries are rare and are the more actionable signal.
+/// The two kinds are kept in independently-capped buffers so a burst of
+/// query-result logging can never evict a mismatch record.
 @MainActor
 final class AXWindowsQueryRecorder {
     private static let defaultLimit = 256
 
-    private let limit: Int
+    private let queryResultLimit: Int
+    private let countMismatchLimit: Int
     private var nextSequence: UInt64 = 1
-    private var records: [AXWindowsQueryRecord] = []
+    private var queryResults: [AXWindowsQueryRecord] = []
+    private var countMismatches: [AXWindowsQueryRecord] = []
 
-    init(limit: Int = defaultLimit) {
-        self.limit = max(1, limit)
+    init(queryResultLimit: Int = defaultLimit, countMismatchLimit: Int = defaultLimit) {
+        self.queryResultLimit = max(1, queryResultLimit)
+        self.countMismatchLimit = max(1, countMismatchLimit)
     }
 
     func append(_ kind: AXWindowsQueryRecord.Kind, timestamp: Date = Date()) {
         let record = AXWindowsQueryRecord(sequence: nextSequence, timestamp: timestamp, kind: kind)
         nextSequence += 1
+        switch kind {
+        case .queryResult:
+            Self.appendBounded(record, to: &queryResults, limit: queryResultLimit)
+        case .countMismatch:
+            Self.appendBounded(record, to: &countMismatches, limit: countMismatchLimit)
+        }
+    }
+
+    func dump() -> String {
+        let combined = (queryResults + countMismatches).sorted { $0.sequence < $1.sequence }
+        if combined.isEmpty {
+            return "ax windows query trace empty"
+        }
+        return combined.map { "\($0.timestamp.ISO8601Format()) \($0.description)" }.joined(separator: "\n")
+    }
+
+    func reset() {
+        queryResults.removeAll(keepingCapacity: true)
+        countMismatches.removeAll(keepingCapacity: true)
+        nextSequence = 1
+    }
+
+    private static func appendBounded(
+        _ record: AXWindowsQueryRecord,
+        to records: inout [AXWindowsQueryRecord],
+        limit: Int
+    ) {
         if records.count == limit {
             records.removeFirst()
         }
         records.append(record)
-    }
-
-    func dump() -> String {
-        if records.isEmpty {
-            return "ax windows query trace empty"
-        }
-        return records.map { "\($0.timestamp.ISO8601Format()) \($0.description)" }.joined(separator: "\n")
-    }
-
-    func reset() {
-        records.removeAll(keepingCapacity: true)
-        nextSequence = 1
     }
 }

--- a/Sources/Nehir/Core/Ax/AXWindowsQueryTrace.swift
+++ b/Sources/Nehir/Core/Ax/AXWindowsQueryTrace.swift
@@ -1,0 +1,78 @@
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=nehir-original; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
+import Foundation
+
+/// One entry in the AX windows-query trace ring.
+///
+/// Diagnostic only — records every raw `kAXWindowsAttribute` result and any
+/// AX-vs-WindowServer window-count mismatch detected during a full rescan, so
+/// a capture can show directly whether a per-app AX windows query returned an
+/// incomplete list. See
+/// `plans/discovery/20260701-startup-full-rescan-under-enumerates-multi-window-app.md`
+/// and `plans/discovery/20260630-visible-unmanaged-windows-admitted-late-as-columns.md`.
+struct AXWindowsQueryRecord: Equatable {
+    enum Kind: Equatable {
+        /// The raw result of an `AppAXContext.getWindowsAsync()` call.
+        /// `newContext` is `true` only for the first `getWindowsAsync()` call
+        /// made against a given `AppAXContext` instance — the call most
+        /// likely to race a still-settling app/AX bookkeeping state.
+        case queryResult(pid: pid_t, windowIds: [Int], newContext: Bool)
+        /// A full-rescan per-pid AX window count fell short of the
+        /// WindowServer/CGWindowList on-screen window count for that pid.
+        case countMismatch(pid: pid_t, axCount: Int, windowServerCount: Int)
+    }
+
+    let sequence: UInt64
+    let timestamp: Date
+    let kind: Kind
+}
+
+extension AXWindowsQueryRecord: CustomStringConvertible {
+    var description: String {
+        switch kind {
+        case let .queryResult(pid, windowIds, newContext):
+            "ax_windows_query pid=\(pid) newContext=\(newContext) count=\(windowIds.count) windowIds=\(windowIds)"
+        case let .countMismatch(pid, axCount, windowServerCount):
+            "ax_window_count_mismatch pid=\(pid) ax=\(axCount) windowServer=\(windowServerCount)"
+        }
+    }
+}
+
+/// Bounded ring of AX windows-query trace records, mirroring
+/// `RawAXNotificationRecorder`.
+@MainActor
+final class AXWindowsQueryRecorder {
+    private static let defaultLimit = 256
+
+    private let limit: Int
+    private var nextSequence: UInt64 = 1
+    private var records: [AXWindowsQueryRecord] = []
+
+    init(limit: Int = defaultLimit) {
+        self.limit = max(1, limit)
+    }
+
+    func append(_ kind: AXWindowsQueryRecord.Kind, timestamp: Date = Date()) {
+        let record = AXWindowsQueryRecord(sequence: nextSequence, timestamp: timestamp, kind: kind)
+        nextSequence += 1
+        if records.count == limit {
+            records.removeFirst()
+        }
+        records.append(record)
+    }
+
+    func dump() -> String {
+        if records.isEmpty {
+            return "ax windows query trace empty"
+        }
+        return records.map { "\($0.timestamp.ISO8601Format()) \($0.description)" }.joined(separator: "\n")
+    }
+
+    func reset() {
+        records.removeAll(keepingCapacity: true)
+        nextSequence = 1
+    }
+}

--- a/Sources/Nehir/Core/Ax/AppAXContext.swift
+++ b/Sources/Nehir/Core/Ax/AppAXContext.swift
@@ -108,6 +108,10 @@ final class AppAXContext {
     private let axObserver: ThreadGuardedValue<AXObserver?>
     private let focusedWindowObserver: ThreadGuardedValue<AXObserver?>
     private let subscribedWindows: ThreadGuardedValue<[Int: AXUIElement]>
+    /// Diagnostic only: true until the first `getWindowsAsync()` call against
+    /// this context completes — i.e. while the context is still "newly
+    /// created" for tracing purposes.
+    private var hasCompletedFirstWindowsQuery = false
 
     @MainActor static var onWindowDestroyed: ((pid_t, Int) -> Void)?
     @MainActor static var onWindowMiniaturized: ((pid_t, Int) -> Void)?
@@ -117,6 +121,11 @@ final class AppAXContext {
     /// captured before the destroy/miniaturize filter. Diagnostic only — see
     /// `RawAXNotificationRecorder`.
     @MainActor static let rawAXNotificationRecorder = RawAXNotificationRecorder()
+
+    /// Bounded ring of raw `kAXWindowsAttribute` query results and AX-vs-
+    /// WindowServer count mismatches. Diagnostic only — see
+    /// `AXWindowsQueryRecorder`.
+    @MainActor static let axWindowsQueryRecorder = AXWindowsQueryRecorder()
 
     @MainActor static var contexts: [pid_t: AppAXContext] = [:]
     @MainActor private static var inFlightCreations: [pid_t: Task<AppAXContext?, Error>] = [:]
@@ -278,6 +287,20 @@ final class AppAXContext {
 
     @MainActor static func resetRawAXNotificationTraceForDebug() {
         rawAXNotificationRecorder.reset()
+    }
+
+    @MainActor static func axWindowsQueryTraceDump() -> String {
+        axWindowsQueryRecorder.dump()
+    }
+
+    @MainActor static func resetAXWindowsQueryTraceForDebug() {
+        axWindowsQueryRecorder.reset()
+    }
+
+    /// Records a full-rescan per-pid AX-vs-WindowServer window-count
+    /// mismatch. Called from `AXManager.fullRescanEnumerationSnapshot()`.
+    @MainActor static func recordAXWindowCountMismatch(pid: pid_t, axCount: Int, windowServerCount: Int) {
+        axWindowsQueryRecorder.append(.countMismatch(pid: pid, axCount: axCount, windowServerCount: windowServerCount))
     }
 
     nonisolated static func handleWindowDestroyedCallback(
@@ -479,6 +502,12 @@ final class AppAXContext {
             frameWriteGenerations.remove(deadWindowId)
             unsuppressFrameWrites(for: [deadWindowId])
         }
+
+        let isFirstWindowsQuery = !hasCompletedFirstWindowsQuery
+        hasCompletedFirstWindowsQuery = true
+        AppAXContext.axWindowsQueryRecorder.append(
+            .queryResult(pid: pid, windowIds: results.map(\.1), newContext: isFirstWindowsQuery)
+        )
 
         return results
     }

--- a/Sources/Nehir/Core/Ax/AppAXContext.swift
+++ b/Sources/Nehir/Core/Ax/AppAXContext.swift
@@ -108,9 +108,9 @@ final class AppAXContext {
     private let axObserver: ThreadGuardedValue<AXObserver?>
     private let focusedWindowObserver: ThreadGuardedValue<AXObserver?>
     private let subscribedWindows: ThreadGuardedValue<[Int: AXUIElement]>
-    /// Diagnostic only: true until the first `getWindowsAsync()` call against
-    /// this context completes — i.e. while the context is still "newly
-    /// created" for tracing purposes.
+    /// Diagnostic only: `false` until the first `getWindowsAsync()` call
+    /// against this context completes — i.e. while the context is still
+    /// "newly created" for tracing purposes.
     private var hasCompletedFirstWindowsQuery = false
 
     @MainActor static var onWindowDestroyed: ((pid_t, Int) -> Void)?

--- a/Sources/Nehir/Core/Controller/AXEventHandler.swift
+++ b/Sources/Nehir/Core/Controller/AXEventHandler.swift
@@ -1144,7 +1144,10 @@ final class AXEventHandler: CGSEventDelegate {
         }
     }
 
-    private func trackPreparedCreate(_ candidate: PreparedCreate) {
+    private func trackPreparedCreate(
+        _ candidate: PreparedCreate,
+        admissionContext: WindowAdmissionContext = .windowCreate
+    ) {
         guard let controller else { return }
         cancelCreatedWindowRetry(windowId: candidate.windowId)
         discardCreatePlacementContext(windowId: candidate.windowId)
@@ -1181,7 +1184,8 @@ final class AXEventHandler: CGSEventDelegate {
             to: candidate.workspaceId,
             mode: candidate.mode,
             ruleEffects: candidate.ruleEffects,
-            managedReplacementMetadata: candidate.replacementMetadata
+            managedReplacementMetadata: candidate.replacementMetadata,
+            admissionContext: admissionContext
         )
         guard let trackedEntry = controller.workspaceManager.entry(for: trackedToken) else {
             scheduleAXContextWarmup(for: candidate.token.pid)
@@ -2253,7 +2257,7 @@ final class AXEventHandler: CGSEventDelegate {
             return true
         }
 
-        trackPreparedCreate(candidate)
+        trackPreparedCreate(candidate, admissionContext: .focusedAdmission)
         guard let entry = controller.workspaceManager.entry(for: candidate.token) else {
             return true
         }

--- a/Sources/Nehir/Core/Controller/AXEventHandler.swift
+++ b/Sources/Nehir/Core/Controller/AXEventHandler.swift
@@ -820,7 +820,8 @@ final class AXEventHandler: CGSEventDelegate {
         token: WindowToken,
         bundleId: String?,
         mode: TrackedWindowMode,
-        facts: WindowRuleFacts
+        facts: WindowRuleFacts,
+        admittedThisPass: Set<WindowToken>
     ) -> WorkspaceDescriptor.ID? {
         if let workspaceId = recentManagedAdmissionWorkspaceId(for: token) {
             return workspaceId
@@ -829,7 +830,8 @@ final class AXEventHandler: CGSEventDelegate {
             token: token,
             bundleId: bundleId,
             mode: mode,
-            facts: facts
+            facts: facts,
+            admittedThisPass: admittedThisPass
         )?.workspaceId
     }
 
@@ -840,13 +842,15 @@ final class AXEventHandler: CGSEventDelegate {
         axRef: AXWindowRef,
         bundleId: String?,
         mode: TrackedWindowMode,
-        facts: WindowRuleFacts
+        facts: WindowRuleFacts,
+        admittedThisPass: Set<WindowToken>
     ) -> Bool {
         guard let match = structuralReplacementMatch(
             token: token,
             bundleId: bundleId,
             mode: mode,
-            facts: facts
+            facts: facts,
+            admittedThisPass: admittedThisPass
         ) else {
             return false
         }
@@ -3198,7 +3202,8 @@ final class AXEventHandler: CGSEventDelegate {
             token: token,
             bundleId: resolvedBundleId,
             mode: trackedMode,
-            facts: evaluation.facts
+            facts: evaluation.facts,
+            admittedThisPass: []
         )
         let inheritTrackedParentWorkspace = controller.shouldInheritTrackedParentWorkspace(for: evaluation)
         let placementFrame = evaluation.facts.windowServer?.frame ?? matchingWindowInfo?.frame
@@ -3784,7 +3789,8 @@ final class AXEventHandler: CGSEventDelegate {
         token: WindowToken,
         bundleId: String?,
         mode: TrackedWindowMode,
-        facts: WindowRuleFacts
+        facts: WindowRuleFacts,
+        admittedThisPass: Set<WindowToken>
     ) -> StructuralReplacementMatch? {
         guard let controller,
               let fallbackWorkspaceId = controller.interactionWorkspace()?.id
@@ -3840,7 +3846,9 @@ final class AXEventHandler: CGSEventDelegate {
             }
         }
 
-        for entry in controller.workspaceManager.entries(forPid: token.pid) where entry.token != token {
+        for entry in controller.workspaceManager.entries(forPid: token.pid)
+            where entry.token != token && !admittedThisPass.contains(entry.token)
+        {
             let cachedMetadata = cachedManagedReplacementMetadata(
                 for: entry,
                 fallbackBundleId: bundleId

--- a/Sources/Nehir/Core/Controller/LayoutRefreshController.swift
+++ b/Sources/Nehir/Core/Controller/LayoutRefreshController.swift
@@ -1221,6 +1221,13 @@ import QuartzCore
         try Task.checkCancellation()
         var seenKeys: Set<WindowModel.WindowKey> = []
         var decisionBasedRemovals: [WindowToken] = []
+        // Tokens admitted (fresh or via structural rekey) earlier in this
+        // rescan pass are excluded as structural-replacement match targets
+        // for later candidates in the same pass: several distinct windows of
+        // the same app can share an identical pre-layout default frame at
+        // rescan time, which would otherwise let them get merged into one
+        // managed entry via a spurious "replacement".
+        var structuralReplacementAdmittedThisPass: Set<WindowToken> = []
         let focusedWorkspaceId = controller.interactionWorkspace()?.id
 
         for (ax, pid, winId) in windows {
@@ -1340,7 +1347,8 @@ import QuartzCore
                     token: token,
                     bundleId: bundleId ?? evaluation.facts.ax.bundleId,
                     mode: trackedMode,
-                    facts: evaluation.facts
+                    facts: evaluation.facts,
+                    admittedThisPass: structuralReplacementAdmittedThisPass
                 )
                 : nil
             if existingEntry == nil,
@@ -1351,10 +1359,12 @@ import QuartzCore
                    axRef: ax,
                    bundleId: bundleId ?? evaluation.facts.ax.bundleId,
                    mode: trackedMode,
-                   facts: evaluation.facts
+                   facts: evaluation.facts,
+                   admittedThisPass: structuralReplacementAdmittedThisPass
                )
             {
                 seenKeys.insert(token)
+                structuralReplacementAdmittedThisPass.insert(token)
                 controller.axEventHandler.discardCreatePlacementContext(for: winId)
                 continue
             }
@@ -1446,6 +1456,7 @@ import QuartzCore
                 admissionContext: .startupFullRescan
             )
             if existingEntry == nil {
+                structuralReplacementAdmittedThisPass.insert(token)
                 controller.axEventHandler.discardCreatePlacementContext(for: winId)
             }
 

--- a/Sources/Nehir/Core/Controller/LayoutRefreshController.swift
+++ b/Sources/Nehir/Core/Controller/LayoutRefreshController.swift
@@ -1442,7 +1442,8 @@ import QuartzCore
                 to: wsForWindow,
                 mode: admittedMode,
                 ruleEffects: ruleEffects,
-                managedReplacementMetadata: managedReplacementMetadata
+                managedReplacementMetadata: managedReplacementMetadata,
+                admissionContext: .startupFullRescan
             )
             if existingEntry == nil {
                 controller.axEventHandler.discardCreatePlacementContext(for: winId)

--- a/Sources/Nehir/Core/Controller/WMController.swift
+++ b/Sources/Nehir/Core/Controller/WMController.swift
@@ -3930,6 +3930,12 @@ final class WMController {
         var relayoutNeeded = false
         var evaluatedAnyWindow = false
         var affectedWorkspaceIds: Set<WorkspaceDescriptor.ID> = []
+        // See the matching comment in LayoutRefreshController's full-rescan
+        // loop: tokens admitted earlier in this reevaluation pass must not be
+        // eligible structural-replacement match targets for later candidates
+        // in the same pass (e.g. a `.pid` target's fresh AX query returning
+        // several distinct, never-before-tracked windows at once).
+        var structuralReplacementAdmittedThisPass: Set<WindowToken> = []
 
         for token in tokensToReevaluate.sorted(by: {
             if $0.pid == $1.pid {
@@ -3995,7 +4001,8 @@ final class WMController {
                     token: token,
                     bundleId: evaluation.facts.ax.bundleId,
                     mode: effectiveTrackedMode,
-                    facts: evaluation.facts
+                    facts: evaluation.facts,
+                    admittedThisPass: structuralReplacementAdmittedThisPass
                 )
                 : nil
             let workspaceId = resolvedWorkspaceId(
@@ -4017,12 +4024,18 @@ final class WMController {
                    axRef: axRef,
                    bundleId: evaluation.facts.ax.bundleId,
                    mode: effectiveTrackedMode,
-                   facts: evaluation.facts
+                   facts: evaluation.facts,
+                   admittedThisPass: structuralReplacementAdmittedThisPass
                )
             {
+                structuralReplacementAdmittedThisPass.insert(token)
                 affectedWorkspaceIds.insert(workspaceId)
                 relayoutNeeded = true
                 continue
+            }
+
+            if existingEntry == nil {
+                structuralReplacementAdmittedThisPass.insert(token)
             }
 
             _ = workspaceManager.addWindow(

--- a/Sources/Nehir/Core/Controller/WMController.swift
+++ b/Sources/Nehir/Core/Controller/WMController.swift
@@ -3672,6 +3672,7 @@ final class WMController {
         workspaceManager.resetInteractionMonitorWriteTraceForDebug()
         workspaceManager.resetFloatingBarProjectionTraceForDebug()
         AppAXContext.resetRawAXNotificationTraceForDebug()
+        AppAXContext.resetAXWindowsQueryTraceForDebug()
         workspaceBarManager.update()
         debugBarManager.update()
         return .executed
@@ -3709,6 +3710,7 @@ final class WMController {
             ? "create focus trace empty"
             : createFocusTraceEvents.map(\.description).joined(separator: "\n")
         let rawAXNotificationDump = AppAXContext.rawAXNotificationTraceDump()
+        let axWindowsQueryDump = AppAXContext.axWindowsQueryTraceDump()
         let interactionMonitorWriteDump = workspaceManager.interactionMonitorWriteTraceDump()
         let floatingBarProjectionDump = workspaceManager.floatingBarProjectionTraceDump()
         let body = [
@@ -3737,6 +3739,9 @@ final class WMController {
             "",
             "## AX notification trace",
             rawAXNotificationDump,
+            "",
+            "## AX windows query trace",
+            axWindowsQueryDump,
             "",
             "## Interaction monitor writes",
             interactionMonitorWriteDump,
@@ -3867,6 +3872,11 @@ final class WMController {
         var tokensToReevaluate: Set<WindowToken> = []
         var pidTargets: Set<pid_t> = []
         var resolvedAnyTarget = false
+        // Diagnostic only: tracks which tokens reached this reevaluation via a
+        // `.pid` target (a whole-pid AX re-query) vs a `.window` target (a
+        // single-token reevaluation), so the resulting `windowAdmitted` event
+        // can be tagged with an accurate admission context.
+        var tokensFromPidTarget: Set<WindowToken> = []
 
         for target in targets {
             switch target {
@@ -3899,11 +3909,13 @@ final class WMController {
                     let token = WindowToken(pid: pid, windowId: windowId)
                     tokensToReevaluate.insert(token)
                     liveWindowsByToken[token] = axRef
+                    tokensFromPidTarget.insert(token)
                 }
             }
 
             for entry in managedEntries {
                 tokensToReevaluate.insert(entry.token)
+                tokensFromPidTarget.insert(entry.token)
             }
         }
 
@@ -4019,7 +4031,8 @@ final class WMController {
                 windowId: token.windowId,
                 to: workspaceId,
                 mode: oldMode ?? effectiveTrackedMode,
-                ruleEffects: effectiveRuleEffects
+                ruleEffects: effectiveRuleEffects,
+                admissionContext: tokensFromPidTarget.contains(token) ? .pidReevaluation : .windowRuleReevaluation
             )
             if existingEntry == nil {
                 axEventHandler.discardCreatePlacementContext(for: token.windowId)

--- a/Sources/Nehir/Core/Reconcile/EventNormalizer.swift
+++ b/Sources/Nehir/Core/Reconcile/EventNormalizer.swift
@@ -13,13 +13,14 @@ enum EventNormalizer {
         monitors _: [Monitor]
     ) -> WMEvent {
         switch event {
-        case let .windowAdmitted(token, workspaceId, monitorId, mode, source):
+        case let .windowAdmitted(token, workspaceId, monitorId, mode, source, admissionContext):
             return .windowAdmitted(
                 token: token,
                 workspaceId: workspaceId,
                 monitorId: monitorId ?? existingEntry?.observedState.monitorId ?? existingEntry?.desiredState.monitorId,
                 mode: mode,
-                source: source
+                source: source,
+                admissionContext: admissionContext
             )
 
         case let .windowRekeyed(from, to, workspaceId, monitorId, reason, source):

--- a/Sources/Nehir/Core/Reconcile/StateReducer.swift
+++ b/Sources/Nehir/Core/Reconcile/StateReducer.swift
@@ -17,7 +17,7 @@ enum StateReducer {
         var plan = ActionPlan()
 
         switch event {
-        case let .windowAdmitted(_, workspaceId, monitorId, mode, _):
+        case let .windowAdmitted(_, workspaceId, monitorId, mode, _, _):
             plan.lifecyclePhase = lifecyclePhase(for: mode)
             plan.observedState = baseObservedState(
                 from: existingEntry,

--- a/Sources/Nehir/Core/Reconcile/WMEvent.swift
+++ b/Sources/Nehir/Core/Reconcile/WMEvent.swift
@@ -44,7 +44,7 @@ enum WindowAdmissionContext: String, Equatable {
     case axContextConfirmation = "ax_context_confirmation"
     /// Call sites (mostly tests) that have not been threaded with a specific
     /// admission context.
-    case unspecified
+    case unspecified = "unspecified"
 }
 
 enum WMEvent: Equatable {

--- a/Sources/Nehir/Core/Reconcile/WMEvent.swift
+++ b/Sources/Nehir/Core/Reconcile/WMEvent.swift
@@ -16,13 +16,45 @@ enum WMEventSource: String, Equatable {
     case focusPolicy
 }
 
+/// Why a `windowAdmitted` event fired — diagnostic only, does not affect
+/// admission decisions. Added to confirm/refute the hypothesis (see
+/// `plans/discovery/20260701-startup-full-rescan-under-enumerates-multi-window-app.md`
+/// and `plans/discovery/20260630-visible-unmanaged-windows-admitted-late-as-columns.md`)
+/// that a multi-window app's first per-app AX windows query can under-report
+/// its windows, leaving the rest to be admitted late by an incidental event.
+enum WindowAdmissionContext: String, Equatable {
+    /// Admitted by the startup/full-rescan path
+    /// (`AXManager.fullRescanEnumerationSnapshot()`).
+    case startupFullRescan = "startup_full_rescan"
+    /// Admitted by `WMController.reevaluateWindowRules`'s `.pid` target —
+    /// a fresh whole-pid AX windows query swept this token in.
+    case pidReevaluation = "pid_reevaluation"
+    /// Admitted by `WMController.reevaluateWindowRules`'s `.window` target —
+    /// single-token rule reevaluation, not a pid-wide re-query.
+    case windowRuleReevaluation = "window_rule_reevaluation"
+    /// Admitted via `admitFocusedWindowBeforeNonManagedFallback` — the window
+    /// took AX focus before Nehir otherwise knew about it.
+    case focusedAdmission = "focused_admission"
+    /// Admitted via the normal CGS-create pipeline (`trackPreparedCreate`'s
+    /// default path — a real `.created` event, deferred-create replay, or a
+    /// managed-replacement-delayed create).
+    case windowCreate = "window_create"
+    /// Reserved for the Phase 2-3 confirm-after-admission re-query
+    /// (see the plan above) — not yet emitted by any code path.
+    case axContextConfirmation = "ax_context_confirmation"
+    /// Call sites (mostly tests) that have not been threaded with a specific
+    /// admission context.
+    case unspecified
+}
+
 enum WMEvent: Equatable {
     case windowAdmitted(
         token: WindowToken,
         workspaceId: WorkspaceDescriptor.ID,
         monitorId: Monitor.ID?,
         mode: TrackedWindowMode,
-        source: WMEventSource
+        source: WMEventSource,
+        admissionContext: WindowAdmissionContext
     )
     case windowRekeyed(
         from: WindowToken,
@@ -118,7 +150,7 @@ enum WMEvent: Equatable {
 
     var token: WindowToken? {
         switch self {
-        case let .windowAdmitted(token, _, _, _, _),
+        case let .windowAdmitted(token, _, _, _, _, _),
              let .windowRemoved(token, _, _),
              let .workspaceAssigned(token, _, _, _, _),
              let .windowModeChanged(token, _, _, _, _),
@@ -145,7 +177,7 @@ enum WMEvent: Equatable {
 
     var source: WMEventSource {
         switch self {
-        case let .windowAdmitted(_, _, _, _, source),
+        case let .windowAdmitted(_, _, _, _, source, _),
              let .windowRekeyed(_, _, _, _, _, source),
              let .windowRemoved(_, _, source),
              let .workspaceAssigned(_, _, _, _, source),
@@ -169,8 +201,8 @@ enum WMEvent: Equatable {
 
     var summary: String {
         switch self {
-        case let .windowAdmitted(token, workspaceId, _, mode, _):
-            "window_admitted token=\(token) workspace=\(workspaceId.uuidString) mode=\(mode)"
+        case let .windowAdmitted(token, workspaceId, _, mode, _, admissionContext):
+            "window_admitted token=\(token) workspace=\(workspaceId.uuidString) mode=\(mode) context=\(admissionContext.rawValue)"
         case let .windowRekeyed(from, to, workspaceId, _, reason, _):
             "window_rekeyed from=\(from) to=\(to) workspace=\(workspaceId.uuidString) reason=\(reason.rawValue)"
         case let .windowRemoved(token, workspaceId, _):

--- a/Sources/Nehir/Core/Workspace/WorkspaceManager.swift
+++ b/Sources/Nehir/Core/Workspace/WorkspaceManager.swift
@@ -2559,7 +2559,8 @@ final class WorkspaceManager {
         to workspace: WorkspaceDescriptor.ID,
         mode: TrackedWindowMode = .tiling,
         ruleEffects: ManagedWindowRuleEffects = .none,
-        managedReplacementMetadata: ManagedReplacementMetadata? = nil
+        managedReplacementMetadata: ManagedReplacementMetadata? = nil,
+        admissionContext: WindowAdmissionContext = .unspecified
     ) -> WindowToken {
         let token = windows.upsert(
             window: ax,
@@ -2584,7 +2585,8 @@ final class WorkspaceManager {
                 workspaceId: workspace,
                 monitorId: monitorId(for: workspace),
                 mode: mode,
-                source: .workspaceManager
+                source: .workspaceManager,
+                admissionContext: admissionContext
             )
         )
         invalidateWorkspaceProjection(reason: "windowAdded")

--- a/Tests/NehirTests/AXEventHandlerTests.swift
+++ b/Tests/NehirTests/AXEventHandlerTests.swift
@@ -5205,6 +5205,57 @@ private func waitUntilAXEventTest(
         #expect(controller.workspaceManager.entry(for: replacementToken)?.workspaceId == replacementWorkspaceId)
     }
 
+    @Test @MainActor func fullRescanDoesNotMergeDistinctSamePidWindowsSharingStartupFrame() async {
+        let bundleId = currentTestBundleId()
+        let controller = makeAXEventTestController(
+            trackedBundleId: bundleId,
+            workspaceConfigurations: [
+                WorkspaceConfiguration(name: "1", monitorAssignment: .main)
+            ]
+        )
+        defer { controller.axManager.fullRescanEnumerationOverrideForTests = nil }
+
+        // Two brand-new windows of the same app, discovered in the same
+        // rescan pass, sharing the identical pre-layout default frame and
+        // parent ID that an app's just-opened windows commonly share before
+        // Niri lays them out distinctly.
+        let sharedFrame = CGRect(x: -971, y: 71, width: 972, height: 1226)
+        let firstInfo = makeAXEventWindowInfo(id: 900, title: "Welcome", frame: sharedFrame, parentId: 92)
+        let secondInfo = makeAXEventWindowInfo(id: 901, title: "project.swift", frame: sharedFrame, parentId: 92)
+        let firstAXRef = AXWindowRef(element: AXUIElementCreateSystemWide(), windowId: 900)
+        let secondAXRef = AXWindowRef(element: AXUIElementCreateSystemWide(), windowId: 901)
+
+        controller.axManager.fullRescanEnumerationOverrideForTests = {
+            AXManager.FullRescanEnumerationSnapshot(
+                windows: [(firstAXRef, getpid(), 900), (secondAXRef, getpid(), 901)],
+                failedPIDs: []
+            )
+        }
+        controller.axEventHandler.windowFactsProvider = { axRef, _ in
+            switch axRef.windowId {
+            case 900:
+                makeAXEventWindowRuleFacts(bundleId: bundleId, title: firstInfo.title, windowServer: firstInfo)
+            default:
+                makeAXEventWindowRuleFacts(bundleId: bundleId, title: secondInfo.title, windowServer: secondInfo)
+            }
+        }
+
+        controller.layoutRefreshController.requestFullRescan(reason: .startup)
+        await controller.layoutRefreshController.waitForRefreshWorkForTests()
+        await waitUntilAXEventTest {
+            controller.workspaceManager.entry(forPid: getpid(), windowId: 900) != nil
+                && controller.workspaceManager.entry(forPid: getpid(), windowId: 901) != nil
+        }
+
+        guard let firstEntry = controller.workspaceManager.entry(forPid: getpid(), windowId: 900),
+              let secondEntry = controller.workspaceManager.entry(forPid: getpid(), windowId: 901)
+        else {
+            Issue.record("Missing one or both distinct same-pid entries")
+            return
+        }
+        #expect(firstEntry.handle !== secondEntry.handle)
+    }
+
     @Test @MainActor func fullRescanUsesFrameMonitorWhenInteractionMonitorIsStale() async {
         let controller = makeAXEventTestController(
             workspaceConfigurations: [

--- a/Tests/NehirTests/ReconcileStateTests.swift
+++ b/Tests/NehirTests/ReconcileStateTests.swift
@@ -105,7 +105,7 @@ private func lastWindowRemovedTrace(in manager: WorkspaceManager) -> ReconcileTr
 
         let trace = manager.reconcileTraceSnapshotForTests()
         #expect(trace.contains { record in
-            if case let .windowAdmitted(recordedToken, recordedWorkspaceId, _, recordedMode, _) = record.event {
+            if case let .windowAdmitted(recordedToken, recordedWorkspaceId, _, recordedMode, _, _) = record.event {
                 return recordedToken == token
                     && recordedWorkspaceId == workspaceId
                     && recordedMode == .floating


### PR DESCRIPTION
## Summary

A pid's brand-new windows discovered in the same admission pass (a full
rescan, or a pid-wide reevaluation) commonly share an identical pre-layout
default frame. The structural-replacement matcher used that frame to decide
"this is the same window recreated under a new id", so several genuinely
distinct windows of a multi-window app could collapse into a single managed
entry, leaving the rest permanently unmanaged.

Exclude tokens admitted earlier in the current pass from being eligible
match targets; genuine cross-pass replacement (an already-tracked window
destroyed and recreated later) is unaffected.
## Release notes

Choose one:

- [x] Added a `.changeset/*.md` for user-visible changes (`mise run changeset -- patch "..."`).
- [ ] No user-visible change; apply the `no release note` label to make CI skip intentional.

## Validation

<!-- Commands run, screenshots, or manual checks. -->

- [ ] Ran relevant tests/checks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved multi-window startup and full refresh handling to prevent windows from disappearing or being incorrectly merged when apps have multiple same-PID windows.
  * Refined structural replacement admission so tokens admitted earlier in the same pass aren’t repeatedly rematched.
* **Diagnostics**
  * Added AX windows query tracing and AX-vs-WindowServer count mismatch recording to make startup/refresh issues easier to debug.
* **Tests**
  * Added coverage to ensure distinct same-PID windows aren’t merged during full rescan.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->