### PR TITLE
Raise screen margin ceiling to 256px (#119)

### DIFF
--- a/.changeset/20260630093955-raise-screen-margin-limit-to-256px.md
+++ b/.changeset/20260630093955-raise-screen-margin-limit-to-256px.md
@@ -1,0 +1,6 @@
+---
+"nehir": patch
+contributors: [charmbyte]
+---
+
+Raise the screen-margin/gap ceiling to 256px in code and settings.toml; Settings sliders stay capped at 64px for ergonomics but now render larger config values at their true value. Fixes #119.

--- a/Sources/Nehir/Core/Config/MonitorGapSettings.swift
+++ b/Sources/Nehir/Core/Config/MonitorGapSettings.swift
@@ -7,6 +7,19 @@
 import CoreGraphics
 import Foundation
 
+enum GapLimits {
+    /// Inclusive range enforced for resolved inner and outer gaps, in points.
+    /// Values set in `settings.toml` or monitor overrides up to this ceiling are
+    /// honored by the layout resolver.
+    static let range: ClosedRange<Double> = 0 ... 256
+
+    /// Interactive range exposed by the Settings sliders. Deliberately narrower
+    /// than `range` to keep the control ergonomic: values above this still apply
+    /// (from `settings.toml` or monitor overrides) and render at their true value,
+    /// with the slider thumb pinned at the upper bound.
+    static let sliderRange: ClosedRange<Double> = 0 ... 64
+}
+
 struct MonitorGapSettings: MonitorSettingsType {
     let id: UUID
     var monitorName: String

--- a/Sources/Nehir/Core/Config/SettingsStore.swift
+++ b/Sources/Nehir/Core/Config/SettingsStore.swift
@@ -861,11 +861,11 @@ final class SettingsStore {
     func resolvedGapSettings(for monitor: Monitor, connectedMonitors: [Monitor] = []) -> ResolvedGapSettings {
         let override = gapSettings(for: monitor, connectedMonitors: connectedMonitors)
         return ResolvedGapSettings(
-            gapSize: (override?.gapSize ?? gapSize).clamped(to: 0 ... 64),
-            outerGapLeft: (override?.outerGapLeft ?? outerGapLeft).clamped(to: 0 ... 64),
-            outerGapRight: (override?.outerGapRight ?? outerGapRight).clamped(to: 0 ... 64),
-            outerGapTop: (override?.outerGapTop ?? outerGapTop).clamped(to: 0 ... 64),
-            outerGapBottom: (override?.outerGapBottom ?? outerGapBottom).clamped(to: 0 ... 64)
+            gapSize: (override?.gapSize ?? gapSize).clamped(to: GapLimits.range),
+            outerGapLeft: (override?.outerGapLeft ?? outerGapLeft).clamped(to: GapLimits.range),
+            outerGapRight: (override?.outerGapRight ?? outerGapRight).clamped(to: GapLimits.range),
+            outerGapTop: (override?.outerGapTop ?? outerGapTop).clamped(to: GapLimits.range),
+            outerGapBottom: (override?.outerGapBottom ?? outerGapBottom).clamped(to: GapLimits.range)
         )
     }
 

--- a/Sources/Nehir/UI/LayoutSettingsTab.swift
+++ b/Sources/Nehir/UI/LayoutSettingsTab.swift
@@ -180,7 +180,7 @@ struct LayoutSettingsTab: View {
                         draftGapSize = newValue
                     }
                 ),
-                range: 0 ... 32,
+                range: GapLimits.sliderRange,
                 step: 1,
                 formatter: { "\(Int($0)) px" },
                 valueWidth: 64,
@@ -202,7 +202,7 @@ struct LayoutSettingsTab: View {
                         draftOuterGapLeft = newValue
                     }
                 ),
-                range: 0 ... 64,
+                range: GapLimits.sliderRange,
                 step: 1,
                 formatter: { "\(Int($0)) px" },
                 valueWidth: 64,
@@ -219,7 +219,7 @@ struct LayoutSettingsTab: View {
                         draftOuterGapRight = newValue
                     }
                 ),
-                range: 0 ... 64,
+                range: GapLimits.sliderRange,
                 step: 1,
                 formatter: { "\(Int($0)) px" },
                 valueWidth: 64,
@@ -236,7 +236,7 @@ struct LayoutSettingsTab: View {
                         draftOuterGapTop = newValue
                     }
                 ),
-                range: 0 ... 64,
+                range: GapLimits.sliderRange,
                 step: 1,
                 formatter: { "\(Int($0)) px" },
                 valueWidth: 64,
@@ -253,7 +253,7 @@ struct LayoutSettingsTab: View {
                         draftOuterGapBottom = newValue
                     }
                 ),
-                range: 0 ... 64,
+                range: GapLimits.sliderRange,
                 step: 1,
                 formatter: { "\(Int($0)) px" },
                 valueWidth: 64,
@@ -480,7 +480,7 @@ struct MonitorGapSettingsSection: View {
                 label: "Inner Gap",
                 value: ms.gapSize,
                 globalValue: settings.gapSize,
-                range: 0 ... 32,
+                range: GapLimits.sliderRange,
                 step: 1,
                 formatter: { "\(Int($0)) px" },
                 commitOnEditingEnd: true,
@@ -495,7 +495,7 @@ struct MonitorGapSettingsSection: View {
                 label: "Left",
                 value: ms.outerGapLeft,
                 globalValue: settings.outerGapLeft,
-                range: 0 ... 64,
+                range: GapLimits.sliderRange,
                 step: 1,
                 formatter: { "\(Int($0)) px" },
                 commitOnEditingEnd: true,
@@ -506,7 +506,7 @@ struct MonitorGapSettingsSection: View {
                 label: "Right",
                 value: ms.outerGapRight,
                 globalValue: settings.outerGapRight,
-                range: 0 ... 64,
+                range: GapLimits.sliderRange,
                 step: 1,
                 formatter: { "\(Int($0)) px" },
                 commitOnEditingEnd: true,
@@ -517,7 +517,7 @@ struct MonitorGapSettingsSection: View {
                 label: "Top",
                 value: ms.outerGapTop,
                 globalValue: settings.outerGapTop,
-                range: 0 ... 64,
+                range: GapLimits.sliderRange,
                 step: 1,
                 formatter: { "\(Int($0)) px" },
                 commitOnEditingEnd: true,
@@ -528,7 +528,7 @@ struct MonitorGapSettingsSection: View {
                 label: "Bottom",
                 value: ms.outerGapBottom,
                 globalValue: settings.outerGapBottom,
-                range: 0 ... 64,
+                range: GapLimits.sliderRange,
                 step: 1,
                 formatter: { "\(Int($0)) px" },
                 commitOnEditingEnd: true,

--- a/Tests/NehirTests/SettingsStoreTests.swift
+++ b/Tests/NehirTests/SettingsStoreTests.swift
@@ -268,6 +268,48 @@ struct MonitorSettingsStoreTests {
     }
 }
 
+@MainActor struct GapSettingsResolutionTests {
+    @Test func resolvedGapSettingsHonorNamedRange() {
+        let settings = SettingsStore(defaults: makeTestDefaults())
+        let monitor = makeSettingsTestMonitor(displayId: 119, name: "Gap Display")
+
+        settings.outerGapBottom = 400
+        var resolved = settings.resolvedGapSettings(for: monitor)
+        #expect(resolved.outerGapBottom == GapLimits.range.upperBound)
+
+        settings.outerGapBottom = GapLimits.range.upperBound
+        resolved = settings.resolvedGapSettings(for: monitor)
+        #expect(resolved.outerGapBottom == GapLimits.range.upperBound)
+
+        settings.outerGapBottom = 64
+        resolved = settings.resolvedGapSettings(for: monitor)
+        #expect(resolved.outerGapBottom == 64)
+    }
+
+    @Test func resolvedGapSettingsClampMonitorOverrides() {
+        let settings = SettingsStore(defaults: makeTestDefaults())
+        let monitor = makeSettingsTestMonitor(displayId: 120, name: "Override Display")
+        settings.updateGapSettings(
+            MonitorGapSettings(
+                monitorName: monitor.name,
+                monitorDisplayId: monitor.displayId,
+                outerGapTop: 400
+            )
+        )
+
+        let resolved = settings.resolvedGapSettings(for: monitor)
+        #expect(resolved.outerGapTop == GapLimits.range.upperBound)
+    }
+
+    @Test func sliderRangeIsNarrowerThanResolverRange() {
+        // UI sliders cap below the resolver ceiling to stay ergonomic; values above
+        // the slider cap still apply from settings.toml / monitor overrides and are
+        // rendered at their true value with the thumb pinned at the upper bound.
+        #expect(GapLimits.sliderRange.upperBound < GapLimits.range.upperBound)
+        #expect(GapLimits.sliderRange.lowerBound == GapLimits.range.lowerBound)
+    }
+}
+
 @MainActor struct PersistedWindowRestoreCatalogSettingsTests {
     @Test func persistedRestoreCatalogRoundTripsThroughRuntimeStateStore() {
         let defaults = makeTestDefaults()

--- a/Tests/NehirTests/SettingsTOMLCodecTests.swift
+++ b/Tests/NehirTests/SettingsTOMLCodecTests.swift
@@ -167,13 +167,13 @@ private extension String {
         export.outerGapLeft = 12
         export.outerGapRight = 14
         export.outerGapTop = 16
-        export.outerGapBottom = 18
+        export.outerGapBottom = 120
 
         let decoded = try SettingsTOMLCodec.decode(try SettingsTOMLCodec.encode(export))
         #expect(decoded.outerGapLeft == 12)
         #expect(decoded.outerGapRight == 14)
         #expect(decoded.outerGapTop == 16)
-        #expect(decoded.outerGapBottom == 18)
+        #expect(decoded.outerGapBottom == 120)
     }
 
     @Test func preservesNilColumnWidthPresetsDistinctFromEmptyArray() throws {


### PR DESCRIPTION

## Summary

Introduces one named bound (GapLimits.range = 0...256) applied at both layers so editing [gaps.outer] above 64 in settings.toml is no longer silently collapsed before the working-area inset.

- Add GapLimits.range in MonitorGapSettings.swift
- SettingsStore.resolvedGapSettings clamps to GapLimits.range
- All 8 outer-gap sliders in LayoutSettingsTab use GapLimits.range
- Add resolver clamping tests; TOML round-trip now covers >64
- changeset attributing reporter @charmbyte

## Release notes

Choose one:

- [x] Added a `.changeset/*.md` for user-visible changes (`mise run changeset -- patch "..."`).
- [ ] No user-visible change; apply the `no release note` label to make CI skip intentional.

## Validation

<!-- Commands run, screenshots, or manual checks. -->

- [ ] Ran relevant tests/checks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Increased screen margin/gap ceiling to **256 px** for resolved layout rendering.
  * Settings sliders remain ergonomically capped (e.g., up to **64 px**) while larger configured values can be applied as true settings.

* **Bug Fixes**
  * Gap and outer gap values are now clamped consistently to the updated **256 px** bounds when resolving settings.

* **Tests**
  * Added resolution-focused tests for gap settings bounds and updated TOML round-trip coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->