### PR TITLE
Re-center lone survivor after manual-resize move to another workspace

### DIFF
--- a/.changeset/20260707014928-re-center-the-surviving-lone-window-after-moving.md
+++ b/.changeset/20260707014928-re-center-the-surviving-lone-window-after-moving.md
@@ -1,0 +1,6 @@
+---
+"nehir": patch
+contributors: [flschulz]
+---
+
+Re-center the surviving lone window after moving a manually-resized window to another workspace. Fixes #99.

--- a/Sources/Nehir/Core/Layout/Niri/NiriLayoutEngine+WorkspaceOps.swift
+++ b/Sources/Nehir/Core/Layout/Niri/NiriLayoutEngine+WorkspaceOps.swift
@@ -57,6 +57,7 @@ extension NiriLayoutEngine {
         cleanupEmptyColumn(sourceColumn, in: sourceWorkspaceId, state: &sourceState)
 
         sourceState.selectedNodeId = fallbackSelection
+        resetManualLoneWindowWidthOverrideIfNeeded(in: sourceWorkspaceId)
 
         targetState.selectedNodeId = window.id
 
@@ -106,6 +107,7 @@ extension NiriLayoutEngine {
         }
 
         sourceState.selectedNodeId = fallbackSelection
+        resetManualLoneWindowWidthOverrideIfNeeded(in: sourceWorkspaceId)
 
         targetState.selectedNodeId = column.firstChild()?.id
 
@@ -116,6 +118,15 @@ extension NiriLayoutEngine {
             movedHandle: firstWindowHandle,
             targetWorkspaceId: targetWorkspaceId
         )
+    }
+
+    private func resetManualLoneWindowWidthOverrideIfNeeded(in workspaceId: WorkspaceDescriptor.ID) {
+        guard let column = singleWindowLayoutContext(in: workspaceId)?.container,
+              column.hasManualSingleWindowWidthOverride
+        else { return }
+
+        column.hasManualSingleWindowWidthOverride = false
+        column.cachedWidth = 0
     }
 
     func adjacentWorkspace(

--- a/Tests/NehirTests/NiriLayoutEngineTests.swift
+++ b/Tests/NehirTests/NiriLayoutEngineTests.swift
@@ -3895,6 +3895,92 @@ private func makeCenteredCrossMonitorFixture(
         #expect(targetColumn.presetWidthIdx == nil)
     }
 
+    @Test func moveWindowToWorkspaceClearsManualLoneSurvivorWidthOverride() {
+        let engine = NiriLayoutEngine(balancedColumnCount: 3)
+        engine.loneWindowPolicy = .centered(maxWidthFraction: 0.6)
+        let sourceWorkspaceId = UUID()
+        let targetWorkspaceId = UUID()
+
+        let movedWindow = engine.addWindow(handle: makeTestHandle(pid: 91), to: sourceWorkspaceId, afterSelection: nil)
+        let survivorWindow = engine.addWindow(
+            handle: makeTestHandle(pid: 92),
+            to: sourceWorkspaceId,
+            afterSelection: movedWindow.id
+        )
+
+        guard let movedColumn = engine.column(of: movedWindow),
+              let survivorColumn = engine.column(of: survivorWindow)
+        else {
+            Issue.record("Expected two source columns before workspace move")
+            return
+        }
+
+        for column in [movedColumn, survivorColumn] {
+            column.hasManualSingleWindowWidthOverride = true
+            column.cachedWidth = 800
+        }
+
+        var sourceState = ViewportState()
+        var targetState = ViewportState()
+
+        let moved = engine.moveWindowToWorkspace(
+            movedWindow,
+            from: sourceWorkspaceId,
+            to: targetWorkspaceId,
+            sourceState: &sourceState,
+            targetState: &targetState
+        )
+
+        #expect(moved != nil)
+        #expect(engine.columns(in: sourceWorkspaceId).count == 1)
+        #expect(engine.columns(in: sourceWorkspaceId).first === survivorColumn)
+        #expect(!survivorColumn.hasManualSingleWindowWidthOverride)
+        #expect(survivorColumn.cachedWidth == 0)
+    }
+
+    @Test func moveColumnToWorkspaceClearsManualLoneSurvivorWidthOverride() {
+        let engine = NiriLayoutEngine(balancedColumnCount: 3)
+        engine.loneWindowPolicy = .centered(maxWidthFraction: 0.6)
+        let sourceWorkspaceId = UUID()
+        let targetWorkspaceId = UUID()
+
+        let movedWindow = engine.addWindow(handle: makeTestHandle(pid: 93), to: sourceWorkspaceId, afterSelection: nil)
+        let survivorWindow = engine.addWindow(
+            handle: makeTestHandle(pid: 94),
+            to: sourceWorkspaceId,
+            afterSelection: movedWindow.id
+        )
+
+        guard let movedColumn = engine.column(of: movedWindow),
+              let survivorColumn = engine.column(of: survivorWindow)
+        else {
+            Issue.record("Expected two source columns before column workspace move")
+            return
+        }
+
+        for column in [movedColumn, survivorColumn] {
+            column.hasManualSingleWindowWidthOverride = true
+            column.cachedWidth = 800
+        }
+
+        var sourceState = ViewportState()
+        var targetState = ViewportState()
+
+        let moved = engine.moveColumnToWorkspace(
+            movedColumn,
+            from: sourceWorkspaceId,
+            to: targetWorkspaceId,
+            sourceState: &sourceState,
+            targetState: &targetState
+        )
+
+        #expect(moved != nil)
+        #expect(engine.columns(in: sourceWorkspaceId).count == 1)
+        #expect(engine.columns(in: sourceWorkspaceId).first === survivorColumn)
+        #expect(!survivorColumn.hasManualSingleWindowWidthOverride)
+        #expect(survivorColumn.cachedWidth == 0)
+    }
+
     @Test func moveLastColumnToWorkspaceLeavesSourceWorkspaceEmpty() {
         let engine = NiriLayoutEngine()
         let sourceWorkspaceId = UUID()


### PR DESCRIPTION

## Summary

Moving a manually-resized window away could leave the source workspace with a lone survivor that kept its two-column cached width and offset. Reset the source-side lone survivor's manual width override after window and column workspace moves so the existing lone-window recenter path resolves the centered policy again.

Fixes #99

## Release notes

Choose one:

- [x] Added a `.changeset/*.md` for user-visible changes (`mise run changeset -- patch "..."`).
- [ ] No user-visible change; apply the `no release note` label to make CI skip intentional.

## Validation

<!-- Commands run, screenshots, or manual checks. -->

- [ ] Ran relevant tests/checks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed workspace moves so the surviving single window is re-centered after moving a manually resized window or column to another workspace.
  * Cleared the source workspace’s manual single-window width override for the remaining “lone survivor,” resetting any saved width to prevent stale sizing.
* **Tests**
  * Added regression coverage for moving both individual windows and entire columns to ensure the surviving window’s sizing state is cleared correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->