### PR TITLE
Fix foreach index identity

### DIFF
--- a/.changeset/20260703155614-fix-resize-presets-in-settings-so-removing-a-pre.md
+++ b/.changeset/20260703155614-fix-resize-presets-in-settings-so-removing-a-pre.md
@@ -1,0 +1,6 @@
+---
+"nehir": patch
+
+---
+
+Fix Resize Presets in settings so removing a preset from the middle of the list no longer shifts the remaining values onto the wrong rows; the edited or removed preset now stays bound to its own row.

--- a/.changeset/20260703155614-stabilize-list-identity-in-onboarding-and-diagno.md
+++ b/.changeset/20260703155614-stabilize-list-identity-in-onboarding-and-diagno.md
@@ -1,0 +1,6 @@
+---
+"nehir": patch
+
+---
+
+Stabilize list identity in onboarding and diagnostics views (What's New, keyboard shortcut preview, workspace bar animation, config recovery, and app-rule diagnostics) so rows keep their identity when items are added or removed.

--- a/Sources/Nehir/UI/Onboarding/Animations/WorkspaceBarAnimation.swift
+++ b/Sources/Nehir/UI/Onboarding/Animations/WorkspaceBarAnimation.swift
@@ -258,7 +258,7 @@ struct WorkspaceBarAnimation: View {
                     .foregroundStyle(isFocused ? Color.accentColor : Color.secondary)
                     .frame(minWidth: 10)
             }
-            ForEach(Array(displayedWindows(ws.tiledWindows).enumerated()), id: \.offset) { _, item in
+            ForEach(displayedWindows(ws.tiledWindows)) { item in
                 windowIcon(symbol: item.symbol, count: item.count, isFocused: isFocused)
             }
             if showFloatingWindows && !ws.floatingWindows.isEmpty {
@@ -320,9 +320,17 @@ struct WorkspaceBarAnimation: View {
 
     /// Collapses duplicate app icons into a single icon with a count badge when
     /// "Group Windows by App" is on; otherwise renders every window icon individually.
-    private func displayedWindows(_ windows: [MockWindow]) -> [(symbol: String, count: Int)] {
+    private struct DisplayedWindow: Identifiable {
+        let id: String
+        let symbol: String
+        let count: Int
+    }
+
+    private func displayedWindows(_ windows: [MockWindow]) -> [DisplayedWindow] {
         if !deduplicateAppIcons {
-            return windows.map { (symbol: $0.symbol, count: 1) }
+            return windows.map { window in
+                DisplayedWindow(id: window.id.uuidString, symbol: window.symbol, count: 1)
+            }
         }
         var order: [String] = []
         var counts: [String: Int] = [:]
@@ -330,7 +338,7 @@ struct WorkspaceBarAnimation: View {
             if counts[window.symbol] == nil { order.append(window.symbol) }
             counts[window.symbol, default: 0] += 1
         }
-        return order.map { (symbol: $0, count: counts[$0] ?? 0) }
+        return order.map { DisplayedWindow(id: $0, symbol: $0, count: counts[$0] ?? 0) }
     }
 
     private func windowIcon(symbol: String, count: Int, isFocused: Bool) -> some View {
@@ -356,7 +364,7 @@ struct WorkspaceBarAnimation: View {
                 .font(.system(size: max(9, iconSize * 0.58), weight: .medium))
                 .foregroundStyle(isFocused ? Color.primary : Color.secondary)
                 .accessibilityHidden(true)
-            ForEach(Array(displayedWindows(windows).enumerated()), id: \.offset) { _, item in
+            ForEach(displayedWindows(windows)) { item in
                 windowIcon(symbol: item.symbol, count: item.count, isFocused: isFocused)
             }
         }

--- a/Sources/Nehir/UI/Onboarding/ConfigRecoveryView.swift
+++ b/Sources/Nehir/UI/Onboarding/ConfigRecoveryView.swift
@@ -45,7 +45,7 @@ struct ConfigRecoveryView: View {
                     .foregroundStyle(.secondary)
                     .textSelection(.enabled)
 
-                ForEach(Array(details.enumerated()), id: \.offset) { _, detail in
+                ForEach(details, id: \.self) { detail in
                     HStack(alignment: .top, spacing: 10) {
                         Image(systemName: "xmark.circle.fill")
                             .font(.callout)

--- a/Sources/Nehir/UI/Onboarding/OnboardingStepControls.swift
+++ b/Sources/Nehir/UI/Onboarding/OnboardingStepControls.swift
@@ -229,7 +229,7 @@ struct NavigationStepControl: View {
 
     var body: some View {
         VStack(spacing: 8) {
-            ForEach(Array(rows.enumerated()), id: \.offset) { index, row in
+            ForEach(Array(rows.enumerated()), id: \.element.bindingID) { index, row in
                 NavigationShortcutRow(
                     keys: keyDisplayString(for: row.bindingID),
                     description: row.description

--- a/Sources/Nehir/UI/Onboarding/WhatsNewView.swift
+++ b/Sources/Nehir/UI/Onboarding/WhatsNewView.swift
@@ -39,7 +39,7 @@ struct WhatsNewView: View {
                         settingsWarningsCard
                     }
 
-                    ForEach(Array(sections.enumerated()), id: \.offset) { _, section in
+                    ForEach(sections, id: \.title) { section in
                         sectionCard(section)
                     }
                 }
@@ -150,7 +150,7 @@ struct WhatsNewView: View {
             }
             .padding(.bottom, 4)
 
-            ForEach(Array(section.bullets.enumerated()), id: \.offset) { index, bullet in
+            ForEach(Array(section.bullets.enumerated()), id: \.element) { index, bullet in
                 if index > 0 {
                     Divider().opacity(0.5)
                 }

--- a/Sources/Nehir/UI/SettingsView.swift
+++ b/Sources/Nehir/UI/SettingsView.swift
@@ -563,9 +563,31 @@ private struct PercentTextField: View {
     }
 }
 
+private struct PresetRow: Identifiable {
+    let id: UUID
+    var value: Double
+}
+
 struct GlobalNiriSettingsSection: View {
     @Bindable var settings: SettingsStore
     @Bindable var controller: WMController
+
+    @State private var presetRows: [PresetRow]
+
+    init(settings: SettingsStore, controller: WMController) {
+        self.settings = settings
+        self.controller = controller
+        _presetRows = State(
+            initialValue: settings.niriColumnWidthPresets.map { PresetRow(id: UUID(), value: $0) }
+        )
+    }
+
+    private func syncPresetRows() {
+        let external = settings.niriColumnWidthPresets
+        if presetRows.map(\.value) != external {
+            presetRows = external.map { PresetRow(id: UUID(), value: $0) }
+        }
+    }
 
     var body: some View {
         let defaultColumnWidthMode = Binding(
@@ -603,7 +625,6 @@ struct GlobalNiriSettingsSection: View {
                 controller.updateNiriConfig(loneWindowPolicy: settings.loneWindowPolicy)
             }
         )
-        let presets = settings.niriColumnWidthPresets
 
         Section("Default Column Width") {
             LabeledContent("Mode") {
@@ -664,25 +685,25 @@ struct GlobalNiriSettingsSection: View {
         }
 
         Section("Resize Presets") {
-            ForEach(presets.indices, id: \.self) { index in
+            ForEach(Array(presetRows.enumerated()), id: \.element.id) { index, row in
                 LabeledContent("Preset \(index + 1)") {
                     HStack {
                         PercentTextField(
                             title: "Preset \(index + 1)",
-                            value: Int(presets[index] * 100),
+                            value: Int(row.value * 100),
                             range: 5 ... 100,
                             onCommit: { newPercent in
-                                var current = settings.niriColumnWidthPresets
-                                current[index] = Double(newPercent) / 100.0
-                                settings.niriColumnWidthPresets = current
+                                guard let idx = presetRows.firstIndex(where: { $0.id == row.id }) else { return }
+                                presetRows[idx].value = Double(newPercent) / 100.0
+                                settings.niriColumnWidthPresets = presetRows.map(\.value)
                                 controller.updateNiriConfig(columnWidthPresets: settings.niriColumnWidthPresets)
                             }
                         )
                         .accessibilityLabel("Preset \(index + 1) width")
                         Button(role: .destructive) {
-                            var presets = settings.niriColumnWidthPresets
-                            presets.remove(at: index)
-                            settings.niriColumnWidthPresets = presets
+                            guard let idx = presetRows.firstIndex(where: { $0.id == row.id }) else { return }
+                            presetRows.remove(at: idx)
+                            settings.niriColumnWidthPresets = presetRows.map(\.value)
                             controller.updateNiriConfig(columnWidthPresets: settings.niriColumnWidthPresets)
                         } label: {
                             Label("Remove preset \(index + 1)", systemImage: "minus.circle")
@@ -690,16 +711,15 @@ struct GlobalNiriSettingsSection: View {
                         }
                         .buttonStyle(.borderless)
                         .help("Remove preset \(index + 1)")
-                        .disabled(settings.niriColumnWidthPresets.count <= 2)
+                        .disabled(presetRows.count <= 2)
                     }
                 }
             }
 
             HStack {
                 Button("Add Preset") {
-                    var presets = settings.niriColumnWidthPresets
-                    presets.append(0.5)
-                    settings.niriColumnWidthPresets = presets
+                    presetRows.append(PresetRow(id: UUID(), value: 0.5))
+                    settings.niriColumnWidthPresets = presetRows.map(\.value)
                     controller.updateNiriConfig(columnWidthPresets: settings.niriColumnWidthPresets)
                 }
                 Button("Reset Resize Presets") {
@@ -709,7 +729,8 @@ struct GlobalNiriSettingsSection: View {
             }
             SettingsCaption("Used only by width-cycle commands. These do not affect default column width.")
         }
-        .id(settings.niriColumnWidthPresets.count)
+        .onAppear { syncPresetRows() }
+        .onChange(of: settings.niriColumnWidthPresets) { _, _ in syncPresetRows() }
     }
 }
 


### PR DESCRIPTION
## Summary

<!-- What changed and why? -->

## Release notes

Choose one:

- [x] Added a `.changeset/*.md` for user-visible changes (`mise run changeset -- patch "..."`).
- [ ] No user-visible change; apply the `no release note` label to make CI skip intentional.

## Validation

<!-- Commands run, screenshots, or manual checks. -->

- [ ] Ran relevant tests/checks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed SwiftUI list/row identity so items stay attached to the correct positions when entries are added or removed across onboarding, “What’s New”, diagnostics, config recovery, and workspace displays.
  * Corrected an issue in Settings where removing a middle resize preset could cause subsequent preset values to jump to incorrect rows, keeping the edited/removed row stable.
  * Updated settings preset handling to keep row order and values in sync reliably when editing, removing, or adding presets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->