### PR TITLE
Fix focus-follows-mouse regressions with a fixed Dock and app context menus (#112)

### DIFF
--- a/.changeset/20260705012430-fix-focus-follows-mouse-being-suppressed-by-a-fi.md
+++ b/.changeset/20260705012430-fix-focus-follows-mouse-being-suppressed-by-a-fi.md
@@ -1,0 +1,6 @@
+---
+"nehir": patch
+contributors: [charmbyte]
+---
+
+Fix focus-follows-mouse being suppressed by a fixed Dock (#112)

--- a/.changeset/20260705014523-stop-focus-follows-mouse-stealing-focus-at-conte.md
+++ b/.changeset/20260705014523-stop-focus-follows-mouse-stealing-focus-at-conte.md
@@ -1,0 +1,5 @@
+---
+"nehir": patch
+---
+
+Stop focus-follows-mouse from stealing focus while navigating app context menus

--- a/Sources/Nehir/Core/Controller/MouseEventHandler.swift
+++ b/Sources/Nehir/Core/Controller/MouseEventHandler.swift
@@ -15,6 +15,7 @@ private let macNormalizedTouchPositionToNiriGestureUnits: CGFloat = 500.0
 private let mouseWheelAxisEpsilon: CGFloat = 0.001
 private let niriWheelScrollTickAmount: CGFloat = 120.0
 private let queuedMouseMoveCurrentPointerTolerance: CGFloat = 2.0
+private let ffmOcclusionGrace: TimeInterval = 0.35
 private let mouseRelevantModifierFlags: CGEventFlags = [
     .maskAlternate,
     .maskShift,
@@ -1301,6 +1302,9 @@ final class MouseEventHandler {
             windowUnderPointer: windowUnderPointer
         )
         guard case let .target(target) = resolution else {
+            if case .occlusion = resolution {
+                state.suppressFocusFollowsMouseUntil = now.addingTimeInterval(ffmOcclusionGrace)
+            }
             traceMouseFocus(
                 "ffm.skip reason=noTarget sub=\(resolution.skipReason) loc=\(formatPoint(location)) windowUnderPointer=\(windowUnderPointer.map(String.init) ?? "nil") confirmed=\(formatToken(confirmedToken)) pending=\(formatToken(pendingToken))"
             )

--- a/Sources/Nehir/Core/Controller/WMController.swift
+++ b/Sources/Nehir/Core/Controller/WMController.swift
@@ -231,6 +231,12 @@ final class WMController {
         CGWindowListCopyWindowInfo(.optionOnScreenOnly, kCGNullWindowID) as? [[String: Any]] ?? []
     }
 
+    @ObservationIgnored
+    var unmanagedWindowServerWindowOwnerProvider: @MainActor (Int) -> (pid: pid_t, ownerName: String?)? = { windowId in
+        guard windowId > 0, let info = SkyLight.shared.queryWindowInfo(UInt32(windowId)) else { return nil }
+        return (pid_t(info.pid), nil)
+    }
+
     /// Reports whether the process owning an overlay window is a registered,
     /// bundled application. This is a structural, timing-independent signal
     /// (unlike an `AXUIElementCopyAttributeNames` query, which can transiently
@@ -2561,7 +2567,7 @@ final class WMController {
     /// whose WindowServer owner name matches a known decorative border utility
     /// (e.g. `borders` / JankyBorders) is excluded (#64). Unknown faceless
     /// owners remain occluding, preserving Ghostty Quick terminal suppression.
-    /// The number fast-path is unchanged.
+    /// System chrome such as the Dock is also excluded on both paths.
     func unmanagedInteractiveWindowServerWindowCovers(
         point: CGPoint,
         windowUnderPointer: Int? = nil,
@@ -2569,7 +2575,7 @@ final class WMController {
     ) -> Bool {
         let trackedWindowIds = Set(workspaceManager.trackedWindowIdsForDebug())
         if let windowUnderPointer, windowUnderPointer > 0 {
-            return isUnmanagedWindowServerWindow(
+            return isUnmanagedInteractiveWindowServerWindow(
                 windowId: windowUnderPointer,
                 trackedWindowIds: trackedWindowIds
             )
@@ -2622,8 +2628,8 @@ final class WMController {
                   let y = (bounds["Y"] as? NSNumber)?.doubleValue,
                   let width = (bounds["Width"] as? NSNumber)?.doubleValue,
                   let height = (bounds["Height"] as? NSNumber)?.doubleValue,
-                  width >= 80,
-                  height >= 80
+                  width > 0,
+                  height > 0
             else { continue }
 
             let frame = ScreenCoordinateSpace.toAppKit(
@@ -2635,16 +2641,22 @@ final class WMController {
             guard windowId > 0 else { continue }
             if isOwnedWindowNumber(windowId) { continue }
             if trackedWindowIds.contains(windowId) { continue }
+            if width < 80 || height < 80,
+               !isTransientWindowServerSurface(windowId: windowId)
+            {
+                continue
+            }
 
             let pid = (info[kCGWindowOwnerPID as String] as? NSNumber)?.int32Value ?? 0
             let ownerName = info[kCGWindowOwnerName as String] as? String
             // Only a known decorative border utility gets the faceless-process
             // exemption. Ghostty's Quick terminal can also appear faceless on
             // the snapshot path, but it is interactive and must still occlude.
-            if pid > 0,
-               !ownerAppIsInteractiveApplication(pid),
-               isDecorativeBorderOverlayOwner(ownerName)
-            {
+            if isExemptUnmanagedInteractiveOwner(
+                ownerName: ownerName,
+                pid: pid,
+                ownerAppIsInteractiveApplication: ownerAppIsInteractiveApplication
+            ) {
                 continue
             }
 
@@ -2660,9 +2672,45 @@ final class WMController {
         return normalized == "borders" || normalized == "jankyborders" || normalized == "janky borders"
     }
 
+    private static func isExemptUnmanagedInteractiveOwner(
+        ownerName: String?,
+        pid: pid_t,
+        ownerAppIsInteractiveApplication: @MainActor (pid_t) -> Bool
+    ) -> Bool {
+        isSystemChromeOwner(ownerName: ownerName, pid: pid)
+            || (pid > 0 && !ownerAppIsInteractiveApplication(pid) && isDecorativeBorderOverlayOwner(ownerName))
+    }
+
+    private static func isSystemChromeOwner(ownerName: String?, pid: pid_t) -> Bool {
+        if pid > 0,
+           NSRunningApplication(processIdentifier: pid)?.bundleIdentifier == "com.apple.dock"
+        {
+            return true
+        }
+
+        return ownerName?.trimmingCharacters(in: .whitespacesAndNewlines) == "Dock"
+    }
+
+    private static func isTransientWindowServerSurface(windowId: Int) -> Bool {
+        guard let windowInfo = SkyLight.shared.queryWindowInfo(UInt32(windowId)) else { return false }
+        return windowInfo.hasTransientSurfaceEvidence
+    }
+
     private func isUnmanagedWindowServerWindow(windowId: Int, trackedWindowIds: Set<Int>) -> Bool {
         guard !trackedWindowIds.contains(windowId) else { return false }
         guard !ownedWindowRegistry.contains(windowNumber: windowId) else { return false }
+        return true
+    }
+
+    private func isUnmanagedInteractiveWindowServerWindow(windowId: Int, trackedWindowIds: Set<Int>) -> Bool {
+        guard isUnmanagedWindowServerWindow(windowId: windowId, trackedWindowIds: trackedWindowIds) else {
+            return false
+        }
+        if let owner = unmanagedWindowServerWindowOwnerProvider(windowId),
+           Self.isSystemChromeOwner(ownerName: owner.ownerName, pid: owner.pid)
+        {
+            return false
+        }
         return true
     }
 

--- a/Sources/Nehir/Core/Rules/WindowRuleEngine.swift
+++ b/Sources/Nehir/Core/Rules/WindowRuleEngine.swift
@@ -118,16 +118,20 @@ struct WindowRuleFacts: Equatable, Sendable {
     let sizeConstraints: WindowSizeConstraints?
     let windowServer: WindowServerInfo?
 
+    private var axLessNonPipTransientWindowServer: WindowServerInfo? {
+        guard !ax.attributeFetchSucceeded, let windowServer else { return nil }
+        if windowServer.parentId == 0, isTopLevelResizableMediaLikeSurface(windowServer) { return nil }
+        return windowServer
+    }
+
     var degradedWindowServerChildEvidence: Bool {
-        guard !ax.attributeFetchSucceeded,
-              let windowServer
-        else {
-            return false
-        }
-        if windowServer.parentId == 0, isTopLevelResizableMediaLikeSurface(windowServer) {
-            return false
-        }
-        return windowServer.hasModalTag || (windowServer.hasFloatingTag && !windowServer.hasDocumentTag)
+        guard let ws = axLessNonPipTransientWindowServer else { return false }
+        return ws.hasModalTag || (ws.hasFloatingTag && !ws.hasDocumentTag)
+    }
+
+    var axFetchFailedTransientSurfaceEvidence: Bool {
+        guard let ws = axLessNonPipTransientWindowServer else { return false }
+        return ws.hasTransientSurfaceEvidence
     }
 
     var userAddressableTransientWindowServerSurface: Bool {
@@ -320,6 +324,7 @@ final class WindowRuleEngine {
     static let systemTextInputPanelRuleName = "systemTextInputPanel"
     private static let transientWindowServerSurfaceRuleName = "transientWindowServerSurface"
     private static let parentedWindowServerSurfaceRuleName = "parentedWindowServerSurface"
+    private static let degradedWindowServerChildSurfaceRuleName = "degradedWindowServerChildSurface"
     private static let transientSystemDialogSurfaceRuleName = "transientSystemDialogSurface"
     private static let cleanShotRecordingOverlayRuleName = "cleanShotRecordingOverlay"
     private static let ghosttyQuickTerminalRuleName = "ghosttyQuickTerminalOverlay"
@@ -576,6 +581,18 @@ final class WindowRuleEngine {
         }
 
         if !facts.ax.attributeFetchSucceeded {
+            if facts.degradedWindowServerChildEvidence || facts.axFetchFailedTransientSurfaceEvidence {
+                return WindowDecision(
+                    disposition: .unmanaged,
+                    source: .builtInRule(Self.degradedWindowServerChildSurfaceRuleName),
+                    layoutDecisionKind: .explicitLayout,
+                    workspaceName: nil,
+                    ruleEffects: .none,
+                    heuristicReasons: [],
+                    deferredReason: nil
+                )
+            }
+
             if let userRule, userRule.rule.effectiveLayoutAction == .float {
                 return fallbackDecisionForMatchedUserRule(
                     userRule,

--- a/Tests/NehirTests/MouseEventHandlerTests.swift
+++ b/Tests/NehirTests/MouseEventHandlerTests.swift
@@ -2552,11 +2552,13 @@ private func prepareMouseWheelScrollFixtureWithDefaultSensitivity() async -> (
         }
         controller.ownerAppIsInteractiveApplicationProvider = { _ in true }
 
+        let beforeMove = Date()
         controller.mouseEventHandler.dispatchMouseMoved(at: unmanagedFrame.center)
         await controller.layoutRefreshController.waitForRefreshWorkForTests()
 
         #expect(controller.workspaceManager.confirmedManagedFocusToken == firstToken)
         #expect(controller.workspaceManager.activeFocusRequestToken == nil)
+        #expect(controller.mouseEventHandler.state.suppressFocusFollowsMouseUntil > beforeMove)
     }
 
     @Test @MainActor func mouseDraggedDoesNotPollWindowServerSnapshotWhenEventWindowIsUnavailable() {
@@ -3482,6 +3484,68 @@ private func prepareMouseWheelScrollFixtureWithDefaultSensitivity() async -> (
         #expect(resolvedWindow == 8822)
         #expect(controller.workspaceManager.pendingFocusedHandle == secondHandle)
         #expect(snapshotCalls == 0)
+    }
+
+    @Test @MainActor func unmanagedInteractiveOcclusionExemptsDockAndDecorativeBordersOnly() {
+        let point = CGPoint(x: 100, y: 100)
+        let frame = CGRect(x: 50, y: 50, width: 160, height: 120)
+
+        let dockCovers = WMController.visibleUnmanagedInteractiveWindowServerWindowCovers(
+            point: point,
+            windows: [makeUnmanagedOverlayWindowInfo(
+                windowId: 77_001,
+                pid: 77_101,
+                appKitFrame: frame,
+                layer: 20,
+                ownerName: "Dock"
+            )],
+            ownerAppIsInteractiveApplication: { _ in true }
+        )
+        let decorativeBorderCovers = WMController.visibleUnmanagedInteractiveWindowServerWindowCovers(
+            point: point,
+            windows: [makeUnmanagedOverlayWindowInfo(
+                windowId: 77_002,
+                pid: 77_102,
+                appKitFrame: frame,
+                ownerName: "borders"
+            )],
+            ownerAppIsInteractiveApplication: { _ in false }
+        )
+        let ghosttyCovers = WMController.visibleUnmanagedInteractiveWindowServerWindowCovers(
+            point: point,
+            windows: [makeUnmanagedOverlayWindowInfo(
+                windowId: 77_003,
+                pid: 77_103,
+                appKitFrame: frame,
+                layer: 25,
+                ownerName: "Ghostty"
+            )],
+            ownerAppIsInteractiveApplication: { _ in false }
+        )
+
+        #expect(dockCovers == false)
+        #expect(decorativeBorderCovers == false)
+        #expect(ghosttyCovers)
+    }
+
+    @Test @MainActor func unmanagedInteractiveFastPathExemptsDockOnly() {
+        let controller = makeMouseEventTestController()
+        let dockWindowId = 78_001
+        let ghosttyWindowId = 78_002
+        controller.unmanagedWindowServerWindowOwnerProvider = { windowId in
+            windowId == dockWindowId
+                ? (pid: 0, ownerName: "Dock")
+                : (pid: 4321, ownerName: "Ghostty")
+        }
+
+        #expect(controller.unmanagedInteractiveWindowServerWindowCovers(
+            point: CGPoint(x: 100, y: 100),
+            windowUnderPointer: dockWindowId
+        ) == false)
+        #expect(controller.unmanagedInteractiveWindowServerWindowCovers(
+            point: CGPoint(x: 100, y: 100),
+            windowUnderPointer: ghosttyWindowId
+        ))
     }
 
     // MARK: - #64: snapshot-fallback path (windowUnderPointer == nil)

--- a/Tests/NehirTests/WindowRuleEngineTests.swift
+++ b/Tests/NehirTests/WindowRuleEngineTests.swift
@@ -240,9 +240,37 @@ private func makeWindowRuleFacts(
         #expect(decision.heuristicReasons == [])
     }
 
-    @Test func degradedAxFloatingTaggedWindowServerTransientRemainsUndecided() {
+    @Test func degradedAxFloatingTaggedWindowServerTransientIsUnmanaged() {
         let engine = WindowRuleEngine()
         var windowServer = WindowServerInfo(id: 3202, pid: 3202, level: 0, frame: .zero)
+        windowServer.tags = 0x2
+
+        let decision = engine.decision(
+            for: makeWindowRuleFacts(
+                role: kAXWindowRole as String,
+                subrole: "AXUnknown",
+                attributeFetchSucceeded: false,
+                windowServer: windowServer
+            ),
+            token: nil,
+            appFullscreen: false
+        )
+
+        #expect(decision.disposition == .unmanaged)
+        #expect(decision.source == .builtInRule("degradedWindowServerChildSurface"))
+        #expect(decision.deferredReason == nil)
+        #expect(decision.trackedMode == nil)
+        #expect(decision.heuristicReasons == [])
+    }
+
+    @Test func axFetchFailedPipLikeTransientSurfaceRemainsDeferred() {
+        let engine = WindowRuleEngine()
+        var windowServer = WindowServerInfo(
+            id: 3206,
+            pid: 3206,
+            level: 3,
+            frame: CGRect(x: 20, y: 20, width: 320, height: 180)
+        )
         windowServer.tags = 0x2
 
         let decision = engine.decision(


### PR DESCRIPTION

## Summary

Two focus-follows-mouse (FFM) fixes plus regression tests:

- Fixed Dock (#112): a fixed Dock is a persistent on-screen window that FFM's occlusion check treated as an interactive occluder, so FFM stopped working on the Dock's monitor (an exemption narrowed in #64 had dropped the Dock). Re-exempt the Dock / system chrome on both the snapshot and fast occlusion paths; Ghostty Quick terminal and JankyBorders behavior preserved.

- Context menus: FFM stole focus to the tile beneath an app context menu when the pointer crossed the menu edge, dismissing the menu. Arm a short FFM suppression grace period on occlusion, and classify AX-less transient menu popups as unmanaged so they occlude reliably. The classifier keys on dimension-free WindowServer transient-surface evidence and is PiP-safe (PiP requires AX and is excluded by the existing media-surface carve-out); small transient surfaces are treated as occluders too.

Adds regression tests across WMController occlusion, MouseEventHandler grace, and WindowRuleEngine classification. Full test suite green.

## Release notes

Choose one:

- [x] Added a `.changeset/*.md` for user-visible changes (`mise run changeset -- patch "..."`).
- [ ] No user-visible change; apply the `no release note` label to make CI skip intentional.

## Validation

<!-- Commands run, screenshots, or manual checks. -->

- [ ] Ran relevant tests/checks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Restored more reliable focus-follows-mouse behavior after occlusions, preventing unwanted suppression and focus stealing during app context menu navigation.
  * Refined occlusion handling for interactive unmanaged overlays, with improved exemptions for Dock and decorative border overlays while keeping other overlays responsive.
  * Improved decisions under degraded accessibility conditions, reducing unexpected unmanaged/floating behavior by more accurately recognizing transient window-server evidence.
* **Tests**
  * Expanded and updated mouse and window-rule regression coverage for the occlusion and degraded AX scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->