### PR TITLE
Reveal a same-app focus switch that lands on a window on an inactive workspace

### DIFF
--- a/.changeset/20260706022503-internal-emit-a-focus-reality-trace-record-next-.md
+++ b/.changeset/20260706022503-internal-emit-a-focus-reality-trace-record-next-.md
@@ -1,0 +1,6 @@
+---
+"nehir": none
+
+---
+
+Internal: emit a focus_reality trace record next to every focus_confirmed carrying the macOS-observed truth (observed_focused, observed_visible, on_screen, ws_visible, app_frontmost, app_focused_window). Runtime focus traces previously logged only Nehir's intended focus model, which could read as success while the window server never made the window key or its workspace visible; the new record makes that model/reality divergence visible in the trace. No behavior change.

--- a/.changeset/20260706123539-switching-focus-within-an-app-to-another-of-its-.md
+++ b/.changeset/20260706123539-switching-focus-within-an-app-to-another-of-its-.md
@@ -1,0 +1,6 @@
+---
+"nehir": patch
+
+---
+
+Switching focus within an app to another of its windows on a different Nehir workspace now switches to that workspace instead of leaving the window parked off-screen.

--- a/Sources/Nehir/Core/Controller/AXEventHandler.swift
+++ b/Sources/Nehir/Core/Controller/AXEventHandler.swift
@@ -72,6 +72,7 @@ struct NiriCreateFocusTraceEvent: Equatable {
         case relayoutActivatedWindow(token: WindowToken, workspaceId: WorkspaceDescriptor.ID)
         case pendingFocusStarted(requestId: UInt64, token: WindowToken, workspaceId: WorkspaceDescriptor.ID)
         case activationSourceObserved(pid: pid_t, source: ActivationEventSource)
+        case followFocusToParkedWindow(token: WindowToken, workspaceId: WorkspaceDescriptor.ID, decision: String)
         /// The macOS-observed reality for a focus Nehir just confirmed. Emitted
         /// alongside `focus_confirmed` so a reader can tell Nehir's *intent*
         /// (`focus_confirmed`/`focused=`) from what the window server actually
@@ -104,9 +105,8 @@ struct NiriCreateFocusTraceEvent: Equatable {
             source: ActivationEventSource
         )
         /// A window-rule reevaluation moved an already-placed window to a
-        /// different workspace (the harmful churn the profile-switch "storm"
-        /// was suspected of). Measured at zero on current builds, kept as a
-        /// regression tripwire.
+        /// different workspace (a suspected source of workspace-assignment churn).
+        /// Measured at zero on current builds, kept as a regression tripwire.
         case reevalWorkspaceChanged(
             token: WindowToken,
             from: WorkspaceDescriptor.ID,
@@ -255,6 +255,8 @@ extension NiriCreateFocusTraceEvent: CustomStringConvertible {
             "pending_focus_started request=\(requestId) token=\(token) workspace=\(workspaceId.uuidString)"
         case let .activationSourceObserved(pid, source):
             "activation_source_observed pid=\(pid) source=\(source.rawValue)"
+        case let .followFocusToParkedWindow(token, workspaceId, decision):
+            "follow_focus_to_parked_window token=\(token) workspace=\(workspaceId.uuidString) decision=\(decision)"
         case let .focusReality(
             token,
             observedFocused,
@@ -268,12 +270,12 @@ extension NiriCreateFocusTraceEvent: CustomStringConvertible {
                 + "observed_visible=\(observedVisible) on_screen=\(onScreen) ws_visible=\(wsVisible) "
                 + "app_frontmost=\(appFrontmost) app_focused_window=\(appFocusedWindowId.map(String.init) ?? "nil")"
         case let .revealDecision(token, targetWs, isWorkspaceActive, shouldActivate, targetWsVisible, source):
-            "reveal_decision token=\(token) target_ws=\(targetWs.uuidString.prefix(8)) "
+            "reveal_decision token=\(token) target_ws=\(targetWs.uuidString) "
                 + "is_ws_active=\(isWorkspaceActive) should_activate=\(shouldActivate) "
                 + "target_ws_visible=\(targetWsVisible) source=\(source.rawValue)"
         case let .reevalWorkspaceChanged(token, from, to, context):
-            "reeval_workspace_changed token=\(token) from=\(from.uuidString.prefix(8)) "
-                + "to=\(to.uuidString.prefix(8)) context=\(context)"
+            "reeval_workspace_changed token=\(token) from=\(from.uuidString) "
+                + "to=\(to.uuidString) context=\(context)"
         case let .activationDeferred(requestId, token, source, reason, attempt):
             "activation_deferred request=\(requestId) token=\(token) source=\(source.rawValue) reason=\(reason.rawValue) attempt=\(attempt)"
         case let .focusConfirmed(token, workspaceId, source):
@@ -538,6 +540,18 @@ final class AXEventHandler: CGSEventDelegate {
 
     private var recentManagedWorkspaceByPid: [pid_t: RecentManagedWorkspace] = [:]
     private var recentAppActivationByPid: [pid_t: TimeInterval] = [:]
+    // A same-app window that recently closed is the only case the
+    // inactive-workspace activation guard is meant for (macOS re-focuses a
+    // successor window of the same app after a close). Tracked per pid.
+    private static let recentSameAppWindowCloseTTL: TimeInterval = 2
+    private var recentSameAppWindowCloseByPid: [pid_t: TimeInterval] = [:]
+    private static let parkedFocusFollowDedupTTL: TimeInterval = 1.5
+    private var recentParkedFocusFollowByToken: [WindowToken: TimeInterval] = [:]
+    // After follow_focus switches an app to a parked window's workspace, hold
+    // that workspace briefly so a same-app confirm of another window does not
+    // bounce the view back.
+    private static let parkedFollowHoldTTL: TimeInterval = 1.2
+    private var parkedFollowHoldByPid: [pid_t: (workspaceId: WorkspaceDescriptor.ID, at: TimeInterval)] = [:]
     private var recentManagedAdmissionByToken: [WindowToken: RecentManagedAdmission] = [:]
     private var pendingManagedReplacementBursts: [ManagedReplacementKey: PendingManagedReplacementBurst] = [:]
     private var pendingManagedReplacementTasks: [ManagedReplacementKey: Task<Void, Never>] = [:]
@@ -587,6 +601,9 @@ final class AXEventHandler: CGSEventDelegate {
         resetCreatePlacementContextState()
         recentManagedWorkspaceByPid.removeAll()
         recentAppActivationByPid.removeAll()
+        recentSameAppWindowCloseByPid.removeAll()
+        recentParkedFocusFollowByToken.removeAll()
+        parkedFollowHoldByPid.removeAll()
         recentManagedAdmissionByToken.removeAll()
         resetManagedReplacementState()
         endWindowCloseFocusRecovery()
@@ -731,6 +748,9 @@ final class AXEventHandler: CGSEventDelegate {
         resetCreatePlacementContextState()
         recentManagedWorkspaceByPid.removeAll()
         recentAppActivationByPid.removeAll()
+        recentSameAppWindowCloseByPid.removeAll()
+        recentParkedFocusFollowByToken.removeAll()
+        parkedFollowHoldByPid.removeAll()
         recentManagedAdmissionByToken.removeAll()
         resetActivationRetryState()
         controller?.focusBridge.reset()
@@ -1534,6 +1554,7 @@ final class AXEventHandler: CGSEventDelegate {
 
     func handleRemoved(token: WindowToken) {
         guard let controller else { return }
+        recordRecentSameAppWindowClose(pid: token.pid)
         let entry = controller.workspaceManager.entry(for: token)
         let affectedWorkspaceId = entry?.workspaceId
 
@@ -1909,6 +1930,16 @@ final class AXEventHandler: CGSEventDelegate {
     ) -> Bool {
         guard case .unrelatedNoRequest = requestDisposition else { return false }
         guard let controller else { return false }
+
+        // This guard exists only to absorb the successor-focus churn macOS emits
+        // when one of the app's own windows *closes* (it re-focuses another of
+        // the app's windows, possibly on an inactive workspace). It must not fire
+        // for an ordinary same-app focus switch with no close — that is a
+        // legitimate move to another of the app's windows and should reveal its
+        // workspace. Gate on a recent same-app window close.
+        guard hasRecentSameAppWindowClose(for: observedEntry.pid) else {
+            return false
+        }
 
         if let currentTarget = controller.currentBorderTarget(),
            currentTarget.token != observedEntry.token,
@@ -2465,7 +2496,14 @@ final class AXEventHandler: CGSEventDelegate {
         _ = restoreManagedWindowFromNativeFullscreen(entry)
         let wsId = entry.workspaceId
         let monitorId = controller.workspaceManager.monitorId(for: wsId)
-        let shouldActivateWorkspace = !isWorkspaceActive && !controller.isTransferringWindow
+        // If follow_focus just switched this app to a parked window's workspace,
+        // hold there briefly: an immediate confirm of another of the app's
+        // windows (the still-on-screen origin) must not bounce the view back to
+        // a different workspace. Suppress the workspace activation while the hold
+        // is on a different workspace than this window's.
+        let heldWorkspace = activeParkedFollowHoldWorkspace(forPid: entry.pid)
+        let bounceBlocked = heldWorkspace != nil && heldWorkspace != wsId
+        let shouldActivateWorkspace = !isWorkspaceActive && !controller.isTransferringWindow && !bounceBlocked
         recordNiriCreateFocusTrace(
             .init(
                 kind: .revealDecision(
@@ -2525,7 +2563,9 @@ final class AXEventHandler: CGSEventDelegate {
                     )
                 )
             )
-            recordFocusRealityCheck(entry: entry)
+            let onScreen = isEntryOnScreen(entry)
+            recordFocusRealityCheck(entry: entry, onScreen: onScreen)
+            followFocusToParkedWindowWorkspaceIfNeeded(entry: entry, onScreen: onScreen)
         } else {
             _ = controller.workspaceManager.setManagedFocus(
                 entry.token,
@@ -3623,6 +3663,9 @@ final class AXEventHandler: CGSEventDelegate {
         let resolvedToken = resolveWindowToken(windowId)
             ?? resolveTrackedToken(windowId)
             ?? pidHint.map { WindowToken(pid: $0, windowId: Int(windowId)) }
+        if let closedPid = pidHint ?? resolvedToken?.pid {
+            recordRecentSameAppWindowClose(pid: closedPid)
+        }
         if let resolvedToken {
             cancelWindowStabilizationRetry(for: resolvedToken)
             cancelPostCreateLifecycleVerification(for: resolvedToken)
@@ -4042,19 +4085,99 @@ final class AXEventHandler: CGSEventDelegate {
     /// trace records intent *and* what the window server actually did. Without
     /// this, `focus_confirmed`/`focused=` alone can read as success while the
     /// window is not key (`observed_focused=false`) or its workspace is not the
-    /// visible one — the profile-switch failure mode where the trace looked
-    /// like it worked but nothing was on screen.
-    private func recordFocusRealityCheck(entry: WindowModel.Entry) {
+    /// visible one — a model/reality divergence where the trace looked like it
+    /// worked but nothing was on screen.
+    /// Whether the window's live frame physically overlaps the visible area of
+    /// the monitors by at least half of its area — i.e. it is actually on
+    /// screen, not parked off the edge on an inactive workspace. Overlap is
+    /// summed across monitors so a window straddling two displays is not
+    /// misjudged as off-screen. Frame is resolved through the same injectable
+    /// path as the rest of the handler (`observedFrame`) so it stays testable.
+    private func isEntryOnScreen(_ entry: WindowModel.Entry) -> Bool {
+        guard let controller, let frame = observedFrame(for: entry) else {
+            return false
+        }
+        let frameArea = frame.width * frame.height
+        guard frameArea > 0 else { return false }
+        let visibleArea = controller.workspaceManager.monitors.reduce(CGFloat.zero) { total, monitor in
+            let overlap = monitor.visibleFrame.intersection(frame)
+            return overlap.isNull ? total : total + overlap.width * overlap.height
+        }
+        return visibleArea >= frameArea * 0.5
+    }
+
+    /// After a same-app focus switch, Nehir can end up with focus on one of the
+    /// app's windows that is parked off-screen (its workspace not actually
+    /// rendered), so nothing appears and the user has to reveal it by hand. If
+    /// the just-confirmed focus is on a managed, non-sticky window that is
+    /// physically off screen, follow it — switch to / re-reveal its workspace.
+    /// Keyed on the trustworthy on-screen signal (liveAXFrame), not the model's
+    /// visibility flag, because the bug is precisely that the model believes the
+    /// workspace is visible while the window is parked.
+    ///
+    /// Deduplicated per token for a short grace so the re-confirmation that
+    /// `activateWorkspace` triggers does not loop before the window unparks.
+    /// Restricted to tiling windows: `activateWorkspace` reveals a tiled column;
+    /// a floating window has no niri node for it to select, so it would no-op
+    /// and emit a misleading `switch` decision.
+    private func followFocusToParkedWindowWorkspaceIfNeeded(entry: WindowModel.Entry, onScreen: Bool) {
         guard let controller else { return }
-        let liveFrame = try? AXWindowService.frame(entry.axRef)
-        let onScreen = liveFrame.map { frame in
-            controller.workspaceManager.monitors.contains { monitor in
-                let overlap = monitor.visibleFrame.intersection(frame)
-                let frameArea = frame.width * frame.height
-                return !overlap.isNull && frameArea > 0
-                    && (overlap.width * overlap.height) >= frameArea * 0.5
-            }
-        } ?? false
+        let manager = controller.workspaceManager
+        let now = managedReplacementCurrentUptime()
+        recentParkedFocusFollowByToken = recentParkedFocusFollowByToken.filter {
+            now - $0.value <= Self.parkedFocusFollowDedupTTL
+        }
+        guard entry.mode == .tiling,
+              !onScreen,
+              !manager.hasStickyWindowSource(entry.token),
+              manager.monitorId(for: entry.workspaceId) != nil,
+              recentParkedFocusFollowByToken[entry.token] == nil
+        else {
+            return
+        }
+        recentParkedFocusFollowByToken[entry.token] = now
+        parkedFollowHoldByPid[entry.pid] = (workspaceId: entry.workspaceId, at: now)
+        recordNiriCreateFocusTrace(
+            .init(
+                kind: .followFocusToParkedWindow(
+                    token: entry.token,
+                    workspaceId: entry.workspaceId,
+                    decision: "switch"
+                )
+            )
+        )
+        controller.workspaceNavigationHandler.activateWorkspace(
+            entry.workspaceId,
+            focusing: entry.token
+        )
+    }
+
+    private func recordRecentSameAppWindowClose(pid: pid_t) {
+        recentSameAppWindowCloseByPid[pid] = managedReplacementCurrentUptime()
+    }
+
+    private func hasRecentSameAppWindowClose(for pid: pid_t) -> Bool {
+        guard let at = recentSameAppWindowCloseByPid[pid] else { return false }
+        guard managedReplacementCurrentUptime() - at <= Self.recentSameAppWindowCloseTTL else {
+            recentSameAppWindowCloseByPid.removeValue(forKey: pid)
+            return false
+        }
+        return true
+    }
+
+    /// The workspace a recent follow_focus pinned for `pid`, if the hold has not
+    /// expired.
+    private func activeParkedFollowHoldWorkspace(forPid pid: pid_t) -> WorkspaceDescriptor.ID? {
+        guard let hold = parkedFollowHoldByPid[pid] else { return nil }
+        guard managedReplacementCurrentUptime() - hold.at <= Self.parkedFollowHoldTTL else {
+            parkedFollowHoldByPid.removeValue(forKey: pid)
+            return nil
+        }
+        return hold.workspaceId
+    }
+
+    private func recordFocusRealityCheck(entry: WindowModel.Entry, onScreen: Bool) {
+        guard let controller else { return }
         let wsVisible = controller.workspaceManager.visibleWorkspaceIds().contains(entry.workspaceId)
         // App-level ground truth: is the app even frontmost, and which window
         // does the app itself report as focused. An `observed_focused=false`

--- a/Sources/Nehir/Core/Controller/AXEventHandler.swift
+++ b/Sources/Nehir/Core/Controller/AXEventHandler.swift
@@ -72,6 +72,47 @@ struct NiriCreateFocusTraceEvent: Equatable {
         case relayoutActivatedWindow(token: WindowToken, workspaceId: WorkspaceDescriptor.ID)
         case pendingFocusStarted(requestId: UInt64, token: WindowToken, workspaceId: WorkspaceDescriptor.ID)
         case activationSourceObserved(pid: pid_t, source: ActivationEventSource)
+        /// The macOS-observed reality for a focus Nehir just confirmed. Emitted
+        /// alongside `focus_confirmed` so a reader can tell Nehir's *intent*
+        /// (`focus_confirmed`/`focused=`) from what the window server actually
+        /// did: whether macOS made the window key (`observed_focused`), whether
+        /// it is physically on screen (`on_screen`), and whether its workspace
+        /// is the visible one (`ws_visible`). A confirmed focus with
+        /// `observed_focused=false` or `ws_visible=false` is a model/reality
+        /// divergence, not a success.
+        case focusReality(
+            token: WindowToken,
+            observedFocused: Bool,
+            observedVisible: Bool,
+            onScreen: Bool,
+            wsVisible: Bool,
+            appFrontmost: Bool,
+            appFocusedWindowId: Int?
+        )
+        /// The reveal decision at focus-confirm time: does Nehir actually issue a
+        /// workspace switch for the confirmed window, or skip it. This is the
+        /// model→screen boundary. `should_activate=false` while `visible=false`
+        /// means Nehir believes the target workspace is already active and never
+        /// commands the display to switch — the model diverges from the screen
+        /// and nothing appears.
+        case revealDecision(
+            token: WindowToken,
+            targetWs: WorkspaceDescriptor.ID,
+            isWorkspaceActive: Bool,
+            shouldActivate: Bool,
+            targetWsVisible: Bool,
+            source: ActivationEventSource
+        )
+        /// A window-rule reevaluation moved an already-placed window to a
+        /// different workspace (the harmful churn the profile-switch "storm"
+        /// was suspected of). Measured at zero on current builds, kept as a
+        /// regression tripwire.
+        case reevalWorkspaceChanged(
+            token: WindowToken,
+            from: WorkspaceDescriptor.ID,
+            to: WorkspaceDescriptor.ID,
+            context: String
+        )
         case activationDeferred(
             requestId: UInt64,
             token: WindowToken,
@@ -214,6 +255,25 @@ extension NiriCreateFocusTraceEvent: CustomStringConvertible {
             "pending_focus_started request=\(requestId) token=\(token) workspace=\(workspaceId.uuidString)"
         case let .activationSourceObserved(pid, source):
             "activation_source_observed pid=\(pid) source=\(source.rawValue)"
+        case let .focusReality(
+            token,
+            observedFocused,
+            observedVisible,
+            onScreen,
+            wsVisible,
+            appFrontmost,
+            appFocusedWindowId
+        ):
+            "focus_reality token=\(token) observed_focused=\(observedFocused) "
+                + "observed_visible=\(observedVisible) on_screen=\(onScreen) ws_visible=\(wsVisible) "
+                + "app_frontmost=\(appFrontmost) app_focused_window=\(appFocusedWindowId.map(String.init) ?? "nil")"
+        case let .revealDecision(token, targetWs, isWorkspaceActive, shouldActivate, targetWsVisible, source):
+            "reveal_decision token=\(token) target_ws=\(targetWs.uuidString.prefix(8)) "
+                + "is_ws_active=\(isWorkspaceActive) should_activate=\(shouldActivate) "
+                + "target_ws_visible=\(targetWsVisible) source=\(source.rawValue)"
+        case let .reevalWorkspaceChanged(token, from, to, context):
+            "reeval_workspace_changed token=\(token) from=\(from.uuidString.prefix(8)) "
+                + "to=\(to.uuidString.prefix(8)) context=\(context)"
         case let .activationDeferred(requestId, token, source, reason, attempt):
             "activation_deferred request=\(requestId) token=\(token) source=\(source.rawValue) reason=\(reason.rawValue) attempt=\(attempt)"
         case let .focusConfirmed(token, workspaceId, source):
@@ -2406,6 +2466,18 @@ final class AXEventHandler: CGSEventDelegate {
         let wsId = entry.workspaceId
         let monitorId = controller.workspaceManager.monitorId(for: wsId)
         let shouldActivateWorkspace = !isWorkspaceActive && !controller.isTransferringWindow
+        recordNiriCreateFocusTrace(
+            .init(
+                kind: .revealDecision(
+                    token: entry.token,
+                    targetWs: wsId,
+                    isWorkspaceActive: isWorkspaceActive,
+                    shouldActivate: shouldActivateWorkspace,
+                    targetWsVisible: controller.workspaceManager.visibleWorkspaceIds().contains(wsId),
+                    source: source
+                )
+            )
+        )
         let activeRequest = controller.focusBridge.activeManagedRequest(for: entry.pid)
         let shouldConfirmRequest = confirmRequest ?? true
         // Detect re-confirmation of an already-confirmed focus token. A
@@ -2453,6 +2525,7 @@ final class AXEventHandler: CGSEventDelegate {
                     )
                 )
             )
+            recordFocusRealityCheck(entry: entry)
         } else {
             _ = controller.workspaceManager.setManagedFocus(
                 entry.token,
@@ -3962,6 +4035,46 @@ final class AXEventHandler: CGSEventDelegate {
         recentManagedWorkspaceByPid[pid] = RecentManagedWorkspace(
             workspaceId: workspaceId,
             recordedAt: managedReplacementCurrentUptime()
+        )
+    }
+
+    /// Emit the macOS-observed reality for a focus Nehir just confirmed, so the
+    /// trace records intent *and* what the window server actually did. Without
+    /// this, `focus_confirmed`/`focused=` alone can read as success while the
+    /// window is not key (`observed_focused=false`) or its workspace is not the
+    /// visible one — the profile-switch failure mode where the trace looked
+    /// like it worked but nothing was on screen.
+    private func recordFocusRealityCheck(entry: WindowModel.Entry) {
+        guard let controller else { return }
+        let liveFrame = try? AXWindowService.frame(entry.axRef)
+        let onScreen = liveFrame.map { frame in
+            controller.workspaceManager.monitors.contains { monitor in
+                let overlap = monitor.visibleFrame.intersection(frame)
+                let frameArea = frame.width * frame.height
+                return !overlap.isNull && frameArea > 0
+                    && (overlap.width * overlap.height) >= frameArea * 0.5
+            }
+        } ?? false
+        let wsVisible = controller.workspaceManager.visibleWorkspaceIds().contains(entry.workspaceId)
+        // App-level ground truth: is the app even frontmost, and which window
+        // does the app itself report as focused. An `observed_focused=false`
+        // with `app_frontmost=false` means macOS never activated the app; an
+        // `app_focused_window` that differs from the token means Nehir confirmed
+        // a different window than the one the app actually made key.
+        let appFrontmost = NSWorkspace.shared.frontmostApplication?.processIdentifier == entry.pid
+        let appFocusedWindowId = resolveFocusedAXWindowRef(pid: entry.pid)?.windowId
+        recordNiriCreateFocusTrace(
+            .init(
+                kind: .focusReality(
+                    token: entry.token,
+                    observedFocused: entry.observedState.isFocused,
+                    observedVisible: entry.observedState.isVisible,
+                    onScreen: onScreen,
+                    wsVisible: wsVisible,
+                    appFrontmost: appFrontmost,
+                    appFocusedWindowId: appFocusedWindowId
+                )
+            )
         )
     }
 

--- a/Sources/Nehir/Core/Controller/WMController.swift
+++ b/Sources/Nehir/Core/Controller/WMController.swift
@@ -3006,9 +3006,9 @@ final class WMController {
             }
 
             // Tripwire: a reevaluation that moves an already-placed window to a
-            // different workspace is the harmful churn the profile-switch "storm"
-            // was suspected of. Measured at zero on current builds; kept so a
-            // regression is visible in the trace.
+            // different workspace is a suspected source of workspace-assignment
+            // churn. Measured at zero on current builds; kept so a regression is
+            // visible in the trace.
             if let existingEntry, existingEntry.workspaceId != workspaceId {
                 diagnostics.recordNiriCreateFocusTrace(
                     .reevalWorkspaceChanged(

--- a/Sources/Nehir/Core/Controller/WMController.swift
+++ b/Sources/Nehir/Core/Controller/WMController.swift
@@ -3005,6 +3005,21 @@ final class WMController {
                 structuralReplacementAdmittedThisPass.insert(token)
             }
 
+            // Tripwire: a reevaluation that moves an already-placed window to a
+            // different workspace is the harmful churn the profile-switch "storm"
+            // was suspected of. Measured at zero on current builds; kept so a
+            // regression is visible in the trace.
+            if let existingEntry, existingEntry.workspaceId != workspaceId {
+                diagnostics.recordNiriCreateFocusTrace(
+                    .reevalWorkspaceChanged(
+                        token: token,
+                        from: existingEntry.workspaceId,
+                        to: workspaceId,
+                        context: "\(context)"
+                    )
+                )
+            }
+
             _ = workspaceManager.addWindow(
                 axRef,
                 pid: token.pid,

--- a/Tests/NehirTests/AXEventHandlerTests.swift
+++ b/Tests/NehirTests/AXEventHandlerTests.swift
@@ -1885,6 +1885,9 @@ private func waitUntilAXEventTest(
             return AXWindowRef(element: AXUIElementCreateSystemWide(), windowId: inactiveToken.windowId)
         }
 
+        // The guard only applies to successor-focus churn after one of the app's
+        // windows closes; simulate that close first.
+        controller.axEventHandler.handleRemoved(pid: appPid, winId: 9_799)
         controller.axEventHandler.handleAppActivation(pid: appPid, source: .focusedWindowChanged)
         await controller.layoutRefreshController.waitForRefreshWorkForTests()
 

--- a/Tests/NehirTests/WMControllerFocusTests.swift
+++ b/Tests/NehirTests/WMControllerFocusTests.swift
@@ -989,7 +989,12 @@ private func waitForFocusRefresh(on controller: WMController) async {
         controller.axEventHandler.isFullscreenProvider = { _ in false }
         controller.axEventHandler.focusedWindowRefProvider = { pid in
             guard pid == getpid() else { return nil }
-            return AXWindowRef(element: AXUIElementCreateSystemWide(), windowId: crossWorkspaceHandle.id.windowId)
+            // Before the close macOS reports the focused window; once it is gone
+            // the successor is the same-app window on the other workspace.
+            let windowId = controller.workspaceManager.entry(for: removedToken) != nil
+                ? removedHandle.id.windowId
+                : crossWorkspaceHandle.id.windowId
+            return AXWindowRef(element: AXUIElementCreateSystemWide(), windowId: windowId)
         }
 
         controller.axEventHandler.handleAppActivation(pid: getpid(), source: .focusedWindowChanged)
@@ -1056,6 +1061,9 @@ private func waitForFocusRefresh(on controller: WMController) async {
             return AXWindowRef(element: AXUIElementCreateSystemWide(), windowId: inactiveHandle.id.windowId)
         }
 
+        // The guard only applies to successor-focus churn after one of the app's
+        // windows closes; simulate that close first.
+        controller.axEventHandler.handleRemoved(pid: ghosttyPid, winId: 79_999)
         controller.axEventHandler.handleAppActivation(pid: ghosttyPid, source: .focusedWindowChanged)
         controller.axEventHandler.handleWindowMiniaturized(pid: unmanagedToken.pid, windowId: unmanagedToken.windowId)
         #expect(controller.workspaceManager.activeWorkspace(on: monitorId)?.id == workspaceId)
@@ -1110,6 +1118,9 @@ private func waitForFocusRefresh(on controller: WMController) async {
             return AXWindowRef(element: AXUIElementCreateSystemWide(), windowId: sameWorkspaceHandle.id.windowId)
         }
 
+        // The guard only applies to successor-focus churn after one of the app's
+        // windows closes; simulate that close first.
+        controller.axEventHandler.handleRemoved(pid: ghosttyPid, winId: 79_998)
         controller.axEventHandler.handleAppActivation(pid: ghosttyPid, source: .focusedWindowChanged)
         controller.axEventHandler.handleWindowMiniaturized(pid: unmanagedToken.pid, windowId: unmanagedToken.windowId)
         try? await Task.sleep(for: .milliseconds(50))


### PR DESCRIPTION
## Summary

Switching focus within one app to another of its windows that Nehir has
parked on an inactive workspace did nothing visible: the target window
stayed off-screen and the view stayed on the origin.

Three causes, all fixed:

1. shouldSuppressSameAppInactiveWorkspaceActivationBeforeCloseRecovery
   suppressed the reveal. That guard exists only to absorb the
   successor-focus churn macOS emits when one of the app's windows
   *closes*; it was also firing for ordinary same-app focus switches
with
   no close. Gate it on a recent same-app window close
   (recentSameAppWindowCloseByPid, set on window destroy), so a plain
focus
   switch to another of the app's windows is no longer suppressed.

2. Even past the guard, Nehir's active/visible workspace pointers can
   diverge so shouldActivateWorkspace stays false and no switch is
issued.
   When a managed focus confirmation lands on a non-sticky tiling window
   that is physically off-screen (trustworthy liveAXFrame signal, not
the
   model's visibility flag), follow it: activateWorkspace(workspace,
   focusing: window). Deduplicated per token for a short grace.

3. After following, an immediate confirm of another of the app's windows
   (the still-on-screen origin) could bounce the view back. A short
   per-pid hold on the just-revealed workspace suppresses that bounce.

Adds trace records used to pin this down: focus_reality (macOS-observed
focus/visibility next to focus_confirmed), reveal_decision (the
model->screen reveal decision), follow_focus_to_parked_window, and
reeval_workspace_changed.

## Release notes

Choose one:

- [x] Added a `.changeset/*.md` for user-visible changes (`mise run changeset -- patch "..."`).
- [ ] No user-visible change; apply the `no release note` label to make CI skip intentional.

## Validation

<!-- Commands run, screenshots, or manual checks. -->

- [ ] Ran relevant tests/checks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Switching focus within an app to another of its windows on a different workspace now reliably switches to that workspace instead of leaving the window off-screen.
* **Improvements**
  * Focus tracing now emits an additional “reality” record alongside focus confirmation, including macOS-observed visibility/focus indicators, to surface cases where the intended model looked successful even if the window server never made the window key or the workspace visible.
  * No runtime focus behavior change—this is tracing/visibility reporting only.
* **Diagnostics**
  * Added extra diagnostics when workspace assignment changes during rule reevaluation.
* **Tests**
  * Updated focus and window-close sequencing coverage in related focus-tracing tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->