### PR TITLE
Migrate remaining foregroundColor call sites to foregroundStyle

### DIFF
--- a/.changeset/20260703155659-internal-migrate-remaining-swiftui-foregroundcol.md
+++ b/.changeset/20260703155659-internal-migrate-remaining-swiftui-foregroundcol.md
@@ -1,0 +1,6 @@
+---
+"nehir": none
+
+---
+
+Internal: migrate remaining SwiftUI foregroundColor call sites to foregroundStyle (deprecated API cleanup, no behavior change).

--- a/Sources/Nehir/UI/AppRulesView.swift
+++ b/Sources/Nehir/UI/AppRulesView.swift
@@ -281,12 +281,12 @@ struct AppRulesEmptyState: View {
             VStack(spacing: 16) {
                 Image(systemName: "app.badge.checkmark")
                     .font(.system(size: 48))
-                    .foregroundColor(.secondary)
+                    .foregroundStyle(.secondary)
                 Text("No App Rule Selected")
                     .font(.headline)
                 Text("Select an app rule from the sidebar to edit it,\nor add a new rule to get started.")
                     .font(.subheadline)
-                    .foregroundColor(.secondary)
+                    .foregroundStyle(.secondary)
                     .multilineTextAlignment(.center)
                 Button("Add Rule", action: onAdd)
                     .buttonStyle(.borderedProminent)
@@ -337,7 +337,7 @@ struct AppRuleDetailView: View {
                 LabeledContent("Bundle ID") {
                     Text(draft.bundleId)
                         .font(.system(.body, design: .monospaced))
-                        .foregroundColor(.secondary)
+                        .foregroundStyle(.secondary)
                 }
             }
 
@@ -394,7 +394,7 @@ struct AppRuleDetailView: View {
                             .textFieldStyle(.roundedBorder)
                             .frame(width: 100)
                         Text("px")
-                            .foregroundColor(.secondary)
+                            .foregroundStyle(.secondary)
                     }
                 }
 
@@ -406,7 +406,7 @@ struct AppRuleDetailView: View {
                             .textFieldStyle(.roundedBorder)
                             .frame(width: 100)
                         Text("px")
-                            .foregroundColor(.secondary)
+                            .foregroundStyle(.secondary)
                     }
                 }
 
@@ -490,13 +490,13 @@ struct AppRuleAddPane: View {
                     if let error = bundleIdError {
                         Text(error)
                             .font(.caption)
-                            .foregroundColor(.red)
+                            .foregroundStyle(.red)
                     }
 
                     DisclosureGroup(isExpanded: $isPickerExpanded) {
                         if runningApps.isEmpty {
                             Text("No apps with windows found")
-                                .foregroundColor(.secondary)
+                                .foregroundStyle(.secondary)
                                 .font(.caption)
                         } else {
                             ScrollView {
@@ -535,7 +535,7 @@ struct AppRuleAddPane: View {
 
                     Text("Examples: com.apple.finder or dentalplus-air")
                         .font(.caption)
-                        .foregroundColor(.secondary)
+                        .foregroundStyle(.secondary)
                 }
 
                 Section("Window Behavior") {
@@ -550,7 +550,7 @@ struct AppRuleAddPane: View {
                             "Ignored windows are left out of Nehir's managed model. Layout, Sticky, workspace, and size effects will not apply."
                         )
                         .font(.caption)
-                        .foregroundColor(.secondary)
+                        .foregroundStyle(.secondary)
                     }
 
                     Picker("Layout", selection: $draft.layoutAction) {
@@ -581,7 +581,7 @@ struct AppRuleAddPane: View {
                         if workspaceNames.isEmpty {
                             Text("No workspaces configured. Add workspaces in Settings.")
                                 .font(.caption)
-                                .foregroundColor(.secondary)
+                                .foregroundStyle(.secondary)
                         }
                     }
                 }
@@ -595,7 +595,7 @@ struct AppRuleAddPane: View {
                                 .textFieldStyle(.roundedBorder)
                                 .frame(width: 100)
                             Text("px")
-                                .foregroundColor(.secondary)
+                                .foregroundStyle(.secondary)
                         }
                     }
 
@@ -607,13 +607,13 @@ struct AppRuleAddPane: View {
                                 .textFieldStyle(.roundedBorder)
                                 .frame(width: 100)
                             Text("px")
-                                .foregroundColor(.secondary)
+                                .foregroundStyle(.secondary)
                         }
                     }
 
                     Text("Prevents layout engine from sizing window smaller than these values.")
                         .font(.caption)
-                        .foregroundColor(.secondary)
+                        .foregroundStyle(.secondary)
                 }
 
                 Section {
@@ -694,7 +694,7 @@ struct AdvancedMatchersEditor: View {
         VStack(alignment: .leading, spacing: 12) {
             Text("Use advanced matchers when bundle-level rules are too broad.")
                 .font(.caption)
-                .foregroundColor(.secondary)
+                .foregroundStyle(.secondary)
 
             Toggle("App Name Contains", isOn: $draft.appNameMatcherEnabled)
             if draft.appNameMatcherEnabled {
@@ -721,7 +721,7 @@ struct AdvancedMatchersEditor: View {
                 if let regexError {
                     Text("Title regex is invalid: \(regexError)")
                         .font(.caption)
-                        .foregroundColor(.red)
+                        .foregroundStyle(.red)
                 }
             }
 
@@ -785,7 +785,7 @@ struct FocusedWindowInspectorView: View {
                 } else {
                     Text("No focused window is available for inspection.")
                         .font(.caption)
-                        .foregroundColor(.secondary)
+                        .foregroundStyle(.secondary)
                 }
             }
             .frame(maxWidth: .infinity, alignment: .leading)
@@ -810,7 +810,7 @@ struct RuleBadge: View {
             .padding(.horizontal, 6)
             .padding(.vertical, 2)
             .background(color.opacity(0.2))
-            .foregroundColor(color)
+            .foregroundStyle(color)
             .clipShape(RoundedRectangle(cornerRadius: 4))
     }
 }
@@ -835,21 +835,21 @@ struct RunningAppRow: View {
                 VStack(alignment: .leading, spacing: 2) {
                     Text(app.appName)
                         .font(.body)
-                        .foregroundColor(.primary)
+                        .foregroundStyle(.primary)
                     Text(app.bundleId)
                         .font(.caption)
-                        .foregroundColor(.secondary)
+                        .foregroundStyle(.secondary)
                 }
 
                 Spacer()
 
                 Text("\(Int(app.windowSize.width))x\(Int(app.windowSize.height))")
                     .font(.caption)
-                    .foregroundColor(.secondary)
+                    .foregroundStyle(.secondary)
 
                 if isSelected {
                     Image(systemName: "checkmark.circle.fill")
-                        .foregroundColor(.accentColor)
+                        .foregroundStyle(Color.accentColor)
                 }
             }
             .padding(.vertical, 4)

--- a/Sources/Nehir/UI/CommandPalette/CommandPaletteController.swift
+++ b/Sources/Nehir/UI/CommandPalette/CommandPaletteController.swift
@@ -1223,14 +1223,14 @@ private struct CommandPaletteView: View {
 
                 HStack(spacing: 8) {
                     Image(systemName: "magnifyingglass")
-                        .foregroundColor(.secondary)
+                        .foregroundStyle(.secondary)
                     TextField(searchPlaceholder, text: $controller.searchText)
                         .textFieldStyle(.plain)
                         .font(.system(size: 18))
                     if !controller.searchText.isEmpty {
                         Button(action: { controller.searchText = "" }) {
                             Image(systemName: "xmark.circle.fill")
-                                .foregroundColor(.secondary)
+                                .foregroundStyle(.secondary)
                         }
                         .buttonStyle(.plain)
                     }
@@ -1239,7 +1239,7 @@ private struct CommandPaletteView: View {
                 HStack(spacing: 8) {
                     Text(statusText)
                         .font(.system(size: 12))
-                        .foregroundColor(.secondary)
+                        .foregroundStyle(.secondary)
                         .lineLimit(1)
                     Spacer()
                 }
@@ -1467,10 +1467,10 @@ private struct CommandPaletteModePicker: View {
             HStack(spacing: 10) {
                 Text(hint.title)
                     .font(.system(size: 12, weight: .semibold))
-                    .foregroundColor(tabTitleColor(isSelected: isSelected, enabled: enabled))
+                    .foregroundStyle(tabTitleColor(isSelected: isSelected, enabled: enabled))
                 Text(hint.shortcut)
                     .font(.system(size: 11, weight: .semibold))
-                    .foregroundColor(tabShortcutColor(isSelected: isSelected, enabled: enabled))
+                    .foregroundStyle(tabShortcutColor(isSelected: isSelected, enabled: enabled))
             }
             .frame(maxWidth: .infinity)
             .padding(.horizontal, 10)
@@ -1513,7 +1513,7 @@ private struct CommandPaletteShortcutBadge: View {
     var body: some View {
         Text(text)
             .font(.system(size: 10, weight: .semibold, design: .monospaced))
-            .foregroundColor(foregroundColor)
+            .foregroundStyle(foregroundColor)
             .padding(.horizontal, 6)
             .padding(.vertical, 2)
             .background(backgroundColor)
@@ -1548,7 +1548,7 @@ private struct CommandPaletteLoadingView: View {
                 .scaleEffect(0.85)
             Text(text)
                 .font(.system(size: 13))
-                .foregroundColor(.secondary)
+                .foregroundStyle(.secondary)
                 .padding(.top, 8)
             Spacer()
         }
@@ -1565,10 +1565,10 @@ private struct CommandPaletteEmptyStateView: View {
             Spacer()
             Image(systemName: symbolName)
                 .font(.system(size: 30))
-                .foregroundColor(.secondary)
+                .foregroundStyle(.secondary)
             Text(text)
                 .font(.system(size: 13))
-                .foregroundColor(.secondary)
+                .foregroundStyle(.secondary)
                 .padding(.top, 8)
                 .multilineTextAlignment(.center)
                 .padding(.horizontal, 24)
@@ -1584,7 +1584,7 @@ private struct CommandPaletteFallbackSectionHeader: View {
     var body: some View {
         Text(title)
             .font(.system(size: 11, weight: .semibold))
-            .foregroundColor(.secondary)
+            .foregroundStyle(.secondary)
             .frame(maxWidth: .infinity, alignment: .leading)
             .padding(.horizontal, 16)
             .padding(.top, 8)
@@ -1612,7 +1612,7 @@ private struct CommandPaletteWindowRow: View {
                 Image(systemName: "app.fill")
                     .resizable()
                     .frame(width: 32, height: 32)
-                    .foregroundColor(.secondary)
+                    .foregroundStyle(.secondary)
             }
 
             VStack(alignment: .leading, spacing: 2) {
@@ -1621,7 +1621,7 @@ private struct CommandPaletteWindowRow: View {
                     .lineLimit(1)
                 Text(item.appName)
                     .font(.system(size: 12))
-                    .foregroundColor(.secondary)
+                    .foregroundStyle(.secondary)
                     .lineLimit(1)
             }
 
@@ -1631,7 +1631,7 @@ private struct CommandPaletteWindowRow: View {
                 if let summonHint {
                     Text(summonHint.title)
                         .font(.system(size: 11, weight: .medium))
-                        .foregroundColor(.secondary)
+                        .foregroundStyle(.secondary)
                     CommandPaletteShortcutBadge(text: summonHint.shortcut)
                 }
 
@@ -1663,7 +1663,7 @@ private struct CommandPaletteMenuRow: View {
                 if !item.parentTitles.isEmpty {
                     Text(item.parentTitles.joined(separator: " > "))
                         .font(.system(size: 11))
-                        .foregroundColor(.secondary)
+                        .foregroundStyle(.secondary)
                         .lineLimit(1)
                 }
             }
@@ -1693,7 +1693,7 @@ private struct CommandPaletteCommandRow: View {
                     .lineLimit(1)
                 Text(item.category.rawValue)
                     .font(.system(size: 11))
-                    .foregroundColor(.secondary)
+                    .foregroundStyle(.secondary)
                     .lineLimit(1)
             }
 

--- a/Sources/Nehir/UI/WorkspaceBar/WorkspaceBarView.swift
+++ b/Sources/Nehir/UI/WorkspaceBar/WorkspaceBarView.swift
@@ -644,7 +644,7 @@ private struct WorkspaceLabelButton: View {
         Button(action: onFocusWorkspace) {
             Text(item.name)
                 .font(.system(.caption, design: .monospaced).weight(.medium))
-                .foregroundColor(resolvedLabelColor)
+                .foregroundStyle(resolvedLabelColor)
                 .frame(minWidth: 16)
                 .contentShape(Rectangle())
         }
@@ -693,7 +693,7 @@ private struct ForeignWorkspaceGroupView: View {
         HStack(spacing: 4) {
             Image(systemName: "display")
                 .font(.system(size: max(9, iconSize * 0.58), weight: .medium))
-                .foregroundColor(resolvedSecondaryTextColor.opacity(0.75))
+                .foregroundStyle(resolvedSecondaryTextColor.opacity(0.75))
                 .accessibilityHidden(true)
 
             ForEach(group.items, id: \.id) { item in
@@ -750,7 +750,7 @@ private struct ForeignWorkspaceItemView: View {
                 }
                 Text(item.name)
                     .font(.system(.caption, design: .monospaced).weight(.medium))
-                    .foregroundColor(textColor ?? .primary)
+                    .foregroundStyle(textColor ?? .primary)
                     .frame(minWidth: 16)
             }
             .padding(.horizontal, 6)
@@ -880,7 +880,7 @@ private struct StickyPillView: View {
         HStack(spacing: 5) {
             Image(systemName: "pin.fill")
                 .font(.system(size: max(10, iconSize * 0.64), weight: .semibold))
-                .foregroundColor(isFocused ? resolvedAccentColor : resolvedSecondaryTextColor)
+                .foregroundStyle(isFocused ? resolvedAccentColor : resolvedSecondaryTextColor)
                 .accessibilityHidden(true)
 
             ForEach(item.windows, id: \.id) { window in
@@ -952,7 +952,7 @@ private struct ScratchpadPillView: View {
             HStack(spacing: 5) {
                 Image(systemName: "tray.fill")
                     .font(.system(size: max(10, iconSize * 0.64), weight: .semibold))
-                    .foregroundColor(item.window.isFocused ? resolvedAccentColor : resolvedSecondaryTextColor)
+                    .foregroundStyle(item.window.isFocused ? resolvedAccentColor : resolvedSecondaryTextColor)
                     .accessibilityHidden(true)
 
                 AppIconImage(icon: item.window.icon)
@@ -1239,7 +1239,7 @@ private struct WindowCountBadge: View {
     var body: some View {
         Text("\(count)")
             .font(.caption2.weight(.semibold).monospacedDigit())
-            .foregroundColor(textColor ?? .primary)
+            .foregroundStyle(textColor ?? .primary)
             .padding(.horizontal, 3)
             .padding(.vertical, 1)
             .background(
@@ -1414,12 +1414,12 @@ private struct WindowListSheet: View {
                 } label: {
                     HStack {
                         Text(windowInfo.title)
-                            .foregroundColor(windowInfo
+                            .foregroundStyle(windowInfo
                                 .isFocused ? resolvedPrimaryTextColor : resolvedSecondaryTextColor)
                         Spacer()
                         if windowInfo.isFocused {
                             Image(systemName: "checkmark.circle.fill")
-                                .foregroundColor(resolvedAccentColor)
+                                .foregroundStyle(resolvedAccentColor)
                         }
                     }
                 }

--- a/Sources/Nehir/UI/WorkspacesSettingsTab.swift
+++ b/Sources/Nehir/UI/WorkspacesSettingsTab.swift
@@ -262,7 +262,7 @@ struct WorkspaceSidebarRow: View {
             HStack(alignment: .firstTextBaseline, spacing: 6) {
                 Text(configuration.name)
                     .font(.system(.body, design: .monospaced).weight(.bold))
-                    .foregroundColor(.secondary)
+                    .foregroundStyle(.secondary)
 
                 Text(configuration.displayName.flatMap { $0.isEmpty ? nil : $0 } ?? "Workspace \(configuration.name)")
                     .font(.body)
@@ -275,7 +275,7 @@ struct WorkspaceSidebarRow: View {
                     .frame(width: 6, height: 6)
                 Text(monitorLabel)
                     .font(.caption2)
-                    .foregroundColor(.secondary)
+                    .foregroundStyle(.secondary)
             }
         }
         .padding(.vertical, 4)
@@ -303,12 +303,12 @@ struct WorkspacesEmptyState: View {
             VStack(spacing: 16) {
                 Image(systemName: "square.grid.2x2")
                     .font(.system(size: 48))
-                    .foregroundColor(.secondary)
+                    .foregroundStyle(.secondary)
                 Text("No Workspace Selected")
                     .font(.headline)
                 Text("Select a workspace from the sidebar to edit it,\nor add a new workspace to get started.")
                     .font(.subheadline)
-                    .foregroundColor(.secondary)
+                    .foregroundStyle(.secondary)
                     .multilineTextAlignment(.center)
                 Button("Add Workspace", action: onAdd)
                     .buttonStyle(.borderedProminent)
@@ -316,7 +316,7 @@ struct WorkspacesEmptyState: View {
                 GroupBox {
                     Text(WorkspaceConfigurationAddPolicy.footerText)
                         .font(.caption)
-                        .foregroundColor(.secondary)
+                        .foregroundStyle(.secondary)
                         .multilineTextAlignment(.center)
                         .frame(maxWidth: .infinity)
                 }
@@ -348,7 +348,7 @@ struct WorkspaceDetailPane: View {
                 LabeledContent("Internal ID") {
                     Text(configuration.name)
                         .font(.system(.body, design: .monospaced))
-                        .foregroundColor(.secondary)
+                        .foregroundStyle(.secondary)
                 }
             } header: {
                 Text("Identity")
@@ -429,7 +429,7 @@ struct WorkspaceAddPane: View {
                 LabeledContent("Internal ID") {
                     Text(configuration.name)
                         .font(.system(.body, design: .monospaced))
-                        .foregroundColor(.secondary)
+                        .foregroundStyle(.secondary)
                 }
             } header: {
                 Text("Identity")
@@ -482,7 +482,7 @@ struct HomeMonitorPicker: View {
                 HStack {
                     Text(monitor.name)
                     if monitor.isMain {
-                        Text("(Main)").foregroundColor(.secondary)
+                        Text("(Main)").foregroundStyle(.secondary)
                     }
                 }
                 .tag(MonitorAssignment.specificDisplay(OutputId(from: monitor)))

--- a/Sources/NehirApp/SettingsSceneRedirectView.swift
+++ b/Sources/NehirApp/SettingsSceneRedirectView.swift
@@ -19,7 +19,7 @@ struct SettingsSceneRedirectView: View {
         VStack(spacing: 8) {
             ProgressView()
             Text(didRedirect ? "Opening Nehir Settings…" : "Starting Nehir…")
-                .foregroundColor(.secondary)
+                .foregroundStyle(.secondary)
         }
         .frame(width: 1, height: 1)
         .background(


### PR DESCRIPTION
## Summary

Internal: migrate remaining SwiftUI foregroundColor call sites to foregroundStyle (deprecated API cleanup, no behavior change).

## Release notes

Choose one:

- [x] Added a `.changeset/*.md` for user-visible changes (`mise run changeset -- patch "..."`).
- [ ] No user-visible change; apply the `no release note` label to make CI skip intentional.

## Validation

<!-- Commands run, screenshots, or manual checks. -->

- [ ] Ran relevant tests/checks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated app UI styling to use the newer SwiftUI foreground styling approach throughout workspace, command palette, settings, and app rules screens.
  * Kept the same visual appearance while modernizing text, icon, badge, and empty-state color handling.
  * Included a changeset entry to document the update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->