### PR TITLE
Surface app-rule config parse diagnostics

### DIFF
--- a/.changeset/20260702000914-warn-when-app-rule-config-files-contain-malforme.md
+++ b/.changeset/20260702000914-warn-when-app-rule-config-files-contain-malforme.md
@@ -1,0 +1,6 @@
+---
+"nehir": patch
+
+---
+
+Warn when app-rule config files contain malformed or ignored lines

--- a/Sources/Nehir/Core/Config/AppRuleFileStore.swift
+++ b/Sources/Nehir/Core/Config/AppRuleFileStore.swift
@@ -4,6 +4,7 @@
 // SPDX-License-Identifier: GPL-2.0-only
 
 import Foundation
+import os
 
 /// Reads and writes app rules from `apprules.d/*.toml` — one file per rule.
 ///
@@ -17,6 +18,8 @@ import Foundation
 /// minHeight = 375
 /// ```
 enum AppRuleFileStore {
+    private static let logger = Logger(subsystem: "com.nehir", category: "config")
+
     // MARK: - Encode (write directory)
 
     static func write(_ rules: [AppRule], to directory: URL) throws {
@@ -77,23 +80,14 @@ enum AppRuleFileStore {
     // MARK: - Decode (read directory)
 
     static func read(from directory: URL) -> [AppRule] {
-        let fm = FileManager.default
-        guard let contents = try? fm.contentsOfDirectory(
-            at: directory,
-            includingPropertiesForKeys: [.nameKey],
-            options: [.skipsHiddenFiles]
-        ) else {
-            return []
-        }
-
-        let tomlFiles = contents
-            .filter { $0.pathExtension == "toml" }
-            .sorted { $0.lastPathComponent < $1.lastPathComponent }
+        let tomlFiles = tomlFiles(in: directory)
 
         return tomlFiles.compactMap { fileURL -> (Int?, AppRule)? in
-            guard let data = try? String(contentsOf: fileURL, encoding: .utf8),
-                  let decoded = decodeWithOrder(data, sourceFile: fileURL.lastPathComponent)
-            else { return nil }
+            guard let data = try? String(contentsOf: fileURL, encoding: .utf8) else {
+                warn("App rule \(fileURL.lastPathComponent): skipping unreadable file")
+                return nil
+            }
+            guard let decoded = decodeWithOrder(data, sourceFile: fileURL.lastPathComponent) else { return nil }
             return decoded
         }
         .sorted { lhs, rhs in
@@ -111,53 +105,405 @@ enum AppRuleFileStore {
         decodeWithOrder(content, sourceFile: sourceFile)?.1
     }
 
+    static func diagnostics(from directory: URL) -> [AppRuleFileDiagnosticIssue] {
+        tomlFiles(in: directory).compactMap { fileURL in
+            guard let data = try? String(contentsOf: fileURL, encoding: .utf8) else {
+                return AppRuleFileDiagnosticIssue(
+                    fileURL: fileURL,
+                    messages: ["File could not be read as UTF-8."],
+                    canClean: false
+                )
+            }
+
+            let result = diagnostics(for: data)
+            guard !result.messages.isEmpty else { return nil }
+            return AppRuleFileDiagnosticIssue(
+                fileURL: fileURL,
+                messages: result.messages,
+                canClean: result.canClean
+            )
+        }
+    }
+
+    @discardableResult
+    static func cleanIgnoredEntries(fileURL: URL) throws -> URL {
+        let content = try String(contentsOf: fileURL, encoding: .utf8)
+        guard let (order, rule) = decodeWithOrder(content, sourceFile: fileURL.lastPathComponent) else {
+            throw CocoaError(.fileReadCorruptFile)
+        }
+
+        let backupURL = try createTimestampedBackup(for: fileURL)
+        try encode(rule, order: order).write(to: fileURL, atomically: true, encoding: .utf8)
+        return backupURL
+    }
+
+    private static func tomlFiles(in directory: URL) -> [URL] {
+        let fm = FileManager.default
+        guard let contents = try? fm.contentsOfDirectory(
+            at: directory,
+            includingPropertiesForKeys: [.nameKey],
+            options: [.skipsHiddenFiles]
+        ) else {
+            return []
+        }
+
+        return contents
+            .filter { $0.pathExtension == "toml" }
+            .sorted { $0.lastPathComponent < $1.lastPathComponent }
+    }
+
     private static func decodeWithOrder(_ content: String, sourceFile: String = "") -> (Int?, AppRule)? {
+        let sourceLabel = sourceFile.isEmpty ? "<memory>" : sourceFile
         var currentSection = ""
         var documentFields: [String: String] = [:]
         var matchFields: [String: String] = [:]
         var effectFields: [String: String] = [:]
 
-        for line in content.components(separatedBy: "\n") {
-            let trimmed = line.trimmingCharacters(in: .whitespaces)
-            if trimmed.isEmpty || trimmed.hasPrefix("#") { continue }
+        func warn(_ message: String) {
+            Self.warn("App rule \(sourceLabel): \(message)")
+        }
 
-            if trimmed.hasPrefix("[") && trimmed.hasSuffix("]") {
-                currentSection = String(trimmed.dropFirst().dropLast())
-                    .trimmingCharacters(in: .whitespaces)
-                continue
-            }
-
-            guard let eqIndex = trimmed.firstIndex(of: "=") else { continue }
-            let key = String(trimmed[trimmed.startIndex ..< eqIndex]).trimmingCharacters(in: .whitespaces)
-            let rawValue = String(trimmed[trimmed.index(after: eqIndex)...]).trimmingCharacters(in: .whitespaces)
-
-            switch currentSection {
-            case "": documentFields[key] = rawValue
-            case "match": matchFields[key] = rawValue
-            case "effect": effectFields[key] = rawValue
-            default: break
+        func store(
+            _ key: String,
+            value rawValue: String,
+            in fields: inout [String: String],
+            section: String,
+            lineNumber: Int
+        ) {
+            if fields.updateValue(rawValue, forKey: key) != nil {
+                warn("line \(lineNumber): duplicate \(section).\(key); using the last value")
             }
         }
 
-        guard let bundleId = extractString(matchFields["bundleId"]) else { return nil }
+        for parsedLine in parsedLines(from: content) {
+            let lineNumber = parsedLine.number
+            let trimmed = parsedLine.text
+
+            if trimmed.hasPrefix("[") {
+                guard trimmed.hasSuffix("]") else {
+                    warn("line \(lineNumber): skipping malformed section header")
+                    continue
+                }
+
+                let section = String(trimmed.dropFirst().dropLast())
+                    .trimmingCharacters(in: .whitespaces)
+                guard !section.isEmpty else {
+                    currentSection = ""
+                    warn("line \(lineNumber): skipping empty section header")
+                    continue
+                }
+
+                currentSection = section
+                switch section {
+                case "match",
+                     "effect": break
+                default:
+                    warn("line \(lineNumber): ignoring unknown section [\(section)]")
+                }
+                continue
+            }
+
+            guard let eqIndex = trimmed.firstIndex(of: "=") else {
+                warn("line \(lineNumber): skipping malformed line without '='")
+                continue
+            }
+            let key = String(trimmed[trimmed.startIndex ..< eqIndex]).trimmingCharacters(in: .whitespaces)
+            let rawValue = String(trimmed[trimmed.index(after: eqIndex)...]).trimmingCharacters(in: .whitespaces)
+            guard !key.isEmpty else {
+                warn("line \(lineNumber): skipping malformed line with an empty key")
+                continue
+            }
+
+            switch currentSection {
+            case "":
+                switch key {
+                case "id",
+                     "order": store(
+                        key,
+                        value: rawValue,
+                        in: &documentFields,
+                        section: "document",
+                        lineNumber: lineNumber
+                    )
+                default: warn("line \(lineNumber): ignoring unknown document key \(key)")
+                }
+            case "match":
+                switch key {
+                case "bundleId",
+                     "appName",
+                     "titleSubstring",
+                     "titleRegex",
+                     "axRole",
+                     "axSubrole":
+                    store(key, value: rawValue, in: &matchFields, section: "match", lineNumber: lineNumber)
+                default:
+                    warn("line \(lineNumber): ignoring unknown match key \(key)")
+                }
+            case "effect":
+                switch key {
+                case "manage",
+                     "layout",
+                     "sticky",
+                     "minWidth",
+                     "minHeight",
+                     "assignToWorkspace":
+                    store(key, value: rawValue, in: &effectFields, section: "effect", lineNumber: lineNumber)
+                default:
+                    warn("line \(lineNumber): ignoring unknown effect key \(key)")
+                }
+            default:
+                warn("line \(lineNumber): ignoring key \(key) in unknown section [\(currentSection)]")
+            }
+        }
+
+        func stringField(_ fields: [String: String], _ key: String, path: String) -> String? {
+            guard let raw = fields[key] else { return nil }
+            guard let value = extractString(raw) else {
+                warn("ignoring \(path); expected a non-empty quoted string")
+                return nil
+            }
+            return value
+        }
+
+        func doubleField(_ fields: [String: String], _ key: String, path: String) -> Double? {
+            guard let raw = fields[key] else { return nil }
+            guard let value = extractDouble(raw) else {
+                warn("ignoring \(path); expected a number")
+                return nil
+            }
+            return value
+        }
+
+        func boolField(_ fields: [String: String], _ key: String, path: String) -> Bool? {
+            guard let raw = fields[key] else { return nil }
+            guard let value = extractBool(raw) else {
+                warn("ignoring \(path); expected true or false")
+                return nil
+            }
+            return value
+        }
+
+        func manageField() -> WindowRuleManageAction? {
+            guard let raw = effectFields["manage"] else { return nil }
+            guard let value = extractString(raw) else {
+                warn("ignoring effect.manage; expected a quoted string")
+                return nil
+            }
+            guard let action = WindowRuleManageAction(rawValue: value) else {
+                warn("ignoring effect.manage; unknown value \(value)")
+                return nil
+            }
+            return action
+        }
+
+        func layoutField() -> WindowRuleLayoutAction? {
+            guard let raw = effectFields["layout"] else { return nil }
+            guard let value = extractString(raw) else {
+                warn("ignoring effect.layout; expected a quoted string")
+                return nil
+            }
+            guard let action = WindowRuleLayoutAction(rawValue: value) else {
+                warn("ignoring effect.layout; unknown value \(value)")
+                return nil
+            }
+            return action
+        }
+
+        let id = stringField(documentFields, "id", path: "document.id").flatMap { value -> UUID? in
+            guard let uuid = UUID(uuidString: value) else {
+                warn("ignoring document.id; expected a UUID string")
+                return nil
+            }
+            return uuid
+        }
+
+        let order = documentFields["order"].flatMap { raw -> Int? in
+            guard let value = extractInt(raw) else {
+                warn("ignoring document.order; expected an integer")
+                return nil
+            }
+            return value
+        }
+
+        guard let bundleId = stringField(matchFields, "bundleId", path: "match.bundleId") else {
+            warn("skipping file; missing or invalid required match.bundleId")
+            return nil
+        }
 
         let rule = AppRule(
-            id: extractString(documentFields["id"]).flatMap(UUID.init(uuidString:))
-                ?? stableID(for: sourceFile, bundleId: bundleId),
+            id: id ?? stableID(for: sourceFile, bundleId: bundleId),
             bundleId: bundleId,
-            appNameSubstring: extractString(matchFields["appName"]),
-            titleSubstring: extractString(matchFields["titleSubstring"]),
-            titleRegex: extractString(matchFields["titleRegex"]),
-            axRole: extractString(matchFields["axRole"]),
-            axSubrole: extractString(matchFields["axSubrole"]),
-            manage: extractString(effectFields["manage"]).flatMap(WindowRuleManageAction.init(rawValue:)),
-            layout: extractString(effectFields["layout"]).flatMap(WindowRuleLayoutAction.init(rawValue:)),
-            assignToWorkspace: extractString(effectFields["assignToWorkspace"]),
-            minWidth: extractDouble(effectFields["minWidth"]),
-            minHeight: extractDouble(effectFields["minHeight"]),
-            sticky: extractBool(effectFields["sticky"])
+            appNameSubstring: stringField(matchFields, "appName", path: "match.appName"),
+            titleSubstring: stringField(matchFields, "titleSubstring", path: "match.titleSubstring"),
+            titleRegex: stringField(matchFields, "titleRegex", path: "match.titleRegex"),
+            axRole: stringField(matchFields, "axRole", path: "match.axRole"),
+            axSubrole: stringField(matchFields, "axSubrole", path: "match.axSubrole"),
+            manage: manageField(),
+            layout: layoutField(),
+            assignToWorkspace: stringField(effectFields, "assignToWorkspace", path: "effect.assignToWorkspace"),
+            minWidth: doubleField(effectFields, "minWidth", path: "effect.minWidth"),
+            minHeight: doubleField(effectFields, "minHeight", path: "effect.minHeight"),
+            sticky: boolField(effectFields, "sticky", path: "effect.sticky")
         )
-        return (documentFields["order"].flatMap(extractInt), rule)
+        return (order, rule)
+    }
+
+    private struct AppRuleDiagnostics {
+        let messages: [String]
+        let canClean: Bool
+    }
+
+    private static func diagnostics(for content: String) -> AppRuleDiagnostics {
+        var currentSection = ""
+        var documentFields: [String: String] = [:]
+        var matchFields: [String: String] = [:]
+        var effectFields: [String: String] = [:]
+        var messages: [String] = []
+
+        func append(_ lineNumber: Int?, _ message: String) {
+            if let lineNumber {
+                messages.append("Line \(lineNumber): \(message)")
+            } else {
+                messages.append(message)
+            }
+        }
+
+        func store(
+            _ key: String,
+            value rawValue: String,
+            in fields: inout [String: String],
+            path: String,
+            lineNumber: Int
+        ) {
+            if fields.updateValue(rawValue, forKey: key) != nil {
+                append(lineNumber, "duplicate \(path).\(key); the last value is used")
+            }
+        }
+
+        for parsedLine in parsedLines(from: content) {
+            let lineNumber = parsedLine.number
+            let trimmed = parsedLine.text
+
+            if trimmed.hasPrefix("[") {
+                guard trimmed.hasSuffix("]") else {
+                    append(lineNumber, "malformed section header")
+                    continue
+                }
+
+                let section = String(trimmed.dropFirst().dropLast())
+                    .trimmingCharacters(in: .whitespaces)
+                guard !section.isEmpty else {
+                    currentSection = ""
+                    append(lineNumber, "empty section header")
+                    continue
+                }
+
+                currentSection = section
+                switch section {
+                case "match",
+                     "effect": break
+                default:
+                    append(lineNumber, "unknown section [\(section)]")
+                }
+                continue
+            }
+
+            guard let eqIndex = trimmed.firstIndex(of: "=") else {
+                append(lineNumber, "malformed line without '='")
+                continue
+            }
+
+            let key = String(trimmed[trimmed.startIndex ..< eqIndex]).trimmingCharacters(in: .whitespaces)
+            let rawValue = String(trimmed[trimmed.index(after: eqIndex)...]).trimmingCharacters(in: .whitespaces)
+            guard !key.isEmpty else {
+                append(lineNumber, "empty key")
+                continue
+            }
+
+            switch currentSection {
+            case "":
+                switch key {
+                case "id",
+                     "order": store(
+                        key,
+                        value: rawValue,
+                        in: &documentFields,
+                        path: "document",
+                        lineNumber: lineNumber
+                    )
+                default: append(lineNumber, "unknown document key \(key)")
+                }
+            case "match":
+                switch key {
+                case "bundleId",
+                     "appName",
+                     "titleSubstring",
+                     "titleRegex",
+                     "axRole",
+                     "axSubrole":
+                    store(key, value: rawValue, in: &matchFields, path: "match", lineNumber: lineNumber)
+                default:
+                    append(lineNumber, "unknown match key \(key)")
+                }
+            case "effect":
+                switch key {
+                case "manage",
+                     "layout",
+                     "sticky",
+                     "minWidth",
+                     "minHeight",
+                     "assignToWorkspace":
+                    store(key, value: rawValue, in: &effectFields, path: "effect", lineNumber: lineNumber)
+                default:
+                    append(lineNumber, "unknown effect key \(key)")
+                }
+            default:
+                append(lineNumber, "key \(key) is ignored because section [\(currentSection)] is unknown")
+            }
+        }
+
+        appendInvalidString(documentFields["id"], path: "document.id", to: &messages)
+        if let rawID = documentFields["id"], let id = extractString(rawID), UUID(uuidString: id) == nil {
+            messages.append("document.id is not a valid UUID string")
+        }
+        if let rawOrder = documentFields["order"], extractInt(rawOrder) == nil {
+            messages.append("document.order is not a valid integer")
+        }
+
+        let validBundleId = extractString(matchFields["bundleId"]) != nil
+        if matchFields["bundleId"] == nil {
+            messages.append("match.bundleId is required and must be a non-empty quoted string")
+        } else {
+            appendInvalidString(matchFields["bundleId"], path: "match.bundleId", to: &messages)
+        }
+        for key in ["appName", "titleSubstring", "titleRegex", "axRole", "axSubrole"] {
+            appendInvalidString(matchFields[key], path: "match.\(key)", to: &messages)
+        }
+
+        appendInvalidEnum(
+            effectFields["manage"],
+            path: "effect.manage",
+            validValues: WindowRuleManageAction.allCases.map(\.rawValue),
+            to: &messages
+        )
+        appendInvalidEnum(
+            effectFields["layout"],
+            path: "effect.layout",
+            validValues: WindowRuleLayoutAction.allCases.map(\.rawValue),
+            to: &messages
+        )
+        appendInvalidString(effectFields["assignToWorkspace"], path: "effect.assignToWorkspace", to: &messages)
+        if let rawMinWidth = effectFields["minWidth"], extractDouble(rawMinWidth) == nil {
+            messages.append("effect.minWidth is not a valid number")
+        }
+        if let rawMinHeight = effectFields["minHeight"], extractDouble(rawMinHeight) == nil {
+            messages.append("effect.minHeight is not a valid number")
+        }
+        if let rawSticky = effectFields["sticky"], extractBool(rawSticky) == nil {
+            messages.append("effect.sticky must be true or false")
+        }
+
+        return AppRuleDiagnostics(messages: messages, canClean: validBundleId)
     }
 
     // MARK: - Samples
@@ -245,6 +591,47 @@ enum AppRuleFileStore {
 
     // MARK: - Helpers
 
+    private struct ParsedLine {
+        let number: Int
+        let text: String
+    }
+
+    private static func parsedLines(from content: String) -> [ParsedLine] {
+        let normalized = content
+            .replacingOccurrences(of: "\r\n", with: "\n")
+            .replacingOccurrences(of: "\r", with: "\n")
+
+        return normalized.components(separatedBy: "\n").enumerated().compactMap { offset, line in
+            let trimmed = stripInlineComment(from: line).trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmed.isEmpty else { return nil }
+            return ParsedLine(number: offset + 1, text: trimmed)
+        }
+    }
+
+    private static func stripInlineComment(from line: String) -> String {
+        var result = ""
+        var isInString = false
+        var isEscaped = false
+
+        for character in line {
+            if character == "#", !isInString {
+                break
+            }
+
+            result.append(character)
+
+            if isEscaped {
+                isEscaped = false
+            } else if character == "\\", isInString {
+                isEscaped = true
+            } else if character == "\"" {
+                isInString.toggle()
+            }
+        }
+
+        return result
+    }
+
     private static func sanitizedFilename(for rule: AppRule) -> String {
         let base = rule.bundleId
             .replacingOccurrences(of: ".", with: "-")
@@ -298,5 +685,60 @@ enum AppRuleFileStore {
 
     private static func extractInt(_ raw: String) -> Int? {
         Int(raw.trimmingCharacters(in: .whitespaces))
+    }
+
+    private static func appendInvalidString(_ raw: String?, path: String, to messages: inout [String]) {
+        guard let raw, extractString(raw) == nil else { return }
+        messages.append("\(path) must be a non-empty quoted string")
+    }
+
+    private static func appendInvalidEnum(
+        _ raw: String?,
+        path: String,
+        validValues: [String],
+        to messages: inout [String]
+    ) {
+        guard let raw else { return }
+        guard let value = extractString(raw) else {
+            messages.append("\(path) must be a quoted string")
+            return
+        }
+        if !validValues.contains(value) {
+            messages
+                .append("\(path) has unknown value \(value); expected one of \(validValues.joined(separator: ", "))")
+        }
+    }
+
+    private static func createTimestampedBackup(for fileURL: URL) throws -> URL {
+        let fileManager = FileManager.default
+        let directory = fileURL.deletingLastPathComponent()
+
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.dateFormat = "yyyyMMdd-HHmmss"
+        let stamp = formatter.string(from: Date())
+
+        let baseName = fileURL.deletingPathExtension().lastPathComponent
+        let fileExtension = fileURL.pathExtension
+        let backupName = fileExtension.isEmpty
+            ? "\(baseName)-\(stamp).backup"
+            : "\(baseName)-\(stamp).\(fileExtension).backup"
+
+        var backupURL = directory.appendingPathComponent(backupName, isDirectory: false)
+        var suffix = 2
+        while fileManager.fileExists(atPath: backupURL.path) {
+            let suffixedName = fileExtension.isEmpty
+                ? "\(baseName)-\(stamp)-\(suffix).backup"
+                : "\(baseName)-\(stamp)-\(suffix).\(fileExtension).backup"
+            backupURL = directory.appendingPathComponent(suffixedName, isDirectory: false)
+            suffix += 1
+        }
+
+        try fileManager.copyItem(at: fileURL, to: backupURL)
+        return backupURL
+    }
+
+    private static func warn(_ message: String) {
+        logger.warning("\(message, privacy: .public)")
     }
 }

--- a/Sources/Nehir/Core/Config/SettingsDiagnosticsIssue.swift
+++ b/Sources/Nehir/Core/Config/SettingsDiagnosticsIssue.swift
@@ -18,6 +18,16 @@ struct UnknownSettingsKeysIssue: Identifiable, Equatable {
     }
 }
 
+struct AppRuleFileDiagnosticIssue: Identifiable, Equatable {
+    let fileURL: URL
+    let messages: [String]
+    let canClean: Bool
+
+    var id: String {
+        "app-rule-file:\(fileURL.path)"
+    }
+}
+
 /// A live (Carbon-level or internal Nehir) hotkey registration failure surfaced as a
 /// Diagnostics row. Built from `HotkeyCenter.registrationFailures`.
 struct HotkeyConflictIssue: Identifiable, Equatable {
@@ -67,6 +77,7 @@ struct HotkeyAdvisoryIssue: Identifiable, Equatable {
 enum SettingsDiagnosticsIssue: Identifiable, Equatable {
     case softMigration(PendingSettingsMigration)
     case unknownKeys(UnknownSettingsKeysIssue)
+    case appRuleFile(AppRuleFileDiagnosticIssue)
     case hotkeyConflict(HotkeyConflictIssue)
     case hotkeyAdvisory(HotkeyAdvisoryIssue)
 
@@ -75,6 +86,8 @@ enum SettingsDiagnosticsIssue: Identifiable, Equatable {
         case .softMigration(let migration):
             return "migration:\(migration.id)"
         case .unknownKeys(let issue):
+            return issue.id
+        case .appRuleFile(let issue):
             return issue.id
         case .hotkeyConflict(let issue):
             return issue.id
@@ -128,10 +141,12 @@ enum SettingsDiagnosticsDetector {
             return migration.id
         case .unknownKeys(let issue):
             return issue.id
-        case .hotkeyConflict,
+        case .appRuleFile,
+             .hotkeyConflict,
              .hotkeyAdvisory:
-            // Live hotkey advisories are not postponable; they clear once the user
-            // reassigns the conflicting chord, so they always pass the postponement filter.
+            // These issues are not postponable. Hotkey conflicts/advisories clear once the user
+            // reassigns the conflicting chord, while app-rule file diagnostics persist until the
+            // malformed config is fixed or removed, so they always pass the postponement filter.
             return Self.nonPostponableID
         }
     }
@@ -149,6 +164,14 @@ enum SettingsDiagnosticsDetector {
         if !unknownKeys.isEmpty {
             issues.append(.unknownKeys(UnknownSettingsKeysIssue(fileURL: settingsURL, keyPaths: unknownKeys)))
         }
+
+        let appRulesDirectoryURL = configDirectory.appendingPathComponent(
+            SettingsFilePersistence.appRulesDirectoryName,
+            isDirectory: true
+        )
+        issues.append(contentsOf: AppRuleFileStore.diagnostics(from: appRulesDirectoryURL).map {
+            SettingsDiagnosticsIssue.appRuleFile($0)
+        })
         return issues
     }
 

--- a/Sources/Nehir/UI/DisplayDiagnosticsSettingsTab.swift
+++ b/Sources/Nehir/UI/DisplayDiagnosticsSettingsTab.swift
@@ -20,6 +20,8 @@ struct DisplayDiagnosticsSettingsTab: View {
     @State private var migrationError: String?
     @State private var unknownKeysConfirmation: String?
     @State private var unknownKeysError: String?
+    @State private var appRuleFileConfirmations: [String: String] = [:]
+    @State private var appRuleFileErrors: [String: String] = [:]
     @State private var traceCaptureStatus: WMController.RuntimeTraceCaptureStatus = .init(
         isActive: false,
         startedAt: nil
@@ -90,7 +92,7 @@ struct DisplayDiagnosticsSettingsTab: View {
 
             if !applicableSettingsIssues
                 .isEmpty || migrationConfirmation != nil || migrationError != nil || unknownKeysConfirmation != nil ||
-                unknownKeysError != nil
+                unknownKeysError != nil || !appRuleFileConfirmations.isEmpty || !appRuleFileErrors.isEmpty
             {
                 Section("Settings Configuration") {
                     ForEach(applicableSettingsIssues) { issue in
@@ -113,6 +115,13 @@ struct DisplayDiagnosticsSettingsTab: View {
                                 onCopyPrompt: { copyUnknownKeysPrompt(issue) },
                                 onPostpone: { postponeUnknownKeys(issue) },
                                 onClean: { cleanUnknownKeys(issue) }
+                            )
+                        case .appRuleFile(let issue):
+                            AppRuleFileDiagnosticWarningView(
+                                issue: issue,
+                                confirmation: appRuleFileConfirmations[issue.id],
+                                error: appRuleFileErrors[issue.id],
+                                onClean: { cleanAppRuleFile(issue) }
                             )
                         case .hotkeyConflict(let issue):
                             HotkeyConflictWarningView(conflict: issue)
@@ -137,6 +146,18 @@ struct DisplayDiagnosticsSettingsTab: View {
                         if let unknownKeysError {
                             Label(unknownKeysError, systemImage: "xmark.circle.fill")
                                 .foregroundStyle(.red)
+                        }
+                        ForEach(appRuleFileConfirmations.keys.sorted(), id: \.self) { issueID in
+                            if let confirmation = appRuleFileConfirmations[issueID] {
+                                Label(confirmation, systemImage: "checkmark.circle.fill")
+                                    .foregroundStyle(.green)
+                            }
+                        }
+                        ForEach(appRuleFileErrors.keys.sorted(), id: \.self) { issueID in
+                            if let error = appRuleFileErrors[issueID] {
+                                Label(error, systemImage: "xmark.circle.fill")
+                                    .foregroundStyle(.red)
+                            }
                         }
                     }
                 }
@@ -652,6 +673,21 @@ struct DisplayDiagnosticsSettingsTab: View {
             unknownKeysError = error.localizedDescription
         }
     }
+
+    private func cleanAppRuleFile(_ issue: AppRuleFileDiagnosticIssue) {
+        appRuleFileConfirmations[issue.id] = nil
+        appRuleFileErrors[issue.id] = nil
+
+        do {
+            let backupURL = try AppRuleFileStore.cleanIgnoredEntries(fileURL: issue.fileURL)
+            appRuleFileConfirmations[issue.id] =
+                "Removed ignored app-rule entries. Backup: \(backupURL.lastPathComponent)"
+            refreshSettingsIssues()
+            NotificationCenter.default.post(name: .settingsMigrationStateDidChange, object: nil)
+        } catch {
+            appRuleFileErrors[issue.id] = error.localizedDescription
+        }
+    }
 }
 
 private struct TraceFile: Identifiable {
@@ -764,6 +800,63 @@ private struct SettingsMigrationWarningView: View {
                     }
                     .buttonStyle(.bordered)
                 }
+            }
+
+            if let confirmation {
+                Label(confirmation, systemImage: "checkmark.circle.fill")
+                    .font(.caption)
+                    .foregroundStyle(.green)
+            }
+
+            if let error {
+                Label(error, systemImage: "xmark.circle.fill")
+                    .font(.caption)
+                    .foregroundStyle(.red)
+            }
+        }
+        .padding(.vertical, 4)
+    }
+}
+
+private struct AppRuleFileDiagnosticWarningView: View {
+    let issue: AppRuleFileDiagnosticIssue
+    let confirmation: String?
+    let error: String?
+    let onClean: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Label("App-rule config issue", systemImage: "exclamationmark.triangle.fill")
+                .font(.headline)
+                .foregroundStyle(Color.yellow)
+
+            Text(
+                "This app-rule file contains lines or values Nehir ignores. Fix the entries below so the rule matches the behavior you expect."
+            )
+            .foregroundStyle(.secondary)
+
+            Text("File: \(issue.fileURL.path)")
+                .font(.caption.monospaced())
+                .foregroundStyle(.secondary)
+                .textSelection(.enabled)
+
+            VStack(alignment: .leading, spacing: 4) {
+                ForEach(Array(issue.messages.enumerated()), id: \.offset) { _, message in
+                    Label(message, systemImage: "questionmark.circle")
+                        .font(.caption.monospaced())
+                        .textSelection(.enabled)
+                }
+            }
+
+            if issue.canClean {
+                Button("Remove Ignored Entries") {
+                    onClean()
+                }
+                .buttonStyle(.bordered)
+            } else {
+                Text("Edit this file manually; Nehir cannot safely rewrite it while required fields are invalid.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
             }
 
             if let confirmation {

--- a/Sources/Nehir/UI/Onboarding/WhatsNewView.swift
+++ b/Sources/Nehir/UI/Onboarding/WhatsNewView.swift
@@ -114,6 +114,7 @@ struct WhatsNewView: View {
         switch issue {
         case .softMigration: return "arrow.triangle.2.circlepath"
         case .unknownKeys: return "questionmark.circle"
+        case .appRuleFile: return "doc.badge.gearshape"
         case .hotkeyConflict,
              .hotkeyAdvisory: return "keyboard"
         }
@@ -126,6 +127,9 @@ struct WhatsNewView: View {
         case .unknownKeys(let unknownKeys):
             let suffix = unknownKeys.keyPaths.count == 1 ? "key" : "keys"
             return "\(unknownKeys.keyPaths.count) unrecognized settings \(suffix)"
+        case .appRuleFile(let issue):
+            let suffix = issue.messages.count == 1 ? "issue" : "issues"
+            return "\(issue.fileURL.lastPathComponent): \(issue.messages.count) app-rule \(suffix)"
         case .hotkeyConflict(let conflict):
             return "\(conflict.commandDisplayName) hotkey conflict"
         case .hotkeyAdvisory(let advisory):

--- a/Sources/Nehir/UI/StatusBar/StatusBarMenu.swift
+++ b/Sources/Nehir/UI/StatusBar/StatusBarMenu.swift
@@ -228,6 +228,7 @@ final class StatusBarMenuBuilder {
         switch issue {
         case .softMigration: return "arrow.triangle.2.circlepath"
         case .unknownKeys: return "questionmark.circle"
+        case .appRuleFile: return "doc.badge.gearshape"
         case .hotkeyConflict,
              .hotkeyAdvisory: return "keyboard"
         }
@@ -240,6 +241,9 @@ final class StatusBarMenuBuilder {
         case .unknownKeys(let unknownKeys):
             let suffix = unknownKeys.keyPaths.count == 1 ? "key" : "keys"
             return "\(unknownKeys.keyPaths.count) unrecognized settings \(suffix)"
+        case .appRuleFile(let issue):
+            let suffix = issue.messages.count == 1 ? "issue" : "issues"
+            return "\(issue.fileURL.lastPathComponent): \(issue.messages.count) app-rule \(suffix)"
         case .hotkeyConflict(let conflict):
             return "\(conflict.commandDisplayName) hotkey conflict"
         case .hotkeyAdvisory(let advisory):


### PR DESCRIPTION
## Summary

Warn when app-rule config files contain malformed or ignored lines

## Release notes

Choose one:

- [x] Added a `.changeset/*.md` for user-visible changes (`mise run changeset -- patch "..."`).
- [ ] No user-visible change; apply the `no release note` label to make CI skip intentional.

## Validation

<!-- Commands run, screenshots, or manual checks. -->

- [ ] Ran relevant tests/checks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dedicated diagnostics warning type for app-rule config files across settings, onboarding, and the status bar.
  * You can now review specific app-rule file issues and remove ignored entries, with guidance when safe rewriting isn’t possible.

* **Bug Fixes**
  * Improved detection and reporting for malformed, unreadable, or partially invalid app-rule entries, including clearer per-file messaging.
  * App-rule cleanup now creates a backup and preserves rule ordering when rewriting files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->