### PR TITLE
Keep the viewport still when focusing an already visible window

### DIFF
--- a/.changeset/20260708145017-stop-focusing-an-already-fully-visible-window-fr.md
+++ b/.changeset/20260708145017-stop-focusing-an-already-fully-visible-window-fr.md
@@ -1,0 +1,6 @@
+---
+"nehir": patch
+
+---
+
+Stop focusing an already fully visible window from scrolling the viewport, and make viewport scroll lock suppress these automatic reveals

--- a/Sources/Nehir/Core/Controller/AXEventHandler.swift
+++ b/Sources/Nehir/Core/Controller/AXEventHandler.swift
@@ -3940,7 +3940,8 @@ final class AXEventHandler: CGSEventDelegate {
                     state: &state,
                     context: context,
                     motion: controller.motionPolicy.snapshot(),
-                    scale: engine.displayScale(in: wsId)
+                    scale: engine.displayScale(in: wsId),
+                    allowFullyVisibleAutomaticRecenter: false
                 )
                 controller.diagnostics.recordRuntimeViewportTrace(
                     workspaceId: wsId,

--- a/Sources/Nehir/Core/Layout/Niri/NiriLayoutEngine+ColumnOps.swift
+++ b/Sources/Nehir/Core/Layout/Niri/NiriLayoutEngine+ColumnOps.swift
@@ -455,7 +455,8 @@ extension NiriLayoutEngine {
             workingFrame: workingFrame,
             gaps: gaps,
             animationConfig: windowMovementAnimationConfig,
-            fromContainerIndex: currentIdx
+            fromContainerIndex: currentIdx,
+            revealTrigger: .explicitNavigation
         )
 
         return true
@@ -900,7 +901,8 @@ extension NiriLayoutEngine {
         workingFrame: CGRect,
         gaps: CGFloat,
         animationConfig: SpringConfig? = nil,
-        fromContainerIndex: Int? = nil
+        fromContainerIndex: Int? = nil,
+        revealTrigger: RevealTrigger = .automatic
     ) {
         if let firstWindow = column.windowNodes.first {
             ensureSelectionVisible(
@@ -911,7 +913,8 @@ extension NiriLayoutEngine {
                 workingFrame: workingFrame,
                 gaps: gaps,
                 animationConfig: animationConfig,
-                fromContainerIndex: fromContainerIndex
+                fromContainerIndex: fromContainerIndex,
+                revealTrigger: revealTrigger
             )
         }
     }

--- a/Sources/Nehir/Core/Layout/Niri/NiriLayoutEngine+Sizing.swift
+++ b/Sources/Nehir/Core/Layout/Niri/NiriLayoutEngine+Sizing.swift
@@ -295,7 +295,8 @@ extension NiriLayoutEngine {
                 motion: motion,
                 state: &state,
                 workingFrame: workingFrame,
-                gaps: gaps
+                gaps: gaps,
+                revealTrigger: .explicitNavigation
             )
             ensureColumnWidthVisible(
                 column,

--- a/Sources/Nehir/Core/Layout/Niri/NiriLayoutEngine+ViewportCommands.swift
+++ b/Sources/Nehir/Core/Layout/Niri/NiriLayoutEngine+ViewportCommands.swift
@@ -75,6 +75,7 @@ extension NiriLayoutEngine {
         motion: MotionSnapshot,
         scale: CGFloat = 2.0,
         animationConfig: SpringConfig? = nil,
+        allowFullyVisibleAutomaticRecenter: Bool = false,
         trigger: RevealTrigger = .automatic
     ) -> Bool {
         guard !isFFM else { return false }
@@ -98,9 +99,11 @@ extension NiriLayoutEngine {
         let targetSnap: SnapPoint?
         switch visibility {
         case .fullyVisible:
+            guard !trigger.respectsScrollLock || !state.isScrollLocked else { return false }
             // Re-centering a fully visible filling group is viewport-position maintenance,
             // not a reveal. Keep the proportional slack / lone-column centering contract
-            // even when no hidden content needs to be revealed.
+            // even when no hidden content needs to be revealed, while still honoring
+            // scroll lock for automatic triggers.
             if context.fillsViewport(at: viewStart, in: state) {
                 guard let centeredStart = context.centeredFillingViewportStart(
                     at: viewStart,
@@ -119,7 +122,9 @@ extension NiriLayoutEngine {
                 state.animateToOffset(targetOffset, motion: motion, config: animationConfig, scale: scale)
                 return true
             }
-            guard revealStyle == .auto else { return false }
+            guard revealStyle == .auto,
+                  trigger == .explicitNavigation || allowFullyVisibleAutomaticRecenter
+            else { return false }
             targetSnap = autoSnap()
         case .parked,
              .clipped:

--- a/Sources/Nehir/Core/Layout/Niri/NiriNavigation.swift
+++ b/Sources/Nehir/Core/Layout/Niri/NiriNavigation.swift
@@ -241,6 +241,7 @@ extension NiriLayoutEngine {
                 motion: motion,
                 scale: scale,
                 animationConfig: animationConfig,
+                allowFullyVisibleAutomaticRecenter: revealTrigger == .explicitNavigation,
                 trigger: revealTrigger
             )
         }

--- a/Tests/NehirTests/MotionTestSupport.swift
+++ b/Tests/NehirTests/MotionTestSupport.swift
@@ -34,7 +34,8 @@ extension NiriLayoutEngine {
         orientation: Monitor.Orientation = .horizontal,
         animationConfig: SpringConfig? = nil,
         fromContainerIndex: Int? = nil,
-        previousActiveContainerPosition: CGFloat? = nil
+        previousActiveContainerPosition: CGFloat? = nil,
+        revealTrigger: RevealTrigger = .automatic
     ) {
         ensureSelectionVisible(
             node: node,
@@ -46,7 +47,8 @@ extension NiriLayoutEngine {
             orientation: orientation,
             animationConfig: animationConfig,
             fromContainerIndex: fromContainerIndex,
-            previousActiveContainerPosition: previousActiveContainerPosition
+            previousActiveContainerPosition: previousActiveContainerPosition,
+            revealTrigger: revealTrigger
         )
     }
 

--- a/Tests/NehirTests/NiriLayoutEngineTests.swift
+++ b/Tests/NehirTests/NiriLayoutEngineTests.swift
@@ -3009,7 +3009,8 @@ private func makeCenteredCrossMonitorFixture(
             in: wsId,
             state: &state,
             workingFrame: CGRect(x: 0, y: 0, width: 1200, height: 900),
-            gaps: 8
+            gaps: 8,
+            revealTrigger: .explicitNavigation
         )
 
         #expect(abs(state.viewOffsetPixels.target() + 400) < 0.1)

--- a/Tests/NehirTests/ViewportSnapContextTests.swift
+++ b/Tests/NehirTests/ViewportSnapContextTests.swift
@@ -571,6 +571,65 @@ private func makeContext(
         #expect(fixture.state.viewOffsetPixels.target() == originalTarget)
     }
 
+    @Test func scrollToRevealSuppressesFullyVisibleAutomaticRecenter() {
+        var fixture = makeRevealFixture(viewportWidth: 1000)
+        let originalTarget = fixture.state.viewOffsetPixels.target()
+        let viewStart = fixture.context.currentViewStart(in: fixture.state)
+        let closest = fixture.context.snapCandidates(for: 0, in: fixture.state).closest(to: viewStart)
+        let expected = expectedRevealTargetOffset(style: .auto, columnIndex: 0, fixture: fixture)
+
+        #expect(fixture.context.visibility(of: 0, viewportOffset: viewStart, in: fixture.state) == .fullyVisible)
+        #expect(closest.map { fixture.context.fillsViewport(at: $0.offset, in: fixture.state) } == false)
+        #expect(expected != originalTarget)
+
+        let revealed = fixture.engine.scrollToReveal(
+            columnIndex: 0,
+            isFFM: false,
+            state: &fixture.state,
+            context: fixture.context,
+            motion: .disabled,
+            trigger: .automatic
+        )
+
+        #expect(!revealed)
+        #expect(fixture.state.viewOffsetPixels.target() == originalTarget)
+    }
+
+    @Test func scrollToRevealAllowsFullyVisibleExplicitNavigationRecenter() {
+        var fixture = makeRevealFixture(viewportWidth: 1000)
+        let expected = expectedRevealTargetOffset(style: .auto, columnIndex: 0, fixture: fixture)
+
+        let revealed = fixture.engine.scrollToReveal(
+            columnIndex: 0,
+            isFFM: false,
+            state: &fixture.state,
+            context: fixture.context,
+            motion: .disabled,
+            trigger: .explicitNavigation
+        )
+
+        #expect(revealed)
+        #expect(fixture.state.viewOffsetPixels.target() == expected)
+    }
+
+    @Test func scrollToRevealSkipsFullyVisibleAutomaticWhenLocked() {
+        var fixture = makeRevealFixture(viewportWidth: 1000)
+        fixture.state.isScrollLocked = true
+        let originalTarget = fixture.state.viewOffsetPixels.target()
+
+        let revealed = fixture.engine.scrollToReveal(
+            columnIndex: 0,
+            isFFM: false,
+            state: &fixture.state,
+            context: fixture.context,
+            motion: .disabled,
+            trigger: .automatic
+        )
+
+        #expect(!revealed)
+        #expect(fixture.state.viewOffsetPixels.target() == originalTarget)
+    }
+
     @Test func scrollToRevealUsesClosestStyleForParkedTargets() {
         var fixture = makeRevealFixture(style: .closest, viewportWidth: 800)
         let expected = expectedRevealTargetOffset(style: .closest, columnIndex: 2, fixture: fixture)


### PR DESCRIPTION
## Summary

Stop focusing an already fully visible window from scrolling the viewport, and make viewport scroll lock suppress these automatic reveals

## Release notes

Choose one:

- [x] Added a `.changeset/*.md` for user-visible changes (`mise run changeset -- patch "..."`).
- [ ] No user-visible change; apply the `no release note` label to make CI skip intentional.

## Validation

<!-- Commands run, screenshots, or manual checks. -->

- [ ] Ran relevant tests/checks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented automatic recentering when a target window is already fully visible, avoiding unnecessary viewport scrolling.
  * Honored viewport scroll lock to suppress auto-reveal/recenter behavior even when no reveal is required.
  * Refined reveal handling so automatic recentering only occurs for the intended triggers, while explicit navigation can still recenter when appropriate.
* **Tests**
  * Added/expanded `scrollToReveal` test coverage for fully-visible and scroll-locked scenarios, distinguishing automatic vs explicit navigation outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->