### PR TITLE
Keep learned window minimum size across float, fullscreen, and rekey

### DIFF
--- a/.changeset/20260707025008-stop-min-width-windows-from-re-fighting-their-mi.md
+++ b/.changeset/20260707025008-stop-min-width-windows-from-re-fighting-their-mi.md
@@ -1,0 +1,6 @@
+---
+"nehir": patch
+
+---
+
+Stop min-width windows from re-fighting their minimum size after floating, fullscreen, or moving between displays

--- a/Sources/Nehir/Core/Workspace/WindowModel.swift
+++ b/Sources/Nehir/Core/Workspace/WindowModel.swift
@@ -454,7 +454,7 @@ final class WindowModel {
             entry.axRef = newAXRef
             entry.cachedConstraints = nil
             entry.constraintsCacheTime = nil
-            entry.inferredResizeMinimumSize = nil
+            // Preserve inferred resize minimum: it is a physical app invariant and survives AX-ref refresh.
             if let managedReplacementMetadata {
                 entry.managedReplacementMetadata = managedReplacementMetadata
             }
@@ -593,9 +593,7 @@ final class WindowModel {
             tokenIndexByKey: &tokenIndexByWorkspaceMode
         )
         entry.mode = mode
-        if mode != .tiling {
-            entry.inferredResizeMinimumSize = nil
-        }
+        // Preserve inferred resize minimum: it is a physical app invariant and survives mode changes.
         appendToken(
             token,
             to: WorkspaceModeKey(workspaceId: entry.workspaceId, mode: mode),
@@ -725,9 +723,7 @@ final class WindowModel {
             entry.prevParentKind = entry.parentKind
         }
         entry.layoutReason = reason
-        if reason != .standard {
-            entry.inferredResizeMinimumSize = nil
-        }
+        // Preserve inferred resize minimum: it is a physical app invariant and survives layout-reason changes.
     }
 
     func restoreFromNativeState(for token: WindowToken) -> ParentKind? {


### PR DESCRIPTION
## Summary

The learned resize-minimum is a physical app invariant; clearing it on identity-preserving lifecycle events (AX-ref self-rekey, float/unfloat, native fullscreen) forced a re-learn and a visible refusal-thrash on the next animated resize. Keep it across those transitions.

## Release notes

Choose one:

- [x] Added a `.changeset/*.md` for user-visible changes (`mise run changeset -- patch "..."`).
- [ ] No user-visible change; apply the `no release note` label to make CI skip intentional.

## Validation

<!-- Commands run, screenshots, or manual checks. -->

- [ ] Ran relevant tests/checks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed windows from repeatedly reapplying their minimum size after floating, entering fullscreen, or moving between displays.
  * Improved window behavior so inferred minimum sizing is preserved more consistently during state changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->