### PR TITLE
Float Gecko transient dialogs (Thunderbird/Firefox) (#142)

### DIFF
--- a/.changeset/20260706161214-float-thunderbird-firefox-transient-dialogs-that.md
+++ b/.changeset/20260706161214-float-thunderbird-firefox-transient-dialogs-that.md
@@ -1,0 +1,6 @@
+---
+"nehir": patch
+
+---
+
+Float Thunderbird/Firefox transient dialogs that previously tiled as columns

--- a/Sources/Nehir/Core/Rules/WindowRuleEngine.swift
+++ b/Sources/Nehir/Core/Rules/WindowRuleEngine.swift
@@ -327,8 +327,16 @@ final class WindowRuleEngine {
     private static let degradedWindowServerChildSurfaceRuleName = "degradedWindowServerChildSurface"
     private static let transientSystemDialogSurfaceRuleName = "transientSystemDialogSurface"
     private static let cleanShotRecordingOverlayRuleName = "cleanShotRecordingOverlay"
+    private static let geckoTransientDialogRuleName = "geckoTransientDialog"
     private static let ghosttyQuickTerminalRuleName = "ghosttyQuickTerminalOverlay"
     private static let ghosttyBundleId = "com.mitchellh.ghostty"
+    private static let geckoBundleIds: Set<String> = [
+        "org.mozilla.thunderbird",
+        "org.mozilla.firefox",
+        "org.mozilla.firefoxdeveloperedition",
+        "app.zen-browser.zen",
+        "org.mozilla.seamonkey"
+    ]
     private static let systemTextInputPanelBundleIds: Set<String> = [
         "com.apple.characterpaletteim",
         "com.apple.emojifunctionrowitem-container",
@@ -550,6 +558,14 @@ final class WindowRuleEngine {
             return cleanShotDecision
         }
 
+        if let geckoDecision = geckoTransientDialogDecision(
+            for: facts,
+            workspaceName: workspaceName,
+            effects: effects
+        ) {
+            return geckoDecision
+        }
+
         if facts.ax.title == nil,
            requiresTitle(for: facts.ax.bundleId)
         {
@@ -712,6 +728,44 @@ final class WindowRuleEngine {
             disposition: .floating,
             source: .builtInRule(Self.cleanShotRecordingOverlayRuleName),
             layoutDecisionKind: .explicitLayout,
+            workspaceName: workspaceName,
+            ruleEffects: effects,
+            heuristicReasons: [],
+            deferredReason: nil
+        )
+    }
+
+    // Gecko apps (Thunderbird/Firefox) report transient dialogs — e.g. the
+    // Thunderbird "message sent" confirmation — as top-level AXStandardWindows
+    // with all window buttons and an enabled fullscreen button, and with a nil AX
+    // title. They are indistinguishable from real document windows by AX alone, so
+    // the heuristic tiles them (#142). The one durable discriminator is the
+    // WindowServer document tag: real Gecko windows (main, compose) carry it; the
+    // transient dialog carries neither the document nor the floating tag. Float
+    // those. Title-based user rules cannot address this (title is nil).
+    private func geckoTransientDialogDecision(
+        for facts: WindowRuleFacts,
+        workspaceName: String?,
+        effects: ManagedWindowRuleEffects
+    ) -> WindowDecision? {
+        guard let bundleId = facts.ax.bundleId?.lowercased(),
+              Self.geckoBundleIds.contains(bundleId),
+              facts.ax.attributeFetchSucceeded,
+              facts.ax.role == kAXWindowRole as String,
+              facts.ax.subrole == kAXStandardWindowSubrole as String,
+              let windowServer = facts.windowServer,
+              !windowServer.frame.isEmpty,
+              windowServer.parentId == 0,
+              !windowServer.hasDocumentTag,
+              !windowServer.hasFloatingTag
+        else {
+            return nil
+        }
+
+        return WindowDecision(
+            disposition: .floating,
+            source: .builtInRule(Self.geckoTransientDialogRuleName),
+            layoutDecisionKind: .fallbackLayout,
             workspaceName: workspaceName,
             ruleEffects: effects,
             heuristicReasons: [],

--- a/Tests/NehirTests/WindowRuleEngineTests.swift
+++ b/Tests/NehirTests/WindowRuleEngineTests.swift
@@ -9,6 +9,21 @@ import ApplicationServices
 @testable import Nehir
 import Testing
 
+private func makeGeckoDialogWindowServerInfo(
+    tags: UInt64,
+    parentId: UInt32 = 0
+) -> WindowServerInfo {
+    var windowServer = WindowServerInfo(
+        id: 4201,
+        pid: 10123,
+        level: 0,
+        frame: CGRect(x: 100, y: 100, width: 520, height: 260)
+    )
+    windowServer.tags = tags
+    windowServer.parentId = parentId
+    return windowServer
+}
+
 private func makeWindowRuleFacts(
     bundleId: String = "com.example.app",
     appName: String? = nil,
@@ -483,6 +498,163 @@ private func makeWindowRuleFacts(
         } else {
             Issue.record("Expected CleanShot capture overlays to use the built-in floating rule")
         }
+    }
+
+    @Test func geckoTaglessTopLevelStandardWindowFloatsAsTransientDialog() {
+        let engine = WindowRuleEngine()
+
+        let decision = engine.decision(
+            for: makeWindowRuleFacts(
+                bundleId: "org.mozilla.thunderbird",
+                title: nil,
+                role: kAXWindowRole as String,
+                subrole: kAXStandardWindowSubrole as String,
+                hasCloseButton: true,
+                hasFullscreenButton: true,
+                fullscreenButtonEnabled: true,
+                hasZoomButton: true,
+                hasMinimizeButton: true,
+                windowServer: makeGeckoDialogWindowServerInfo(tags: 0)
+            ),
+            token: nil,
+            appFullscreen: false
+        )
+
+        #expect(decision.disposition == .floating)
+        #expect(decision.source == .builtInRule("geckoTransientDialog"))
+        #expect(decision.layoutDecisionKind == .fallbackLayout)
+        #expect(decision.heuristicReasons.isEmpty)
+    }
+
+    @Test func geckoDocumentTaggedTopLevelStandardWindowTilesHeuristically() {
+        let engine = WindowRuleEngine()
+
+        let decision = engine.decision(
+            for: makeWindowRuleFacts(
+                bundleId: "org.mozilla.thunderbird",
+                title: "Write: Subject",
+                role: kAXWindowRole as String,
+                subrole: kAXStandardWindowSubrole as String,
+                hasCloseButton: true,
+                hasFullscreenButton: true,
+                fullscreenButtonEnabled: true,
+                hasZoomButton: true,
+                hasMinimizeButton: true,
+                windowServer: makeGeckoDialogWindowServerInfo(tags: 0x1)
+            ),
+            token: nil,
+            appFullscreen: false
+        )
+
+        #expect(decision.disposition == .managed)
+        #expect(decision.source == .heuristic)
+        #expect(decision.heuristicReasons.isEmpty)
+    }
+
+    @Test func geckoFloatingTaggedSurfaceKeepsExistingTransientSurfaceRule() {
+        let engine = WindowRuleEngine()
+
+        let decision = engine.decision(
+            for: makeWindowRuleFacts(
+                bundleId: "org.mozilla.thunderbird",
+                title: nil,
+                role: kAXWindowRole as String,
+                subrole: kAXStandardWindowSubrole as String,
+                hasCloseButton: true,
+                hasFullscreenButton: true,
+                fullscreenButtonEnabled: true,
+                hasZoomButton: true,
+                hasMinimizeButton: true,
+                windowServer: makeGeckoDialogWindowServerInfo(tags: 0x2)
+            ),
+            token: nil,
+            appFullscreen: false
+        )
+
+        #expect(decision.disposition == .floating)
+        #expect(decision.source == .builtInRule("transientWindowServerSurface"))
+        #expect(decision.heuristicReasons.isEmpty)
+    }
+
+    @Test func geckoParentedSurfaceKeepsExistingParentedSurfaceRule() {
+        let engine = WindowRuleEngine()
+
+        let decision = engine.decision(
+            for: makeWindowRuleFacts(
+                bundleId: "org.mozilla.thunderbird",
+                title: nil,
+                role: kAXWindowRole as String,
+                subrole: kAXStandardWindowSubrole as String,
+                hasCloseButton: true,
+                hasFullscreenButton: true,
+                fullscreenButtonEnabled: true,
+                hasZoomButton: true,
+                hasMinimizeButton: true,
+                windowServer: makeGeckoDialogWindowServerInfo(tags: 0, parentId: 44)
+            ),
+            token: nil,
+            appFullscreen: false
+        )
+
+        #expect(decision.disposition == .floating)
+        #expect(decision.source == .builtInRule("parentedWindowServerSurface"))
+        #expect(decision.heuristicReasons.isEmpty)
+    }
+
+    @Test func nonGeckoTaglessTopLevelStandardWindowTilesHeuristically() {
+        let engine = WindowRuleEngine()
+
+        let decision = engine.decision(
+            for: makeWindowRuleFacts(
+                bundleId: "com.example.app",
+                title: nil,
+                role: kAXWindowRole as String,
+                subrole: kAXStandardWindowSubrole as String,
+                hasCloseButton: true,
+                hasFullscreenButton: true,
+                fullscreenButtonEnabled: true,
+                hasZoomButton: true,
+                hasMinimizeButton: true,
+                windowServer: makeGeckoDialogWindowServerInfo(tags: 0)
+            ),
+            token: nil,
+            appFullscreen: false
+        )
+
+        #expect(decision.disposition == .managed)
+        #expect(decision.source == .heuristic)
+        #expect(decision.heuristicReasons.isEmpty)
+    }
+
+    @Test func explicitUserTileRuleOverridesGeckoTransientDialogRule() {
+        let engine = WindowRuleEngine()
+        let rule = AppRule(
+            id: UUID(uuidString: "00000000-0000-0000-0000-000000000166")!,
+            bundleId: "org.mozilla.thunderbird",
+            layout: .tile
+        )
+        engine.rebuild(rules: [rule])
+
+        let decision = engine.decision(
+            for: makeWindowRuleFacts(
+                bundleId: "org.mozilla.thunderbird",
+                title: nil,
+                role: kAXWindowRole as String,
+                subrole: kAXStandardWindowSubrole as String,
+                hasCloseButton: true,
+                hasFullscreenButton: true,
+                fullscreenButtonEnabled: true,
+                hasZoomButton: true,
+                hasMinimizeButton: true,
+                windowServer: makeGeckoDialogWindowServerInfo(tags: 0)
+            ),
+            token: nil,
+            appFullscreen: false
+        )
+
+        #expect(decision.disposition == .managed)
+        #expect(decision.source == .userRule(rule.id))
+        #expect(decision.heuristicReasons.isEmpty)
     }
 
     @Test func cleanShotDialogAtCaptureLevelStillFloats() {


### PR DESCRIPTION
## Summary

Thunderbird's send-confirmation dialog opens as a tiled column. It presents as a top-level AXStandardWindow with all buttons, an enabled fullscreen button, and a nil AX title — indistinguishable from a real document window by AX, so the heuristic tiles it. The only durable discriminator is the WindowServer document tag: real Gecko windows carry it, the transient dialog carries neither document nor floating tag. Add a scoped built-in decision that floats top-level, tagless, standard Gecko-family windows. Title-based user rules cannot address this (title is nil). Mirrors AeroSpace's hardcoded-Firefox handling.

## Release notes

Choose one:

- [x] Added a `.changeset/*.md` for user-visible changes (`mise run changeset -- patch "..."`).
- [ ] No user-visible change; apply the `no release note` label to make CI skip intentional.

## Validation

<!-- Commands run, screenshots, or manual checks. -->

- [ ] Ran relevant tests/checks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added special handling for Thunderbird/Firefox transient dialogs so they now float instead of being tiled.
  * Improved window classification for Gecko-based apps, including better handling of dialog-like windows and existing tag-based surfaces.

* **Bug Fixes**
  * Fixed an issue where some transient dialogs were incorrectly treated as columns, improving window placement behavior.
  * Preserved user-defined tiling rules when they conflict with the built-in dialog behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->