### PR TITLE
Exempt user-activated apps from the unrequested-admission guard

### DIFF
--- a/.changeset/20260703161500-tile-user-activated-windows-during-non-mana.md
+++ b/.changeset/20260703161500-tile-user-activated-windows-during-non-mana.md
@@ -1,0 +1,5 @@
+---
+"nehir": patch
+---
+
+Tile a window you deliberately switch to (Dock, Cmd-Tab, or launcher) even while non-managed focus is active. Previously, activating an app whose window had never been tracked — such as one revealed after being hidden across a restart — left it floating unmanaged and stuck, because its own focus kept re-arming the guard that dropped it.

--- a/Sources/Nehir/Core/Controller/AXEventHandler.swift
+++ b/Sources/Nehir/Core/Controller/AXEventHandler.swift
@@ -107,6 +107,15 @@ struct NiriCreateFocusTraceEvent: Equatable {
             hasExplicitWorkspaceAssignment: Bool,
             activeManagedRequestToken: WindowToken?
         )
+        // Emitted when a `window_decision` is vetoed by the
+        // unrequested-admission guard (i.e.
+        // `shouldSuppressUnrequestedAdmissionDuringNonManagedFocus` returns
+        // true), so tooling grepping decision records alone does not conclude
+        // the window was admitted.
+        case windowDecisionSuppressed(
+            token: WindowToken,
+            reason: String
+        )
         case windowDecision(
             token: WindowToken,
             context: String,
@@ -240,6 +249,8 @@ extension NiriCreateFocusTraceEvent: CustomStringConvertible {
             activeManagedRequestToken
         ):
             "unrequested_admission_nonmanaged_focus_decision token=\(token) suppressed=\(suppressed) reason=\(reason) context_source=\(createContextSource ?? "nil") recent_pid_workspace=\(recentPidWorkspaceId?.uuidString ?? "nil") explicit_workspace_assignment=\(hasExplicitWorkspaceAssignment) active_managed_request_token=\(String(describing: activeManagedRequestToken))"
+        case let .windowDecisionSuppressed(token, reason):
+            "window_decision_suppressed token=\(token) reason=\(reason)"
         case let .windowDecision(
             token,
             context,
@@ -440,6 +451,13 @@ final class AXEventHandler: CGSEventDelegate {
     private static let createdWindowRetryLimit = 5
     private static let createPlacementContextTTL: TimeInterval = 15
     private static let recentManagedAdmissionTTL: TimeInterval = 15
+    // A deliberate user app switch (Dock/Cmd-Tab/launcher) and the target
+    // window's focused-admission arrive within a second or two of each other,
+    // so a short window suffices to bridge them. Kept well below
+    // recentManagedAdmissionTTL (15s) on purpose: this exemption widens the
+    // unrequested-admission guard, so it should decay quickly to avoid
+    // admitting unrelated surfaces that merely happen to share the pid.
+    private static let recentAppActivationTTL: TimeInterval = 10
     private static let activationRetryLimit = 5
     private static let nativeAppSwitchLeaseRequestConfirmationGrace: TimeInterval = 0.6
     private static let createFocusTraceLimit = 128
@@ -459,6 +477,7 @@ final class AXEventHandler: CGSEventDelegate {
     }
 
     private var recentManagedWorkspaceByPid: [pid_t: RecentManagedWorkspace] = [:]
+    private var recentAppActivationByPid: [pid_t: TimeInterval] = [:]
     private var recentManagedAdmissionByToken: [WindowToken: RecentManagedAdmission] = [:]
     private var pendingManagedReplacementBursts: [ManagedReplacementKey: PendingManagedReplacementBurst] = [:]
     private var pendingManagedReplacementTasks: [ManagedReplacementKey: Task<Void, Never>] = [:]
@@ -507,6 +526,7 @@ final class AXEventHandler: CGSEventDelegate {
     func cleanup() {
         resetCreatePlacementContextState()
         recentManagedWorkspaceByPid.removeAll()
+        recentAppActivationByPid.removeAll()
         recentManagedAdmissionByToken.removeAll()
         resetManagedReplacementState()
         endWindowCloseFocusRecovery()
@@ -650,6 +670,7 @@ final class AXEventHandler: CGSEventDelegate {
         resetCreatedWindowRetryState()
         resetCreatePlacementContextState()
         recentManagedWorkspaceByPid.removeAll()
+        recentAppActivationByPid.removeAll()
         recentManagedAdmissionByToken.removeAll()
         resetActivationRetryState()
         controller?.focusBridge.reset()
@@ -781,6 +802,23 @@ final class AXEventHandler: CGSEventDelegate {
             )
             return false
         }
+        // A deliberate user app switch to this pid (observed as a
+        // workspaceDidActivateApplication activation moments earlier) is an
+        // intent signal on par with a CGS create. Without this, launcher/Dock/
+        // Cmd-Tab switches to an existing-but-untracked window are dropped and
+        // the untracked window's own focus keeps non-managed focus armed,
+        // trapping it permanently.
+        if hasRecentAppActivation(for: token.pid) {
+            recordUnrequestedAdmissionDuringNonManagedFocusDecision(
+                token: token,
+                suppressed: false,
+                reason: "recent_app_activation",
+                createPlacementContext: createPlacementContext,
+                hasExplicitWorkspaceAssignment: hasExplicitWorkspaceAssignment,
+                activeManagedRequestToken: activeManagedRequestToken
+            )
+            return false
+        }
 
         recordUnrequestedAdmissionDuringNonManagedFocusDecision(
             token: token,
@@ -789,6 +827,14 @@ final class AXEventHandler: CGSEventDelegate {
             createPlacementContext: createPlacementContext,
             hasExplicitWorkspaceAssignment: hasExplicitWorkspaceAssignment,
             activeManagedRequestToken: activeManagedRequestToken
+        )
+        recordNiriCreateFocusTrace(
+            .init(
+                kind: .windowDecisionSuppressed(
+                    token: token,
+                    reason: "stale_unrequested_nonmanaged_focus"
+                )
+            )
         )
         return true
     }
@@ -1862,6 +1908,14 @@ final class AXEventHandler: CGSEventDelegate {
                 )
             )
         )
+        // A genuine app-level switch (Dock, Cmd-Tab, launcher activate()) is a
+        // user-intent signal that should still admit the app's window even while
+        // non-managed focus is active. Window-level focus churn
+        // (.focusedWindowChanged) does not qualify, so only record app
+        // activations here.
+        if source == .workspaceDidActivateApplication {
+            recordRecentAppActivation(pid: pid)
+        }
         guard controller.hasStartedServices else { return }
 
         let activeRequest = controller.focusBridge.activeManagedRequest
@@ -3929,6 +3983,23 @@ final class AXEventHandler: CGSEventDelegate {
         }
     }
 
+    private func recordRecentAppActivation(pid: pid_t) {
+        pruneRecentAppActivations()
+        recentAppActivationByPid[pid] = managedReplacementCurrentUptime()
+    }
+
+    private func hasRecentAppActivation(for pid: pid_t) -> Bool {
+        pruneRecentAppActivations()
+        return recentAppActivationByPid[pid] != nil
+    }
+
+    private func pruneRecentAppActivations(now: TimeInterval? = nil) {
+        let now = now ?? managedReplacementCurrentUptime()
+        recentAppActivationByPid = recentAppActivationByPid.filter { _, recordedAt in
+            now - recordedAt <= Self.recentAppActivationTTL
+        }
+    }
+
     private func recentManagedAdmissionWorkspaceId(for token: WindowToken) -> WorkspaceDescriptor.ID? {
         pruneRecentManagedAdmissions()
         guard let admission = recentManagedAdmissionByToken[token],
@@ -4637,6 +4708,7 @@ final class AXEventHandler: CGSEventDelegate {
 
     func cleanupFocusStateForTerminatedApp(pid: pid_t) {
         recentManagedWorkspaceByPid.removeValue(forKey: pid)
+        recentAppActivationByPid.removeValue(forKey: pid)
 
         guard let controller else { return }
 

--- a/Tests/NehirTests/AXEventHandlerTests.swift
+++ b/Tests/NehirTests/AXEventHandlerTests.swift
@@ -263,6 +263,36 @@ private func createFocusTraceEvents(on controller: WMController) -> [NiriCreateF
     controller.axEventHandler.niriCreateFocusTraceSnapshotForTests()
 }
 
+private func makeSynthesizedFocusedAdmissionContext() -> WindowCreatePlacementContext {
+    WindowCreatePlacementContext(
+        nativeSpaceMonitorId: nil,
+        activeFocusRequestWorkspaceId: nil,
+        activeFocusRequestMonitorId: nil,
+        focusedWorkspaceId: nil,
+        focusedMonitorId: nil,
+        interactionMonitorId: nil,
+        source: "ax_focused_admission_synthesized",
+        focusedWorkspaceSource: nil,
+        recentPidWorkspaceId: nil,
+        createdAt: Date()
+    )
+}
+
+@MainActor
+private func unrequestedAdmissionDecisionReason(
+    on controller: WMController,
+    for token: WindowToken
+) -> String? {
+    for event in controller.axEventHandler.niriCreateFocusTraceSnapshotForTests().reversed() {
+        if case let .unrequestedAdmissionDuringNonManagedFocusDecision(
+            decisionToken, _, reason, _, _, _, _
+        ) = event.kind, decisionToken == token {
+            return reason
+        }
+    }
+    return nil
+}
+
 @MainActor
 private func managedReplacementTraceEvents(
     on controller: WMController
@@ -1689,6 +1719,88 @@ private func waitUntilAXEventTest(
         #expect(controller.interactionWorkspace()?.id == workspaceTwo)
         #expect(controller.workspaceManager.confirmedManagedFocusToken == nil)
         #expect(controller.workspaceManager.isNonManagedFocusActive)
+    }
+
+    @Test @MainActor func recentAppActivationExemptsUnrequestedAdmissionDuringNonManagedFocus() {
+        let controller = makeAXEventTestController()
+        let appPid: pid_t = 8_662
+        let token = WindowToken(pid: appPid, windowId: 8_983)
+
+        // A genuine user app switch to this pid is recorded as intent.
+        controller.axEventHandler.handleAppActivation(
+            pid: appPid,
+            source: .workspaceDidActivateApplication
+        )
+        #expect(controller.workspaceManager.enterNonManagedFocus(appFullscreen: false))
+        #expect(controller.workspaceManager.isNonManagedFocusActive)
+
+        let suppressed = controller.axEventHandler.shouldSuppressUnrequestedAdmissionDuringNonManagedFocus(
+            token: token,
+            createPlacementContext: makeSynthesizedFocusedAdmissionContext()
+        )
+
+        #expect(suppressed == false)
+        #expect(unrequestedAdmissionDecisionReason(on: controller, for: token) == "recent_app_activation")
+    }
+
+    @Test @MainActor func staleAppActivationDoesNotExemptUnrequestedAdmission() {
+        let controller = makeAXEventTestController()
+        var clock: TimeInterval = 0
+        controller.axEventHandler.managedReplacementTimeSourceForTests = { clock }
+        let appPid: pid_t = 8_662
+        let token = WindowToken(pid: appPid, windowId: 8_983)
+
+        controller.axEventHandler.handleAppActivation(
+            pid: appPid,
+            source: .workspaceDidActivateApplication
+        )
+        #expect(controller.workspaceManager.enterNonManagedFocus(appFullscreen: false))
+
+        // Advance past the recent-app-activation TTL (10s).
+        clock = 11
+
+        let suppressed = controller.axEventHandler.shouldSuppressUnrequestedAdmissionDuringNonManagedFocus(
+            token: token,
+            createPlacementContext: makeSynthesizedFocusedAdmissionContext()
+        )
+
+        #expect(suppressed)
+        #expect(
+            unrequestedAdmissionDecisionReason(on: controller, for: token)
+                == "stale_unrequested_nonmanaged_focus"
+        )
+        let trace = controller.axEventHandler.niriCreateFocusTraceSnapshotForTests()
+        #expect(trace.contains { event in
+            if case let .windowDecisionSuppressed(suppressedToken, reason) = event.kind {
+                return suppressedToken == token && reason == "stale_unrequested_nonmanaged_focus"
+            }
+            return false
+        })
+    }
+
+    @Test @MainActor func focusedWindowChangedActivationDoesNotExemptUnrequestedAdmission() {
+        let controller = makeAXEventTestController()
+        let appPid: pid_t = 8_662
+        let token = WindowToken(pid: appPid, windowId: 8_983)
+
+        // Window-level focus churn is not an app-level switch and must not
+        // create an exemption.
+        controller.axEventHandler.handleAppActivation(
+            pid: appPid,
+            source: .focusedWindowChanged
+        )
+        #expect(controller.workspaceManager.enterNonManagedFocus(appFullscreen: false))
+
+        let suppressed = controller.axEventHandler.shouldSuppressUnrequestedAdmissionDuringNonManagedFocus(
+            token: token,
+            createPlacementContext: makeSynthesizedFocusedAdmissionContext()
+        )
+
+        #expect(suppressed)
+        #expect(
+            unrequestedAdmissionDecisionReason(on: controller, for: token)
+                == "stale_unrequested_nonmanaged_focus"
+        )
     }
 
     @Test @MainActor func untrackedSamePidDestroySuppressesUnrelatedInactiveWorkspaceActivation() async {


### PR DESCRIPTION


## Summary

While non-managed focus is active,
shouldSuppressUnrequestedAdmissionDuringNonManagedFocus vetoed the focused-admission of any window lacking a CGS-create context, a recent managed workspace, an explicit rule, or an active managed request. A deliberate app switch (Dock/Cmd-Tab/launcher) to an existing-but-untracked window failed all four exemptions and was dropped — and the drop was self-perpetuating, since the rejected window's own focus kept isNonManagedFocusActive true.

Record app-level activations (source == .workspaceDidActivateApplication) in a short-TTL (10s) recentAppActivationByPid map, mirroring the recentManagedWorkspaceByPid mechanics, and add a new guard exemption (reason "recent_app_activation") for recently activated pids. Window-level focus churn (.focusedWindowChanged) does not feed the map, so only genuine app switches are exempted.

Also emit a follow-up window_decision_suppressed trace record when a trackedTiling decision is vetoed, so tooling grepping decision records alone no longer concludes the window was tiled.
## Release notes

Choose one:

- [x] Added a `.changeset/*.md` for user-visible changes (`mise run changeset -- patch "..."`).
- [ ] No user-visible change; apply the `no release note` label to make CI skip intentional.

## Validation

<!-- Commands run, screenshots, or manual checks. -->

- [ ] Ran relevant tests/checks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Windows opened during non-managed focus now tile correctly when the user switches to them via Dock, app switcher, or launcher.
  * Recent app activations are honored briefly, so user-initiated windows aren’t left unmanaged.
  * Stale non-managed-focus scenarios follow the existing suppression rules, with clearer focus decision reporting for easier diagnosis.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->