### PR TITLE
Verify window liveness before honoring a spurious AX destroy on cold start

### DIFF
--- a/.changeset/20260707023920-stop-wiping-all-managed-windows-on-a-cold-start-.md
+++ b/.changeset/20260707023920-stop-wiping-all-managed-windows-on-a-cold-start-.md
@@ -1,0 +1,6 @@
+---
+"nehir": patch
+
+---
+
+Stop wiping all managed windows on a cold start when macOS fires spurious AX destroy notifications

--- a/Sources/Nehir/Core/Controller/AXEventHandler.swift
+++ b/Sources/Nehir/Core/Controller/AXEventHandler.swift
@@ -571,6 +571,7 @@ final class AXEventHandler: CGSEventDelegate {
     private var pendingWindowRuleReevaluationTargets: Set<WindowRuleReevaluationTarget> = []
     private var pendingWindowStabilizationTasks: [WindowToken: Task<Void, Never>] = [:]
     private var pendingPostCreateLifecycleVerificationTasks: [WindowToken: Task<Void, Never>] = [:]
+    private var pendingDestroyLivenessVerificationTasks: [WindowToken: Task<Void, Never>] = [:]
     private var pendingCreatedWindowRetryTasks: [UInt32: Task<Void, Never>] = [:]
     private var createdWindowRetryCountById: [UInt32: Int] = [:]
     private var pendingActivationRetryTask: Task<Void, Never>?
@@ -620,7 +621,7 @@ final class AXEventHandler: CGSEventDelegate {
         endWindowCloseFocusRecovery()
         resetNativeFullscreenReplacementState()
         resetWindowStabilizationState()
-        resetPostCreateLifecycleVerificationState()
+        resetLifecycleVerificationState()
         resetCreatedWindowRetryState()
         resetActivationRetryState()
         pendingWindowRuleReevaluationTask?.cancel()
@@ -754,7 +755,7 @@ final class AXEventHandler: CGSEventDelegate {
         resetManagedReplacementState()
         resetNativeFullscreenReplacementState()
         resetWindowStabilizationState()
-        resetPostCreateLifecycleVerificationState()
+        resetLifecycleVerificationState()
         resetCreatedWindowRetryState()
         resetCreatePlacementContextState()
         recentManagedWorkspaceByPid.removeAll()
@@ -1222,7 +1223,7 @@ final class AXEventHandler: CGSEventDelegate {
         cancelCreatedWindowRetry(windowId: windowId)
         discardCreatePlacementContext(windowId: windowId)
         removeDeferredCreatedWindow(windowId)
-        handleWindowDestroyed(windowId: windowId, pidHint: nil)
+        handleWindowDestroyed(windowId: windowId, pidHint: nil, verifyWindowServerLiveness: false)
     }
 
     func subscribeToManagedWindows() {
@@ -1293,6 +1294,22 @@ final class AXEventHandler: CGSEventDelegate {
         admissionContext: WindowAdmissionContext = .windowCreate
     ) {
         guard let controller else { return }
+        if controller.diagnostics.isRuntimeTraceCaptureActive {
+            let pendingRemoval = controller.layoutRefreshController.pendingWindowRemovalPayload(
+                for: candidate.token,
+                workspaceId: candidate.workspaceId
+            )
+            controller.diagnostics.recordRuntimeViewportTrace(
+                workspaceId: candidate.workspaceId,
+                reason: "readmit_pending_removal",
+                details: [
+                    "token=\(candidate.token)",
+                    "workspaceId=\(candidate.workspaceId.uuidString)",
+                    "pendingRemovalExists=\(pendingRemoval != nil)",
+                    "pendingRemovalSeedNodeId=\(pendingRemoval?.removedNodeId.map(String.init(describing:)) ?? "nil")"
+                ]
+            )
+        }
         cancelCreatedWindowRetry(windowId: candidate.windowId)
         discardCreatePlacementContext(windowId: candidate.windowId)
         recordNiriCreateFocusTrace(
@@ -1475,11 +1492,46 @@ final class AXEventHandler: CGSEventDelegate {
         pendingPostCreateLifecycleVerificationTasks[token] = nil
     }
 
-    private func resetPostCreateLifecycleVerificationState() {
+    private func scheduleDestroyLivenessVerification(for token: WindowToken) {
+        pendingDestroyLivenessVerificationTasks[token]?.cancel()
+        let task = Task { @MainActor [weak self] in
+            defer { self?.pendingDestroyLivenessVerificationTasks[token] = nil }
+            try? await Task.sleep(for: Self.postCreateLifecycleVerificationDelay)
+            guard !Task.isCancelled,
+                  let self,
+                  let controller = self.controller,
+                  controller.workspaceManager.entry(for: token) != nil,
+                  let windowId = UInt32(exactly: token.windowId)
+            else {
+                return
+            }
+            await self.warmAXContextIfNeeded(for: token.pid)
+            guard !Task.isCancelled,
+                  controller.workspaceManager.entry(for: token) != nil,
+                  self.resolveWindowInfo(windowId) == nil
+            else {
+                return
+            }
+            AXWindowService.invalidateCachedTitle(windowId: windowId)
+            self.handleRemoved(token: token)
+        }
+        pendingDestroyLivenessVerificationTasks[token] = task
+    }
+
+    private func cancelDestroyLivenessVerification(for token: WindowToken) {
+        pendingDestroyLivenessVerificationTasks[token]?.cancel()
+        pendingDestroyLivenessVerificationTasks[token] = nil
+    }
+
+    private func resetLifecycleVerificationState() {
         for (_, task) in pendingPostCreateLifecycleVerificationTasks {
             task.cancel()
         }
         pendingPostCreateLifecycleVerificationTasks.removeAll()
+        for (_, task) in pendingDestroyLivenessVerificationTasks {
+            task.cancel()
+        }
+        pendingDestroyLivenessVerificationTasks.removeAll()
     }
 
     private func scheduleFloatingCreateFrameApplication(
@@ -1563,7 +1615,7 @@ final class AXEventHandler: CGSEventDelegate {
         AXWindowService.invalidateCachedTitle(windowId: windowId)
         cancelCreatedWindowRetry(windowId: windowId)
         removeDeferredCreatedWindow(windowId)
-        handleWindowDestroyed(windowId: windowId, pidHint: pid)
+        handleWindowDestroyed(windowId: windowId, pidHint: pid, verifyWindowServerLiveness: true)
     }
 
     func handleRemoved(token: WindowToken) {
@@ -1573,6 +1625,7 @@ final class AXEventHandler: CGSEventDelegate {
         let affectedWorkspaceId = entry?.workspaceId
 
         cancelPostCreateLifecycleVerification(for: token)
+        cancelDestroyLivenessVerification(for: token)
         controller.axManager.removeWindowState(pid: token.pid, windowId: token.windowId)
         if handleNativeFullscreenDestroy(token) {
             return
@@ -4126,7 +4179,8 @@ final class AXEventHandler: CGSEventDelegate {
 
     private func handleWindowDestroyed(
         windowId: UInt32,
-        pidHint: pid_t?
+        pidHint: pid_t?,
+        verifyWindowServerLiveness: Bool
     ) {
         let resolvedToken = resolveWindowToken(windowId)
             ?? resolveTrackedToken(windowId)
@@ -4163,6 +4217,20 @@ final class AXEventHandler: CGSEventDelegate {
             }
             return
         }
+
+        if verifyWindowServerLiveness {
+            if handleNativeFullscreenDestroy(candidate.token) {
+                return
+            }
+            if resolveWindowInfo(windowId)?.pid == candidate.token.pid {
+                if pendingDestroyLivenessVerificationTasks[candidate.token] == nil {
+                    scheduleDestroyLivenessVerification(for: candidate.token)
+                }
+                return
+            }
+        }
+
+        cancelDestroyLivenessVerification(for: candidate.token)
 
         let shouldDelayDestroy = shouldDelayManagedReplacementDestroy(candidate)
         if shouldDelayDestroy, handleNativeFullscreenDestroy(candidate.token) {
@@ -4565,13 +4633,7 @@ final class AXEventHandler: CGSEventDelegate {
         guard let controller, let frame = observedFrame(for: entry) else {
             return false
         }
-        let frameArea = frame.width * frame.height
-        guard frameArea > 0 else { return false }
-        let visibleArea = controller.workspaceManager.monitors.reduce(CGFloat.zero) { total, monitor in
-            let overlap = monitor.visibleFrame.intersection(frame)
-            return overlap.isNull ? total : total + overlap.width * overlap.height
-        }
-        return visibleArea >= frameArea * 0.5
+        return Monitor.isFrameOnScreen(frame, across: controller.workspaceManager.monitors)
     }
 
     /// After a same-app focus switch, Nehir can end up with focus on one of the

--- a/Sources/Nehir/Core/Controller/LayoutRefreshController.swift
+++ b/Sources/Nehir/Core/Controller/LayoutRefreshController.swift
@@ -472,6 +472,8 @@ import QuartzCore
 
         executeLayoutPlans(plan.workspacePlans)
 
+        recordWindowModelNiriDesyncIfNeeded(activeWorkspaceIds: plan.effects.visibility?.activeWorkspaceIds)
+
         // Keep the Dock-edge shield in sync on every refresh (idempotent — skips
         // AppKit work when geometry is unchanged). This is the central execution path
         // (startup, relayout, scroll, visibility all route here), so the shield
@@ -846,6 +848,21 @@ import QuartzCore
         )
     }
 
+    func pendingWindowRemovalPayload(
+        for token: WindowToken,
+        workspaceId: WorkspaceDescriptor.ID
+    ) -> WindowRemovalPayload? {
+        for refresh in [layoutState.activeRefresh, layoutState.pendingRefresh].compactMap({ $0 }) {
+            guard refresh.kind == .windowRemoval else { continue }
+            if let payload = refresh.windowRemovalPayloads.first(where: { payload in
+                payload.workspaceId == workspaceId && payload.niriOldFrames[token] != nil
+            }) {
+                return payload
+            }
+        }
+        return nil
+    }
+
     func commitWorkspaceTransition(
         affectedWorkspaces: Set<WorkspaceDescriptor.ID> = [],
         reason: RefreshReason = .workspaceTransition,
@@ -1159,6 +1176,93 @@ import QuartzCore
         return RefreshExecutionPlan(workspacePlans: workspacePlans, effects: effects)
     }
 
+    private func recordWindowModelNiriDesyncIfNeeded(activeWorkspaceIds: Set<WorkspaceDescriptor.ID>?) {
+        guard let controller, controller.diagnostics.isRuntimeTraceCaptureActive else { return }
+        guard let engine = controller.niriEngine else { return }
+
+        let workspaceIds = activeWorkspaceIds ?? currentActiveWorkspaceIds()
+        for workspaceId in workspaceIds {
+            for entry in controller.workspaceManager.tiledEntries(in: workspaceId) {
+                guard engine.findNode(for: entry.token) == nil else { continue }
+                controller.diagnostics.recordRuntimeViewportTrace(
+                    workspaceId: workspaceId,
+                    reason: "windowmodel_niri_desync",
+                    details: [
+                        "token=\(entry.token)",
+                        "workspaceId=\(workspaceId.uuidString)",
+                        "phase=\(entry.lifecyclePhase.rawValue)",
+                        "hidden=\(runtimeTraceHiddenReason(entry.visibility.hiddenReason))",
+                        "liveAXFrame=\(fastFrame(for: entry.token, axRef: entry.axRef).map(LayoutTrace.rect) ?? "nil")",
+                        "replacementFrame=\(entry.managedReplacementMetadata?.frame.map(LayoutTrace.rect) ?? "nil")",
+                        "onScreen=\(isEntryOnScreen(entry))"
+                    ]
+                )
+            }
+        }
+    }
+
+    private func recordWindowRemovalSeedCheck(_ payload: WindowRemovalPayload) {
+        guard let controller, controller.diagnostics.isRuntimeTraceCaptureActive else { return }
+        guard let seedNodeId = payload.removedNodeId else {
+            controller.diagnostics.recordRuntimeViewportTrace(
+                workspaceId: payload.workspaceId,
+                reason: "window_removal_seed_check",
+                details: [
+                    "workspaceId=\(payload.workspaceId.uuidString)",
+                    "seedNodeId=nil",
+                    "liveNodeIdForReadmittedToken=nil",
+                    "windowModelStillTracks=false"
+                ]
+            )
+            return
+        }
+
+        var liveNodeIdForReadmittedToken: NodeId?
+        var windowModelStillTracks = false
+        for token in payload.niriOldFrames.keys {
+            guard let entry = controller.workspaceManager.entry(for: token),
+                  entry.workspaceId == payload.workspaceId,
+                  entry.mode == .tiling
+            else { continue }
+            windowModelStillTracks = true
+            let liveNodeId = controller.niriEngine?.findNode(for: token)?.id
+            if liveNodeId != seedNodeId {
+                liveNodeIdForReadmittedToken = liveNodeId
+                break
+            }
+        }
+
+        controller.diagnostics.recordRuntimeViewportTrace(
+            workspaceId: payload.workspaceId,
+            reason: "window_removal_seed_check",
+            details: [
+                "workspaceId=\(payload.workspaceId.uuidString)",
+                "seedNodeId=\(seedNodeId)",
+                "liveNodeIdForReadmittedToken=\(liveNodeIdForReadmittedToken.map(String.init(describing:)) ?? "nil")",
+                "windowModelStillTracks=\(windowModelStillTracks)"
+            ]
+        )
+    }
+
+    private func isEntryOnScreen(_ entry: WindowModel.Entry) -> Bool {
+        guard let controller, let frame = fastFrame(for: entry.token, axRef: entry.axRef) else {
+            return false
+        }
+        return Monitor.isFrameOnScreen(frame, across: controller.workspaceManager.monitors)
+    }
+
+    private func runtimeTraceHiddenReason(_ reason: WindowModel.HiddenReason?) -> String {
+        guard let reason else { return "nil" }
+        switch reason {
+        case .workspaceInactive:
+            return "workspaceInactive"
+        case let .layoutTransient(side):
+            return "layoutTransient(\(side))"
+        case .scratchpad:
+            return "scratchpad"
+        }
+    }
+
     private func buildWindowRemovalExecutionPlan(
         payloads: [WindowRemovalPayload]
     ) async throws -> RefreshExecutionPlan {
@@ -1168,6 +1272,8 @@ import QuartzCore
         var niriRemovalSeeds: [WorkspaceDescriptor.ID: NiriWindowRemovalSeed] = [:]
 
         for payload in payloads {
+            recordWindowRemovalSeedCheck(payload)
+
             var removedNodeIds = niriRemovalSeeds[payload.workspaceId]?.removedNodeIds ?? []
             if let removedNodeId = payload.removedNodeId {
                 removedNodeIds.append(removedNodeId)

--- a/Sources/Nehir/Core/Monitor/Monitor.swift
+++ b/Sources/Nehir/Core/Monitor/Monitor.swift
@@ -103,6 +103,23 @@ extension Monitor {
             return $0.frame.maxY > $1.frame.maxY
         }
     }
+
+    static func visibleOverlapArea(of frame: CGRect, across monitors: [Monitor]) -> CGFloat {
+        monitors.reduce(CGFloat.zero) { total, monitor in
+            let overlap = monitor.visibleFrame.intersection(frame)
+            return overlap.isNull ? total : total + overlap.width * overlap.height
+        }
+    }
+
+    static func isFrameOnScreen(
+        _ frame: CGRect,
+        across monitors: [Monitor],
+        minimumVisibleFraction: CGFloat = 0.5
+    ) -> Bool {
+        let frameArea = frame.width * frame.height
+        guard frameArea > 0 else { return false }
+        return visibleOverlapArea(of: frame, across: monitors) >= frameArea * minimumVisibleFraction
+    }
 }
 
 extension NSScreen {


### PR DESCRIPTION
## Summary

Stop wiping all managed windows on a cold start when macOS fires spurious AX destroy notifications
## Release notes

Choose one:

- [x] Added a `.changeset/*.md` for user-visible changes (`mise run changeset -- patch "..."`).
- [ ] No user-visible change; apply the `no release note` label to make CI skip intentional.

## Validation

<!-- Commands run, screenshots, or manual checks. -->

- [ ] Ran relevant tests/checks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Stopped macOS cold-start behavior that could wipe managed windows due to spurious window-destroy notifications.
  * Improved window close/destroy handling to verify actual window-server liveness before removing entries, reducing unintended disappearances.
  * Enhanced refresh planning stability and removal correctness, including more reliable on-screen detection to support focus-related behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->