### PR TITLE
Reconcile stale hidden-window live frames

### DIFF
--- a/.changeset/20260625213015-reliably-re-park-hidden-windows-whose-live-frame.md
+++ b/.changeset/20260625213015-reliably-re-park-hidden-windows-whose-live-frame.md
@@ -1,0 +1,6 @@
+---
+"nehir": patch
+
+---
+
+Improve hidden-window recovery so windows that unexpectedly reappear while Nehir still considers them hidden are re-parked more reliably, including offscreen scrolling columns that have been hidden for a while. This does not remove macOS's offscreen parking limitations, so a thin parked-window strip may still be visible in some configurations.

--- a/Sources/Nehir/Core/Ax/AXWindow.swift
+++ b/Sources/Nehir/Core/Ax/AXWindow.swift
@@ -223,6 +223,11 @@ enum AXWindowService {
         -> AXFrameWriteResult)?
     nonisolated(unsafe) static var pinnedWindowIdProviderForTests: ((UInt32) -> CGWindowID?)?
     @MainActor static var fastFrameProviderForTests: ((AXWindowRef) -> CGRect?)?
+    /// Test override for the slow (real AX) frame read, mirroring
+    /// `fastFrameProviderForTests`. Used to exercise the stale-cached-already-hidden
+    /// re-read in `resolveHideOperation`, which deliberately bypasses the fast cache
+    /// to detect live drift. When `nil`, behavior is unchanged (real AX read).
+    nonisolated(unsafe) static var frameProviderForTests: ((AXWindowRef) throws(AXErrorWrapper) -> CGRect)?
     @MainActor static var titleLookupProviderForTests: ((UInt32) -> String?)?
     @MainActor static var timeSourceForTests: (() -> TimeInterval)?
 
@@ -353,6 +358,9 @@ enum AXWindowService {
     }
 
     static func frame(_ window: AXWindowRef) throws(AXErrorWrapper) -> CGRect {
+        if let frameProviderForTests {
+            return try frameProviderForTests(window)
+        }
         let attributes = [
             kAXPositionAttribute as CFString,
             kAXSizeAttribute as CFString

--- a/Sources/Nehir/Core/Controller/LayoutRefreshController.swift
+++ b/Sources/Nehir/Core/Controller/LayoutRefreshController.swift
@@ -2866,24 +2866,47 @@ import QuartzCore
         if abs(frame.origin.x - origin.x) < moveEpsilon,
            abs(frame.origin.y - origin.y) < moveEpsilon
         {
-            if reason == .layoutTransient,
-               let liveFrame = try? AXWindowService.frame(entry.axRef)
+            // The cached frame is already at the computed park origin. Re-read the
+            // live AX frame and, if it has drifted back on-screen (a clamp failure,
+            // an app self-move, or a restore race), re-issue the park move. This
+            // applies to every hide reason that parks at a computed origin —
+            // layoutTransient, workspaceInactive, and scratchpad — not just
+            // layoutTransient, because the stale-live-frame invariant is identical
+            // for all of them. The re-read is bounded: it only runs when the cached
+            // frame is already near the origin (i.e. the cache believes the window
+            // is parked), so it does not add a live-AX read on every refresh — only
+            // for windows suspected of being already hidden.
+            if let liveFrame = try? AXWindowService.frame(entry.axRef),
+               let liveOrigin = liveFrameHideOrigin(
+                   for: liveFrame,
+                   monitor: monitor,
+                   side: side,
+                   pid: entry.handle.pid,
+                   reason: reason,
+                   hiddenPlacementMonitors: hiddenPlacementMonitors
+               )
             {
-                let liveDx = abs(liveFrame.origin.x - origin.x)
-                let liveDy = abs(liveFrame.origin.y - origin.y)
+                let liveDx = abs(liveFrame.origin.x - liveOrigin.x)
+                let liveDy = abs(liveFrame.origin.y - liveOrigin.y)
                 if liveDx > moveEpsilon || liveDy > moveEpsilon {
                     controller.axManager
                         .recordFrameApplyTrace(
-                            "hidePlan.staleCachedAlreadyHidden id=\(entry.windowId) cached=\(LayoutTrace.rect(frame)) live=\(LayoutTrace.rect(liveFrame)) requested=\(LayoutTrace.point(origin))"
+                            "hidePlan.staleCachedAlreadyHidden id=\(entry.windowId) reason=\(reason) cached=\(LayoutTrace.rect(frame)) live=\(LayoutTrace.rect(liveFrame)) requested=\(LayoutTrace.point(liveOrigin))"
                         )
                     return .movable(
                         WindowPositionPlan(
                             entry: entry,
-                            origin: origin,
+                            origin: liveOrigin,
                             frameSize: liveFrame.size,
                             displayId: monitor.displayId
                         ),
-                        hiddenState: hiddenState
+                        hiddenState: updatedHiddenState(
+                            for: entry,
+                            frame: liveFrame,
+                            monitor: monitor,
+                            side: side,
+                            reason: reason
+                        )
                     )
                 }
             }
@@ -3968,6 +3991,17 @@ import QuartzCore
 @MainActor
 final class LayoutDiffExecutor {
     private unowned let refreshController: LayoutRefreshController
+    /// Per-workspace monotonic timestamp of the last stably-hidden-column
+    /// reconciliation sweep, used to throttle the Fix C sweep so its per-window
+    /// live-AX reads do not run on every scroll frame. A missing entry means "never
+    /// run yet". Keyed per workspace (not globally) so that in a multi-monitor
+    /// refresh — where each monitor's plan executes in the same batch — one
+    /// workspace's sweep never starves another's by resetting a shared timer.
+    private var lastStableHideReconciliationUptimeByWorkspace: [WorkspaceDescriptor.ID: TimeInterval] = [:]
+    /// Minimum interval between stably-hidden-column reconciliation sweeps for a
+    /// given workspace. The drift this sweep corrects otherwise persists indefinitely,
+    /// so a sub-second cadence is plenty while keeping the AX-read cost negligible.
+    private static let stableHideReconciliationInterval: TimeInterval = 0.5
 
     init(refreshController: LayoutRefreshController) {
         self.refreshController = refreshController
@@ -4174,6 +4208,22 @@ final class LayoutDiffExecutor {
                 }
             }
         }
+
+        // Reconcile stably-hidden `layoutTransient` columns whose live AX frame may
+        // have drifted back on-screen. The transition-based hide above only re-parks
+        // windows that emitted a `.hide` this pass; a column already stably hidden
+        // produces no transition, so without this sweep its drift is never corrected
+        // and it stays visibly parked-on-screen until the user scrolls its column
+        // back into the apply band. Time-throttled inside the helper.
+        let reconciledHiddenTokens = reconcileStablyHiddenLayoutTransientColumns(
+            controller: controller,
+            monitor: monitor,
+            workspaceId: plan.workspaceId,
+            excludedTokens: hiddenTokens
+                .union(restoreTokens)
+                .union(shownEntries.map(\.entry.token))
+        )
+        hiddenTokens.formUnion(reconciledHiddenTokens)
 
         if !restoreEntries.isEmpty {
             let restorePlans: [LayoutRefreshController.WindowPositionPlan] = restoreEntries
@@ -4395,6 +4445,119 @@ final class LayoutDiffExecutor {
         }
 
         return controller.workspaceManager.monitors.first(where: { $0.displayId == snapshot.displayId })
+    }
+
+    /// Reconciles `layoutTransient`-hidden columns that are already stably hidden
+    /// when their live AX frame drifts back on-screen. The transition-based hide in
+    /// `execute` only re-parks windows that emitted a `.hide` this pass; a column
+    /// already stably hidden produces no transition, so without this sweep its drift
+    /// is never corrected (it stays visibly parked-on-screen until the user scrolls
+    /// its column back into the viewport apply band). Folded into the layout tick
+    /// (so `resolveHideOperation`'s fastFrame cache is valid) and time-throttled so
+    /// the per-window live-AX read does not run on every scroll frame — at most once
+    /// per `stableHideReconciliationInterval`, which is plenty against a drift that
+    /// otherwise persists indefinitely. Workspace-inactive drift is reconciled
+    /// separately in `hideWorkspace`; scratchpad is user-driven.
+    ///
+    /// This re-drives the park move toward the computed origin; it does NOT defeat
+    /// the macOS offscreen clamp (a correctly-issued edge-park can still leave a
+    /// strip). See `docs/offscreen-clamp-fix.md`.
+    private func reconcileStablyHiddenLayoutTransientColumns(
+        controller: WMController,
+        monitor: Monitor,
+        workspaceId: WorkspaceDescriptor.ID,
+        excludedTokens: Set<WindowToken>
+    ) -> Set<WindowToken> {
+        let now = ProcessInfo.processInfo.systemUptime
+        let last = lastStableHideReconciliationUptimeByWorkspace[workspaceId]
+        let due = last.map {
+            now - $0 >= Self.stableHideReconciliationInterval
+        } ?? true
+        guard due else { return [] }
+        lastStableHideReconciliationUptimeByWorkspace[workspaceId] = now
+
+        let candidates = stablyHiddenLayoutTransientCandidates(
+            controller: controller,
+            workspaceId: workspaceId,
+            excludedTokens: excludedTokens
+        )
+        guard !candidates.isEmpty else { return [] }
+
+        var reconcilePlans: [LayoutRefreshController.WindowPositionPlan] = []
+        var reconcileJobs: [(pid: pid_t, windowId: Int)] = []
+        for candidate in candidates {
+            switch refreshController.resolveHideOperation(
+                for: candidate.entry,
+                monitor: monitor,
+                side: candidate.side,
+                reason: .layoutTransient
+            ) {
+            case let .movable(plan, hiddenState):
+                controller.workspaceManager.setHiddenState(hiddenState, for: candidate.entry.token)
+                reconcileJobs.append((candidate.entry.handle.pid, candidate.entry.windowId))
+                reconcilePlans.append(plan)
+            case .alreadyHidden:
+                // Correctly parked — leave untouched (idempotency / no churn).
+                continue
+            case .unavailable:
+                continue
+            }
+        }
+
+        applyReconciledHidePlans(
+            reconcilePlans,
+            jobs: reconcileJobs,
+            traceLabel: "stably-hidden drift"
+        )
+        return Set(candidates.map(\.entry.token))
+    }
+
+    /// Returns the already-hidden `layoutTransient` columns for `workspaceId` that
+    /// are not transitioning this pass, paired with their parked side. These are the
+    /// windows the transition-based hide will miss (no `.hide` event) and whose drift
+    /// the reconciliation sweep must re-check.
+    private func stablyHiddenLayoutTransientCandidates(
+        controller: WMController,
+        workspaceId: WorkspaceDescriptor.ID,
+        excludedTokens: Set<WindowToken>
+    ) -> [(entry: WindowModel.Entry, side: HideSide)] {
+        controller.workspaceManager.allEntries().compactMap { entry in
+            guard !excludedTokens.contains(entry.token),
+                  entry.workspaceId == workspaceId,
+                  entry.layoutReason != .nativeFullscreen,
+                  let side = controller.workspaceManager.hiddenState(for: entry.token)?.offscreenSide
+            else { return nil }
+            return (entry, side)
+        }
+    }
+
+    /// Shared apply path for the reconciliation sweep: cancel/suppress in-flight
+    /// frame jobs, move the windows to their recomputed park origins, order them
+    /// below, and emit a trace marker. Mirrors the transition-based hide apply.
+    private func applyReconciledHidePlans(
+        _ plans: [LayoutRefreshController.WindowPositionPlan],
+        jobs: [(pid: pid_t, windowId: Int)],
+        traceLabel: String
+    ) {
+        guard let controller = refreshController.controller else { return }
+        if !jobs.isEmpty {
+            controller.axManager.cancelPendingFrameJobs(jobs)
+            controller.axManager.suppressFrameWrites(jobs)
+        }
+        guard !plans.isEmpty else { return }
+        refreshController.applyPositionPlans(plans)
+        for plan in plans {
+            if let windowId = UInt32(exactly: plan.entry.windowId) {
+                SkyLight.shared.orderWindow(windowId, relativeTo: 0, order: .below)
+            }
+        }
+        if LayoutTrace.isEnabled {
+            for plan in plans {
+                LayoutTrace.log(
+                    "  reconcileHide id=\(plan.entry.windowId) -> origin=\(LayoutTrace.point(plan.origin)) order=below (\(traceLabel))"
+                )
+            }
+        }
     }
 }
 

--- a/Tests/NehirTests/LayoutRefreshControllerTests.swift
+++ b/Tests/NehirTests/LayoutRefreshControllerTests.swift
@@ -2312,6 +2312,351 @@ private func makeUnavailableLayoutPlanTestWindow(windowId: Int) -> AXWindowRef {
         }
     }
 
+    // MARK: - Stale-live-frame reconciliation (park issued / not undone)
+
+    @Test @MainActor func hideWorkspaceReparksAlreadyHiddenWorkspaceInactiveWindowWithDriftedLiveFrame() {
+        // Gap 1a (Fix B): a window Nehir already believes is `workspaceInactive`-hidden
+        // but whose live AX frame bled back on-screen must be re-parked, not merely
+        // logged as drift. Single monitor; workspace "2" is inactive.
+        let controller = makeLayoutPlanTestController()
+        guard let monitor = controller.workspaceManager.monitors.first,
+              let activeWorkspaceId = controller.workspaceManager.workspaceId(for: "1", createIfMissing: false),
+              let inactiveWorkspaceId = controller.workspaceManager.workspaceId(for: "2", createIfMissing: false)
+        else {
+            Issue.record("Missing monitor or workspaces for workspace-inactive reconciliation test")
+            return
+        }
+        controller.workspaceManager.setActiveWorkspace(activeWorkspaceId, on: monitor.id)
+
+        let windowId = 701
+        let token = addLayoutPlanTestWindow(on: controller, workspaceId: inactiveWorkspaceId, windowId: windowId)
+        setWorkspaceInactiveHiddenStateForLayoutPlanTests(on: controller, token: token, monitor: monitor)
+
+        // Live AX frame is fully on-screen (center of the 1920x1080 monitor) — the
+        // stale-live-frame signature: hidden metadata set, but the window is visible.
+        let driftedFrame = CGRect(x: 560, y: 180, width: 800, height: 600)
+        AXWindowService.fastFrameProviderForTests = { window in
+            window.windowId == windowId ? driftedFrame : fallbackFastFrameForTests(window)
+        }
+        defer { AXWindowService.fastFrameProviderForTests = nil }
+
+        controller.layoutRefreshController.hideInactiveWorkspacesSync()
+
+        let dump = controller.axManager.windowStateDebugDump(windowIds: [windowId])
+        // The already-hidden workspace-inactive window with a drifted live frame is
+        // re-parked (a hide plan is issued), not merely logged. This now exercises
+        // main's `isWorkspaceInactiveWindowVisiblyDrifting` repair path.
+        #expect(dump.contains("hidePlan.apply id=\(windowId)"))
+        #expect(controller.workspaceManager.hiddenState(for: token)?.workspaceInactive == true)
+    }
+
+    @Test @MainActor func hideWorkspaceDoesNotChurnAlreadyParkedWorkspaceInactiveWindow() {
+        // Regression / idempotency: a workspace-inactive window whose live frame is
+        // correctly parked offscreen (not bleeding onto the active monitor) is NOT
+        // re-moved on every visibility refresh.
+        let controller = makeLayoutPlanTestController()
+        guard let monitor = controller.workspaceManager.monitors.first,
+              let activeWorkspaceId = controller.workspaceManager.workspaceId(for: "1", createIfMissing: false),
+              let inactiveWorkspaceId = controller.workspaceManager.workspaceId(for: "2", createIfMissing: false)
+        else {
+            Issue.record("Missing monitor or workspaces for workspace-inactive no-churn test")
+            return
+        }
+        controller.workspaceManager.setActiveWorkspace(activeWorkspaceId, on: monitor.id)
+
+        let windowId = 702
+        let token = addLayoutPlanTestWindow(on: controller, workspaceId: inactiveWorkspaceId, windowId: windowId)
+        setWorkspaceInactiveHiddenStateForLayoutPlanTests(on: controller, token: token, monitor: monitor)
+
+        // Live frame parked well offscreen, not intersecting the active monitor.
+        let parkedFrame = CGRect(x: 5000, y: 180, width: 800, height: 600)
+        AXWindowService.fastFrameProviderForTests = { window in
+            window.windowId == windowId ? parkedFrame : fallbackFastFrameForTests(window)
+        }
+        defer { AXWindowService.fastFrameProviderForTests = nil }
+
+        controller.layoutRefreshController.hideInactiveWorkspacesSync()
+
+        let dump = controller.axManager.windowStateDebugDump(windowIds: [windowId])
+        #expect(!dump.contains("hidePlan.apply id=\(windowId)"))
+        #expect(!dump.contains("SkyLight.move id=\(windowId)"))
+    }
+
+    @Test @MainActor func resolveHideOperationStaleCachedGuardFiresForWorkspaceInactiveReason() {
+        // Gap 1b (Fix A): the stale-cached-already-hidden re-read must fire for
+        // `.workspaceInactive`, not only `.layoutTransient`. Setup: the cached frame
+        // is already at the computed park origin, but the live (slow) AX frame has
+        // drifted on-screen — the re-read must detect the drift and re-issue the park.
+        let controller = makeLayoutPlanTestController()
+        guard let monitor = controller.workspaceManager.monitors.first,
+              let workspaceId = controller.workspaceManager.activeWorkspaceOrFirst(on: monitor.id)?.id
+        else {
+            Issue.record("Missing monitor or active workspace for stale-cached workspace-inactive test")
+            return
+        }
+
+        let windowId = 711
+        let token = addLayoutPlanTestWindow(on: controller, workspaceId: workspaceId, windowId: windowId)
+        let frameSize = CGSize(width: 800, height: 600)
+        let parkedY: CGFloat = 180
+        guard let parkedOrigin = controller.layoutRefreshController.liveFrameHideOrigin(
+            for: CGRect(x: 0, y: parkedY, width: frameSize.width, height: frameSize.height),
+            monitor: monitor,
+            side: .right,
+            pid: getpid(),
+            reason: .workspaceInactive
+        ) else {
+            Issue.record("Expected a workspace-inactive park origin for stale-cached test")
+            return
+        }
+        // Cached frame already at the park origin; live AX frame drifted on-screen
+        // with different geometry. The repair must derive its new park origin from
+        // this live frame, not from the stale cached frame.
+        let cachedFrame = CGRect(origin: parkedOrigin, size: frameSize)
+        let driftedFrame = CGRect(x: 560, y: parkedY + 80, width: 900, height: 640)
+        guard let liveOrigin = controller.layoutRefreshController.liveFrameHideOrigin(
+            for: driftedFrame,
+            monitor: monitor,
+            side: .right,
+            pid: getpid(),
+            reason: .workspaceInactive
+        ) else {
+            Issue.record("Expected a live-frame workspace-inactive park origin for stale-cached test")
+            return
+        }
+        AXWindowService.fastFrameProviderForTests = { window in
+            window.windowId == windowId ? cachedFrame : fallbackFastFrameForTests(window)
+        }
+        // Non-throwing provider: a `(AXWindowRef) -> CGRect` converts to the
+        // `throws(AXErrorWrapper)` expected type. Only the target window's slow
+        // frame is read in this isolated test; others fall back to the test default.
+        let slowFrameProvider: (AXWindowRef) -> CGRect = { window in
+            window.windowId == windowId
+                ? driftedFrame
+                : (fallbackFastFrameForTests(window) ?? CGRect(x: 0, y: 0, width: 1, height: 1))
+        }
+        AXWindowService.frameProviderForTests = slowFrameProvider
+        defer {
+            AXWindowService.fastFrameProviderForTests = nil
+            AXWindowService.frameProviderForTests = nil
+        }
+
+        guard let entry = controller.workspaceManager.entry(for: token) else {
+            Issue.record("Missing entry for stale-cached workspace-inactive test")
+            return
+        }
+        controller.layoutRefreshController.hideWindow(
+            entry,
+            monitor: monitor,
+            side: .right,
+            reason: .workspaceInactive
+        )
+
+        let dump = controller.axManager.windowStateDebugDump(windowIds: [windowId])
+        #expect(dump.contains("hidePlan.staleCachedAlreadyHidden id=\(windowId) reason=workspaceInactive"))
+        #expect(dump.contains("requested=\(LayoutTrace.point(liveOrigin))"))
+        #expect(dump.contains("hidePlan.apply id=\(windowId)"))
+    }
+
+    @Test @MainActor func resolveHideOperationStaleCachedGuardDoesNotChurnWhenLiveFrameMatchesOrigin() {
+        // Regression / idempotency: when both the cached frame and the live frame are
+        // at the park origin, the stale-cached guard returns `.alreadyHidden` and does
+        // NOT re-issue a park move.
+        let controller = makeLayoutPlanTestController()
+        guard let monitor = controller.workspaceManager.monitors.first,
+              let workspaceId = controller.workspaceManager.activeWorkspaceOrFirst(on: monitor.id)?.id
+        else {
+            Issue.record("Missing monitor or active workspace for stale-cached no-churn test")
+            return
+        }
+
+        let windowId = 712
+        let token = addLayoutPlanTestWindow(on: controller, workspaceId: workspaceId, windowId: windowId)
+        let frameSize = CGSize(width: 800, height: 600)
+        let parkedY: CGFloat = 180
+        guard let parkedOrigin = controller.layoutRefreshController.liveFrameHideOrigin(
+            for: CGRect(x: 0, y: parkedY, width: frameSize.width, height: frameSize.height),
+            monitor: monitor,
+            side: .right,
+            pid: getpid(),
+            reason: .workspaceInactive
+        ) else {
+            Issue.record("Expected a workspace-inactive park origin for stale-cached no-churn test")
+            return
+        }
+        let parkedFrame = CGRect(origin: parkedOrigin, size: frameSize)
+        AXWindowService.fastFrameProviderForTests = { window in
+            window.windowId == windowId ? parkedFrame : fallbackFastFrameForTests(window)
+        }
+        let slowFrameProvider: (AXWindowRef) -> CGRect = { window in
+            window.windowId == windowId
+                ? parkedFrame
+                : (fallbackFastFrameForTests(window) ?? CGRect(x: 0, y: 0, width: 1, height: 1))
+        }
+        AXWindowService.frameProviderForTests = slowFrameProvider
+        defer {
+            AXWindowService.fastFrameProviderForTests = nil
+            AXWindowService.frameProviderForTests = nil
+        }
+
+        guard let entry = controller.workspaceManager.entry(for: token) else {
+            Issue.record("Missing entry for stale-cached no-churn test")
+            return
+        }
+        controller.layoutRefreshController.hideWindow(
+            entry,
+            monitor: monitor,
+            side: .right,
+            reason: .workspaceInactive
+        )
+
+        let dump = controller.axManager.windowStateDebugDump(windowIds: [windowId])
+        #expect(!dump.contains("hidePlan.staleCachedAlreadyHidden id=\(windowId)"))
+        #expect(!dump.contains("hidePlan.apply id=\(windowId)"))
+        #expect(!dump.contains("SkyLight.move id=\(windowId)"))
+    }
+
+    @Test @MainActor func executeLayoutPlanReconcilesStablyHiddenLayoutTransientColumnWithoutTransition() {
+        // Gap 2 (Fix C): a `layoutTransient` column that is already stably hidden but
+        // whose live AX drifted on-screen is re-parked without requiring a fresh
+        // `.hide` transition. The diff carries no visibility change for the window.
+        let controller = makeLayoutPlanTestController()
+        guard let monitor = controller.workspaceManager.monitors.first,
+              let workspaceId = controller.workspaceManager.activeWorkspaceOrFirst(on: monitor.id)?.id
+        else {
+            Issue.record("Missing monitor or active workspace for stably-hidden reconciliation test")
+            return
+        }
+
+        let windowId = 721
+        let token = addLayoutPlanTestWindow(on: controller, workspaceId: workspaceId, windowId: windowId)
+        controller.workspaceManager.setHiddenState(
+            .init(
+                proportionalPosition: .zero,
+                referenceMonitorId: monitor.id,
+                reason: .layoutTransient(.left)
+            ),
+            for: token
+        )
+        // Live AX drifted back on-screen while the column is stably hidden.
+        let driftedFrame = CGRect(x: 560, y: 180, width: 800, height: 600)
+        AXWindowService.fastFrameProviderForTests = { window in
+            window.windowId == windowId ? driftedFrame : fallbackFastFrameForTests(window)
+        }
+        defer { AXWindowService.fastFrameProviderForTests = nil }
+
+        // Empty diff: no `.hide`/`.show` transition for the window (stably hidden).
+        let plan = WorkspaceLayoutPlan(
+            workspaceId: workspaceId,
+            monitor: controller.layoutRefreshController.buildMonitorSnapshot(for: monitor),
+            sessionPatch: WorkspaceSessionPatch(workspaceId: workspaceId),
+            diff: WorkspaceLayoutDiff()
+        )
+        controller.layoutRefreshController.executeLayoutPlan(plan)
+
+        let dump = controller.axManager.windowStateDebugDump(windowIds: [windowId])
+        #expect(dump.contains("hidePlan.apply id=\(windowId)"))
+    }
+
+    @Test @MainActor func executeLayoutPlanDoesNotApplyFrameChangeAfterReparkingStablyHiddenColumn() {
+        // Defensive regression: if a malformed/stale diff carries a frameChange for a
+        // stably-hidden column that the reconciliation sweep re-parks, the reconciled
+        // token must be treated like other hidden entries and excluded from ordinary
+        // frame writes.
+        let controller = makeLayoutPlanTestController()
+        guard let monitor = controller.workspaceManager.monitors.first,
+              let workspaceId = controller.workspaceManager.activeWorkspaceOrFirst(on: monitor.id)?.id
+        else {
+            Issue.record("Missing monitor or active workspace for stably-hidden frame-write exclusion test")
+            return
+        }
+
+        let windowId = 723
+        let token = addLayoutPlanTestWindow(on: controller, workspaceId: workspaceId, windowId: windowId)
+        controller.workspaceManager.setHiddenState(
+            .init(
+                proportionalPosition: .zero,
+                referenceMonitorId: monitor.id,
+                reason: .layoutTransient(.left)
+            ),
+            for: token
+        )
+        let driftedFrame = CGRect(x: 560, y: 180, width: 800, height: 600)
+        AXWindowService.fastFrameProviderForTests = { window in
+            window.windowId == windowId ? driftedFrame : fallbackFastFrameForTests(window)
+        }
+        defer { AXWindowService.fastFrameProviderForTests = nil }
+
+        let visibleFrame = CGRect(x: 120, y: 120, width: 800, height: 600)
+        var diff = WorkspaceLayoutDiff()
+        diff.frameChanges = [LayoutFrameChange(token: token, frame: visibleFrame, forceApply: false)]
+        let plan = WorkspaceLayoutPlan(
+            workspaceId: workspaceId,
+            monitor: controller.layoutRefreshController.buildMonitorSnapshot(for: monitor),
+            sessionPatch: WorkspaceSessionPatch(workspaceId: workspaceId),
+            diff: diff
+        )
+        controller.layoutRefreshController.executeLayoutPlan(plan)
+
+        let dump = controller.axManager.windowStateDebugDump(windowIds: [windowId])
+        #expect(dump.contains("hidePlan.apply id=\(windowId)"))
+        #expect(controller.axManager.lastAppliedFrame(for: windowId) == nil)
+        #expect(!dump.contains("confirmed id=\(windowId)"))
+    }
+
+    @Test @MainActor func executeLayoutPlanDoesNotChurnCorrectlyParkedStablyHiddenColumn() {
+        // Regression / idempotency: a stably-hidden `layoutTransient` column whose
+        // live AX is already at the park origin is NOT re-moved by the reconciliation
+        // sweep.
+        let controller = makeLayoutPlanTestController()
+        guard let monitor = controller.workspaceManager.monitors.first,
+              let workspaceId = controller.workspaceManager.activeWorkspaceOrFirst(on: monitor.id)?.id
+        else {
+            Issue.record("Missing monitor or active workspace for stably-hidden no-churn test")
+            return
+        }
+
+        let windowId = 722
+        let token = addLayoutPlanTestWindow(on: controller, workspaceId: workspaceId, windowId: windowId)
+        let frameSize = CGSize(width: 800, height: 600)
+        let parkedY: CGFloat = 180
+        guard let parkedOrigin = controller.layoutRefreshController.liveFrameHideOrigin(
+            for: CGRect(x: 0, y: parkedY, width: frameSize.width, height: frameSize.height),
+            monitor: monitor,
+            side: .left,
+            pid: getpid(),
+            reason: .layoutTransient
+        ) else {
+            Issue.record("Expected a layout-transient park origin for stably-hidden no-churn test")
+            return
+        }
+        controller.workspaceManager.setHiddenState(
+            .init(
+                proportionalPosition: .zero,
+                referenceMonitorId: monitor.id,
+                reason: .layoutTransient(.left)
+            ),
+            for: token
+        )
+        let parkedFrame = CGRect(origin: parkedOrigin, size: frameSize)
+        AXWindowService.fastFrameProviderForTests = { window in
+            window.windowId == windowId ? parkedFrame : fallbackFastFrameForTests(window)
+        }
+        defer { AXWindowService.fastFrameProviderForTests = nil }
+
+        let plan = WorkspaceLayoutPlan(
+            workspaceId: workspaceId,
+            monitor: controller.layoutRefreshController.buildMonitorSnapshot(for: monitor),
+            sessionPatch: WorkspaceSessionPatch(workspaceId: workspaceId),
+            diff: WorkspaceLayoutDiff()
+        )
+        controller.layoutRefreshController.executeLayoutPlan(plan)
+
+        let dump = controller.axManager.windowStateDebugDump(windowIds: [windowId])
+        #expect(!dump.contains("hidePlan.apply id=\(windowId)"))
+        #expect(!dump.contains("SkyLight.move id=\(windowId)"))
+    }
+
     // MARK: - Selection revision guard
 
     @Test @MainActor func staleRelayoutPatchDoesNotOverwriteNewerSelection() {


### PR DESCRIPTION
## Summary

Keep only the reconciliation fixes still missing after rebasing on main:

- Generalize resolveHideOperation's stale-cached-already-hidden live AX re-read from layoutTransient-only to all hide reasons, so main's workspaceInactive drift repair can actually re-issue the park when cached state says parked but live AX drifted.
- Add a throttled per-workspace sweep for stably-hidden layoutTransient columns so drifted live AX frames are re-parked without requiring a fresh .hide transition.

Includes focused tests for both fixes and idempotency/no-churn, plus the release changeset. This does not defeat the macOS offscreen clamp; it only re-drives Nehir's park request when hidden state and live AX state diverge.
## Release notes

Choose one:

- [x] Added a `.changeset/*.md` for user-visible changes (`mise run changeset -- patch "..."`).
- [ ] No user-visible change; apply the `no release note` label to make CI skip intentional.

## Validation

<!-- Commands run, screenshots, or manual checks. -->

- [ ] Ran relevant tests/checks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recovery for windows that unexpectedly drift back on screen while they’re still considered hidden, so they’re re-parked more reliably.
  * Enhanced reconciliation for long-stably-hidden `layoutTransient` columns and workspace-inactive hidden windows to reduce repeat reappearance and unnecessary move churn.
  * Avoids extra operations when windows are already parked correctly; note that in some setups a very thin parked strip may still remain visible.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->