### PR TITLE
Restore screen-share trackpad gestures

### DIFF
--- a/.changeset/20260701143434-restore-trackpad-gestures-during-screen-sharing.md
+++ b/.changeset/20260701143434-restore-trackpad-gestures-during-screen-sharing.md
@@ -1,0 +1,6 @@
+---
+"nehir": patch
+
+---
+
+Restore trackpad gestures during screen sharing

--- a/Sources/Nehir/Core/Controller/MouseEventHandler.swift
+++ b/Sources/Nehir/Core/Controller/MouseEventHandler.swift
@@ -1493,23 +1493,24 @@ final class MouseEventHandler {
             abortActiveGestureIfNeeded()
             return
         }
-        let shouldProbeWindowServerOverlay = snapshot.windowUnderPointer == nil
-            && state.gesturePhase == .idle
-            && phase != .ended
-            && phase != .cancelled
-            && activeTouchCount > 0
+        // Gestures only trust the event-provided window id for unmanaged-overlay
+        // suppression. Screen-share/capture surfaces can appear in the broad
+        // WindowServer snapshot fallback while gesture events report no
+        // window-under-pointer, so probing the snapshot-only path here can
+        // suppress an otherwise valid touch sequence. Focus-follows-mouse keeps
+        // its stricter snapshot policy separately.
         let isOverUnmanagedOverlay = controller.unmanagedWindowServerWindowCovers(
             point: location,
             windowUnderPointer: snapshot.windowUnderPointer,
             allowWindowServerSnapshotFallback: false
-        ) || (shouldProbeWindowServerOverlay && controller.unmanagedOverlayWindowServerWindowCovers(point: location))
+        )
         if isOverUnmanagedOverlay,
            phase != .ended,
            phase != .cancelled,
            activeTouchCount > 0
         {
             traceMouseFocus(
-                "gesture.skip reason=unmanagedOverlay loc=\(formatPoint(location)) windowUnderPointer=\(snapshot.windowUnderPointer.map(String.init) ?? "nil") snapshotProbe=\(shouldProbeWindowServerOverlay)"
+                "gesture.skip reason=unmanagedOverlay loc=\(formatPoint(location)) windowUnderPointer=\(snapshot.windowUnderPointer.map(String.init) ?? "nil") snapshotProbe=false"
             )
             abortActiveGestureIfNeeded()
             state.suppressGestureUntilTouchesEnd = true

--- a/Tests/NehirTests/MouseEventHandlerTests.swift
+++ b/Tests/NehirTests/MouseEventHandlerTests.swift
@@ -1373,7 +1373,7 @@ private func prepareMouseWheelScrollFixtureWithDefaultSensitivity() async -> (
         #expect(covers == true)
     }
 
-    @Test @MainActor func trackpadGestureSuppressesViaOverlaySnapshotOnlyWhenEventWindowIsMissing() async {
+    @Test @MainActor func trackpadGestureIgnoresSnapshotOnlyOverlayWhenEventWindowIsMissing() async {
         let fixture = await prepareMouseWheelScrollFixture()
         let controller = fixture.controller
         let handler = fixture.handler
@@ -1383,6 +1383,7 @@ private func prepareMouseWheelScrollFixtureWithDefaultSensitivity() async -> (
             overlayProbeCount += 1
             return true
         }
+        controller.toggleRuntimeTraceCapture(desiredState: .active)
 
         handler.receiveTapGestureEvent(
             .init(
@@ -1401,9 +1402,16 @@ private func prepareMouseWheelScrollFixtureWithDefaultSensitivity() async -> (
             )
         )
 
-        #expect(overlayProbeCount == 1)
-        #expect(handler.state.gesturePhase == .idle)
-        #expect(handler.state.lockedGestureContext == nil)
+        let mouseTraces = controller.runtimeMouseTraceRecordsForTests()
+        let viewportTraces = controller.runtimeViewportTraceRecordsForTests()
+        #expect(overlayProbeCount == 0)
+        #expect(mouseTraces.contains { $0.contains("gesture.skip reason=unmanagedOverlay") } == false)
+        #expect(mouseTraces.contains { $0.contains("gesture.skip reason=suppressed") } == false)
+        #expect(viewportTraces.contains { $0.contains("reason=touch_scroll_gesture_armed") })
+        #expect(viewportTraces.contains { $0.contains("reason=touch_scroll_gesture_committed") })
+        #expect(handler.state.gesturePhase == .committed)
+        #expect(handler.state.lockedGestureContext != nil)
+        #expect(handler.state.suppressGestureUntilTouchesEnd == false)
     }
 
     @Test @MainActor func trackpadGestureSuppressesViaEventWindowUnderPointerWithoutSnapshot() async {
@@ -1416,6 +1424,7 @@ private func prepareMouseWheelScrollFixtureWithDefaultSensitivity() async -> (
             snapshotCalls += 1
             return []
         }
+        controller.toggleRuntimeTraceCapture(desiredState: .active)
 
         handler.receiveTapGestureEvent(
             .init(
@@ -1436,9 +1445,58 @@ private func prepareMouseWheelScrollFixtureWithDefaultSensitivity() async -> (
             )
         )
 
+        let mouseTraces = controller.runtimeMouseTraceRecordsForTests()
         #expect(snapshotCalls == 0)
+        #expect(mouseTraces.contains {
+            $0.contains("gesture.skip reason=unmanagedOverlay")
+                && $0.contains("windowUnderPointer=55555")
+                && $0.contains("snapshotProbe=false")
+        })
+        #expect(mouseTraces.contains {
+            $0.contains("gesture.skip reason=suppressed")
+        })
         #expect(handler.state.gesturePhase == .idle)
         #expect(handler.state.lockedGestureContext == nil)
+        #expect(handler.state.suppressGestureUntilTouchesEnd == true)
+    }
+
+    @Test @MainActor func suppressedTrackpadGestureClearsOnEndedCancelledOrNoActiveTouches() async {
+        let fixture = await prepareMouseWheelScrollFixture()
+        let handler = fixture.handler
+        let baseTime = CACurrentMediaTime()
+
+        handler.state.suppressGestureUntilTouchesEnd = true
+        handler.receiveTapGestureEvent(
+            .init(
+                location: fixture.location,
+                phaseRawValue: NSEvent.Phase.ended.rawValue,
+                timestamp: baseTime,
+                touches: makeGestureTouchSamples(xPositions: [0.20, 0.25, 0.30], phase: .ended)
+            )
+        )
+        #expect(handler.state.suppressGestureUntilTouchesEnd == false)
+
+        handler.state.suppressGestureUntilTouchesEnd = true
+        handler.receiveTapGestureEvent(
+            .init(
+                location: fixture.location,
+                phaseRawValue: NSEvent.Phase.cancelled.rawValue,
+                timestamp: baseTime + 0.016,
+                touches: makeGestureTouchSamples(xPositions: [0.20, 0.25, 0.30], phase: .cancelled)
+            )
+        )
+        #expect(handler.state.suppressGestureUntilTouchesEnd == false)
+
+        handler.state.suppressGestureUntilTouchesEnd = true
+        handler.receiveTapGestureEvent(
+            .init(
+                location: fixture.location,
+                phaseRawValue: NSEvent.Phase.changed.rawValue,
+                timestamp: baseTime + 0.032,
+                touches: makeGestureTouchSamples(xPositions: [0.20, 0.25, 0.30], phase: .ended)
+            )
+        )
+        #expect(handler.state.suppressGestureUntilTouchesEnd == false)
     }
 
     @Test @MainActor func trackpadGestureFocusSuppressesMouseMoveToFocusedWindow() async {


### PR DESCRIPTION
## Summary

Restore trackpad gestures during screen sharing

Initially introduced by attempt to avoid gestures to work over ghostty quick terminal. Now this back as tradeoff. Details in plans branch.

## Release notes

Choose one:

- [x] Added a `.changeset/*.md` for user-visible changes (`mise run changeset -- patch "..."`).
- [ ] No user-visible change; apply the `no release note` label to make CI skip intentional.

## Validation

<!-- Commands run, screenshots, or manual checks. -->

- [ ] Ran relevant tests/checks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Restored trackpad gesture behavior during screen sharing.
  - Reduced cases where gestures were incorrectly blocked when overlays were present, improving scroll and gesture responsiveness.

- **Tests**
  - Updated and expanded regression coverage for gesture handling and suppression scenarios.
  - Added checks to verify gestures complete correctly when touch input ends or is canceled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->