### PR TITLE
Show other displays in the workspace bar

### DIFF
--- a/.changeset/20260702143749-add-a-per-display-workspace-bar-toggle-to-show-o.md
+++ b/.changeset/20260702143749-add-a-per-display-workspace-bar-toggle-to-show-o.md
@@ -1,0 +1,6 @@
+---
+"nehir": minor
+
+---
+
+Add a per-display workspace-bar toggle to show other displays' workspaces after a display icon. Click a foreign workspace to switch that display; shift-click to move the focused window there. Off by default; configurable globally and per monitor.

--- a/Sources/Nehir/Core/Config/CanonicalTOMLConfig.swift
+++ b/Sources/Nehir/Core/Config/CanonicalTOMLConfig.swift
@@ -164,6 +164,7 @@ struct CanonicalTOMLConfig: Codable, Equatable {
         var notchAware: Bool
         var deduplicateAppIcons: Bool
         var hideEmptyWorkspaces: Bool
+        var showWorkspacesFromOtherDisplays: Bool
         var reserveLayoutSpace: Bool
         var height: Double
         var backgroundOpacity: Double
@@ -177,7 +178,8 @@ struct CanonicalTOMLConfig: Codable, Equatable {
         enum CodingKeys: String, CodingKey, CaseIterable {
             case enabled, showLabels, showFloatingWindows, showTraceButton, showScrollLockButton, windowLevel, position,
                  notchAware,
-                 deduplicateAppIcons, hideEmptyWorkspaces, reserveLayoutSpace, height, backgroundOpacity, xOffset,
+                 deduplicateAppIcons, hideEmptyWorkspaces, showWorkspacesFromOtherDisplays, reserveLayoutSpace, height,
+                 backgroundOpacity, xOffset,
                  yOffset, labelFontSize, accentColor, textColor
         }
 
@@ -327,6 +329,7 @@ extension CanonicalTOMLConfig {
             notchAware: export.workspaceBarNotchAware,
             deduplicateAppIcons: export.workspaceBarDeduplicateAppIcons,
             hideEmptyWorkspaces: export.workspaceBarHideEmptyWorkspaces,
+            showWorkspacesFromOtherDisplays: export.workspaceBarShowWorkspacesFromOtherDisplays,
             reserveLayoutSpace: export.workspaceBarReserveLayoutSpace,
             height: export.workspaceBarHeight,
             backgroundOpacity: export.workspaceBarBackgroundOpacity,
@@ -421,6 +424,7 @@ extension CanonicalTOMLConfig {
             workspaceBarNotchAware: workspaceBar.notchAware,
             workspaceBarDeduplicateAppIcons: workspaceBar.deduplicateAppIcons,
             workspaceBarHideEmptyWorkspaces: workspaceBar.hideEmptyWorkspaces,
+            workspaceBarShowWorkspacesFromOtherDisplays: workspaceBar.showWorkspacesFromOtherDisplays,
             workspaceBarReserveLayoutSpace: workspaceBar.reserveLayoutSpace,
             workspaceBarHeight: workspaceBar.height,
             workspaceBarBackgroundOpacity: workspaceBar.backgroundOpacity,
@@ -749,6 +753,11 @@ extension CanonicalTOMLConfig.WorkspaceBar {
             forKey: .hideEmptyWorkspaces,
             default: d.hideEmptyWorkspaces
         )
+        showWorkspacesFromOtherDisplays = try container.decodeWithDefault(
+            Bool.self,
+            forKey: .showWorkspacesFromOtherDisplays,
+            default: d.showWorkspacesFromOtherDisplays
+        )
         reserveLayoutSpace = try container.decodeWithDefault(
             Bool.self,
             forKey: .reserveLayoutSpace,
@@ -780,6 +789,7 @@ extension CanonicalTOMLConfig.WorkspaceBar {
         try container.encode(notchAware, forKey: "notchAware")
         try container.encode(deduplicateAppIcons, forKey: "deduplicateAppIcons")
         try container.encode(hideEmptyWorkspaces, forKey: "hideEmptyWorkspaces")
+        try container.encode(showWorkspacesFromOtherDisplays, forKey: "showWorkspacesFromOtherDisplays")
         try container.encode(reserveLayoutSpace, forKey: "reserveLayoutSpace")
         try container.encode(height, forKey: "height")
         try container.encode(backgroundOpacity, forKey: "backgroundOpacity")

--- a/Sources/Nehir/Core/Config/MonitorBarSettings.swift
+++ b/Sources/Nehir/Core/Config/MonitorBarSettings.swift
@@ -18,6 +18,7 @@ struct MonitorBarSettings: MonitorSettingsType {
     var showFloatingWindows: Bool?
     var deduplicateAppIcons: Bool?
     var hideEmptyWorkspaces: Bool?
+    var showWorkspacesFromOtherDisplays: Bool?
     var reserveLayoutSpace: Bool?
     var notchAware: Bool?
     var showTraceButton: Bool?
@@ -39,6 +40,7 @@ struct MonitorBarSettings: MonitorSettingsType {
         showFloatingWindows: Bool? = nil,
         deduplicateAppIcons: Bool? = nil,
         hideEmptyWorkspaces: Bool? = nil,
+        showWorkspacesFromOtherDisplays: Bool? = nil,
         reserveLayoutSpace: Bool? = nil,
         notchAware: Bool? = nil,
         showTraceButton: Bool? = nil,
@@ -59,6 +61,7 @@ struct MonitorBarSettings: MonitorSettingsType {
         self.showFloatingWindows = showFloatingWindows
         self.deduplicateAppIcons = deduplicateAppIcons
         self.hideEmptyWorkspaces = hideEmptyWorkspaces
+        self.showWorkspacesFromOtherDisplays = showWorkspacesFromOtherDisplays
         self.reserveLayoutSpace = reserveLayoutSpace
         self.notchAware = notchAware
         self.showTraceButton = showTraceButton
@@ -74,8 +77,8 @@ struct MonitorBarSettings: MonitorSettingsType {
     private enum CodingKeys: String, CodingKey {
         case id, monitorName, monitorDisplayId, monitorAnchorPoint
         case enabled, showLabels, showFloatingWindows, deduplicateAppIcons
-        case hideEmptyWorkspaces, reserveLayoutSpace, notchAware, showTraceButton, showScrollLockButton, position,
-             windowLevel
+        case hideEmptyWorkspaces, showWorkspacesFromOtherDisplays, reserveLayoutSpace, notchAware, showTraceButton,
+             showScrollLockButton, position, windowLevel
         case height, backgroundOpacity, xOffset, yOffset
     }
 
@@ -90,6 +93,10 @@ struct MonitorBarSettings: MonitorSettingsType {
         showFloatingWindows = try container.decodeIfPresent(Bool.self, forKey: .showFloatingWindows)
         deduplicateAppIcons = try container.decodeIfPresent(Bool.self, forKey: .deduplicateAppIcons)
         hideEmptyWorkspaces = try container.decodeIfPresent(Bool.self, forKey: .hideEmptyWorkspaces)
+        showWorkspacesFromOtherDisplays = try container.decodeIfPresent(
+            Bool.self,
+            forKey: .showWorkspacesFromOtherDisplays
+        )
         reserveLayoutSpace = try container.decodeIfPresent(Bool.self, forKey: .reserveLayoutSpace)
         notchAware = try container.decodeIfPresent(Bool.self, forKey: .notchAware)
         showTraceButton = try container.decodeIfPresent(Bool.self, forKey: .showTraceButton)
@@ -115,6 +122,7 @@ struct MonitorBarSettings: MonitorSettingsType {
         try container.encodeIfPresent(showFloatingWindows, forKey: .showFloatingWindows)
         try container.encodeIfPresent(deduplicateAppIcons, forKey: .deduplicateAppIcons)
         try container.encodeIfPresent(hideEmptyWorkspaces, forKey: .hideEmptyWorkspaces)
+        try container.encodeIfPresent(showWorkspacesFromOtherDisplays, forKey: .showWorkspacesFromOtherDisplays)
         try container.encodeIfPresent(reserveLayoutSpace, forKey: .reserveLayoutSpace)
         try container.encodeIfPresent(notchAware, forKey: .notchAware)
         try container.encodeIfPresent(showTraceButton, forKey: .showTraceButton)
@@ -136,6 +144,7 @@ struct ResolvedBarSettings {
     let showScrollLockButton: Bool
     let deduplicateAppIcons: Bool
     let hideEmptyWorkspaces: Bool
+    let showWorkspacesFromOtherDisplays: Bool
     let reserveLayoutSpace: Bool
     let notchAware: Bool
     let position: WorkspaceBarPosition
@@ -155,6 +164,7 @@ struct ResolvedBarSettings {
         showScrollLockButton: false,
         deduplicateAppIcons: false,
         hideEmptyWorkspaces: false,
+        showWorkspacesFromOtherDisplays: false,
         reserveLayoutSpace: false,
         notchAware: true,
         position: .overlappingMenuBar,

--- a/Sources/Nehir/Core/Config/MonitorOverrideFileStore.swift
+++ b/Sources/Nehir/Core/Config/MonitorOverrideFileStore.swift
@@ -132,6 +132,7 @@ enum MonitorOverrideFileStore {
             if let v = bar.showFloatingWindows { lines.append("showFloatingWindows = \(v)") }
             if let v = bar.deduplicateAppIcons { lines.append("deduplicateAppIcons = \(v)") }
             if let v = bar.hideEmptyWorkspaces { lines.append("hideEmptyWorkspaces = \(v)") }
+            if let v = bar.showWorkspacesFromOtherDisplays { lines.append("showWorkspacesFromOtherDisplays = \(v)") }
             if let v = bar.reserveLayoutSpace { lines.append("reserveLayoutSpace = \(v)") }
             if let v = bar.notchAware { lines.append("notchAware = \(v)") }
             if let v = bar.position { lines.append("position = \(quoted(v.rawValue))") }
@@ -217,6 +218,7 @@ enum MonitorOverrideFileStore {
                 showFloatingWindows: bar["showFloatingWindows"].flatMap(extractBool),
                 deduplicateAppIcons: bar["deduplicateAppIcons"].flatMap(extractBool),
                 hideEmptyWorkspaces: bar["hideEmptyWorkspaces"].flatMap(extractBool),
+                showWorkspacesFromOtherDisplays: bar["showWorkspacesFromOtherDisplays"].flatMap(extractBool),
                 reserveLayoutSpace: bar["reserveLayoutSpace"].flatMap(extractBool),
                 notchAware: bar["notchAware"].flatMap(extractBool),
                 position: bar["position"].flatMap(extractString).flatMap(WorkspaceBarPosition.init(rawValue:)),

--- a/Sources/Nehir/Core/Config/SettingsExport.swift
+++ b/Sources/Nehir/Core/Config/SettingsExport.swift
@@ -59,6 +59,7 @@ struct SettingsExport: Equatable, Sendable {
     var workspaceBarNotchAware: Bool
     var workspaceBarDeduplicateAppIcons: Bool
     var workspaceBarHideEmptyWorkspaces: Bool
+    var workspaceBarShowWorkspacesFromOtherDisplays: Bool
     var workspaceBarReserveLayoutSpace: Bool
     var workspaceBarHeight: Double
     var workspaceBarBackgroundOpacity: Double
@@ -151,6 +152,7 @@ extension SettingsExport {
             workspaceBarNotchAware: true,
             workspaceBarDeduplicateAppIcons: false,
             workspaceBarHideEmptyWorkspaces: false,
+            workspaceBarShowWorkspacesFromOtherDisplays: false,
             workspaceBarReserveLayoutSpace: false,
             workspaceBarHeight: 24.0,
             workspaceBarBackgroundOpacity: 0.1,

--- a/Sources/Nehir/Core/Config/SettingsStore.swift
+++ b/Sources/Nehir/Core/Config/SettingsStore.swift
@@ -208,6 +208,12 @@ final class SettingsStore {
         didSet { scheduleSave() }
     }
 
+    var workspaceBarShowWorkspacesFromOtherDisplays = SettingsStore.defaultExport
+        .workspaceBarShowWorkspacesFromOtherDisplays
+    {
+        didSet { scheduleSave() }
+    }
+
     var workspaceBarReserveLayoutSpace = SettingsStore.defaultExport.workspaceBarReserveLayoutSpace {
         didSet { scheduleSave() }
     }
@@ -472,6 +478,7 @@ final class SettingsStore {
             workspaceBarNotchAware: workspaceBarNotchAware,
             workspaceBarDeduplicateAppIcons: workspaceBarDeduplicateAppIcons,
             workspaceBarHideEmptyWorkspaces: workspaceBarHideEmptyWorkspaces,
+            workspaceBarShowWorkspacesFromOtherDisplays: workspaceBarShowWorkspacesFromOtherDisplays,
             workspaceBarReserveLayoutSpace: workspaceBarReserveLayoutSpace,
             workspaceBarHeight: workspaceBarHeight,
             workspaceBarBackgroundOpacity: workspaceBarBackgroundOpacity,
@@ -562,6 +569,7 @@ final class SettingsStore {
         workspaceBarNotchAware = export.workspaceBarNotchAware
         workspaceBarDeduplicateAppIcons = export.workspaceBarDeduplicateAppIcons
         workspaceBarHideEmptyWorkspaces = export.workspaceBarHideEmptyWorkspaces
+        workspaceBarShowWorkspacesFromOtherDisplays = export.workspaceBarShowWorkspacesFromOtherDisplays
         workspaceBarReserveLayoutSpace = export.workspaceBarReserveLayoutSpace
         workspaceBarHeight = export.workspaceBarHeight
         workspaceBarBackgroundOpacity = export.workspaceBarBackgroundOpacity
@@ -816,6 +824,8 @@ final class SettingsStore {
             showScrollLockButton: override?.showScrollLockButton ?? workspaceBarShowScrollLockButton,
             deduplicateAppIcons: override?.deduplicateAppIcons ?? workspaceBarDeduplicateAppIcons,
             hideEmptyWorkspaces: override?.hideEmptyWorkspaces ?? workspaceBarHideEmptyWorkspaces,
+            showWorkspacesFromOtherDisplays: override?.showWorkspacesFromOtherDisplays ??
+                workspaceBarShowWorkspacesFromOtherDisplays,
             reserveLayoutSpace: override?.reserveLayoutSpace ?? workspaceBarReserveLayoutSpace,
             notchAware: override?.notchAware ?? workspaceBarNotchAware,
             position: override?.position ?? workspaceBarPosition,

--- a/Sources/Nehir/UI/Onboarding/Animations/WorkspaceBarAnimation.swift
+++ b/Sources/Nehir/UI/Onboarding/Animations/WorkspaceBarAnimation.swift
@@ -10,20 +10,23 @@ import SwiftUI
 /// workspaces so the user sees "this bar tracks active workspaces".
 ///
 /// Reflects the live content settings (`showLabels`, `showFloatingWindows`,
-/// `showScrollLockButton`, `deduplicateAppIcons`, `hideEmptyWorkspaces`) so the onboarding toggles preview changes
-/// in real time. Floating windows are rendered inside their owning workspace pill, matching the
-/// real bar. The focus tour only visits non-empty workspaces so toggling "Hide Empty" can never
-/// strand the highlight on a pill that just vanished.
+/// `showScrollLockButton`, `deduplicateAppIcons`, `hideEmptyWorkspaces`,
+/// `showWorkspacesFromOtherDisplays`) so the onboarding toggles preview changes in real time.
+/// Floating windows are rendered inside their owning workspace pill, matching the real bar. The
+/// focus tour only visits non-empty workspaces so toggling "Hide Empty" can never strand the
+/// highlight on a pill that just vanished.
 struct WorkspaceBarAnimation: View {
     let showLabels: Bool
     let showFloatingWindows: Bool
     let showScrollLockButton: Bool
     let deduplicateAppIcons: Bool
     let hideEmptyWorkspaces: Bool
+    let showWorkspacesFromOtherDisplays: Bool
 
     @State private var isAnimating = false
     @State private var focusedWorkspace = 0
     @State private var animationTask: Task<Void, Never>?
+    @State private var measuredBarSize: CGSize = .zero
 
     private struct MockWindow: Identifiable {
         let id = UUID()
@@ -33,8 +36,23 @@ struct WorkspaceBarAnimation: View {
     private struct MockWorkspace: Identifiable {
         let id: Int
         let label: String
+        let isActiveOnForeignDisplay: Bool
         let tiledWindows: [MockWindow]
         let floatingWindows: [MockWindow]
+
+        init(
+            id: Int,
+            label: String,
+            isActiveOnForeignDisplay: Bool = false,
+            tiledWindows: [MockWindow],
+            floatingWindows: [MockWindow]
+        ) {
+            self.id = id
+            self.label = label
+            self.isActiveOnForeignDisplay = isActiveOnForeignDisplay
+            self.tiledWindows = tiledWindows
+            self.floatingWindows = floatingWindows
+        }
     }
 
     // Workspace 4 is floating-only so "Show Floating Windows" demonstrates the same ownership
@@ -85,10 +103,29 @@ struct WorkspaceBarAnimation: View {
             floatingWindows: []
         )
     ]
+    private let foreignWorkspaces: [MockWorkspace] = [
+        MockWorkspace(
+            id: 10,
+            label: "6",
+            isActiveOnForeignDisplay: true,
+            tiledWindows: [MockWindow(symbol: "terminal")],
+            floatingWindows: []
+        ),
+        MockWorkspace(
+            id: 11,
+            label: "7",
+            tiledWindows: [],
+            floatingWindows: []
+        )
+    ]
+
     private let iconSize: CGFloat = 11
     private let pillHeight: CGFloat = 26
     private let cornerRadius: CGFloat = 6
     private let workspaceSpacing: CGFloat = 8
+    private let barHorizontalPadding: CGFloat = 10
+    private let barVerticalPadding: CGFloat = 8
+    private let workspacePillHorizontalPadding: CGFloat = 8
 
     /// Workspaces shown in the bar. A truly empty workspace drops out when "Hide Empty" is on;
     /// a floating-only workspace also drops out when floating windows are hidden, matching
@@ -99,13 +136,19 @@ struct WorkspaceBarAnimation: View {
             : workspaces
     }
 
+    private var visibleForeignWorkspaces: [MockWorkspace] {
+        hideEmptyWorkspaces
+            ? foreignWorkspaces.filter(hasBarVisibleOccupancy)
+            : foreignWorkspaces
+    }
+
     private func hasBarVisibleOccupancy(_ workspace: MockWorkspace) -> Bool {
         !workspace.tiledWindows.isEmpty || (showFloatingWindows && !workspace.floatingWindows.isEmpty)
     }
 
     var body: some View {
         VStack(spacing: 18) {
-            bar
+            fittedBar
             // Screen-edge cue: the bar sits at the top of the screen.
             RoundedRectangle(cornerRadius: 2, style: .continuous)
                 .fill(Color.secondary.opacity(0.18))
@@ -118,11 +161,40 @@ struct WorkspaceBarAnimation: View {
         .onChange(of: hideEmptyWorkspaces) { _, _ in
             restartLoopIfAnimating()
         }
+        .onChange(of: showWorkspacesFromOtherDisplays) { _, _ in
+            restartLoopIfAnimating()
+        }
         .onDisappear {
             animationTask?.cancel()
             animationTask = nil
             isAnimating = false
         }
+    }
+
+    private var fittedBar: some View {
+        GeometryReader { proxy in
+            let availableWidth = max(1, proxy.size.width - 32)
+            let intrinsicWidth = measuredBarSize.width > 0 ? measuredBarSize.width : availableWidth
+            let intrinsicHeight = measuredBarSize.height > 0 ? measuredBarSize.height : 44
+            let scale = min(1, availableWidth / intrinsicWidth)
+
+            bar
+                .fixedSize(horizontal: true, vertical: false)
+                .background {
+                    GeometryReader { barProxy in
+                        Color.clear
+                            .onAppear { measuredBarSize = barProxy.size }
+                            .onChange(of: barProxy.size) { _, newSize in
+                                measuredBarSize = newSize
+                            }
+                    }
+                }
+                .scaleEffect(scale, anchor: .center)
+                .frame(width: intrinsicWidth * scale, height: intrinsicHeight * scale)
+                .frame(maxWidth: .infinity, minHeight: 44, alignment: .center)
+                .clipped()
+        }
+        .frame(height: 58)
     }
 
     private var bar: some View {
@@ -131,12 +203,21 @@ struct WorkspaceBarAnimation: View {
                 workspacePill(ws)
             }
 
+            if showWorkspacesFromOtherDisplays, !visibleForeignWorkspaces.isEmpty {
+                Divider()
+                    .frame(height: pillHeight)
+                    .opacity(0.4)
+                    .accessibilityHidden(true)
+
+                foreignWorkspaceGroup(visibleForeignWorkspaces)
+            }
+
             if showScrollLockButton {
                 scrollLockButton
             }
         }
-        .padding(.horizontal, 10)
-        .padding(.vertical, 8)
+        .padding(.horizontal, barHorizontalPadding)
+        .padding(.vertical, barVerticalPadding)
         .background {
             RoundedRectangle(cornerRadius: 10, style: .continuous)
                 .fill(.thinMaterial)
@@ -149,6 +230,7 @@ struct WorkspaceBarAnimation: View {
         .animation(.easeInOut(duration: 0.2), value: hideEmptyWorkspaces)
         .animation(.easeInOut(duration: 0.2), value: showFloatingWindows)
         .animation(.easeInOut(duration: 0.2), value: showScrollLockButton)
+        .animation(.easeInOut(duration: 0.2), value: showWorkspacesFromOtherDisplays)
     }
 
     private var scrollLockButton: some View {
@@ -183,7 +265,7 @@ struct WorkspaceBarAnimation: View {
                 floatingWindowGroup(ws.floatingWindows, isFocused: isFocused)
             }
         }
-        .padding(.horizontal, 8)
+        .padding(.horizontal, workspacePillHorizontalPadding)
         .frame(height: pillHeight)
         .background {
             if isFocused {
@@ -196,6 +278,44 @@ struct WorkspaceBarAnimation: View {
             }
         }
         .contentShape(Rectangle())
+    }
+
+    private func foreignWorkspaceGroup(_ workspaces: [MockWorkspace]) -> some View {
+        HStack(spacing: 4) {
+            Image(systemName: "display")
+                .font(.system(size: max(9, iconSize * 0.58), weight: .medium))
+                .foregroundStyle(Color.secondary)
+                .accessibilityHidden(true)
+
+            ForEach(workspaces) { ws in
+                foreignWorkspacePill(ws)
+            }
+        }
+    }
+
+    private func foreignWorkspacePill(_ ws: MockWorkspace) -> some View {
+        HStack(spacing: 4) {
+            if ws.isActiveOnForeignDisplay {
+                Circle()
+                    .fill(Color.accentColor)
+                    .frame(width: 4, height: 4)
+                    .accessibilityHidden(true)
+            }
+            Text(ws.label)
+                .font(.system(.caption2, design: .monospaced).weight(.semibold))
+                .foregroundStyle(Color.primary)
+                .frame(minWidth: 10)
+        }
+        .padding(.horizontal, 7)
+        .frame(height: pillHeight)
+        .background {
+            RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+                .fill(Color.secondary.opacity(0.08))
+                .overlay {
+                    RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+                        .strokeBorder(Color.secondary.opacity(0.24), lineWidth: 0.75)
+                }
+        }
     }
 
     /// Collapses duplicate app icons into a single icon with a count badge when
@@ -264,7 +384,7 @@ struct WorkspaceBarAnimation: View {
             while isAnimating && !Task.isCancelled {
                 // Only tour non-empty workspaces; the empty pill is illustrative, not a focus
                 // target, so toggling "Hide Empty" can't leave the highlight stranded.
-                for ws in workspaces where hasBarVisibleOccupancy(ws) {
+                for ws in visibleWorkspaces where hasBarVisibleOccupancy(ws) {
                     guard isAnimating, !Task.isCancelled else { return }
                     withAnimation(.easeInOut(duration: 0.3)) {
                         focusedWorkspace = ws.id

--- a/Sources/Nehir/UI/Onboarding/OnboardingStepControls.swift
+++ b/Sources/Nehir/UI/Onboarding/OnboardingStepControls.swift
@@ -204,6 +204,11 @@ struct WorkspaceBarStepControl: View {
                 description: "Hide pills with no windows.",
                 isOn: $settings.workspaceBarHideEmptyWorkspaces
             )
+            WorkspaceBarFeatureRow(
+                title: "Show Other Displays' Workspaces",
+                description: "Show other displays' workspaces after a display icon.",
+                isOn: $settings.workspaceBarShowWorkspacesFromOtherDisplays
+            )
         }
         .padding(.horizontal, 32)
     }

--- a/Sources/Nehir/UI/Onboarding/OnboardingStepView.swift
+++ b/Sources/Nehir/UI/Onboarding/OnboardingStepView.swift
@@ -41,8 +41,8 @@ struct OnboardingStepView<Animation: View, Control: View>: View {
             .padding(.bottom, 24)
 
             animation()
-                .frame(height: step.animationHeight)
-                .frame(maxWidth: .infinity)
+                .frame(height: step.animationHeight, alignment: .center)
+                .frame(maxWidth: .infinity, alignment: .center)
 
             Spacer(minLength: 16)
 

--- a/Sources/Nehir/UI/Onboarding/OnboardingSteps.swift
+++ b/Sources/Nehir/UI/Onboarding/OnboardingSteps.swift
@@ -58,7 +58,7 @@ enum OnboardingStep: String, CaseIterable, Identifiable {
              .navigation:
             200
         case .workspaceBar:
-            100
+            130
         case .experimental,
              .done:
             80

--- a/Sources/Nehir/UI/Onboarding/OnboardingView.swift
+++ b/Sources/Nehir/UI/Onboarding/OnboardingView.swift
@@ -35,7 +35,7 @@ struct OnboardingView: View {
         // previous size, and rebuilding via `.id(currentStep)` lost keyboard focus.
         // Instant swap keeps the button's identity stable (focus preserved) and lets
         // the focus ring redraw at the correct size.
-        .frame(width: 480, height: 640)
+        .frame(width: 560, height: 700)
         .background(.thickMaterial)
         .onAppear { isAccessibilityGranted = AccessibilityPermissionMonitor.shared.isGranted }
         .task(id: "accessibility") {
@@ -63,7 +63,8 @@ struct OnboardingView: View {
                 showFloatingWindows: settings.workspaceBarShowFloatingWindows,
                 showScrollLockButton: settings.workspaceBarShowScrollLockButton,
                 deduplicateAppIcons: settings.workspaceBarDeduplicateAppIcons,
-                hideEmptyWorkspaces: settings.workspaceBarHideEmptyWorkspaces
+                hideEmptyWorkspaces: settings.workspaceBarHideEmptyWorkspaces,
+                showWorkspacesFromOtherDisplays: settings.workspaceBarShowWorkspacesFromOtherDisplays
             )
         default:
             StaticStepIcon(step: step)

--- a/Sources/Nehir/UI/WorkspaceBar/WorkspaceBarDataSource.swift
+++ b/Sources/Nehir/UI/WorkspaceBar/WorkspaceBarDataSource.swift
@@ -100,6 +100,41 @@ enum WorkspaceBarDataSource {
         viewportSelectedToken: WindowToken?,
         settings: SettingsStore
     ) -> [WorkspaceBarItem] {
+        var items = localWorkspaceItems(
+            for: monitor,
+            options: options,
+            workspaceManager: workspaceManager,
+            appInfoCache: appInfoCache,
+            niriEngine: niriEngine,
+            focusedToken: focusedToken,
+            viewportSelectedToken: viewportSelectedToken,
+            settings: settings
+        )
+
+        if options.showWorkspacesFromOtherDisplays {
+            items.append(
+                contentsOf: foreignWorkspaceItems(
+                    for: monitor,
+                    options: options,
+                    workspaceManager: workspaceManager,
+                    settings: settings
+                )
+            )
+        }
+
+        return items
+    }
+
+    private static func localWorkspaceItems(
+        for monitor: Monitor,
+        options: WorkspaceBarProjectionOptions,
+        workspaceManager: WorkspaceManager,
+        appInfoCache: AppInfoCache,
+        niriEngine: NiriLayoutEngine?,
+        focusedToken: WindowToken?,
+        viewportSelectedToken: WindowToken?,
+        settings: SettingsStore
+    ) -> [WorkspaceBarItem] {
         var workspaces = workspaceManager.workspaces(on: monitor.id).map { workspace in
             let projectedEntries = workspaceManager.barVisibleEntries(
                 in: workspace.id,
@@ -157,6 +192,57 @@ enum WorkspaceBarDataSource {
                 floatingWindows: floatingWindows
             )
         }
+    }
+
+    /// Workspaces realized on other displays, projected as compact foreign pills
+    /// after the local workspaces. Only monitor-assigned workspaces are included
+    /// (matching `moveTargetItems`), so disconnected workspaces never appear.
+    /// Foreign pills carry no window icons (a navigation aid, not a duplicate of
+    /// the home bar); `hideEmptyWorkspaces` is still respected based on real
+    /// workspace occupancy.
+    private static func foreignWorkspaceItems(
+        for monitor: Monitor,
+        options: WorkspaceBarProjectionOptions,
+        workspaceManager: WorkspaceManager,
+        settings: SettingsStore
+    ) -> [WorkspaceBarItem] {
+        var seen = Set(workspaceManager.workspaces(on: monitor.id).map(\.id))
+        var items: [WorkspaceBarItem] = []
+
+        for (monitorIndex, otherMonitor) in workspaceManager.monitors.enumerated() where otherMonitor.id != monitor.id {
+            let activeOnOther = workspaceManager.activeWorkspace(on: otherMonitor.id)?.id
+            let monitorLabel = compactForeignMonitorLabel(for: otherMonitor, index: monitorIndex)
+            for workspace in workspaceManager.workspaces(on: otherMonitor.id) {
+                guard seen.insert(workspace.id).inserted else { continue }
+                let projectedEntries = workspaceManager.barVisibleEntries(
+                    in: workspace.id,
+                    showFloatingWindows: options.showFloatingWindows
+                ).filter { !workspaceManager.isStickyWindow($0.token) }
+                if options.hideEmptyWorkspaces, projectedEntries.isEmpty { continue }
+                items.append(
+                    WorkspaceBarItem(
+                        id: workspace.id,
+                        name: settings.displayName(for: workspace.name),
+                        rawName: workspace.name,
+                        isFocused: false,
+                        tiledWindows: [],
+                        floatingWindows: [],
+                        isForeign: true,
+                        homeMonitorName: otherMonitor.name,
+                        homeMonitorLabel: monitorLabel,
+                        isActiveOnHomeDisplay: workspace.id == activeOnOther
+                    )
+                )
+            }
+        }
+        return items
+    }
+
+    private static func compactForeignMonitorLabel(for _: Monitor, index: Int) -> String {
+        // Full display names are often verbose and repeated across multiple
+        // workspace pills. Use a stable compact visual tag in the bar; keep the
+        // full name in accessibility/help text via `homeMonitorName`.
+        "D\(index + 1)"
     }
 
     private static func stickyItem(

--- a/Sources/Nehir/UI/WorkspaceBar/WorkspaceBarProjectionOptions.swift
+++ b/Sources/Nehir/UI/WorkspaceBar/WorkspaceBarProjectionOptions.swift
@@ -10,6 +10,7 @@ struct WorkspaceBarProjectionOptions: Equatable {
     let deduplicateAppIcons: Bool
     let hideEmptyWorkspaces: Bool
     let showFloatingWindows: Bool
+    let showWorkspacesFromOtherDisplays: Bool
 }
 
 extension ResolvedBarSettings {
@@ -17,7 +18,8 @@ extension ResolvedBarSettings {
         WorkspaceBarProjectionOptions(
             deduplicateAppIcons: deduplicateAppIcons,
             hideEmptyWorkspaces: hideEmptyWorkspaces,
-            showFloatingWindows: showFloatingWindows
+            showFloatingWindows: showFloatingWindows,
+            showWorkspacesFromOtherDisplays: showWorkspacesFromOtherDisplays
         )
     }
 }

--- a/Sources/Nehir/UI/WorkspaceBar/WorkspaceBarView.swift
+++ b/Sources/Nehir/UI/WorkspaceBar/WorkspaceBarView.swift
@@ -15,6 +15,41 @@ struct WorkspaceBarItem: Identifiable, Equatable {
     let isFocused: Bool
     let tiledWindows: [WorkspaceBarWindowItem]
     let floatingWindows: [WorkspaceBarWindowItem]
+    /// True when this workspace lives on a different display than the bar it is
+    /// rendered on. Foreign pills are appended after the local workspaces behind
+    /// a divider and grouped under a display icon. Plain-click switches their
+    /// home display; shift-click moves the focused window there.
+    let isForeign: Bool
+    let homeMonitorName: String?
+    let homeMonitorLabel: String?
+    /// Whether this workspace is the active one on its home display. Distinct
+    /// from `isFocused` (active *on this monitor*): a foreign workspace can be
+    /// active over there without being this display's focused workspace.
+    let isActiveOnHomeDisplay: Bool
+
+    init(
+        id: WorkspaceDescriptor.ID,
+        name: String,
+        rawName: String,
+        isFocused: Bool,
+        tiledWindows: [WorkspaceBarWindowItem],
+        floatingWindows: [WorkspaceBarWindowItem],
+        isForeign: Bool = false,
+        homeMonitorName: String? = nil,
+        homeMonitorLabel: String? = nil,
+        isActiveOnHomeDisplay: Bool = false
+    ) {
+        self.id = id
+        self.name = name
+        self.rawName = rawName
+        self.isFocused = isFocused
+        self.tiledWindows = tiledWindows
+        self.floatingWindows = floatingWindows
+        self.isForeign = isForeign
+        self.homeMonitorName = homeMonitorName
+        self.homeMonitorLabel = homeMonitorLabel
+        self.isActiveOnHomeDisplay = isActiveOnHomeDisplay
+    }
 
     var windows: [WorkspaceBarWindowItem] {
         tiledWindows + floatingWindows
@@ -194,6 +229,11 @@ struct WorkspaceBarWindowMoveTarget: Identifiable, Hashable {
     let name: String
 }
 
+private struct ForeignWorkspaceItemGroup: Identifiable {
+    let id: String
+    let items: [WorkspaceBarItem]
+}
+
 /// Bundle of right-click actions threaded from the controller through the bar
 /// to each window icon. Bundling keeps `WindowIconView` a value type without a
 /// long parameter list.
@@ -245,6 +285,35 @@ private struct WorkspaceBarContentView: View {
 
     private var iconSize: CGFloat {
         max(12, itemHeight - 6)
+    }
+
+    /// Workspaces on this display, rendered as full pills with window icons.
+    private var localItems: [WorkspaceBarItem] {
+        snapshot.items.filter { !$0.isForeign }
+    }
+
+    /// Workspaces from other displays, rendered as compact navigation pills
+    /// behind a divider. Empty when the per-display toggle is off.
+    private var foreignItems: [WorkspaceBarItem] {
+        snapshot.items.filter { $0.isForeign }
+    }
+
+    /// Foreign workspaces grouped by display so the display icon appears once per
+    /// group instead of repeating a display label in every pill.
+    private var foreignItemGroups: [ForeignWorkspaceItemGroup] {
+        var order: [String] = []
+        var grouped: [String: [WorkspaceBarItem]] = [:]
+        for item in foreignItems {
+            let key = item.homeMonitorLabel ?? item.homeMonitorName ?? "Display"
+            if grouped[key] == nil {
+                order.append(key)
+                grouped[key] = []
+            }
+            grouped[key]?.append(item)
+        }
+        return order.compactMap { key in
+            grouped[key].map { ForeignWorkspaceItemGroup(id: key, items: $0) }
+        }
     }
 
     private let workspaceSpacing: CGFloat = 8
@@ -300,7 +369,7 @@ private struct WorkspaceBarContentView: View {
 
     var body: some View {
         HStack(spacing: workspaceSpacing) {
-            ForEach(snapshot.items, id: \.id) { item in
+            ForEach(localItems, id: \.id) { item in
                 WorkspaceItemView(
                     item: item,
                     iconSize: iconSize,
@@ -316,6 +385,27 @@ private struct WorkspaceBarContentView: View {
                     onFocusWindow: onFocusWindow,
                     windowActions: windowActions
                 )
+            }
+
+            if !foreignItemGroups.isEmpty {
+                Divider()
+                    .frame(height: itemHeight)
+                    .opacity(0.4)
+                    .accessibilityHidden(true)
+
+                ForEach(foreignItemGroups) { group in
+                    ForeignWorkspaceGroupView(
+                        group: group,
+                        iconSize: iconSize,
+                        itemHeight: itemHeight,
+                        cornerRadius: cornerRadius,
+                        animationsEnabled: effectiveAnimationsEnabled,
+                        accentColor: accentColor,
+                        textColor: textColor,
+                        onFocusWorkspace: onFocusWorkspace,
+                        onMoveFocusedWindowToWorkspace: onMoveFocusedWindowToWorkspace
+                    )
+                }
             }
 
             if let sticky = snapshot.sticky {
@@ -579,6 +669,130 @@ private struct WorkspaceLabelButton: View {
         .accessibilityValue(item.isFocused ? "Focused" : "")
         .help(
             "Focus workspace \(item.name). Shift-click or right-click to move the focused window here."
+        )
+    }
+}
+
+@MainActor
+private struct ForeignWorkspaceGroupView: View {
+    let group: ForeignWorkspaceItemGroup
+    let iconSize: CGFloat
+    let itemHeight: CGFloat
+    let cornerRadius: CGFloat
+    let animationsEnabled: Bool
+    let accentColor: Color?
+    let textColor: Color?
+    let onFocusWorkspace: (WorkspaceBarItem) -> Void
+    let onMoveFocusedWindowToWorkspace: (WorkspaceBarItem) -> Void
+
+    private var resolvedSecondaryTextColor: Color {
+        textColor ?? .secondary
+    }
+
+    var body: some View {
+        HStack(spacing: 4) {
+            Image(systemName: "display")
+                .font(.system(size: max(9, iconSize * 0.58), weight: .medium))
+                .foregroundColor(resolvedSecondaryTextColor.opacity(0.75))
+                .accessibilityHidden(true)
+
+            ForEach(group.items, id: \.id) { item in
+                ForeignWorkspaceItemView(
+                    item: item,
+                    iconSize: iconSize,
+                    itemHeight: itemHeight,
+                    cornerRadius: cornerRadius,
+                    animationsEnabled: animationsEnabled,
+                    accentColor: accentColor,
+                    textColor: textColor,
+                    onFocusWorkspace: { onFocusWorkspace(item) },
+                    onMoveFocusedWindowToWorkspace: { onMoveFocusedWindowToWorkspace(item) }
+                )
+            }
+        }
+    }
+}
+
+@MainActor
+private struct ForeignWorkspaceItemView: View {
+    let item: WorkspaceBarItem
+    let iconSize: CGFloat
+    let itemHeight: CGFloat
+    let cornerRadius: CGFloat
+    let animationsEnabled: Bool
+    let accentColor: Color?
+    let textColor: Color?
+    let onFocusWorkspace: () -> Void
+    let onMoveFocusedWindowToWorkspace: () -> Void
+
+    @State private var isHovered = false
+
+    private var resolvedAccentColor: Color {
+        accentColor ?? .accentColor
+    }
+
+    private var accessibilityLabel: String {
+        var label = "Workspace \(item.name)"
+        if let home = item.homeMonitorName {
+            label += " on \(home)"
+        }
+        return label
+    }
+
+    var body: some View {
+        Button(action: onFocusWorkspace) {
+            HStack(spacing: 4) {
+                if item.isActiveOnHomeDisplay {
+                    Circle()
+                        .fill(resolvedAccentColor)
+                        .frame(width: max(4, iconSize * 0.28), height: max(4, iconSize * 0.28))
+                        .accessibilityHidden(true)
+                }
+                Text(item.name)
+                    .font(.system(.caption, design: .monospaced).weight(.medium))
+                    .foregroundColor(textColor ?? .primary)
+                    .frame(minWidth: 16)
+            }
+            .padding(.horizontal, 6)
+            .frame(height: itemHeight)
+            .contentShape(RoundedRectangle(cornerRadius: cornerRadius, style: .continuous))
+        }
+        .buttonStyle(.plain)
+        .scaleEffect(isHovered ? 1.02 : 1.0)
+        .animation(animationsEnabled ? .easeInOut(duration: 0.12) : nil, value: isHovered)
+        .background {
+            RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+                .fill(Color.secondary.opacity(isHovered ? 0.16 : 0.07))
+                .overlay {
+                    RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+                        .strokeBorder(Color.secondary.opacity(0.24), lineWidth: 0.6)
+                }
+        }
+        .onHover { hovering in
+            isHovered = hovering
+        }
+        // Right-click mirrors the local workspace pill: *Focus* equals left-click
+        // (and honors shift to move the focused window); *Move Focused Window
+        // Here* is the explicit shift-click shortcut.
+        .contextMenu {
+            Button {
+                onFocusWorkspace()
+            } label: {
+                Label("Focus Workspace \(item.name)", systemImage: "arrow.right.square")
+            }
+            Button {
+                onMoveFocusedWindowToWorkspace()
+            } label: {
+                Label("Move Focused Window Here", systemImage: "arrowshape.turn.up.right")
+            }
+            Divider()
+            Text("Shift-click also moves one window here.")
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(accessibilityLabel)
+        .accessibilityValue(item.isActiveOnHomeDisplay ? "Active on home display" : "")
+        .help(
+            "Workspace \(item.name) on \(item.homeMonitorName ?? "another display"). Click to switch that display; shift-click to move the focused window there."
         )
     }
 }

--- a/Sources/Nehir/UI/WorkspaceBarSettingsTab.swift
+++ b/Sources/Nehir/UI/WorkspaceBarSettingsTab.swift
@@ -92,6 +92,7 @@ struct WorkspaceBarSettingsTab: View {
                 showScrollLockButton: settings.workspaceBarShowScrollLockButton,
                 deduplicateAppIcons: settings.workspaceBarDeduplicateAppIcons,
                 hideEmptyWorkspaces: settings.workspaceBarHideEmptyWorkspaces,
+                showWorkspacesFromOtherDisplays: settings.workspaceBarShowWorkspacesFromOtherDisplays,
                 scopeDescription: "Preview reflects the global workspace bar defaults."
             )
         case let .connected(monitorId):
@@ -214,6 +215,7 @@ private struct WorkspaceBarPreviewConfiguration {
     let showScrollLockButton: Bool
     let deduplicateAppIcons: Bool
     let hideEmptyWorkspaces: Bool
+    let showWorkspacesFromOtherDisplays: Bool
     let scopeDescription: String
 
     init(
@@ -223,6 +225,7 @@ private struct WorkspaceBarPreviewConfiguration {
         showScrollLockButton: Bool,
         deduplicateAppIcons: Bool,
         hideEmptyWorkspaces: Bool,
+        showWorkspacesFromOtherDisplays: Bool,
         scopeDescription: String
     ) {
         self.isEnabled = isEnabled
@@ -231,6 +234,7 @@ private struct WorkspaceBarPreviewConfiguration {
         self.showScrollLockButton = showScrollLockButton
         self.deduplicateAppIcons = deduplicateAppIcons
         self.hideEmptyWorkspaces = hideEmptyWorkspaces
+        self.showWorkspacesFromOtherDisplays = showWorkspacesFromOtherDisplays
         self.scopeDescription = scopeDescription
     }
 
@@ -242,6 +246,7 @@ private struct WorkspaceBarPreviewConfiguration {
             showScrollLockButton: resolved.showScrollLockButton,
             deduplicateAppIcons: resolved.deduplicateAppIcons,
             hideEmptyWorkspaces: resolved.hideEmptyWorkspaces,
+            showWorkspacesFromOtherDisplays: resolved.showWorkspacesFromOtherDisplays,
             scopeDescription: scopeDescription
         )
     }
@@ -254,6 +259,8 @@ private struct WorkspaceBarPreviewConfiguration {
             showScrollLockButton: override.showScrollLockButton ?? settings.workspaceBarShowScrollLockButton,
             deduplicateAppIcons: override.deduplicateAppIcons ?? settings.workspaceBarDeduplicateAppIcons,
             hideEmptyWorkspaces: override.hideEmptyWorkspaces ?? settings.workspaceBarHideEmptyWorkspaces,
+            showWorkspacesFromOtherDisplays: override.showWorkspacesFromOtherDisplays ??
+                settings.workspaceBarShowWorkspacesFromOtherDisplays,
             scopeDescription: scopeDescription
         )
     }
@@ -266,6 +273,7 @@ private struct WorkspaceBarPreviewConfiguration {
             showScrollLockButton: settings.workspaceBarShowScrollLockButton,
             deduplicateAppIcons: settings.workspaceBarDeduplicateAppIcons,
             hideEmptyWorkspaces: settings.workspaceBarHideEmptyWorkspaces,
+            showWorkspacesFromOtherDisplays: settings.workspaceBarShowWorkspacesFromOtherDisplays,
             scopeDescription: "Preview reflects the global workspace bar defaults."
         )
     }
@@ -294,7 +302,8 @@ private struct WorkspaceBarPreviewSection: View {
                     showFloatingWindows: configuration.showFloatingWindows,
                     showScrollLockButton: configuration.showScrollLockButton,
                     deduplicateAppIcons: configuration.deduplicateAppIcons,
-                    hideEmptyWorkspaces: configuration.hideEmptyWorkspaces
+                    hideEmptyWorkspaces: configuration.hideEmptyWorkspaces,
+                    showWorkspacesFromOtherDisplays: configuration.showWorkspacesFromOtherDisplays
                 )
                 .frame(maxWidth: 360)
                 .opacity(configuration.isEnabled ? 1 : 0.35)
@@ -330,6 +339,11 @@ private struct WorkspaceBarPreviewSection: View {
                 icon: "arrowshape.turn.up.right",
                 title: "Shift-click a workspace",
                 text: "Moves the focused window to that workspace as a quick shortcut."
+            )
+            behaviorRow(
+                icon: "rectangle.connected.to.line.below",
+                title: "Other displays' workspaces (optional)",
+                text: "When enabled, other displays' workspaces appear after a display icon. Click one to switch its display; shift-click to move the focused window there."
             )
             behaviorRow(
                 icon: "square.stack.3d.down.right",
@@ -393,6 +407,17 @@ private struct GlobalBarSettingsSection: View {
                     .onChange(of: settings.workspaceBarHideEmptyWorkspaces) { _, _ in
                         controller.updateWorkspaceBarSettings()
                     }
+
+                Toggle(
+                    "Show Other Displays' Workspaces",
+                    isOn: $settings.workspaceBarShowWorkspacesFromOtherDisplays
+                )
+                .onChange(of: settings.workspaceBarShowWorkspacesFromOtherDisplays) { _, _ in
+                    controller.updateWorkspaceBarSettings()
+                }
+                SettingsCaption(
+                    "Also shows other displays' workspaces after a display icon. Click one to switch its display; shift-click to move the focused window there."
+                )
 
                 Toggle("Show Scroll Lock Button", isOn: $settings.workspaceBarShowScrollLockButton)
                     .onChange(of: settings.workspaceBarShowScrollLockButton) { _, _ in
@@ -613,6 +638,10 @@ private struct SavedMonitorBarOverrideSection: View {
             savedValue("Show Floating Windows", override.showFloatingWindows.map { $0 ? "On" : "Off" })
             savedValue("Group Windows by App", override.deduplicateAppIcons.map { $0 ? "On" : "Off" })
             savedValue("Hide Empty Workspaces", override.hideEmptyWorkspaces.map { $0 ? "On" : "Off" })
+            savedValue(
+                "Show Other Displays' Workspaces",
+                override.showWorkspacesFromOtherDisplays.map { $0 ? "On" : "Off" }
+            )
             savedValue("Show Trace Capture Button", override.showTraceButton.map { $0 ? "On" : "Off" })
             savedValue("Show Scroll Lock Button", override.showScrollLockButton.map { $0 ? "On" : "Off" })
             savedValue("Position", override.position?.displayName)
@@ -708,6 +737,19 @@ private struct MonitorBarSettingsSection: View {
                 globalValue: settings.workspaceBarHideEmptyWorkspaces,
                 onChange: { newValue in updateSetting { $0.hideEmptyWorkspaces = newValue } },
                 onReset: { updateSetting { $0.hideEmptyWorkspaces = nil } }
+            )
+
+            OverridableToggle(
+                label: "Show Other Displays' Workspaces",
+                value: ms.showWorkspacesFromOtherDisplays,
+                globalValue: settings.workspaceBarShowWorkspacesFromOtherDisplays,
+                onChange: { newValue in
+                    updateSetting { $0.showWorkspacesFromOtherDisplays = newValue }
+                },
+                onReset: { updateSetting { $0.showWorkspacesFromOtherDisplays = nil } }
+            )
+            .help(
+                "Also show other displays' workspaces after a display icon."
             )
 
             OverridableToggle(

--- a/Tests/NehirTests/Fixtures/canonical-settings.toml
+++ b/Tests/NehirTests/Fixtures/canonical-settings.toml
@@ -77,6 +77,7 @@ showFloatingWindows = false
 showLabels = true
 showScrollLockButton = false
 showTraceButton = false
+showWorkspacesFromOtherDisplays = false
 windowLevel = "popup"
 xOffset = 0.0
 yOffset = 0.0

--- a/Tests/NehirTests/IPCQueryRouterTests.swift
+++ b/Tests/NehirTests/IPCQueryRouterTests.swift
@@ -527,7 +527,8 @@ private func prepareIPCQueryRouterNiriState(
             options: WorkspaceBarProjectionOptions(
                 deduplicateAppIcons: false,
                 hideEmptyWorkspaces: false,
-                showFloatingWindows: false
+                showFloatingWindows: false,
+                showWorkspacesFromOtherDisplays: false
             ),
             workspaceManager: controller.workspaceManager,
             appInfoCache: controller.appInfoCache,

--- a/Tests/NehirTests/RefreshRoutingTests.swift
+++ b/Tests/NehirTests/RefreshRoutingTests.swift
@@ -255,7 +255,8 @@ private func workspaceBarWindowCount(
         projection: WorkspaceBarProjectionOptions(
             deduplicateAppIcons: false,
             hideEmptyWorkspaces: false,
-            showFloatingWindows: controller.settings.workspaceBarShowFloatingWindows
+            showFloatingWindows: controller.settings.workspaceBarShowFloatingWindows,
+            showWorkspacesFromOtherDisplays: false
         )
     )
     .first { $0.id == workspaceId }?

--- a/Tests/NehirTests/SettingsStoreTests.swift
+++ b/Tests/NehirTests/SettingsStoreTests.swift
@@ -495,6 +495,70 @@ struct SettingsExportTests {
         #expect(resolved.accentColor == nil)
         #expect(resolved.textColor == nil)
     }
+
+    @Test func showWorkspacesFromOtherDisplaysDefaultsOffAndOverridablePerMonitor() {
+        let settings = SettingsStore(defaults: makeTestDefaults())
+        let monitor = makeLayoutPlanTestMonitor(name: "Other Displays Test")
+
+        // Global default is off.
+        #expect(settings.workspaceBarShowWorkspacesFromOtherDisplays == false)
+        #expect(settings.resolvedBarSettings(for: monitor).showWorkspacesFromOtherDisplays == false)
+
+        // Per-monitor override wins over the global default.
+        settings.updateBarSettings(
+            MonitorBarSettings(
+                monitorName: monitor.name,
+                monitorDisplayId: monitor.displayId,
+                showWorkspacesFromOtherDisplays: true
+            )
+        )
+        #expect(settings.resolvedBarSettings(for: monitor).showWorkspacesFromOtherDisplays == true)
+    }
+
+    @Test func showWorkspacesFromOtherDisplaysRoundTripsThroughExport() {
+        let settings = SettingsStore(defaults: makeTestDefaults())
+        let monitor = makeLayoutPlanTestMonitor(name: "Other Displays Round Trip")
+        settings.updateBarSettings(
+            MonitorBarSettings(
+                monitorName: monitor.name,
+                monitorDisplayId: monitor.displayId,
+                showWorkspacesFromOtherDisplays: true
+            )
+        )
+
+        let export = settings.toExport()
+        let reloaded = SettingsStore(defaults: makeTestDefaults())
+        reloaded.applyExport(export, monitors: [monitor])
+
+        #expect(reloaded.resolvedBarSettings(for: monitor).showWorkspacesFromOtherDisplays == true)
+    }
+}
+
+@MainActor struct WorkspaceBarMonitorOverrideFileStoreTests {
+    @Test func monitorBarOverrideRoundTripsShowWorkspacesFromOtherDisplays() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("nehir-other-displays-override-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let monitor = makeLayoutPlanTestMonitor(name: "Override TOML Test")
+        let original = MonitorBarSettings(
+            monitorName: monitor.name,
+            monitorDisplayId: monitor.displayId,
+            monitorAnchorPoint: monitor.workspaceAnchorPoint,
+            showWorkspacesFromOtherDisplays: true
+        )
+
+        try MonitorOverrideFileStore.write(
+            bar: [original],
+            gaps: [],
+            orientation: [],
+            niri: [],
+            to: directory
+        )
+        let restored = try #require(MonitorOverrideFileStore.read(from: directory).bar.first)
+        #expect(restored.showWorkspacesFromOtherDisplays == true)
+    }
 }
 
 struct KeyBindingCodecTests {

--- a/Tests/NehirTests/WorkspaceBarDataSourceTests.swift
+++ b/Tests/NehirTests/WorkspaceBarDataSourceTests.swift
@@ -65,7 +65,8 @@ private func makeWorkspaceBarTestMetadata(
             options: WorkspaceBarProjectionOptions(
                 deduplicateAppIcons: false,
                 hideEmptyWorkspaces: true,
-                showFloatingWindows: false
+                showFloatingWindows: false,
+                showWorkspacesFromOtherDisplays: false
             ),
             workspaceManager: controller.workspaceManager,
             appInfoCache: controller.appInfoCache,
@@ -105,7 +106,8 @@ private func makeWorkspaceBarTestMetadata(
             options: WorkspaceBarProjectionOptions(
                 deduplicateAppIcons: false,
                 hideEmptyWorkspaces: true,
-                showFloatingWindows: true
+                showFloatingWindows: true,
+                showWorkspacesFromOtherDisplays: false
             ),
             workspaceManager: controller.workspaceManager,
             appInfoCache: controller.appInfoCache,
@@ -152,7 +154,8 @@ private func makeWorkspaceBarTestMetadata(
             options: WorkspaceBarProjectionOptions(
                 deduplicateAppIcons: false,
                 hideEmptyWorkspaces: true,
-                showFloatingWindows: false
+                showFloatingWindows: false,
+                showWorkspacesFromOtherDisplays: false
             ),
             workspaceManager: controller.workspaceManager,
             appInfoCache: controller.appInfoCache,
@@ -203,7 +206,8 @@ private func makeWorkspaceBarTestMetadata(
             options: WorkspaceBarProjectionOptions(
                 deduplicateAppIcons: false,
                 hideEmptyWorkspaces: false,
-                showFloatingWindows: true
+                showFloatingWindows: true,
+                showWorkspacesFromOtherDisplays: false
             ),
             workspaceManager: controller.workspaceManager,
             appInfoCache: controller.appInfoCache,
@@ -254,7 +258,8 @@ private func makeWorkspaceBarTestMetadata(
             options: WorkspaceBarProjectionOptions(
                 deduplicateAppIcons: false,
                 hideEmptyWorkspaces: false,
-                showFloatingWindows: true
+                showFloatingWindows: true,
+                showWorkspacesFromOtherDisplays: false
             ),
             workspaceManager: controller.workspaceManager,
             appInfoCache: controller.appInfoCache,
@@ -310,7 +315,8 @@ private func makeWorkspaceBarTestMetadata(
             options: WorkspaceBarProjectionOptions(
                 deduplicateAppIcons: true,
                 hideEmptyWorkspaces: false,
-                showFloatingWindows: true
+                showFloatingWindows: true,
+                showWorkspacesFromOtherDisplays: false
             ),
             workspaceManager: controller.workspaceManager,
             appInfoCache: controller.appInfoCache,
@@ -325,5 +331,84 @@ private func makeWorkspaceBarTestMetadata(
         #expect(workspaceItem.floatingWindows.count == 1)
         #expect(workspaceItem.floatingWindows.first?.windowCount == 1)
         #expect(workspaceItem.windows.map(\.windowCount) == [2, 1])
+    }
+
+    @Test @MainActor func foreignWorkspacesAppearOnlyWhenToggleIsEnabled() throws {
+        let fixture = makeTwoMonitorLayoutPlanTestController(
+            primaryMonitor: makeLayoutPlanPrimaryTestMonitor(name: "Primary"),
+            secondaryMonitor: makeLayoutPlanSecondaryTestMonitor(name: "Built-in Retina Display", x: 1920)
+        )
+        let controller = fixture.controller
+        let primaryMonitor = fixture.primaryMonitor
+        let secondaryMonitor = fixture.secondaryMonitor
+        let secondaryWorkspaceId = fixture.secondaryWorkspaceId
+
+        // Give the secondary display's workspace a tiled window so it is not empty.
+        controller.appInfoCache.storeInfoForTests(pid: 7100, name: "Other", bundleId: "com.example.other")
+        _ = controller.workspaceManager.addWindow(
+            makeLayoutPlanTestWindow(windowId: 1200),
+            pid: 7100,
+            windowId: 1200,
+            to: secondaryWorkspaceId,
+            mode: .tiling
+        )
+
+        func projection(showingForeign: Bool) -> WorkspaceBarProjection {
+            WorkspaceBarDataSource.workspaceBarProjection(
+                for: primaryMonitor,
+                options: WorkspaceBarProjectionOptions(
+                    deduplicateAppIcons: false,
+                    hideEmptyWorkspaces: false,
+                    showFloatingWindows: false,
+                    showWorkspacesFromOtherDisplays: showingForeign
+                ),
+                workspaceManager: controller.workspaceManager,
+                appInfoCache: controller.appInfoCache,
+                niriEngine: nil,
+                focusedToken: controller.workspaceManager.confirmedManagedFocusToken,
+                settings: controller.settings
+            )
+        }
+
+        // Toggle off: only this display's workspaces appear; none are foreign.
+        let off = projection(showingForeign: false)
+        #expect(off.items.contains(where: \.isForeign) == false)
+        #expect(off.items.contains(where: { $0.id == secondaryWorkspaceId }) == false)
+
+        // Toggle on: the secondary's active workspace appears as a compact foreign pill.
+        let on = projection(showingForeign: true)
+        let foreign = try #require(on.items.first(where: { $0.id == secondaryWorkspaceId && $0.isForeign }))
+        #expect(foreign.homeMonitorName == secondaryMonitor.name)
+        #expect(foreign.homeMonitorLabel == "D2")
+        #expect(foreign.isActiveOnHomeDisplay == true)
+        #expect(foreign.isFocused == false)
+        #expect(foreign.windows.isEmpty)
+    }
+
+    @Test @MainActor func foreignEmptyWorkspacesRespectHideEmptyWorkspaces() throws {
+        let fixture = makeTwoMonitorLayoutPlanTestController()
+        let controller = fixture.controller
+        let primaryMonitor = fixture.primaryMonitor
+        let secondaryWorkspaceId = fixture.secondaryWorkspaceId
+        // The secondary display's workspace has no windows.
+
+        let projection = WorkspaceBarDataSource.workspaceBarProjection(
+            for: primaryMonitor,
+            options: WorkspaceBarProjectionOptions(
+                deduplicateAppIcons: false,
+                hideEmptyWorkspaces: true,
+                showFloatingWindows: false,
+                showWorkspacesFromOtherDisplays: true
+            ),
+            workspaceManager: controller.workspaceManager,
+            appInfoCache: controller.appInfoCache,
+            niriEngine: nil,
+            focusedToken: controller.workspaceManager.confirmedManagedFocusToken,
+            settings: controller.settings
+        )
+
+        // An empty foreign workspace is hidden, consistent with local items.
+        #expect(projection.items.contains(where: { $0.id == secondaryWorkspaceId }) == false)
+        #expect(projection.items.contains(where: \.isForeign) == false)
     }
 }

--- a/Tests/NehirTests/WorkspaceBarGeometryTests.swift
+++ b/Tests/NehirTests/WorkspaceBarGeometryTests.swift
@@ -49,6 +49,7 @@ struct WorkspaceBarGeometryTests {
             showScrollLockButton: false,
             deduplicateAppIcons: false,
             hideEmptyWorkspaces: false,
+            showWorkspacesFromOtherDisplays: false,
             reserveLayoutSpace: reserveLayoutSpace,
             notchAware: true,
             position: position,


### PR DESCRIPTION
## Summary

Add a per-display workspace-bar toggle to show other displays' workspaces after a display icon. Click a foreign workspace to switch that display; shift-click to move the focused window there. Off by default; configurable globally and per monitor.
## Release notes

Choose one:

- [x] Added a `.changeset/*.md` for user-visible changes (`mise run changeset -- patch "..."`).
- [ ] No user-visible change; apply the `no release note` label to make CI skip intentional.

## Validation

<!-- Commands run, screenshots, or manual checks. -->

- [ ] Ran relevant tests/checks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a **“Show Other Displays' Workspaces”** option to the workspace bar, configurable globally and per monitor (off by default).
  * When enabled, foreign workspaces appear as compact pills grouped by display, including an “active on home display” indicator.
  * Onboarding and workspace bar settings previews now reflect the toggle, including its shift-click behavior to move the focused window.

* **Bug Fixes**
  * Workspace bar previews, saved settings, and projections now consistently preserve the new display-sharing option.
  * Empty foreign workspaces are hidden when empty-workspace hiding is enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->