### PR TITLE
Remove real AX-closed windows after liveness verification

### DIFF
--- a/.changeset/20260708015201-remove-real-ax-closed-windows-without-reopening-.md
+++ b/.changeset/20260708015201-remove-real-ax-closed-windows-without-reopening-.md
@@ -1,0 +1,6 @@
+---
+"nehir": patch
+
+---
+
+Remove real AX-closed windows without reopening cold-start destroy protection

--- a/Sources/Nehir/Core/Ax/AXManager.swift
+++ b/Sources/Nehir/Core/Ax/AXManager.swift
@@ -34,6 +34,11 @@ final class AXManager {
         static let empty = FullRescanEnumerationSnapshot(windows: [], failedPIDs: [])
     }
 
+    enum PerAppWindowEnumeration {
+        case success([(AXWindowRef, pid_t, Int)])
+        case failed
+    }
+
     private static let systemUIBundleIds: Set<String> = [
         "com.apple.notificationcenterui",
         "com.apple.controlcenter",
@@ -51,6 +56,7 @@ final class AXManager {
     var isRuntimeTraceCaptureActive: () -> Bool = { false }
     var currentWindowsAsyncOverride: (@MainActor () async -> [(AXWindowRef, pid_t, Int)])?
     var fullRescanEnumerationOverrideForTests: (@MainActor () async -> FullRescanEnumerationSnapshot)?
+    var perAppWindowEnumerationOverrideForTests: (@MainActor (pid_t) async -> PerAppWindowEnumeration)?
     var frameApplyOverrideForTests: (([AXFrameApplicationRequest]) -> [AXFrameApplyResult])?
     var frameApplyAsyncOverrideForTests: (([AXFrameApplicationRequest], @escaping ([AXFrameApplyResult]) -> Void)
         -> Void)?
@@ -426,18 +432,52 @@ final class AXManager {
         }
     }
 
-    func windowsForApp(_ app: NSRunningApplication) async -> [(AXWindowRef, pid_t, Int)] {
-        guard shouldTrack(app) else { return [] }
+    private func rawWindowEnumerationForApp(
+        _ app: NSRunningApplication,
+        recordMismatchAgainst windowServerCount: Int? = nil
+    ) async -> PerAppWindowEnumeration {
+        guard shouldTrack(app) else { return .success([]) }
         do {
-            guard let context = try await AppAXContext.getOrCreate(app) else { return [] }
+            guard let context = try await AppAXContext.getOrCreate(app) else { return .failed }
             let appWindows = try await withTimeoutOrNil(seconds: perAppTimeout) {
                 try await context.getWindowsAsync()
             }
             if let windows = appWindows {
-                return windows.map { ($0.0, app.processIdentifier, $0.1) }
+                if let windowServerCount, windows.count < windowServerCount {
+                    AppAXContext.recordAXWindowCountMismatch(
+                        pid: app.processIdentifier,
+                        axCount: windows.count,
+                        windowServerCount: windowServerCount
+                    )
+                }
+                return .success(windows.map { ($0.0, app.processIdentifier, $0.1) })
             }
         } catch {}
-        return []
+        return .failed
+    }
+
+    func windowEnumerationForApp(_ app: NSRunningApplication) async -> PerAppWindowEnumeration {
+        if let perAppWindowEnumerationOverrideForTests {
+            return await perAppWindowEnumerationOverrideForTests(app.processIdentifier)
+        }
+        return await rawWindowEnumerationForApp(app)
+    }
+
+    func windowEnumerationForPID(_ pid: pid_t) async -> PerAppWindowEnumeration {
+        if let perAppWindowEnumerationOverrideForTests {
+            return await perAppWindowEnumerationOverrideForTests(pid)
+        }
+        guard let app = NSRunningApplication(processIdentifier: pid) else { return .failed }
+        return await windowEnumerationForApp(app)
+    }
+
+    func windowsForApp(_ app: NSRunningApplication) async -> [(AXWindowRef, pid_t, Int)] {
+        switch await windowEnumerationForApp(app) {
+        case .success(let windows):
+            return windows
+        case .failed:
+            return []
+        }
     }
 
     func requestPermission() -> Bool {
@@ -511,34 +551,16 @@ final class AXManager {
         ) { group in
             for app in apps {
                 group.addTask {
-                    do {
-                        guard let context = try await AppAXContext.getOrCreate(app) else {
-                            return (app.processIdentifier, [], true)
-                        }
-
-                        let appWindows = try await self.withTimeoutOrNil(seconds: perAppTimeout) {
-                            try await context.getWindowsAsync()
-                        }
-
-                        if let windows = appWindows {
-                            if let windowServerCount = windowServerCounts[app.processIdentifier],
-                               windows.count < windowServerCount
-                            {
-                                await AppAXContext.recordAXWindowCountMismatch(
-                                    pid: app.processIdentifier,
-                                    axCount: windows.count,
-                                    windowServerCount: windowServerCount
-                                )
-                            }
-                            return (
-                                app.processIdentifier,
-                                windows.map { ($0.0, app.processIdentifier, $0.1) },
-                                false
-                            )
-                        }
-                    } catch {
+                    let enumeration = await self.rawWindowEnumerationForApp(
+                        app,
+                        recordMismatchAgainst: windowServerCounts[app.processIdentifier]
+                    )
+                    switch enumeration {
+                    case .success(let windows):
+                        return (app.processIdentifier, windows, false)
+                    case .failed:
+                        return (app.processIdentifier, [], true)
                     }
-                    return (app.processIdentifier, [], true)
                 }
             }
 

--- a/Sources/Nehir/Core/Controller/AXEventHandler.swift
+++ b/Sources/Nehir/Core/Controller/AXEventHandler.swift
@@ -1780,10 +1780,24 @@ final class AXEventHandler: CGSEventDelegate {
             else {
                 return
             }
-            await self.warmAXContextIfNeeded(for: token.pid)
+            let windowServerAlive = self.resolveWindowInfo(windowId)?.pid == token.pid
+            let axEnumerationSucceededAndMissingToken: Bool
+            if windowServerAlive {
+                let axEnumeration = await controller.axManager.windowEnumerationForPID(token.pid)
+                switch axEnumeration {
+                case .success(let windows):
+                    axEnumerationSucceededAndMissingToken = !windows.contains { _, pid, enumeratedWindowId in
+                        pid == token.pid && enumeratedWindowId == token.windowId
+                    }
+                case .failed:
+                    axEnumerationSucceededAndMissingToken = false
+                }
+            } else {
+                axEnumerationSucceededAndMissingToken = false
+            }
             guard !Task.isCancelled,
                   controller.workspaceManager.entry(for: token) != nil,
-                  self.resolveWindowInfo(windowId) == nil
+                  (!windowServerAlive || axEnumerationSucceededAndMissingToken)
             else {
                 return
             }

--- a/Tests/NehirTests/AXEventHandlerTests.swift
+++ b/Tests/NehirTests/AXEventHandlerTests.swift
@@ -10128,6 +10128,151 @@ private func waitUntilAXEventTest(
         #expect(controller.workspaceManager.entry(for: liveToken) != nil)
     }
 
+    @Test @MainActor func axDestroyDeferredVerificationRemovesWhenAXEnumerationMissesWindow() async {
+        let controller = makeAXEventTestController()
+        guard let workspaceId = controller.interactionWorkspace()?.id else {
+            Issue.record("Missing active workspace")
+            return
+        }
+
+        let token = controller.workspaceManager.addWindow(
+            AXWindowRef(element: AXUIElementCreateSystemWide(), windowId: 906),
+            pid: getpid(),
+            windowId: 906,
+            to: workspaceId
+        )
+        controller.axEventHandler.windowInfoProvider = { windowId in
+            guard windowId == 906 else { return nil }
+            return WindowServerInfo(id: windowId, pid: token.pid, level: 0, frame: .zero)
+        }
+        controller.axManager.perAppWindowEnumerationOverrideForTests = { pid in
+            #expect(pid == token.pid)
+            return .success([])
+        }
+        defer {
+            controller.axEventHandler.windowInfoProvider = nil
+            controller.axManager.perAppWindowEnumerationOverrideForTests = nil
+        }
+
+        controller.axEventHandler.handleRemoved(pid: token.pid, winId: token.windowId)
+        #expect(controller.workspaceManager.entry(for: token) != nil)
+
+        await waitUntilAXEventTest(iterations: 250) {
+            controller.workspaceManager.entry(for: token) == nil
+        }
+
+        #expect(controller.workspaceManager.entry(for: token) == nil)
+    }
+
+    @Test @MainActor func axDestroyDeferredVerificationKeepsWindowWhenBothOraclesStillAlive() async {
+        let controller = makeAXEventTestController()
+        guard let workspaceId = controller.interactionWorkspace()?.id else {
+            Issue.record("Missing active workspace")
+            return
+        }
+
+        let token = controller.workspaceManager.addWindow(
+            AXWindowRef(element: AXUIElementCreateSystemWide(), windowId: 907),
+            pid: getpid(),
+            windowId: 907,
+            to: workspaceId
+        )
+        controller.axEventHandler.windowInfoProvider = { windowId in
+            guard windowId == 907 else { return nil }
+            return WindowServerInfo(id: windowId, pid: token.pid, level: 0, frame: .zero)
+        }
+        var axEnumerationCount = 0
+        controller.axManager.perAppWindowEnumerationOverrideForTests = { pid in
+            axEnumerationCount += 1
+            #expect(pid == token.pid)
+            return .success([(AXWindowRef(element: AXUIElementCreateSystemWide(), windowId: 907), pid, 907)])
+        }
+        defer {
+            controller.axEventHandler.windowInfoProvider = nil
+            controller.axManager.perAppWindowEnumerationOverrideForTests = nil
+        }
+
+        controller.axEventHandler.handleRemoved(pid: token.pid, winId: token.windowId)
+        await waitUntilAXEventTest(iterations: 250) {
+            axEnumerationCount > 0
+        }
+
+        #expect(controller.workspaceManager.entry(for: token) != nil)
+    }
+
+    @Test @MainActor func axDestroyDeferredVerificationRemovesWhenWindowServerPidNoLongerMatches() async {
+        let controller = makeAXEventTestController()
+        guard let workspaceId = controller.interactionWorkspace()?.id else {
+            Issue.record("Missing active workspace")
+            return
+        }
+
+        let token = controller.workspaceManager.addWindow(
+            AXWindowRef(element: AXUIElementCreateSystemWide(), windowId: 909),
+            pid: 9_009,
+            windowId: 909,
+            to: workspaceId
+        )
+        var windowServerPid = token.pid
+        var axEnumerationCount = 0
+        controller.axEventHandler.windowInfoProvider = { windowId in
+            guard windowId == 909 else { return nil }
+            return WindowServerInfo(id: windowId, pid: windowServerPid, level: 0, frame: .zero)
+        }
+        controller.axManager.perAppWindowEnumerationOverrideForTests = { _ in
+            axEnumerationCount += 1
+            return .failed
+        }
+        defer {
+            controller.axEventHandler.windowInfoProvider = nil
+            controller.axManager.perAppWindowEnumerationOverrideForTests = nil
+        }
+
+        controller.axEventHandler.handleRemoved(pid: token.pid, winId: token.windowId)
+        windowServerPid = 9_010
+        await waitUntilAXEventTest(iterations: 250) {
+            controller.workspaceManager.entry(for: token) == nil
+        }
+
+        #expect(controller.workspaceManager.entry(for: token) == nil)
+        #expect(axEnumerationCount == 0)
+    }
+
+    @Test @MainActor func axDestroyDeferredVerificationKeepsWindowWhenAXEnumerationFailsAndWindowServerAlive() async {
+        let controller = makeAXEventTestController()
+        guard let workspaceId = controller.interactionWorkspace()?.id else {
+            Issue.record("Missing active workspace")
+            return
+        }
+
+        let token = controller.workspaceManager.addWindow(
+            AXWindowRef(element: AXUIElementCreateSystemWide(), windowId: 908),
+            pid: getpid(),
+            windowId: 908,
+            to: workspaceId
+        )
+        controller.axEventHandler.windowInfoProvider = { windowId in
+            guard windowId == 908 else { return nil }
+            return WindowServerInfo(id: windowId, pid: token.pid, level: 0, frame: .zero)
+        }
+        var axEnumerationCount = 0
+        controller.axManager.perAppWindowEnumerationOverrideForTests = { _ in
+            axEnumerationCount += 1
+            return .failed
+        }
+        defer {
+            controller.axEventHandler.windowInfoProvider = nil
+            controller.axManager.perAppWindowEnumerationOverrideForTests = nil
+        }
+
+        controller.axEventHandler.handleRemoved(pid: token.pid, winId: token.windowId)
+        await waitUntilAXEventTest(iterations: 250) {
+            axEnumerationCount > 0
+        }
+
+        #expect(controller.workspaceManager.entry(for: token) != nil)
+    }
+
     @Test @MainActor func handleRemovedPidPathInvalidatesCachedTitle() async {
         await withAXFrameProviderIsolationForTests {
             AXWindowService.clearTitleCacheForTests()


### PR DESCRIPTION
## Summary

Remove real AX-closed windows without reopening cold-start destroy protection

## Release notes

Choose one:

- [x] Added a `.changeset/*.md` for user-visible changes (`mise run changeset -- patch "..."`).
- [ ] No user-visible change; apply the `no release note` label to make CI skip intentional.

## Validation

<!-- Commands run, screenshots, or manual checks. -->

- [ ] Ran relevant tests/checks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling for AX-closed windows so they’re only removed when the window server and AX enumeration confirm the window is gone, reducing cold-start reappearance and unintended reopening.
  * More reliably distinguishes between “no windows found” and “enumeration failed” to keep or clear cached window data appropriately.
* **Tests**
  * Expanded delayed destruction verification coverage to validate behavior when AX enumeration misses the window, both oracles still indicate it exists, the server PID changes, or AX enumeration fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->