### PR TITLE
Show other displays' workspaces in the workspace bar Move to Workspace submenu

### DIFF
--- a/.changeset/20260702013623-show-other-displays-workspaces-in-the-workspace-.md
+++ b/.changeset/20260702013623-show-other-displays-workspaces-in-the-workspace-.md
@@ -1,0 +1,6 @@
+---
+"nehir": patch
+
+---
+
+Show other displays' workspaces in the workspace bar Move to Workspace submenu

--- a/Sources/Nehir/Core/Controller/WMController.swift
+++ b/Sources/Nehir/Core/Controller/WMController.swift
@@ -686,9 +686,17 @@ final class WMController {
         )
     }
 
+    func workspaceBarMoveTargets() -> [WorkspaceBarWindowMoveTarget] {
+        WorkspaceBarDataSource.workspaceBarMoveTargets(
+            workspaceManager: workspaceManager,
+            settings: settings
+        )
+    }
+
     func workspaceBarProjection(
         for monitor: Monitor,
-        projection options: WorkspaceBarProjectionOptions
+        projection options: WorkspaceBarProjectionOptions,
+        moveTargets: [WorkspaceBarWindowMoveTarget]? = nil
     ) -> WorkspaceBarProjection {
         WorkspaceBarDataSource.workspaceBarProjection(
             for: monitor,
@@ -698,7 +706,8 @@ final class WMController {
             niriEngine: niriEngine,
             focusedToken: workspaceManager.confirmedManagedFocusToken,
             viewportSelectedToken: viewportSelectedToken(for: monitor),
-            settings: settings
+            settings: settings,
+            moveTargets: moveTargets
         )
     }
 

--- a/Sources/Nehir/IPC/IPCQueryRouter.swift
+++ b/Sources/Nehir/IPC/IPCQueryRouter.swift
@@ -32,6 +32,7 @@ final class IPCQueryRouter {
     }
 
     func workspaceBarResult() -> IPCWorkspaceBarQueryResult {
+        let moveTargets = controller.workspaceBarMoveTargets()
         let monitors = controller.workspaceManager.monitors.map { monitor in
             let resolved = controller.settings.resolvedBarSettings(for: monitor)
             let isVisible = controller.isWorkspaceBarVisible(on: monitor, resolved: resolved)
@@ -42,7 +43,8 @@ final class IPCQueryRouter {
             )
             let projection = controller.workspaceBarProjection(
                 for: monitor,
-                projection: resolved.projectionOptions
+                projection: resolved.projectionOptions,
+                moveTargets: moveTargets
             )
 
             return IPCWorkspaceBarMonitor(

--- a/Sources/Nehir/UI/WorkspaceBar/WorkspaceBarDataSource.swift
+++ b/Sources/Nehir/UI/WorkspaceBar/WorkspaceBarDataSource.swift
@@ -46,7 +46,8 @@ enum WorkspaceBarDataSource {
         niriEngine: NiriLayoutEngine?,
         focusedToken: WindowToken?,
         viewportSelectedToken: WindowToken? = nil,
-        settings: SettingsStore
+        settings: SettingsStore,
+        moveTargets: [WorkspaceBarWindowMoveTarget]? = nil
     ) -> WorkspaceBarProjection {
         WorkspaceBarProjection(
             items: workspaceItems(
@@ -76,7 +77,8 @@ enum WorkspaceBarDataSource {
             isViewportScrollLocked: activeWorkspaceScrollLockState(
                 for: monitor,
                 workspaceManager: workspaceManager
-            )
+            ),
+            moveTargets: moveTargets ?? moveTargetItems(workspaceManager: workspaceManager, settings: settings)
         )
     }
 
@@ -364,5 +366,34 @@ enum WorkspaceBarDataSource {
         guard let title = AXWindowService.titlePreferFast(windowId: UInt32(entry.windowId)),
               !title.isEmpty else { return nil }
         return title
+    }
+
+    static func workspaceBarMoveTargets(
+        workspaceManager: WorkspaceManager,
+        settings: SettingsStore
+    ) -> [WorkspaceBarWindowMoveTarget] {
+        moveTargetItems(workspaceManager: workspaceManager, settings: settings)
+    }
+
+    /// Every realized (monitor-assigned) workspace across all monitors, for the
+    /// flat *Move to Workspace ▸* submenu.
+    private static func moveTargetItems(
+        workspaceManager: WorkspaceManager,
+        settings: SettingsStore
+    ) -> [WorkspaceBarWindowMoveTarget] {
+        var seen: Set<WorkspaceDescriptor.ID> = []
+        var targets: [WorkspaceBarWindowMoveTarget] = []
+        for monitor in workspaceManager.monitors {
+            for workspace in workspaceManager.workspaces(on: monitor.id) {
+                guard seen.insert(workspace.id).inserted else { continue }
+                targets.append(
+                    WorkspaceBarWindowMoveTarget(
+                        id: workspace.id,
+                        name: settings.displayName(for: workspace.name)
+                    )
+                )
+            }
+        }
+        return targets
     }
 }

--- a/Sources/Nehir/UI/WorkspaceBar/WorkspaceBarManager.swift
+++ b/Sources/Nehir/UI/WorkspaceBar/WorkspaceBarManager.swift
@@ -171,6 +171,7 @@ final class WorkspaceBarManager {
     func reconfigureBars(using monitors: [Monitor]) {
         guard let controller, let settings else { return }
 
+        let moveTargets = controller.workspaceBarMoveTargets()
         var existingMonitorIds = Set(barsByMonitor.keys)
 
         for monitor in monitors {
@@ -184,12 +185,12 @@ final class WorkspaceBarManager {
             }
 
             if let existing = barsByMonitor[monitor.id] {
-                if !updateBarForMonitor(monitor, instance: existing) {
+                if !updateBarForMonitor(monitor, instance: existing, moveTargets: moveTargets) {
                     removeBarForMonitor(monitor.id)
-                    createBarForMonitor(monitor)
+                    createBarForMonitor(monitor, moveTargets: moveTargets)
                 }
             } else {
-                createBarForMonitor(monitor)
+                createBarForMonitor(monitor, moveTargets: moveTargets)
             }
         }
 
@@ -205,20 +206,21 @@ final class WorkspaceBarManager {
     }
 
     private func refreshBarsContent() {
-        guard settings != nil else { return }
+        guard let controller, settings != nil else { return }
 
+        let moveTargets = controller.workspaceBarMoveTargets()
         let currentMonitors = Dictionary(uniqueKeysWithValues: monitorProvider().map { ($0.id, $0) })
         for instance in barsByMonitor.values {
             let monitor = currentMonitors[instance.monitorId] ?? instance.monitor
-            refreshBarContent(for: monitor, instance: instance)
+            refreshBarContent(for: monitor, instance: instance, moveTargets: moveTargets)
         }
     }
 
-    private func createBarForMonitor(_ monitor: Monitor) {
+    private func createBarForMonitor(_ monitor: Monitor, moveTargets: [WorkspaceBarWindowMoveTarget]) {
         guard let controller, let settings else { return }
 
         let resolved = settings.resolvedBarSettings(for: monitor)
-        let snapshot = makeSnapshot(for: monitor, resolved: resolved)
+        let snapshot = makeSnapshot(for: monitor, resolved: resolved, moveTargets: moveTargets)
         let model = WorkspaceBarModel(snapshot: snapshot)
 
         let hostingView = NSHostingView(
@@ -327,7 +329,11 @@ final class WorkspaceBarManager {
         panel.orderFrontRegardless()
     }
 
-    private func updateBarForMonitor(_ monitor: Monitor, instance: MonitorBarInstance) -> Bool {
+    private func updateBarForMonitor(
+        _ monitor: Monitor,
+        instance: MonitorBarInstance,
+        moveTargets: [WorkspaceBarWindowMoveTarget]
+    ) -> Bool {
         guard let settings else { return false }
 
         let screen = screenProvider(monitor.displayId)
@@ -349,7 +355,7 @@ final class WorkspaceBarManager {
         instance.screenDisplayId = nextScreenDisplayId
 
         let resolved = settings.resolvedBarSettings(for: monitor)
-        let snapshot = makeSnapshot(for: monitor, resolved: resolved)
+        let snapshot = makeSnapshot(for: monitor, resolved: resolved, moveTargets: moveTargets)
         instance.model.snapshot = snapshot
         applyCurrentAppearance(
             to: instance.panel,
@@ -366,14 +372,18 @@ final class WorkspaceBarManager {
         return true
     }
 
-    private func refreshBarContent(for monitor: Monitor, instance: MonitorBarInstance) {
+    private func refreshBarContent(
+        for monitor: Monitor,
+        instance: MonitorBarInstance,
+        moveTargets: [WorkspaceBarWindowMoveTarget]
+    ) {
         guard let settings else { return }
 
         instance.monitor = monitor
         instance.panel.targetFrame = monitor.frame
 
         let resolved = settings.resolvedBarSettings(for: monitor)
-        let snapshot = makeSnapshot(for: monitor, resolved: resolved)
+        let snapshot = makeSnapshot(for: monitor, resolved: resolved, moveTargets: moveTargets)
         if snapshot != instance.model.snapshot {
             instance.model.snapshot = snapshot
         }
@@ -463,13 +473,21 @@ final class WorkspaceBarManager {
 
     private func makeSnapshot(
         for monitor: Monitor,
-        resolved: ResolvedBarSettings
+        resolved: ResolvedBarSettings,
+        moveTargets: [WorkspaceBarWindowMoveTarget]
     ) -> WorkspaceBarSnapshot {
         let geometry = WorkspaceBarGeometry.resolve(monitor: monitor, resolved: resolved, isVisible: true)
         let projection = controller?.workspaceBarProjection(
             for: monitor,
-            projection: resolved.projectionOptions
-        ) ?? WorkspaceBarProjection(items: [], sticky: nil, scratchpad: nil, isViewportScrollLocked: false)
+            projection: resolved.projectionOptions,
+            moveTargets: moveTargets
+        ) ?? WorkspaceBarProjection(
+            items: [],
+            sticky: nil,
+            scratchpad: nil,
+            isViewportScrollLocked: false,
+            moveTargets: []
+        )
 
         return WorkspaceBarSnapshot(
             projection: projection,

--- a/Sources/Nehir/UI/WorkspaceBar/WorkspaceBarView.swift
+++ b/Sources/Nehir/UI/WorkspaceBar/WorkspaceBarView.swift
@@ -26,6 +26,12 @@ struct WorkspaceBarProjection: Equatable {
     let sticky: WorkspaceBarStickyItem?
     let scratchpad: WorkspaceBarScratchpadItem?
     let isViewportScrollLocked: Bool
+
+    /// Every workspace shown across all monitors — the full target set for the
+    /// window-icon *Move to Workspace ▸* submenu. Unlike `items` (scoped to this
+    /// monitor), this includes workspaces on other displays so a window can be
+    /// moved between monitors.
+    let moveTargets: [WorkspaceBarWindowMoveTarget]
 }
 
 struct WorkspaceBarWindowItem: Identifiable, Equatable {
@@ -98,6 +104,10 @@ struct WorkspaceBarSnapshot: Equatable {
 
     var scratchpad: WorkspaceBarScratchpadItem? {
         projection.scratchpad
+    }
+
+    var moveTargets: [WorkspaceBarWindowMoveTarget] {
+        projection.moveTargets
     }
 }
 
@@ -178,7 +188,7 @@ struct WorkspaceBarMeasurementView: View {
 }
 
 /// A target workspace offered by a window icon's *Move to Workspace ▸*
-/// submenu (the other workspaces visible on this monitor).
+/// submenu (all realized workspaces across monitors).
 struct WorkspaceBarWindowMoveTarget: Identifiable, Hashable {
     let id: WorkspaceDescriptor.ID
     let name: String
@@ -263,9 +273,10 @@ private struct WorkspaceBarContentView: View {
         RoundedRectangle(cornerRadius: 8, style: .continuous)
     }
 
-    /// Workspaces on this monitor offered by the *Move to Workspace ▸* submenu.
+    /// Workspaces across all monitors offered by the *Move to Workspace ▸*
+    /// submenu (the window's own workspace is excluded per icon later).
     private var windowMoveTargets: [WorkspaceBarWindowMoveTarget] {
-        snapshot.items.map { WorkspaceBarWindowMoveTarget(id: $0.id, name: $0.name) }
+        snapshot.moveTargets
     }
 
     /// True when the single scratchpad slot is held, so the window-icon


### PR DESCRIPTION
## Summary

Show other displays' workspaces in the workspace bar Move to Workspace submenu
## Release notes

Choose one:

- [x] Added a `.changeset/*.md` for user-visible changes (`mise run changeset -- patch "..."`).
- [ ] No user-visible change; apply the `no release note` label to make CI skip intentional.

## Validation

<!-- Commands run, screenshots, or manual checks. -->

- [ ] Ran relevant tests/checks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The “Move to Workspace” submenu now lists workspace destinations from all displays, not just the current one.
  * The workspace bar’s “Move to Workspace” targets are now expanded to reflect system-wide workspace destinations for the window move action.

* **Bug Fixes**
  * Improved multi-display consistency so window move destinations correctly match the available workspaces across all displays.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->