### PR TITLE
Fix trackpad swipe catch-up jumps and clamp release projection

### DIFF
--- a/.changeset/20260701191524-fix-trackpad-swipe-catch-up-jumps-and-clamp-rele.md
+++ b/.changeset/20260701191524-fix-trackpad-swipe-catch-up-jumps-and-clamp-rele.md
@@ -1,0 +1,6 @@
+---
+"nehir": patch
+
+---
+
+Fix trackpad swipe catch-up jumps and clamp release projection

--- a/Sources/Nehir/Core/Ax/AXManager.swift
+++ b/Sources/Nehir/Core/Ax/AXManager.swift
@@ -500,7 +500,7 @@ final class AXManager {
         }
         let windowServerCounts = windowServerCountsByPid
 
-        return await withTaskGroup(
+        let snapshot = await withTaskGroup(
             of: (pid: pid_t, windows: [(AXWindowRef, pid_t, Int)], failed: Bool).self
         ) { group in
             for app in apps {
@@ -544,7 +544,54 @@ final class AXManager {
                     failedPIDs.insert(result.pid)
                 }
             }
-            return .init(windows: results, failedPIDs: failedPIDs)
+            return FullRescanEnumerationSnapshot(windows: results, failedPIDs: failedPIDs)
+        }
+
+        recordFullRescanOmissions(snapshot: snapshot, visibleWindows: visibleWindows)
+        return snapshot
+    }
+
+    // Diagnostic: after a full rescan enumerates AX windows, cross-check each pid's
+    // AX-tracked window IDs against the WindowServer level-0 visible windows. Emits a
+    // compact `full_rescan_omission` summary (plus one line per omitted candidate) only
+    // when a visible level-0 window was not tracked, so real startup admission gaps are
+    // separated from harmless `missing_ax_ref` menu/overlay surfaces. Never mutates state.
+    private func recordFullRescanOmissions(
+        snapshot: FullRescanEnumerationSnapshot,
+        visibleWindows: [WindowServerInfo]
+    ) {
+        var axIdsByPid: [pid_t: Set<Int>] = [:]
+        for (_, pid, windowId) in snapshot.windows {
+            axIdsByPid[pid, default: []].insert(windowId)
+        }
+
+        var level0ByPid: [pid_t: [WindowServerInfo]] = [:]
+        for window in visibleWindows where window.level == 0 {
+            level0ByPid[pid_t(window.pid), default: []].append(window)
+        }
+
+        for (pid, level0Windows) in level0ByPid {
+            let axIds = axIdsByPid[pid] ?? []
+            let omitted = level0Windows.filter { !axIds.contains(Int($0.id)) }
+            guard !omitted.isEmpty else { continue }
+
+            let omittedIds = omitted.map { String($0.id) }.joined(separator: ",")
+            recordFrameApplyTrace(
+                "full_rescan_omission pid=\(pid) windowServerLevel0VisibleCount=\(level0Windows.count) "
+                    + "axWindowCount=\(axIds.count) failedPID=\(snapshot.failedPIDs.contains(pid)) "
+                    + "omittedVisibleWindowIds=[\(omittedIds)]"
+            )
+            for window in omitted {
+                let axRefResolvable = AXWindowService.axWindowRef(for: window.id, pid: pid) != nil
+                recordFrameApplyTrace(
+                    "full_rescan_omission.window windowId=\(window.id) pid=\(pid) "
+                        + "parent=\(window.parentId) level=\(window.level) "
+                        + "hasDocumentTag=\(window.hasDocumentTag) hasFloatingTag=\(window.hasFloatingTag) "
+                        + "bounds=\(Self.format(frame: window.frame)) "
+                        + "axRefResolvable=\(axRefResolvable) topLevelAX=\(window.parentId == 0) "
+                        + "trackedAfterRescan=false"
+                )
+            }
         }
     }
 

--- a/Sources/Nehir/Core/Ax/AXManager.swift
+++ b/Sources/Nehir/Core/Ax/AXManager.swift
@@ -44,6 +44,11 @@ final class AXManager {
     private var appLaunchObserver: NSObjectProtocol?
     var onAppLaunched: ((NSRunningApplication) -> Void)?
     var onAppTerminated: ((pid_t) -> Void)?
+    /// Set by the controller so full-rescan omission diagnostics — which probe
+    /// `AXWindowService.axWindowRef` — only run while a runtime trace capture is
+    /// active. Defaults to disabled so tests never trigger the AX probe (which would
+    /// otherwise pollute a globally-installed `axWindowRefProviderForTests` spy).
+    var isRuntimeTraceCaptureActive: () -> Bool = { false }
     var currentWindowsAsyncOverride: (@MainActor () async -> [(AXWindowRef, pid_t, Int)])?
     var fullRescanEnumerationOverrideForTests: (@MainActor () async -> FullRescanEnumerationSnapshot)?
     var frameApplyOverrideForTests: (([AXFrameApplicationRequest]) -> [AXFrameApplyResult])?
@@ -560,6 +565,10 @@ final class AXManager {
         snapshot: FullRescanEnumerationSnapshot,
         visibleWindows: [WindowServerInfo]
     ) {
+        // Diagnostic only; skip entirely (including the AX-ref probe below) unless a
+        // runtime trace capture is active.
+        guard isRuntimeTraceCaptureActive() else { return }
+
         var axIdsByPid: [pid_t: Set<Int>] = [:]
         for (_, pid, windowId) in snapshot.windows {
             axIdsByPid[pid, default: []].insert(windowId)

--- a/Sources/Nehir/Core/Ax/AXManager.swift
+++ b/Sources/Nehir/Core/Ax/AXManager.swift
@@ -503,6 +503,7 @@ final class AXManager {
         let apps = NSWorkspace.shared.runningApplications.filter {
             shouldTrack($0) && pidsWithWindows.contains($0.processIdentifier)
         }
+        let trackedPIDs = Set(apps.map(\.processIdentifier))
         let windowServerCounts = windowServerCountsByPid
 
         let snapshot = await withTaskGroup(
@@ -552,7 +553,7 @@ final class AXManager {
             return FullRescanEnumerationSnapshot(windows: results, failedPIDs: failedPIDs)
         }
 
-        recordFullRescanOmissions(snapshot: snapshot, visibleWindows: visibleWindows)
+        recordFullRescanOmissions(snapshot: snapshot, visibleWindows: visibleWindows, trackedPIDs: trackedPIDs)
         return snapshot
     }
 
@@ -563,7 +564,8 @@ final class AXManager {
     // separated from harmless `missing_ax_ref` menu/overlay surfaces. Never mutates state.
     private func recordFullRescanOmissions(
         snapshot: FullRescanEnumerationSnapshot,
-        visibleWindows: [WindowServerInfo]
+        visibleWindows: [WindowServerInfo],
+        trackedPIDs: Set<pid_t>
     ) {
         // Diagnostic only; skip entirely (including the AX-ref probe below) unless a
         // runtime trace capture is active.
@@ -580,6 +582,7 @@ final class AXManager {
         }
 
         for (pid, level0Windows) in level0ByPid {
+            guard trackedPIDs.contains(pid) else { continue }
             let axIds = axIdsByPid[pid] ?? []
             let omitted = level0Windows.filter { !axIds.contains(Int($0.id)) }
             guard !omitted.isEmpty else { continue }

--- a/Sources/Nehir/Core/Controller/LayoutRefreshController.swift
+++ b/Sources/Nehir/Core/Controller/LayoutRefreshController.swift
@@ -2688,6 +2688,89 @@ import QuartzCore
         case unavailable
     }
 
+    // Diagnostic: when a hide/parking write verifies with a mismatch, classify whether
+    // the discrepancy is a visible slide-through (observed frame overlaps the active
+    // viewport) or a coordinate-space readback artifact (e.g. an off-by-height Y flip
+    // or an offscreen X that is expected). Emitted only on mismatch, so it stays quiet
+    // when parking works.
+    private func recordParkingVerifyMismatch(
+        plan: WindowPositionPlan,
+        requestedFrame: CGRect,
+        observedFrame: CGRect?,
+        backend: String
+    ) {
+        guard let controller, controller.isRuntimeTraceCaptureActive else { return }
+        let monitor = plan.displayId.flatMap { displayId -> Monitor? in
+            controller.workspaceManager.monitors.first { $0.displayId == displayId }
+        }
+        let windowId = plan.entry.windowId
+        let requestedOrigin = LayoutTrace.point(requestedFrame.origin)
+        let widthText = String(format: "%.1f", requestedFrame.width)
+        let heightText = String(format: "%.1f", requestedFrame.height)
+
+        guard let observedFrame else {
+            let text = "parking_verify_mismatch id=\(windowId) backend=\(backend)"
+                + " requestedOrigin=\(requestedOrigin) observedOrigin=nil"
+                + " width=\(widthText) height=\(heightText)"
+                + " observedXOffscreen=nil observedYDeltaEqualsHeight=nil visibleRisk=nil"
+            controller.axManager.recordFrameApplyTrace(text)
+            return
+        }
+
+        let dx = observedFrame.origin.x - requestedFrame.origin.x
+        let dy = observedFrame.origin.y - requestedFrame.origin.y
+        let height = requestedFrame.height
+
+        var observedXOffscreen = false
+        var visibleRisk = false
+        if let monitor {
+            let displayFrame = monitor.frame
+            let offscreenLeft = observedFrame.maxX <= displayFrame.minX
+            let offscreenRight = observedFrame.minX >= displayFrame.maxX
+            observedXOffscreen = offscreenLeft || offscreenRight
+            visibleRisk = monitor.visibleFrame.intersects(observedFrame)
+        }
+        let observedYDeltaEqualsHeight = abs(abs(dy) - height) < 2.0
+
+        let dxText = String(format: "%.1f", dx)
+        let dyText = String(format: "%.1f", dy)
+        let text = "parking_verify_mismatch id=\(windowId) backend=\(backend)"
+            + " requestedOrigin=\(requestedOrigin)"
+            + " observedOrigin=\(LayoutTrace.point(observedFrame.origin))"
+            + " dx=\(dxText) dy=\(dyText) width=\(widthText) height=\(heightText)"
+            + " observedXOffscreen=\(observedXOffscreen)"
+            + " observedYDeltaEqualsHeight=\(observedYDeltaEqualsHeight)"
+            + " visibleRisk=\(visibleRisk)"
+        controller.axManager.recordFrameApplyTrace(text)
+    }
+
+    // Diagnostic: when a window is parked offscreen, its managed-replacement metadata
+    // still carries the last on-screen frame. Emit a low-volume record when that
+    // replacement frame disagrees with the parked frame, so a capture can tell whether
+    // stale replacement geometry (not the parked position) is what a later reconcile
+    // would restore. `updatedReplacementMetadata=false` records that main does not
+    // refresh the metadata here.
+    private func recordHiddenReplacementFrameMismatch(
+        plan: WindowPositionPlan,
+        parkedFrame: CGRect
+    ) {
+        guard let controller, controller.isRuntimeTraceCaptureActive else { return }
+        guard let replacementFrame = plan.entry.managedReplacementMetadata?.frame else { return }
+        let dx = replacementFrame.origin.x - parkedFrame.origin.x
+        let dy = replacementFrame.origin.y - parkedFrame.origin.y
+        guard abs(dx) > 1.0 || abs(dy) > 1.0 else { return }
+
+        let hiddenState = controller.workspaceManager.hiddenState(for: plan.entry.token)
+        let hiddenReason = hiddenState.map { "\($0.reason)" } ?? "nil"
+        let hiddenSide = hiddenState?.offscreenSide.map { "\($0)" } ?? "nil"
+        let text = "hidden_replacement_frame_mismatch token=\(String(describing: plan.entry.token))"
+            + " windowId=\(plan.entry.windowId) hiddenReason=\(hiddenReason) hiddenSide=\(hiddenSide)"
+            + " parked=\(LayoutTrace.rect(parkedFrame)) replacement=\(LayoutTrace.rect(replacementFrame))"
+            + " replacementDx=\(String(format: "%.1f", dx)) replacementDy=\(String(format: "%.1f", dy))"
+            + " updatedReplacementMetadata=false"
+        controller.axManager.recordFrameApplyTrace(text)
+    }
+
     private func positionPlanPlacementVerified(
         _ plan: WindowPositionPlan,
         requestedFrame: CGRect,
@@ -2815,6 +2898,15 @@ import QuartzCore
             controller.axManager.recordFrameApplyTrace(
                 "hidePlan.final id=\(plan.entry.windowId) requested=\(LayoutTrace.rect(requestedFrame)) observed=\(observedFrame.map(LayoutTrace.rect) ?? "nil") fallback=\(fallbackAttempted ? "YES" : "no") verified=\(verified)"
             )
+            if !verified {
+                recordParkingVerifyMismatch(
+                    plan: plan,
+                    requestedFrame: requestedFrame,
+                    observedFrame: observedFrame,
+                    backend: fallbackAttempted ? "ax" : "skylight"
+                )
+            }
+            recordHiddenReplacementFrameMismatch(plan: plan, parkedFrame: requestedFrame)
             results.append(
                 WindowPositionApplyResult(
                     token: plan.entry.token,

--- a/Sources/Nehir/Core/Controller/MouseEventHandler.swift
+++ b/Sources/Nehir/Core/Controller/MouseEventHandler.swift
@@ -251,7 +251,6 @@ final class MouseEventHandler {
         var commitCumulativeY: CGFloat = 0.0
         var commitRawDeltaX: CGFloat = 0.0
         var commitInputPhaseName = ""
-        var commitTimestamp: TimeInterval = 0.0
         var suppressGestureUntilTouchesEnd = false
         var pendingTapEvents = PendingTapEvents()
         var debugCounters = DebugCounters()
@@ -1793,7 +1792,6 @@ final class MouseEventHandler {
                 state.commitCumulativeY = cumulativeY
                 state.commitRawDeltaX = cumulativeX
                 state.commitInputPhaseName = Self.gesturePhaseName(phase)
-                state.commitTimestamp = snapshot.timestamp
                 controller.recordRuntimeViewportTrace(
                     workspaceId: wsId,
                     reason: "touch_scroll_gesture_committed",
@@ -2321,7 +2319,6 @@ final class MouseEventHandler {
         state.commitCumulativeY = 0.0
         state.commitRawDeltaX = 0.0
         state.commitInputPhaseName = ""
-        state.commitTimestamp = 0.0
     }
 
     private func currentSelectionNode(

--- a/Sources/Nehir/Core/Controller/MouseEventHandler.swift
+++ b/Sources/Nehir/Core/Controller/MouseEventHandler.swift
@@ -245,7 +245,7 @@ final class MouseEventHandler {
         var lockedGestureContext: LockedGestureContext?
         // Commit metrics retained from the armed→committed transition until the first
         // committed update, so `touch_scroll_gesture_first_update` can report whether
-        // the first applied delta carried the full pre-recognition movement.
+        // the first applied delta honored the recognition dead zone.
         var pendingFirstUpdateAfterCommit = false
         var commitCumulativeX: CGFloat = 0.0
         var commitCumulativeY: CGFloat = 0.0
@@ -1783,14 +1783,15 @@ final class MouseEventHandler {
                     return
                 }
 
-                rawDeltaX = cumulativeX
+                let overshootMagnitude = max(0.0, abs(cumulativeX) - niriTouchpadGestureRecognitionThreshold)
+                rawDeltaX = (cumulativeX < 0 ? -1.0 : 1.0) * overshootMagnitude
                 state.gesturePhase = .committed
                 // Retain the commit metrics so the first committed update can report
-                // how much pre-recognition movement it carried (recognition debt).
+                // how much pre-recognition movement was discarded by the dead zone.
                 state.pendingFirstUpdateAfterCommit = true
                 state.commitCumulativeX = cumulativeX
                 state.commitCumulativeY = cumulativeY
-                state.commitRawDeltaX = rawDeltaX
+                state.commitRawDeltaX = cumulativeX
                 state.commitInputPhaseName = Self.gesturePhaseName(phase)
                 state.commitTimestamp = snapshot.timestamp
                 controller.recordRuntimeViewportTrace(
@@ -1902,26 +1903,21 @@ final class MouseEventHandler {
 
     // Emits `touch_scroll_gesture_first_update` linking the just-applied first
     // committed delta back to the commit's cumulative recognition movement, so a
-    // capture can tell — without manual pairing — whether the first update carried
-    // the full pre-recognition debt and what a dead-zone implementation would apply
-    // instead. Diagnostic only; it does not alter the applied delta.
+    // capture can tell — without manual pairing — whether the first update was
+    // reduced to only the movement beyond the recognition dead zone.
     private func emitFirstUpdateDiagnostic(appliedDelta: CGFloat, wsId: WorkspaceDescriptor.ID) {
         guard let controller else { return }
         let threshold = niriTouchpadGestureRecognitionThreshold
         let rawDeltaX = state.commitRawDeltaX
-        // The commit branch applies the full accumulated pre-recognition movement as
-        // the first delta. A dead-zone implementation would instead apply only the
-        // movement beyond the recognition threshold along the committed axis.
+        // The first committed update should apply only the movement beyond the
+        // recognition threshold along the committed axis.
         let overshootMagnitude = max(0.0, abs(rawDeltaX) - threshold)
         let signedOvershoot = (rawDeltaX < 0 ? -1.0 : 1.0) * overshootMagnitude
         let sensitivity = CGFloat(controller.settings.scrollSensitivity)
         let invert = controller.settings.gestureInvertDirection
         var wouldDeadZoneDelta = signedOvershoot * sensitivity
         if invert { wouldDeadZoneDelta = -wouldDeadZoneDelta }
-        // On current main the first committed update applies the full accumulated
-        // pre-recognition movement (rawDeltaX == commitCumulativeX), so any nonzero
-        // first delta carries recognition debt.
-        let includesRecognitionDebt = abs(rawDeltaX) > 0
+        let includesRecognitionDebt = abs(appliedDelta - wouldDeadZoneDelta) > 0.001
         controller.recordRuntimeViewportTrace(
             workspaceId: wsId,
             reason: "touch_scroll_gesture_first_update",
@@ -2051,15 +2047,26 @@ final class MouseEventHandler {
                 ))
                 let currentOffset = gesture.current()
                 let velocity = gesture.tracker.velocity() * normFactor
-                let projectedOffset = gesture.tracker.projectedEndPosition() * normFactor
+                let rawProjectedOffset = gesture.tracker.projectedEndPosition() * normFactor
                     + gesture.deltaFromTracker
                 let currentViewStart = activeColumnX + currentOffset
-                let projectedViewStart = activeColumnX + projectedOffset
+                let rawProjectedViewStart = activeColumnX + rawProjectedOffset
+                let projectedViewStart = gesture.isTrackpad
+                    ? clampedTrackpadGestureProjectedViewStart(
+                        rawProjectedViewStart: rawProjectedViewStart,
+                        currentViewStart: currentViewStart,
+                        viewportWidth: insetFrame.width
+                    )
+                    : rawProjectedViewStart
+                let projectedOffset = projectedViewStart - activeColumnX
                 let snapContext = endState.snapContext(
                     columns: columns,
                     gap: gap,
                     viewportWidth: insetFrame.width
                 )
+                let rawClosestSnap = snapToColumn
+                    ? snapContext.closest(to: CGFloat(rawProjectedViewStart))
+                    : nil
                 let closestSnap = snapToColumn
                     ? snapContext.closest(to: CGFloat(projectedViewStart))
                     : nil
@@ -2088,18 +2095,32 @@ final class MouseEventHandler {
                 } else {
                     details.append("closestSnap=nil")
                 }
+                if let rawClosestSnap {
+                    details.append(String(format: "rawClosestSnap=%.3f", rawClosestSnap.offset))
+                    details.append("rawClosestSnapColumn=\(rawClosestSnap.columnIndex)")
+                    details.append("rawClosestSnapKind=\(rawClosestSnap.kind)")
+                    details.append(String(
+                        format: "rawClosestSnapDistance=%.3f",
+                        abs(Double(rawClosestSnap.offset) - rawProjectedViewStart)
+                    ))
+                } else {
+                    details.append("rawClosestSnap=nil")
+                }
                 if let targetOffset {
                     details.append(String(format: "targetOffset=%.3f", targetOffset))
                 }
                 // Derived release-projection distances so a capture can classify a
                 // multi-column release by grep alone. `wouldClamp` reports whether the
-                // planned (not-yet-implemented) projection clamp would have changed the
-                // target; `clampScreens=nil` records that no clamp is configured on main.
+                // configured projection clamp changed the raw projected release point.
                 let viewportWidth = Double(insetFrame.width)
+                let rawProjectionDeltaFromCurrent = rawProjectedViewStart - currentViewStart
+                let rawProjectionScreens = viewportWidth > 0 ? rawProjectionDeltaFromCurrent / viewportWidth : 0
                 let projectionDeltaFromCurrent = projectedViewStart - currentViewStart
                 let projectionScreens = viewportWidth > 0 ? projectionDeltaFromCurrent / viewportWidth : 0
-                details.append(String(format: "rawProjectedOffset=%.3f", projectedOffset))
-                details.append(String(format: "rawProjectedViewStart=%.3f", projectedViewStart))
+                details.append(String(format: "rawProjectedOffset=%.3f", rawProjectedOffset))
+                details.append(String(format: "rawProjectedViewStart=%.3f", rawProjectedViewStart))
+                details.append(String(format: "rawProjectionDeltaFromCurrent=%.3f", rawProjectionDeltaFromCurrent))
+                details.append(String(format: "rawProjectionScreens=%.3f", rawProjectionScreens))
                 details.append(String(format: "projectionDeltaFromCurrent=%.3f", projectionDeltaFromCurrent))
                 details.append(String(format: "projectionScreens=%.3f", projectionScreens))
                 details.append("projectedColumnDelta=\(Int(projectionScreens.rounded()))")
@@ -2108,18 +2129,16 @@ final class MouseEventHandler {
                 } else {
                     details.append("targetColumnDelta=nil")
                 }
-                let diagnosticClampScreens = 1.0
-                let clampBound = diagnosticClampScreens * viewportWidth
-                let clampedDelta = max(-clampBound, min(clampBound, projectionDeltaFromCurrent))
-                let clampedProjectedViewStart = currentViewStart + clampedDelta
-                let clampedSnap = snapToColumn
-                    ? snapContext.closest(to: CGFloat(clampedProjectedViewStart))
-                    : nil
-                details.append("wouldClamp=\(abs(projectionScreens) > diagnosticClampScreens)")
-                details.append("clampScreens=nil")
-                details.append(String(format: "diagnosticClampScreens=%.3f", diagnosticClampScreens))
-                details.append(String(format: "clampedProjectedViewStart=%.3f", clampedProjectedViewStart))
-                details.append("clampedTargetColumn=\(clampedSnap.map { String($0.columnIndex) } ?? "nil")")
+                if let rawClosestSnap {
+                    details.append("rawTargetColumnDelta=\(rawClosestSnap.columnIndex - endState.activeColumnIndex)")
+                } else {
+                    details.append("rawTargetColumnDelta=nil")
+                }
+                details.append("wouldClamp=\(abs(rawProjectedViewStart - projectedViewStart) > 0.001)")
+                details.append(String(format: "clampScreens=%.3f", maxTrackpadGestureProjectionScreens))
+                details.append(String(format: "diagnosticClampScreens=%.3f", maxTrackpadGestureProjectionScreens))
+                details.append(String(format: "clampedProjectedViewStart=%.3f", projectedViewStart))
+                details.append("clampedTargetColumn=\(closestSnap.map { String($0.columnIndex) } ?? "nil")")
                 controller.recordRuntimeViewportTrace(
                     workspaceId: wsId,
                     reason: "touch_scroll_gesture_end_candidate",

--- a/Sources/Nehir/Core/Controller/MouseEventHandler.swift
+++ b/Sources/Nehir/Core/Controller/MouseEventHandler.swift
@@ -1642,6 +1642,22 @@ final class MouseEventHandler {
 
         switch state.gesturePhase {
         case .idle:
+            // Only admit a new gesture from an explicit `.began` frame. A valid-count
+            // `.changed` while idle is a stale same-count frame or a continuation after
+            // a prior reset, not a genuine start — the raw source now emits `.began` on
+            // real contact-count ramps (1→2→3), so legitimate ramps still arrive here as
+            // `.began`. This guard only affects idle admission; committed gestures are
+            // handled in the `.armed`/`.committed` case and are untouched.
+            guard phase == .began else {
+                traceGestureSkip(
+                    reason: "changedWithoutBegin",
+                    location: location,
+                    requiredFingers: requiredFingers,
+                    activeTouches: activeTouchCount,
+                    phase: phase
+                )
+                return
+            }
             guard let currentContext = resolveScrollContext(at: location) else {
                 traceGestureSkip(
                     reason: "noScrollContext",
@@ -1665,16 +1681,11 @@ final class MouseEventHandler {
             state.gestureStartY = avgY
             state.gestureLastAverageX = avgX
             state.gestureLastAverageY = avgY
-            // The switch entered on `state.gesturePhase == .idle`, so this arm is by
-            // definition an admission out of the idle phase.
+            // The `.idle` case guarded `phase == .began` above, so this arm is always an
+            // explicit begin admission — kept as an `idleAdmissionKind=began` field so a
+            // validation capture can confirm the fix (no more `idleAdmissionKind=changed`).
             state.gesturePhase = .armed
             let inputPhaseName = Self.gesturePhaseName(phase)
-            let idleAdmissionKind: String
-            switch phase {
-            case .began: idleAdmissionKind = "began"
-            case .changed: idleAdmissionKind = "changed"
-            default: idleAdmissionKind = "other"
-            }
             var armedTraceDetails = [
                 "input=trackpadTouches",
                 "requiredFingers=\(requiredFingers)",
@@ -1684,30 +1695,13 @@ final class MouseEventHandler {
                 "inputPhaseName=\(inputPhaseName)",
                 "previousGesturePhase=idle",
                 "idleAdmission=true",
-                "idleAdmissionKind=\(idleAdmissionKind)",
+                "idleAdmissionKind=began",
                 "rawActiveCount=\(activeTouchCount)",
                 String(format: "startTouch=%.3f,%.3f", avgX, avgY)
             ]
             if let previousRawActiveCount = snapshot.previousRawActiveCount {
                 armedTraceDetails.append("previousRawActiveCount=\(previousRawActiveCount)")
                 armedTraceDetails.append("activeCountDelta=\(activeTouchCount - previousRawActiveCount)")
-            }
-            // Diagnostic-only: an idle gesture admitted from a non-begin phase is the
-            // suspected idle `.changed` admission anomaly. Emit an explicit record so a
-            // capture can grep it directly; do not skip or abort the gesture here.
-            if phase != .began {
-                controller.recordRuntimeViewportTrace(
-                    workspaceId: currentContext.wsId,
-                    reason: "touch_scroll_gesture_idle_changed_admission",
-                    details: [
-                        "input=trackpadTouches",
-                        "inputPhase=\(inputPhaseName)",
-                        "requiredFingers=\(requiredFingers)",
-                        "activeTouches=\(activeTouchCount)",
-                        "previousGesturePhase=idle",
-                        String(format: "startTouch=%.3f,%.3f", avgX, avgY)
-                    ]
-                )
             }
             let viewportState = controller.workspaceManager.niriViewportState(for: currentContext.wsId)
             if !viewportState.viewOffsetPixels.isGesture, viewportState.viewOffsetPixels.isAnimating {

--- a/Sources/Nehir/Core/Controller/MouseEventHandler.swift
+++ b/Sources/Nehir/Core/Controller/MouseEventHandler.swift
@@ -88,6 +88,11 @@ final class MouseEventHandler {
         let modifiers: CGEventFlags
         let windowUnderPointer: Int?
         let touches: [GestureTouchSample]
+        /// Raw contact count observed on the previous multitouch frame, for the
+        /// raw MultitouchSupport source only. `nil` for NSEvent-derived snapshots.
+        /// Lets idle-admission diagnostics report whether an idle `.changed` arm
+        /// came from a contact-count increase or a mid-gesture continuation.
+        let previousRawActiveCount: Int?
 
         init(
             location: CGPoint,
@@ -95,6 +100,7 @@ final class MouseEventHandler {
             timestamp: TimeInterval = CACurrentMediaTime(),
             modifiers: CGEventFlags = [],
             windowUnderPointer: Int? = nil,
+            previousRawActiveCount: Int? = nil,
             touches: [GestureTouchSample]
         ) {
             self.location = location
@@ -102,6 +108,7 @@ final class MouseEventHandler {
             self.timestamp = timestamp
             self.modifiers = modifiers
             self.windowUnderPointer = windowUnderPointer
+            self.previousRawActiveCount = previousRawActiveCount
             self.touches = touches
         }
     }
@@ -236,6 +243,15 @@ final class MouseEventHandler {
         var gestureLastAverageX: CGFloat = 0.0
         var gestureLastAverageY: CGFloat = 0.0
         var lockedGestureContext: LockedGestureContext?
+        // Commit metrics retained from the armed→committed transition until the first
+        // committed update, so `touch_scroll_gesture_first_update` can report whether
+        // the first applied delta carried the full pre-recognition movement.
+        var pendingFirstUpdateAfterCommit = false
+        var commitCumulativeX: CGFloat = 0.0
+        var commitCumulativeY: CGFloat = 0.0
+        var commitRawDeltaX: CGFloat = 0.0
+        var commitInputPhaseName = ""
+        var commitTimestamp: TimeInterval = 0.0
         var suppressGestureUntilTouchesEnd = false
         var pendingTapEvents = PendingTapEvents()
         var debugCounters = DebugCounters()
@@ -840,6 +856,20 @@ final class MouseEventHandler {
 
     private func formatPoint(_ point: CGPoint) -> String {
         String(format: "(%.1f,%.1f)", point.x, point.y)
+    }
+
+    // Human-readable name for a raw `NSEvent.Phase` so idle-admission diagnostics
+    // can grep `inputPhaseName=changed` instead of decoding the OptionSet raw value.
+    static func gesturePhaseName(_ phase: NSEvent.Phase) -> String {
+        switch phase {
+        case .began: return "began"
+        case .stationary: return "stationary"
+        case .changed: return "changed"
+        case .ended: return "ended"
+        case .cancelled: return "cancelled"
+        case .mayBegin: return "mayBegin"
+        default: return "other(\(phase.rawValue))"
+        }
     }
 
     private func formatToken(_ token: WindowToken?) -> String {
@@ -1635,15 +1665,51 @@ final class MouseEventHandler {
             state.gestureStartY = avgY
             state.gestureLastAverageX = avgX
             state.gestureLastAverageY = avgY
+            // The switch entered on `state.gesturePhase == .idle`, so this arm is by
+            // definition an admission out of the idle phase.
             state.gesturePhase = .armed
-            let viewportState = controller.workspaceManager.niriViewportState(for: currentContext.wsId)
-            let armedTraceDetails = [
+            let inputPhaseName = Self.gesturePhaseName(phase)
+            let idleAdmissionKind: String
+            switch phase {
+            case .began: idleAdmissionKind = "began"
+            case .changed: idleAdmissionKind = "changed"
+            default: idleAdmissionKind = "other"
+            }
+            var armedTraceDetails = [
                 "input=trackpadTouches",
                 "requiredFingers=\(requiredFingers)",
                 "activeTouches=\(activeTouchCount)",
                 "phase=\(phase.rawValue)",
+                "inputPhaseRaw=\(phase.rawValue)",
+                "inputPhaseName=\(inputPhaseName)",
+                "previousGesturePhase=idle",
+                "idleAdmission=true",
+                "idleAdmissionKind=\(idleAdmissionKind)",
+                "rawActiveCount=\(activeTouchCount)",
                 String(format: "startTouch=%.3f,%.3f", avgX, avgY)
             ]
+            if let previousRawActiveCount = snapshot.previousRawActiveCount {
+                armedTraceDetails.append("previousRawActiveCount=\(previousRawActiveCount)")
+                armedTraceDetails.append("activeCountDelta=\(activeTouchCount - previousRawActiveCount)")
+            }
+            // Diagnostic-only: an idle gesture admitted from a non-begin phase is the
+            // suspected idle `.changed` admission anomaly. Emit an explicit record so a
+            // capture can grep it directly; do not skip or abort the gesture here.
+            if phase != .began {
+                controller.recordRuntimeViewportTrace(
+                    workspaceId: currentContext.wsId,
+                    reason: "touch_scroll_gesture_idle_changed_admission",
+                    details: [
+                        "input=trackpadTouches",
+                        "inputPhase=\(inputPhaseName)",
+                        "requiredFingers=\(requiredFingers)",
+                        "activeTouches=\(activeTouchCount)",
+                        "previousGesturePhase=idle",
+                        String(format: "startTouch=%.3f,%.3f", avgX, avgY)
+                    ]
+                )
+            }
+            let viewportState = controller.workspaceManager.niriViewportState(for: currentContext.wsId)
             if !viewportState.viewOffsetPixels.isGesture, viewportState.viewOffsetPixels.isAnimating {
                 controller.recordRuntimeViewportTrace(
                     workspaceId: currentContext.wsId,
@@ -1725,6 +1791,14 @@ final class MouseEventHandler {
 
                 rawDeltaX = cumulativeX
                 state.gesturePhase = .committed
+                // Retain the commit metrics so the first committed update can report
+                // how much pre-recognition movement it carried (recognition debt).
+                state.pendingFirstUpdateAfterCommit = true
+                state.commitCumulativeX = cumulativeX
+                state.commitCumulativeY = cumulativeY
+                state.commitRawDeltaX = rawDeltaX
+                state.commitInputPhaseName = Self.gesturePhaseName(phase)
+                state.commitTimestamp = snapshot.timestamp
                 controller.recordRuntimeViewportTrace(
                     workspaceId: wsId,
                     reason: "touch_scroll_gesture_committed",
@@ -1808,19 +1882,68 @@ final class MouseEventHandler {
             controller.layoutRefreshController.stopScrollAnimation(for: monitor.displayId)
         }
         if didApply {
+            let isFirstUpdateAfterCommit = state.pendingFirstUpdateAfterCommit
             if controller.settings.viewportTraceVerbosity.includesGestureFrameUpdates {
+                var updateDetails = [
+                    "input=trackpadTouches",
+                    String(format: "delta=%.3f", delta),
+                    "phase=committed"
+                ]
+                if isFirstUpdateAfterCommit {
+                    updateDetails.append("firstUpdate=true")
+                }
                 controller.recordRuntimeViewportTrace(
                     workspaceId: wsId,
                     reason: "touch_scroll_gesture_update",
-                    details: [
-                        "input=trackpadTouches",
-                        String(format: "delta=%.3f", delta),
-                        "phase=committed"
-                    ]
+                    details: updateDetails
                 )
+            }
+            if isFirstUpdateAfterCommit {
+                emitFirstUpdateDiagnostic(appliedDelta: delta, wsId: wsId)
+                state.pendingFirstUpdateAfterCommit = false
             }
             controller.layoutRefreshController.requestRefresh(reason: .interactiveGesture)
         }
+    }
+
+    // Emits `touch_scroll_gesture_first_update` linking the just-applied first
+    // committed delta back to the commit's cumulative recognition movement, so a
+    // capture can tell — without manual pairing — whether the first update carried
+    // the full pre-recognition debt and what a dead-zone implementation would apply
+    // instead. Diagnostic only; it does not alter the applied delta.
+    private func emitFirstUpdateDiagnostic(appliedDelta: CGFloat, wsId: WorkspaceDescriptor.ID) {
+        guard let controller else { return }
+        let threshold = niriTouchpadGestureRecognitionThreshold
+        let rawDeltaX = state.commitRawDeltaX
+        // The commit branch applies the full accumulated pre-recognition movement as
+        // the first delta. A dead-zone implementation would instead apply only the
+        // movement beyond the recognition threshold along the committed axis.
+        let overshootMagnitude = max(0.0, abs(rawDeltaX) - threshold)
+        let signedOvershoot = (rawDeltaX < 0 ? -1.0 : 1.0) * overshootMagnitude
+        let sensitivity = CGFloat(controller.settings.scrollSensitivity)
+        let invert = controller.settings.gestureInvertDirection
+        var wouldDeadZoneDelta = signedOvershoot * sensitivity
+        if invert { wouldDeadZoneDelta = -wouldDeadZoneDelta }
+        // On current main the first committed update applies the full accumulated
+        // pre-recognition movement (rawDeltaX == commitCumulativeX), so any nonzero
+        // first delta carries recognition debt.
+        let includesRecognitionDebt = abs(rawDeltaX) > 0
+        controller.recordRuntimeViewportTrace(
+            workspaceId: wsId,
+            reason: "touch_scroll_gesture_first_update",
+            details: [
+                "input=trackpadTouches",
+                String(format: "commitCumulativeX=%.3f", state.commitCumulativeX),
+                String(format: "commitCumulativeY=%.3f", state.commitCumulativeY),
+                String(format: "threshold=%.3f", threshold),
+                String(format: "rawDelta=%.3f", rawDeltaX),
+                String(format: "appliedDelta=%.3f", appliedDelta),
+                String(format: "wouldDeadZoneDelta=%.3f", wouldDeadZoneDelta),
+                "includesRecognitionDebt=\(includesRecognitionDebt)",
+                "commitInputPhase=\(state.commitInputPhaseName)",
+                "phase=committed"
+            ]
+        )
     }
 
     private func backingScale(for monitor: Monitor) -> CGFloat {
@@ -1974,6 +2097,35 @@ final class MouseEventHandler {
                 if let targetOffset {
                     details.append(String(format: "targetOffset=%.3f", targetOffset))
                 }
+                // Derived release-projection distances so a capture can classify a
+                // multi-column release by grep alone. `wouldClamp` reports whether the
+                // planned (not-yet-implemented) projection clamp would have changed the
+                // target; `clampScreens=nil` records that no clamp is configured on main.
+                let viewportWidth = Double(insetFrame.width)
+                let projectionDeltaFromCurrent = projectedViewStart - currentViewStart
+                let projectionScreens = viewportWidth > 0 ? projectionDeltaFromCurrent / viewportWidth : 0
+                details.append(String(format: "rawProjectedOffset=%.3f", projectedOffset))
+                details.append(String(format: "rawProjectedViewStart=%.3f", projectedViewStart))
+                details.append(String(format: "projectionDeltaFromCurrent=%.3f", projectionDeltaFromCurrent))
+                details.append(String(format: "projectionScreens=%.3f", projectionScreens))
+                details.append("projectedColumnDelta=\(Int(projectionScreens.rounded()))")
+                if let closestSnap {
+                    details.append("targetColumnDelta=\(closestSnap.columnIndex - endState.activeColumnIndex)")
+                } else {
+                    details.append("targetColumnDelta=nil")
+                }
+                let diagnosticClampScreens = 1.0
+                let clampBound = diagnosticClampScreens * viewportWidth
+                let clampedDelta = max(-clampBound, min(clampBound, projectionDeltaFromCurrent))
+                let clampedProjectedViewStart = currentViewStart + clampedDelta
+                let clampedSnap = snapToColumn
+                    ? snapContext.closest(to: CGFloat(clampedProjectedViewStart))
+                    : nil
+                details.append("wouldClamp=\(abs(projectionScreens) > diagnosticClampScreens)")
+                details.append("clampScreens=nil")
+                details.append(String(format: "diagnosticClampScreens=%.3f", diagnosticClampScreens))
+                details.append(String(format: "clampedProjectedViewStart=%.3f", clampedProjectedViewStart))
+                details.append("clampedTargetColumn=\(clampedSnap.map { String($0.columnIndex) } ?? "nil")")
                 controller.recordRuntimeViewportTrace(
                     workspaceId: wsId,
                     reason: "touch_scroll_gesture_end_candidate",
@@ -2151,6 +2303,12 @@ final class MouseEventHandler {
         state.gestureLastAverageX = 0.0
         state.gestureLastAverageY = 0.0
         state.lockedGestureContext = nil
+        state.pendingFirstUpdateAfterCommit = false
+        state.commitCumulativeX = 0.0
+        state.commitCumulativeY = 0.0
+        state.commitRawDeltaX = 0.0
+        state.commitInputPhaseName = ""
+        state.commitTimestamp = 0.0
     }
 
     private func currentSelectionNode(

--- a/Sources/Nehir/Core/Controller/NiriLayoutHandler.swift
+++ b/Sources/Nehir/Core/Controller/NiriLayoutHandler.swift
@@ -44,6 +44,16 @@ enum NiriWindowMoveResult {
 
     var scrollAnimationByDisplay: [CGDirectDisplayID: WorkspaceDescriptor.ID] = [:]
 
+    // Per-token bucket/frame last emitted by `spring_frame_classification`, used to
+    // dedup the diagnostic so it fires on viewport-boundary/visibility transitions
+    // instead of every animation tick. Cleared when an animation settles.
+    private struct SpringFrameSample {
+        let bucket: String
+        let frame: CGRect
+    }
+
+    private var springFrameClassificationSamples: [WindowToken: SpringFrameSample] = [:]
+
     init(controller: WMController?) {
         self.controller = controller
     }
@@ -165,6 +175,7 @@ enum NiriWindowMoveResult {
 
     private func finalizeAnimation() {
         guard let controller else { return }
+        springFrameClassificationSamples.removeAll(keepingCapacity: true)
 
         let focusedTarget = controller.currentBorderTarget()
         let preferredFrame: CGRect? = if let focusedTarget,
@@ -331,11 +342,139 @@ enum NiriWindowMoveResult {
             canRestoreHiddenWorkspaceWindows: snapshot.isActiveWorkspace
         )
 
+        emitSpringFrameClassifications(
+            workspaceId: snapshot.workspaceId,
+            windows: snapshot.windows,
+            frames: frames,
+            hiddenHandles: hiddenHandles,
+            monitor: snapshot.monitor,
+            // The on-demand path runs from the scroll-animation display-link tick,
+            // sampling the spring at the current animation time.
+            frameSource: animationTime != nil ? "currentSpring" : "springTarget"
+        )
+
         return WorkspaceLayoutPlan(
             workspaceId: snapshot.workspaceId,
             monitor: snapshot.monitor,
             sessionPatch: WorkspaceSessionPatch(workspaceId: snapshot.workspaceId),
             diff: diff
+        )
+    }
+
+    // Classifies each spring-time frame write during an active scroll animation so a
+    // capture can tell whether hidden / edge-revealed windows are being moved by the
+    // current spring sample (slide-through risk) or held at their target. Deduped per
+    // token against the previous tick and restricted to hidden-state / transition /
+    // large-boundary-crossing cases to avoid per-frame spam for normal visible windows.
+    private func emitSpringFrameClassifications(
+        workspaceId: WorkspaceDescriptor.ID,
+        windows: [LayoutWindowSnapshot],
+        frames: [WindowToken: CGRect],
+        hiddenHandles: [WindowToken: HideSide],
+        monitor: LayoutMonitorSnapshot,
+        frameSource: String
+    ) {
+        guard let controller, controller.isRuntimeTraceCaptureActive else { return }
+
+        let viewport = monitor.workingFrame
+        let display = monitor.frame
+        let largeThreshold = 0.25 * Double(display.width) * Double(display.height)
+        var liveTokens = Set<WindowToken>()
+
+        for window in windows {
+            let token = window.token
+            let previousOffscreenSide = window.hiddenState?.offscreenSide
+            let hiddenNowSide = hiddenHandles[token]
+            let hasHiddenState = window.hiddenState != nil || hiddenNowSide != nil
+            guard let frame = frames[token] else {
+                // A token with no applied frame this tick is not slide-through risk.
+                continue
+            }
+
+            let intersection = frame.intersection(viewport)
+            let bucket: String
+            if intersection.isNull || intersection.width <= 0 || intersection.height <= 0 {
+                bucket = "offscreen"
+            } else if abs(intersection.width - frame.width) < 1.0,
+                      abs(intersection.height - frame.height) < 1.0 {
+                bucket = "inside"
+            } else {
+                bucket = "crossing"
+            }
+
+            let visibilityClass: String
+            if previousOffscreenSide != nil, hiddenNowSide == nil, bucket != "offscreen" {
+                visibilityClass = "hiddenToVisible"
+            } else if previousOffscreenSide == nil, hiddenNowSide != nil {
+                visibilityClass = "visibleToHidden"
+            } else if window.hiddenState?.workspaceInactive == true {
+                visibilityClass = "workspaceInactiveHidden"
+            } else if hasHiddenState, bucket == "crossing" {
+                visibilityClass = "edgeReveal"
+            } else if hasHiddenState {
+                visibilityClass = "hidden"
+            } else {
+                visibilityClass = "visible"
+            }
+
+            let frameArea = Double(frame.width) * Double(frame.height)
+            let isLargeCrossing = bucket != "inside" && frameArea >= largeThreshold
+            // Only hidden-state tokens, visibility transitions, and large windows
+            // crossing the boundary are candidates; normal visible windows are skipped.
+            guard hasHiddenState
+                || visibilityClass == "hiddenToVisible"
+                || visibilityClass == "visibleToHidden"
+                || isLargeCrossing
+            else {
+                continue
+            }
+
+            liveTokens.insert(token)
+            let previousSample = springFrameClassificationSamples[token]
+            let isTransition = visibilityClass == "hiddenToVisible"
+                || visibilityClass == "visibleToHidden"
+            let bucketChanged = previousSample?.bucket != bucket
+            let frameMoved = previousSample.map {
+                abs($0.frame.origin.x - frame.origin.x) > 1.0
+                    || abs($0.frame.origin.y - frame.origin.y) > 1.0
+            } ?? true
+            let hiddenRevealMoved = hasHiddenState && bucket != "offscreen" && frameMoved
+            guard isTransition || bucketChanged || hiddenRevealMoved else {
+                continue
+            }
+            springFrameClassificationSamples[token] = SpringFrameSample(bucket: bucket, frame: frame)
+
+            let hiddenSide = hiddenNowSide.map { "\($0)" }
+                ?? previousOffscreenSide.map { "\($0)" }
+                ?? "nil"
+            controller.recordRuntimeViewportTrace(
+                workspaceId: workspaceId,
+                reason: "spring_frame_classification",
+                details: [
+                    "token=\(String(describing: token))",
+                    "windowId=\(token.windowId)",
+                    "frameSource=\(frameSource)",
+                    "visibilityClass=\(visibilityClass)",
+                    "bucket=\(bucket)",
+                    "hiddenSide=\(hiddenSide)",
+                    "wasHiddenState=\(window.hiddenState.map { $0.workspaceInactive ? "wsInactive" : "transient(\(String(describing: $0.offscreenSide)))" } ?? "none")",
+                    "currentFrame=\(Self.formatFrame(frame))",
+                    "viewport=\(Self.formatFrame(viewport))",
+                    "targetPinned=false"
+                ]
+            )
+        }
+
+        // Drop dedup state for tokens no longer classified this tick so a later
+        // re-entry emits a fresh transition record.
+        springFrameClassificationSamples = springFrameClassificationSamples
+            .filter { liveTokens.contains($0.key) }
+    }
+
+    private static func formatFrame(_ rect: CGRect) -> String {
+        String(
+            format: "{{%.1f,%.1f},{%.1f,%.1f}}",
+            rect.origin.x, rect.origin.y, rect.width, rect.height
         )
     }
 

--- a/Sources/Nehir/Core/Controller/NiriLayoutHandler.swift
+++ b/Sources/Nehir/Core/Controller/NiriLayoutHandler.swift
@@ -396,7 +396,8 @@ enum NiriWindowMoveResult {
             if intersection.isNull || intersection.width <= 0 || intersection.height <= 0 {
                 bucket = "offscreen"
             } else if abs(intersection.width - frame.width) < 1.0,
-                      abs(intersection.height - frame.height) < 1.0 {
+                      abs(intersection.height - frame.height) < 1.0
+            {
                 bucket = "inside"
             } else {
                 bucket = "crossing"

--- a/Sources/Nehir/Core/Controller/ServiceLifecycleManager.swift
+++ b/Sources/Nehir/Core/Controller/ServiceLifecycleManager.swift
@@ -80,6 +80,9 @@ final class ServiceLifecycleManager {
         controller.axManager.onAppTerminated = { [weak self] pid in
             self?.handleAppTerminated(pid: pid)
         }
+        controller.axManager.isRuntimeTraceCaptureActive = { [weak controller] in
+            controller?.isRuntimeTraceCaptureActive == true
+        }
         AppAXContext.onWindowDestroyed = { [weak controller] pid, windowId in
             guard let controller else { return }
             controller.axEventHandler.handleRemoved(pid: pid, winId: windowId)
@@ -349,6 +352,7 @@ final class ServiceLifecycleManager {
         AppAXContext.onFocusedWindowChanged = nil
         controller.axManager.onAppLaunched = nil
         controller.axManager.onAppTerminated = nil
+        controller.axManager.isRuntimeTraceCaptureActive = { false }
         controller.workspaceManager.onGapsChanged = nil
 
         controller.layoutRefreshController.resetState()

--- a/Sources/Nehir/Core/Controller/WindowActionHandler.swift
+++ b/Sources/Nehir/Core/Controller/WindowActionHandler.swift
@@ -7,6 +7,19 @@
 import AppKit
 import Foundation
 
+/// Lightweight provenance for direct viewport navigation, used only by runtime
+/// diagnostics so a bar/window-click capture can classify what initiated a
+/// spring without inferring it from `animateToOffset.spring` alone.
+enum NavigationSource: String {
+    case workspaceBarWindow
+    case workspaceBarWorkspace
+    case hotkey
+    case command
+    case overview
+    case focusConfirm
+    case unknown
+}
+
 @MainActor
 final class WindowActionHandler {
     private enum RaisableSurfaceBatchKey: Hashable {
@@ -421,7 +434,11 @@ final class WindowActionHandler {
     }
 
     @discardableResult
-    func navigateToWindowInternal(token: WindowToken, workspaceId: WorkspaceDescriptor.ID) -> Bool {
+    func navigateToWindowInternal(
+        token: WindowToken,
+        workspaceId: WorkspaceDescriptor.ID,
+        source: NavigationSource = .command
+    ) -> Bool {
         guard let controller else { return false }
         guard let engine = controller.niriEngine else { return false }
 
@@ -436,12 +453,15 @@ final class WindowActionHandler {
         }
 
         var targetState = controller.workspaceManager.niriViewportState(for: workspaceId)
+        let fromActiveColumnIndex = targetState.activeColumnIndex
+        var targetColumnIndex: Int?
         if let niriWindow = engine.findNode(for: token) {
             targetState.selectedNodeId = niriWindow.id
 
-            if engine.findColumn(containing: niriWindow, in: workspaceId) != nil,
+            if let column = engine.findColumn(containing: niriWindow, in: workspaceId),
                let monitor = controller.workspaceManager.monitor(for: workspaceId)
             {
+                targetColumnIndex = engine.columnIndex(of: column, in: workspaceId)
                 engine.activateWindow(niriWindow.id)
 
                 let gap = controller.gapSize(for: monitor)
@@ -457,6 +477,20 @@ final class WindowActionHandler {
                 targetState.selectionProgress = 0
             }
         }
+
+        // Diagnostic: record the navigation source and motion policy before applying
+        // the patch, so a bar/window-click capture self-classifies. `.enabled` is the
+        // motion requested by the `ensureSelectionVisible` call above.
+        recordNavigationDiagnostic(
+            reason: "navigate.window",
+            workspaceId: workspaceId,
+            source: source,
+            targetToken: token,
+            fromColumn: fromActiveColumnIndex,
+            targetColumn: targetColumnIndex,
+            requestedMotion: "enabled",
+            directSelection: true
+        )
 
         _ = controller.workspaceManager.applySessionPatch(
             .init(
@@ -571,6 +605,16 @@ final class WindowActionHandler {
         guard let controller else { return false }
 
         let focusedToken = controller.resolveAndSetWorkspaceFocusToken(for: result.workspace.id)
+        recordNavigationDiagnostic(
+            reason: "navigate.workspace",
+            workspaceId: result.workspace.id,
+            source: .workspaceBarWorkspace,
+            targetToken: focusedToken,
+            fromColumn: nil,
+            targetColumn: nil,
+            requestedMotion: "policy",
+            directSelection: true
+        )
         if suppressMouseWarp, let focusedToken {
             controller.suppressMouseMoveToFocusedWindow(for: focusedToken)
         }
@@ -590,7 +634,50 @@ final class WindowActionHandler {
         if suppressMouseWarp {
             controller.suppressMouseMoveToFocusedWindow(for: token)
         }
-        return navigateToWindowInternal(token: token, workspaceId: entry.workspaceId)
+        return navigateToWindowInternal(
+            token: token,
+            workspaceId: entry.workspaceId,
+            source: .workspaceBarWindow
+        )
+    }
+
+    // Emits a compact `navigate.*` diagnostic before a direct navigation applies its
+    // viewport patch, so a capture can distinguish workspace-bar clicks from
+    // command/hotkey navigation and see the motion policy that will drive the spring.
+    private func recordNavigationDiagnostic(
+        reason: String,
+        workspaceId: WorkspaceDescriptor.ID,
+        source: NavigationSource,
+        targetToken: WindowToken?,
+        fromColumn: Int?,
+        targetColumn: Int?,
+        requestedMotion: String,
+        directSelection: Bool
+    ) {
+        guard let controller, controller.isRuntimeTraceCaptureActive else { return }
+        let workspaceName = controller.workspaceManager.descriptor(for: workspaceId)?.name
+            ?? workspaceId.uuidString
+        let columnDelta = (fromColumn != nil && targetColumn != nil)
+            ? String(targetColumn! - fromColumn!)
+            : "nil"
+        var details = [
+            "source=\(source.rawValue)",
+            "targetWorkspace=\(workspaceName)",
+            "fromColumn=\(fromColumn.map(String.init) ?? "nil")",
+            "targetColumn=\(targetColumn.map(String.init) ?? "nil")",
+            "columnDelta=\(columnDelta)",
+            "motionAnimationsEnabled=\(controller.motionPolicy.snapshot().animationsEnabled)",
+            "requestedMotion=\(requestedMotion)",
+            "directSelection=\(directSelection)"
+        ]
+        if let targetToken {
+            details.insert("target=\(String(describing: targetToken))", at: 1)
+        }
+        controller.recordRuntimeViewportTrace(
+            workspaceId: workspaceId,
+            reason: reason,
+            details: details
+        )
     }
 
     func runningAppsWithWindows() -> [RunningAppInfo] {

--- a/Sources/Nehir/Core/Controller/WindowActionHandler.swift
+++ b/Sources/Nehir/Core/Controller/WindowActionHandler.swift
@@ -148,7 +148,7 @@ final class WindowActionHandler {
     private func activateWindowFromOverview(handle: WindowHandle, workspaceId: WorkspaceDescriptor.ID) {
         guard let controller else { return }
         guard controller.workspaceManager.entry(for: handle) != nil else { return }
-        navigateToWindowInternal(token: handle.id, workspaceId: workspaceId)
+        navigateToWindowInternal(token: handle.id, workspaceId: workspaceId, source: .overview)
     }
 
     var closeWindowForTests: ((WindowHandle) -> Void)?
@@ -386,7 +386,7 @@ final class WindowActionHandler {
     func navigateToWindow(handle: WindowHandle) -> Bool {
         guard let controller else { return false }
         guard let entry = controller.workspaceManager.entry(for: handle) else { return false }
-        return navigateToWindowInternal(token: handle.id, workspaceId: entry.workspaceId)
+        return navigateToWindowInternal(token: handle.id, workspaceId: entry.workspaceId, source: .command)
     }
 
     @discardableResult
@@ -437,7 +437,7 @@ final class WindowActionHandler {
     func navigateToWindowInternal(
         token: WindowToken,
         workspaceId: WorkspaceDescriptor.ID,
-        source: NavigationSource = .command
+        source: NavigationSource = .unknown
     ) -> Bool {
         guard let controller else { return false }
         guard let engine = controller.niriEngine else { return false }

--- a/Sources/Nehir/Core/Layout/Niri/ViewportState+Gestures.swift
+++ b/Sources/Nehir/Core/Layout/Niri/ViewportState+Gestures.swift
@@ -8,6 +8,28 @@ import AppKit
 import Foundation
 
 let VIEW_GESTURE_WORKING_AREA_MOVEMENT: Double = 1200.0
+let maxTrackpadGestureProjectionScreens: Double = 1.0
+
+func clampedTrackpadGestureProjectedViewStart(
+    rawProjectedViewStart: Double,
+    currentViewStart: Double,
+    viewportWidth: CGFloat
+) -> Double {
+    let viewportWidth = Double(viewportWidth)
+    guard maxTrackpadGestureProjectionScreens.isFinite,
+          maxTrackpadGestureProjectionScreens > 0,
+          viewportWidth.isFinite,
+          viewportWidth > 0,
+          rawProjectedViewStart.isFinite,
+          currentViewStart.isFinite
+    else {
+        return rawProjectedViewStart
+    }
+
+    let clampBound = maxTrackpadGestureProjectionScreens * viewportWidth
+    let projectionDeltaFromCurrent = rawProjectedViewStart - currentViewStart
+    return currentViewStart + projectionDeltaFromCurrent.clamped(to: -clampBound ... clampBound)
+}
 
 extension ViewportState {
     @discardableResult
@@ -111,7 +133,15 @@ extension ViewportState {
         let projectedOffset = projectedTrackerPos + gesture.deltaFromTracker
 
         let activeColX = columnX(at: activeColumnIndex, columns: columns, gap: gap)
-        let projectedViewPos = Double(activeColX) + projectedOffset
+        let rawProjectedViewPos = Double(activeColX) + projectedOffset
+        let currentViewPos = Double(activeColX) + currentOffset
+        let projectedViewPos = gesture.isTrackpad
+            ? clampedTrackpadGestureProjectedViewStart(
+                rawProjectedViewStart: rawProjectedViewPos,
+                currentViewStart: currentViewPos,
+                viewportWidth: viewportWidth
+            )
+            : rawProjectedViewPos
         let areas = normalizedFittingAreas(
             viewportSpan: viewportWidth,
             workingArea: workingArea,

--- a/Sources/Nehir/Core/Multitouch/MultitouchGestureSource.swift
+++ b/Sources/Nehir/Core/Multitouch/MultitouchGestureSource.swift
@@ -106,6 +106,7 @@ final class MultitouchGestureSource {
                 phaseRawValue: NSEvent.Phase.ended.rawValue,
                 timestamp: frame.timestamp,
                 modifiers: modifiers,
+                previousRawActiveCount: previousActiveCount,
                 touches: []
             )
             return (snapshot, 0)
@@ -123,6 +124,7 @@ final class MultitouchGestureSource {
             phaseRawValue: phase.rawValue,
             timestamp: frame.timestamp,
             modifiers: modifiers,
+            previousRawActiveCount: previousActiveCount,
             touches: touches
         )
         return (snapshot, activeCount)

--- a/Sources/Nehir/Core/Multitouch/MultitouchGestureSource.swift
+++ b/Sources/Nehir/Core/Multitouch/MultitouchGestureSource.swift
@@ -112,7 +112,12 @@ final class MultitouchGestureSource {
             return (snapshot, 0)
         }
 
-        let phase: NSEvent.Phase = previousActiveCount == 0 ? .began : .changed
+        // A contact-count increase (including a 1→2→3 ramp toward the configured
+        // finger count) is the start of a gesture, so emit `.began`; a same-count or
+        // decreasing frame stays `.changed`. This lets the handler require `.began`
+        // for idle admission without rejecting legitimate ramps. The active-count-0
+        // case above already emits `.ended`.
+        let phase: NSEvent.Phase = activeCount > previousActiveCount ? .began : .changed
         let touches = frame.touches.map { touch in
             MouseEventHandler.GestureTouchSample(
                 phase: .moved,

--- a/Tests/NehirTests/MouseEventHandlerTests.swift
+++ b/Tests/NehirTests/MouseEventHandlerTests.swift
@@ -1733,9 +1733,12 @@ private func prepareMouseWheelScrollFixtureWithDefaultSensitivity() async -> (
             Issue.record("Expected in-flight viewport gesture after crossing threshold")
             return
         }
+        let cumulativeX = CGFloat((0.224 - 0.20) * 500.0)
+        let expectedOvershoot = max(0.0, cumulativeX - 16.0)
         let actualAppliedDelta = CGFloat(gesture.currentViewOffset - gesture.stationaryViewOffset)
         #expect(handler.state.gesturePhase == .committed)
-        #expect(actualAppliedDelta >= 0)
+        #expect(expectedOvershoot == 0)
+        #expect(abs(actualAppliedDelta) < 0.1)
     }
 
     @Test @MainActor func committedTrackpadGestureKeepsSubPixelDeltasForVelocity() async {

--- a/Tests/NehirTests/MouseEventHandlerTests.swift
+++ b/Tests/NehirTests/MouseEventHandlerTests.swift
@@ -1643,7 +1643,7 @@ private func prepareMouseWheelScrollFixtureWithDefaultSensitivity() async -> (
         #expect(updatedState.viewOffsetPixels.isGesture == false)
     }
 
-    @Test @MainActor func trackpadGestureCommitAppliesCumulativeArmedDelta() async {
+    @Test @MainActor func trackpadGestureCommitAppliesOnlyDeadZoneOvershoot() async {
         let fixture = await prepareMouseWheelScrollFixture()
         let controller = fixture.controller
         controller.settings.gestureInvertDirection = false
@@ -1685,13 +1685,14 @@ private func prepareMouseWheelScrollFixtureWithDefaultSensitivity() async -> (
             Issue.record("Expected in-flight viewport gesture after crossing threshold")
             return
         }
-        let expectedAppliedDelta = CGFloat((0.235 - 0.20) * 500.0) * viewportWidth / 1200.0
+        let cumulativeDelta = CGFloat((0.235 - 0.20) * 500.0)
+        let expectedAppliedDelta = (cumulativeDelta - 16.0) * viewportWidth / 1200.0
         let actualAppliedDelta = CGFloat(gesture.currentViewOffset - gesture.stationaryViewOffset)
         #expect(handler.state.gesturePhase == .committed)
         #expect(abs(actualAppliedDelta - expectedAppliedDelta) < 0.1)
     }
 
-    @Test @MainActor func trackpadGestureCommitDoesNotReverseOnThresholdJitter() async {
+    @Test @MainActor func trackpadGestureCommitDeadZoneDoesNotReverseOnThresholdJitter() async {
         let fixture = await prepareMouseWheelScrollFixture()
         let controller = fixture.controller
         controller.settings.gestureInvertDirection = false
@@ -1734,7 +1735,7 @@ private func prepareMouseWheelScrollFixtureWithDefaultSensitivity() async -> (
         }
         let actualAppliedDelta = CGFloat(gesture.currentViewOffset - gesture.stationaryViewOffset)
         #expect(handler.state.gesturePhase == .committed)
-        #expect(actualAppliedDelta > 0)
+        #expect(actualAppliedDelta >= 0)
     }
 
     @Test @MainActor func committedTrackpadGestureKeepsSubPixelDeltasForVelocity() async {

--- a/Tests/NehirTests/OverviewModalInteractionTests.swift
+++ b/Tests/NehirTests/OverviewModalInteractionTests.swift
@@ -266,9 +266,11 @@ private func activatePreparedOverviewSelection(
         // in between and cannot leak into a suspended sibling test.
         AXWindowService.fastFrameProviderForTests = { _ in .zero }
         AXWindowService.titleLookupProviderForTests = { _ in nil }
+        defer {
+            AXWindowService.fastFrameProviderForTests = nil
+            AXWindowService.titleLookupProviderForTests = nil
+        }
         overview.prepareOpenState()
-        AXWindowService.fastFrameProviderForTests = nil
-        AXWindowService.titleLookupProviderForTests = nil
 
         await activatePreparedOverviewSelection(in: overview, expectedHandle: firstHandle)
 

--- a/Tests/NehirTests/OverviewModalInteractionTests.swift
+++ b/Tests/NehirTests/OverviewModalInteractionTests.swift
@@ -256,7 +256,20 @@ private func activatePreparedOverviewSelection(
             activatedHandle = handle
         }
 
+        // The overview snapshot reads window frames/titles via
+        // `AXWindowService.framePreferFast`/`titlePreferFast`, which query the live
+        // WindowServer by window id. With fabricated ids these collide with whatever
+        // real windows exist on the host, so the frame-based preview sort becomes
+        // machine-dependent. Pin frames/titles to hermetic values so the fallback
+        // selection order is deterministic. Selection is computed synchronously inside
+        // `prepareOpenState()`, so the override is scoped to that call with no `await`
+        // in between and cannot leak into a suspended sibling test.
+        AXWindowService.fastFrameProviderForTests = { _ in .zero }
+        AXWindowService.titleLookupProviderForTests = { _ in nil }
         overview.prepareOpenState()
+        AXWindowService.fastFrameProviderForTests = nil
+        AXWindowService.titleLookupProviderForTests = nil
+
         await activatePreparedOverviewSelection(in: overview, expectedHandle: firstHandle)
 
         #expect(activatedHandle == firstHandle)

--- a/Tests/NehirTests/ViewportGeometryTests.swift
+++ b/Tests/NehirTests/ViewportGeometryTests.swift
@@ -372,6 +372,25 @@ private func makeViewportGestureContainers(
         #expect(expectedViewPos < 2_000) // still bounded by strip
     }
 
+    @Test func trackpadProjectedViewStartClampsToOneViewport() {
+        // Assumes maxTrackpadGestureProjectionScreens is 1.0: projections clamp to one viewport.
+        #expect(clampedTrackpadGestureProjectedViewStart(
+            rawProjectedViewStart: 3_000,
+            currentViewStart: 1_000,
+            viewportWidth: 500
+        ) == 1_500)
+        #expect(clampedTrackpadGestureProjectedViewStart(
+            rawProjectedViewStart: -1_000,
+            currentViewStart: 1_000,
+            viewportWidth: 500
+        ) == 500)
+        #expect(clampedTrackpadGestureProjectedViewStart(
+            rawProjectedViewStart: 1_250,
+            currentViewStart: 1_000,
+            viewportWidth: 500
+        ) == 1_250)
+    }
+
     @Test func trackpadMomentumSnapAtStripEndNeverWrapsToFront() {
         var state = ViewportState()
         let columns = makeViewportGestureContainers(widths: [300, 300, 300, 300, 300])


### PR DESCRIPTION
## Summary


## Release notes

Choose one:

- [x] Added a `.changeset/*.md` for user-visible changes (`mise run changeset -- patch "..."`).
- [ ] No user-visible change; apply the `no release note` label to make CI skip intentional.

## Validation

<!-- Commands run, screenshots, or manual checks. -->

- [ ] Ran relevant tests/checks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced jumpy trackpad “catch-up” scrolling and improved clamp/release projection behavior.
  * Improved gesture phase recognition and idle admission to better handle threshold jitter and missing `.began`.
  * Improved trackpad gesture end snapping by clamping projected view start to valid bounds.
* **New Features**
  * Added richer runtime diagnostics for gestures, navigation, and layout/parking verification mismatches.
* **Tests**
  * Updated gesture-commit expectations and strengthened viewport projection clamp coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->