### PR TITLE
Keep Gecko transient dialogs floating #142

### DIFF
--- a/.changeset/20260707232424-keep-thunderbird-gecko-transient-dialogs-out-of-.md
+++ b/.changeset/20260707232424-keep-thunderbird-gecko-transient-dialogs-out-of-.md
@@ -1,0 +1,6 @@
+---
+"nehir": patch
+contributors: [etrigan63]
+---
+
+Keep Thunderbird Gecko transient dialogs out of tiled layout projection. Fixes #142.

--- a/Sources/Nehir/Core/Controller/AXEventHandler.swift
+++ b/Sources/Nehir/Core/Controller/AXEventHandler.swift
@@ -5087,7 +5087,10 @@ final class AXEventHandler: CGSEventDelegate {
         mode: TrackedWindowMode,
         facts: WindowRuleFacts
     ) -> ManagedReplacementMetadata {
-        ManagedReplacementMetadata(
+        let hasGeckoTransientDialogEvidence = WindowRuleEngine.isGeckoTransientDialog(facts: facts)
+            || WindowRuleEngine.isGeckoCompactTransientDialog(facts: facts)
+
+        return ManagedReplacementMetadata(
             bundleId: bundleId,
             workspaceId: workspaceId,
             mode: mode,
@@ -5097,9 +5100,12 @@ final class AXEventHandler: CGSEventDelegate {
             windowLevel: facts.windowServer?.level,
             parentWindowId: normalizedParentWindowId(facts.windowServer?.parentId),
             frame: facts.windowServer?.frame,
-            transientWindowServerEvidence: facts.windowServer?.hasTransientSurfaceEvidence ?? false,
+            transientWindowServerEvidence: hasGeckoTransientDialogEvidence
+                || (facts.windowServer?.hasTransientSurfaceEvidence ?? false),
             degradedWindowServerChildEvidence: facts.degradedWindowServerChildEvidence,
-            userAddressableTransientWindowServerSurface: facts.userAddressableTransientWindowServerSurface
+            userAddressableTransientWindowServerSurface: hasGeckoTransientDialogEvidence
+                ? false
+                : facts.userAddressableTransientWindowServerSurface
         )
     }
 

--- a/Sources/Nehir/Core/Rules/WindowRuleEngine.swift
+++ b/Sources/Nehir/Core/Rules/WindowRuleEngine.swift
@@ -328,6 +328,7 @@ final class WindowRuleEngine {
     private static let transientSystemDialogSurfaceRuleName = "transientSystemDialogSurface"
     private static let cleanShotRecordingOverlayRuleName = "cleanShotRecordingOverlay"
     private static let geckoTransientDialogRuleName = "geckoTransientDialog"
+    private static let geckoCompactTransientDialogRuleName = "geckoCompactTransientDialog"
     private static let ghosttyQuickTerminalRuleName = "ghosttyQuickTerminalOverlay"
     private static let ghosttyBundleId = "com.mitchellh.ghostty"
     private static let geckoBundleIds: Set<String> = [
@@ -337,6 +338,16 @@ final class WindowRuleEngine {
         "app.zen-browser.zen",
         "org.mozilla.seamonkey"
     ]
+    // Observed Gecko transient dialogs are 389×131 / 402×176 while real
+    // toplevels are ≥ ~1000 wide; keep slack narrow to avoid stacked-tile demotion.
+    private static let geckoCompactTransientDialogMaxWidth: CGFloat = 480
+    private static let geckoCompactTransientDialogMaxHeight: CGFloat = 240
+
+    static func isGeckoBundle(_ bundleId: String?) -> Bool {
+        guard let bundleId = bundleId?.lowercased() else { return false }
+        return geckoBundleIds.contains(bundleId)
+    }
+
     private static let systemTextInputPanelBundleIds: Set<String> = [
         "com.apple.characterpaletteim",
         "com.apple.emojifunctionrowitem-container",
@@ -582,6 +593,14 @@ final class WindowRuleEngine {
             return geckoDecision
         }
 
+        if let geckoDecision = geckoCompactTransientDialogDecision(
+            for: facts,
+            workspaceName: workspaceName,
+            effects: effects
+        ) {
+            return geckoDecision
+        }
+
         if appFullscreen {
             return WindowDecision(
                 disposition: stickyAdjustedDisposition(.managed, effects: effects),
@@ -737,19 +756,11 @@ final class WindowRuleEngine {
 
     // Gecko apps (Thunderbird/Firefox) report transient dialogs — e.g. the
     // Thunderbird "message sent" confirmation — as top-level AXStandardWindows
-    // with all window buttons and an enabled fullscreen button, and with a nil AX
-    // title. They are indistinguishable from real document windows by AX alone, so
-    // the heuristic tiles them (#142). The one durable discriminator is the
-    // WindowServer document tag: real Gecko windows (main, compose) carry it; the
-    // transient dialog carries neither the document nor the floating tag. Float
-    // those. Title-based user rules cannot address this (title is nil).
-    private func geckoTransientDialogDecision(
-        for facts: WindowRuleFacts,
-        workspaceName: String?,
-        effects: ManagedWindowRuleEffects
-    ) -> WindowDecision? {
-        guard let bundleId = facts.ax.bundleId?.lowercased(),
-              Self.geckoBundleIds.contains(bundleId),
+    // with all window buttons and an enabled fullscreen button. They can either
+    // omit the WindowServer document/floating tags or be born document-tagged but
+    // compact. Keep both out of tiling; title is not a durable discriminator.
+    static func isGeckoTransientDialog(facts: WindowRuleFacts) -> Bool {
+        guard Self.isGeckoBundle(facts.ax.bundleId),
               facts.ax.attributeFetchSucceeded,
               facts.ax.role == kAXWindowRole as String,
               facts.ax.subrole == kAXStandardWindowSubrole as String,
@@ -758,12 +769,56 @@ final class WindowRuleEngine {
               !windowServer.hasDocumentTag,
               !windowServer.hasFloatingTag
         else {
-            return nil
+            return false
         }
+
+        return true
+    }
+
+    private func geckoTransientDialogDecision(
+        for facts: WindowRuleFacts,
+        workspaceName: String?,
+        effects: ManagedWindowRuleEffects
+    ) -> WindowDecision? {
+        guard Self.isGeckoTransientDialog(facts: facts) else { return nil }
 
         return WindowDecision(
             disposition: .floating,
             source: .builtInRule(Self.geckoTransientDialogRuleName),
+            layoutDecisionKind: .fallbackLayout,
+            workspaceName: workspaceName,
+            ruleEffects: effects,
+            heuristicReasons: [],
+            deferredReason: nil
+        )
+    }
+
+    static func isGeckoCompactTransientDialog(facts: WindowRuleFacts) -> Bool {
+        guard Self.isGeckoBundle(facts.ax.bundleId),
+              facts.ax.attributeFetchSucceeded,
+              facts.ax.role == kAXWindowRole as String,
+              facts.ax.subrole == kAXStandardWindowSubrole as String,
+              let windowServer = facts.windowServer,
+              !windowServer.frame.isEmpty,
+              windowServer.frame.width <= Self.geckoCompactTransientDialogMaxWidth,
+              windowServer.frame.height <= Self.geckoCompactTransientDialogMaxHeight
+        else {
+            return false
+        }
+
+        return true
+    }
+
+    private func geckoCompactTransientDialogDecision(
+        for facts: WindowRuleFacts,
+        workspaceName: String?,
+        effects: ManagedWindowRuleEffects
+    ) -> WindowDecision? {
+        guard Self.isGeckoCompactTransientDialog(facts: facts) else { return nil }
+
+        return WindowDecision(
+            disposition: .floating,
+            source: .builtInRule(Self.geckoCompactTransientDialogRuleName),
             layoutDecisionKind: .fallbackLayout,
             workspaceName: workspaceName,
             ruleEffects: effects,

--- a/Tests/NehirTests/WindowRuleEngineTests.swift
+++ b/Tests/NehirTests/WindowRuleEngineTests.swift
@@ -605,6 +605,120 @@ private func makeWindowRuleFacts(
         #expect(decision.heuristicReasons.isEmpty)
     }
 
+    @Test func geckoDocumentTaggedCompactStandardWindowFloatsAsTransientDialog() {
+        let engine = WindowRuleEngine()
+
+        let decision = engine.decision(
+            for: makeWindowRuleFacts(
+                bundleId: "org.mozilla.thunderbird",
+                title: nil,
+                role: kAXWindowRole as String,
+                subrole: kAXStandardWindowSubrole as String,
+                hasCloseButton: true,
+                hasFullscreenButton: true,
+                fullscreenButtonEnabled: true,
+                hasZoomButton: true,
+                hasMinimizeButton: true,
+                windowServer: makeGeckoDialogWindowServerInfo(
+                    tags: 0x1,
+                    frame: CGRect(x: 1342, y: 631, width: 389, height: 131)
+                )
+            ),
+            token: nil,
+            appFullscreen: false
+        )
+
+        #expect(decision.disposition == .floating)
+        #expect(decision.source == .builtInRule("geckoCompactTransientDialog"))
+        #expect(decision.layoutDecisionKind == .fallbackLayout)
+        #expect(decision.heuristicReasons.isEmpty)
+    }
+
+    @Test func geckoDocumentTaggedCompactStandardWindowStillFloatsAfterTitleArrives() {
+        let engine = WindowRuleEngine()
+
+        let decision = engine.decision(
+            for: makeWindowRuleFacts(
+                bundleId: "org.mozilla.thunderbird",
+                title: "Sending Message",
+                role: kAXWindowRole as String,
+                subrole: kAXStandardWindowSubrole as String,
+                hasCloseButton: true,
+                hasFullscreenButton: true,
+                fullscreenButtonEnabled: true,
+                hasZoomButton: true,
+                hasMinimizeButton: true,
+                windowServer: makeGeckoDialogWindowServerInfo(
+                    tags: 0x1,
+                    frame: CGRect(x: 1342, y: 631, width: 389, height: 131)
+                )
+            ),
+            token: nil,
+            appFullscreen: false
+        )
+
+        #expect(decision.disposition == .floating)
+        #expect(decision.source == .builtInRule("geckoCompactTransientDialog"))
+        #expect(decision.layoutDecisionKind == .fallbackLayout)
+        #expect(decision.heuristicReasons.isEmpty)
+    }
+
+    @Test func geckoDocumentTaggedStackedTileSizedWindowTilesHeuristically() {
+        let engine = WindowRuleEngine()
+
+        let decision = engine.decision(
+            for: makeWindowRuleFacts(
+                bundleId: "org.mozilla.thunderbird",
+                title: "Write: Subject",
+                role: kAXWindowRole as String,
+                subrole: kAXStandardWindowSubrole as String,
+                hasCloseButton: true,
+                hasFullscreenButton: true,
+                fullscreenButtonEnabled: true,
+                hasZoomButton: true,
+                hasMinimizeButton: true,
+                windowServer: makeGeckoDialogWindowServerInfo(
+                    tags: 0x1,
+                    frame: CGRect(x: 628, y: 418, width: 510, height: 308)
+                )
+            ),
+            token: nil,
+            appFullscreen: false
+        )
+
+        #expect(decision.disposition == .managed)
+        #expect(decision.source == .heuristic)
+        #expect(decision.heuristicReasons.isEmpty)
+    }
+
+    @Test func nonGeckoCompactStandardWindowTilesHeuristically() {
+        let engine = WindowRuleEngine()
+
+        let decision = engine.decision(
+            for: makeWindowRuleFacts(
+                bundleId: "com.example.app",
+                title: nil,
+                role: kAXWindowRole as String,
+                subrole: kAXStandardWindowSubrole as String,
+                hasCloseButton: true,
+                hasFullscreenButton: true,
+                fullscreenButtonEnabled: true,
+                hasZoomButton: true,
+                hasMinimizeButton: true,
+                windowServer: makeGeckoDialogWindowServerInfo(
+                    tags: 0x1,
+                    frame: CGRect(x: 100, y: 100, width: 389, height: 131)
+                )
+            ),
+            token: nil,
+            appFullscreen: false
+        )
+
+        #expect(decision.disposition == .managed)
+        #expect(decision.source == .heuristic)
+        #expect(decision.heuristicReasons.isEmpty)
+    }
+
     @Test func geckoFloatingTaggedSurfaceKeepsExistingTransientSurfaceRule() {
         let engine = WindowRuleEngine()
 


### PR DESCRIPTION
## Summary

Keep Thunderbird Gecko transient dialogs out of tiled layout projection. Fixes #142.
## Release notes

Choose one:

- [x] Added a `.changeset/*.md` for user-visible changes (`mise run changeset -- patch "..."`).
- [ ] No user-visible change; apply the `no release note` label to make CI skip intentional.

## Validation

<!-- Commands run, screenshots, or manual checks. -->

- [ ] Ran relevant tests/checks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of Thunderbird/Gecko transient dialogs so compact dialog windows are kept out of tiled layouts and float more reliably.
  * Better distinguishes compact dialog windows from standard top-level windows, including improved classification based on window sizing and timing evidence.  

<!-- end of auto-generated comment: release notes by coderabbit.ai -->