### PR TITLE
Float zero-frame Gecko transient dialogs that the first #142 fix still tiled

### DIFF
--- a/.changeset/20260707110730-actually-float-thunderbird-firefox-send-confirma.md
+++ b/.changeset/20260707110730-actually-float-thunderbird-firefox-send-confirma.md
@@ -1,0 +1,6 @@
+---
+"nehir": patch
+contributors: [etrigan63]
+---
+
+Fixes #142: Actually float Thunderbird/Firefox send-confirmation dialogs (the zero-frame case the first fix still tiled)

--- a/Sources/Nehir/Core/Rules/WindowRuleEngine.swift
+++ b/Sources/Nehir/Core/Rules/WindowRuleEngine.swift
@@ -558,14 +558,6 @@ final class WindowRuleEngine {
             return cleanShotDecision
         }
 
-        if let geckoDecision = geckoTransientDialogDecision(
-            for: facts,
-            workspaceName: workspaceName,
-            effects: effects
-        ) {
-            return geckoDecision
-        }
-
         if facts.ax.title == nil,
            requiresTitle(for: facts.ax.bundleId)
         {
@@ -580,6 +572,14 @@ final class WindowRuleEngine {
                 heuristicReasons: [],
                 deferredReason: .requiredTitleMissing
             )
+        }
+
+        if let geckoDecision = geckoTransientDialogDecision(
+            for: facts,
+            workspaceName: workspaceName,
+            effects: effects
+        ) {
+            return geckoDecision
         }
 
         if appFullscreen {
@@ -754,7 +754,6 @@ final class WindowRuleEngine {
               facts.ax.role == kAXWindowRole as String,
               facts.ax.subrole == kAXStandardWindowSubrole as String,
               let windowServer = facts.windowServer,
-              !windowServer.frame.isEmpty,
               windowServer.parentId == 0,
               !windowServer.hasDocumentTag,
               !windowServer.hasFloatingTag

--- a/Tests/NehirTests/WindowRuleEngineTests.swift
+++ b/Tests/NehirTests/WindowRuleEngineTests.swift
@@ -11,13 +11,14 @@ import Testing
 
 private func makeGeckoDialogWindowServerInfo(
     tags: UInt64,
-    parentId: UInt32 = 0
+    parentId: UInt32 = 0,
+    frame: CGRect = .zero
 ) -> WindowServerInfo {
     var windowServer = WindowServerInfo(
         id: 4201,
         pid: 10123,
         level: 0,
-        frame: CGRect(x: 100, y: 100, width: 520, height: 260)
+        frame: frame
     )
     windowServer.tags = tags
     windowServer.parentId = parentId
@@ -500,6 +501,30 @@ private func makeWindowRuleFacts(
         }
     }
 
+    @Test func titleGatedGeckoWindowWithMissingTitleDefersBeforeTransientDialogRule() {
+        let engine = WindowRuleEngine()
+
+        let decision = engine.decision(
+            for: makeWindowRuleFacts(
+                bundleId: "org.mozilla.firefox",
+                title: nil,
+                role: kAXWindowRole as String,
+                subrole: kAXStandardWindowSubrole as String,
+                hasCloseButton: true,
+                hasFullscreenButton: true,
+                fullscreenButtonEnabled: true,
+                hasZoomButton: true,
+                hasMinimizeButton: true,
+                windowServer: makeGeckoDialogWindowServerInfo(tags: 0)
+            ),
+            token: nil,
+            appFullscreen: false
+        )
+
+        #expect(decision.disposition == .undecided)
+        #expect(decision.deferredReason == .requiredTitleMissing)
+    }
+
     @Test func geckoTaglessTopLevelStandardWindowFloatsAsTransientDialog() {
         let engine = WindowRuleEngine()
 
@@ -515,6 +540,35 @@ private func makeWindowRuleFacts(
                 hasZoomButton: true,
                 hasMinimizeButton: true,
                 windowServer: makeGeckoDialogWindowServerInfo(tags: 0)
+            ),
+            token: nil,
+            appFullscreen: false
+        )
+
+        #expect(decision.disposition == .floating)
+        #expect(decision.source == .builtInRule("geckoTransientDialog"))
+        #expect(decision.layoutDecisionKind == .fallbackLayout)
+        #expect(decision.heuristicReasons.isEmpty)
+    }
+
+    @Test func geckoTaglessTopLevelStandardWindowWithNonZeroFrameFloatsAsTransientDialog() {
+        let engine = WindowRuleEngine()
+
+        let decision = engine.decision(
+            for: makeWindowRuleFacts(
+                bundleId: "org.mozilla.thunderbird",
+                title: nil,
+                role: kAXWindowRole as String,
+                subrole: kAXStandardWindowSubrole as String,
+                hasCloseButton: true,
+                hasFullscreenButton: true,
+                fullscreenButtonEnabled: true,
+                hasZoomButton: true,
+                hasMinimizeButton: true,
+                windowServer: makeGeckoDialogWindowServerInfo(
+                    tags: 0,
+                    frame: CGRect(x: 100, y: 100, width: 520, height: 260)
+                )
             ),
             token: nil,
             appFullscreen: false


### PR DESCRIPTION
## Summary

The geckoTransientDialogDecision built-in guarded on !windowServer.frame.isEmpty, but Thunderbird's send-confirmation dialog has a WindowServer frame of (0,0,0,0) = CGRect.zero at admission (CGRect.zero.isEmpty == true), so the guard rejected the exact window the rule targets and it fell back to the tiling heuristic. Drop the frame guard; the remaining bundle/role/subrole/parent/tag guards already scope the rule.

Run the Gecko transient-dialog rule after title-missing deferral so title-gated Gecko apps keep waiting until formed. That preserves Firefox/Zen Picture-in-Picture routing through the title-matched browserPictureInPicture built-in rule while still allowing Thunderbird's title-less send dialog to float.

Update the tests to exercise zero-frame Gecko dialogs and lock in that title-gated zero-frame Firefox windows defer instead of being claimed by the transient-dialog rule.

## Release notes

Choose one:

- [x] Added a `.changeset/*.md` for user-visible changes (`mise run changeset -- patch "..."`).
- [ ] No user-visible change; apply the `no release note` label to make CI skip intentional.

## Validation

<!-- Commands run, screenshots, or manual checks. -->

- [ ] Ran relevant tests/checks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of Thunderbird/Firefox “send-confirmation” dialogs in zero-frame scenarios so they render correctly (previously they could remain tiled).
  * Fixed Gecko transient dialog decisions by prioritizing required-title-missing outcomes and allowing matching even when no window frame data is available.
  * Added automated test coverage for the “required title missing” deferral behavior to prevent regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->