### PR TITLE
Clear stale non-managed focus after quick terminal dismissal

### DIFF
--- a/.changeset/20260710222654-clear-stale-non-managed-focus-after-quick-termin.md
+++ b/.changeset/20260710222654-clear-stale-non-managed-focus-after-quick-termin.md
@@ -1,0 +1,6 @@
+---
+"nehir": patch
+
+---
+
+Clear stale non-managed focus after quick-terminal dismissal so workspace and focus commands keep working

--- a/Sources/Nehir/Core/Controller/AXEventHandler.swift
+++ b/Sources/Nehir/Core/Controller/AXEventHandler.swift
@@ -3085,6 +3085,10 @@ final class AXEventHandler: CGSEventDelegate {
         let recentClose = hasRecentSameAppWindowClose(for: observedEntry.pid)
         let recoveryArmed = activeWindowCloseFocusRecoveryWorkspaceId() != nil
         if recentClose || recoveryArmed {
+            let clearedStaleNonManagedFocus =
+                controller.clearStaleNonManagedFocusAfterOverlaySuppressed(
+                    refreshFocusFollowsMouse: recoveryArmed
+                )
             controller.diagnostics.recordRuntimeViewportTrace(
                 workspaceId: observedEntry.workspaceId,
                 reason: "overlay_close_churn_suppressed",
@@ -3094,6 +3098,7 @@ final class AXEventHandler: CGSEventDelegate {
                     "origin=\(origin.rawValue)",
                     "recentSameAppClose=\(recentClose)",
                     "recoveryArmed=\(recoveryArmed)",
+                    "clearedStaleNonManagedFocus=\(clearedStaleNonManagedFocus)",
                     "reason=close_evidence_present"
                 ]
             )

--- a/Sources/Nehir/Core/Controller/WMController.swift
+++ b/Sources/Nehir/Core/Controller/WMController.swift
@@ -3994,14 +3994,25 @@ extension WMController {
     }
 
     func handleOwnedFocusSuppressingWindowClosed() {
-        guard workspaceManager.isNonManagedFocusActive, !hasVisibleOwnedWindow else { return }
+        guard !hasVisibleOwnedWindow else { return }
+        _ = clearStaleNonManagedFocusAfterOverlaySuppressed(refreshFocusFollowsMouse: true)
+    }
+
+    @discardableResult
+    func clearStaleNonManagedFocusAfterOverlaySuppressed(
+        refreshFocusFollowsMouse: Bool
+    ) -> Bool {
+        guard workspaceManager.isNonManagedFocusActive, !hasVisibleOwnedWindow else { return false }
         let preservedToken = workspaceManager.confirmedManagedFocusToken
-        guard workspaceManager.leaveNonManagedFocus(preserveFocusedToken: true) else { return }
+        guard workspaceManager.leaveNonManagedFocus(preserveFocusedToken: true) else { return false }
         if let preservedToken {
             suppressMouseMoveToFocusedWindow(for: preservedToken)
         }
         _ = focusBorderController.refresh(forceOrdering: true)
-        mouseEventHandler.refreshFocusFollowsMouseAtCurrentPointer()
+        if refreshFocusFollowsMouse {
+            mouseEventHandler.refreshFocusFollowsMouseAtCurrentPointer()
+        }
+        return true
     }
 
     func isOwnedWindow(windowNumber: Int) -> Bool {


### PR DESCRIPTION

## Summary

Quick-terminal close churn remains suppressed so parked windows cannot reveal or move the viewport. When close evidence suppresses that activation, Nehir now leaves stale non-managed focus while preserving the confirmed token and refreshes focus UI state. The suppression trace records whether the stale state was cleared.

## Release notes

Choose one:

- [x] Added a `.changeset/*.md` for user-visible changes (`mise run changeset -- patch "..."`).
- [ ] No user-visible change; apply the `no release note` label to make CI skip intentional.

## Validation

<!-- Commands run, screenshots, or manual checks. -->

- [ ] Ran relevant tests/checks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where dismissing a quick terminal could leave stale (non-managed) focus, causing focus/workspace actions to misbehave.
  * Improved focus cleanup and focus/follow-mouse behavior when overlays close, helping maintain consistent window focus state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->