### PR TITLE
Arm overlay close-churn protection from window-rule classification

### DIFF
--- a/.changeset/20260710224959-arm-quick-terminal-close-churn-protection-from-w.md
+++ b/.changeset/20260710224959-arm-quick-terminal-close-churn-protection-from-w.md
@@ -1,0 +1,6 @@
+---
+"nehir": patch
+
+---
+
+Arm quick-terminal close-churn protection from window-rule classification so the first close after a restart does not reveal a parked column

--- a/Sources/Nehir/Core/Controller/AXEventHandler.swift
+++ b/Sources/Nehir/Core/Controller/AXEventHandler.swift
@@ -2862,14 +2862,31 @@ final class AXEventHandler: CGSEventDelegate {
             appFullscreen: false
         )
         if case let .builtInRule(name) = decision.source,
-           name == "ghosttyQuickTerminalOverlay"
-           || name == "cleanShotRecordingOverlay"
-           || name == "systemTextInputPanel"
+           Self.isOverlayCapableRuleName(name)
         {
             overlayCapablePids.insert(pid)
             return true
         }
         return false
+    }
+
+    func armOverlayCapabilityIfNeeded(source: WindowDecisionSource, pid: pid_t) {
+        guard case let .builtInRule(name) = source,
+              Self.isOverlayCapableRuleName(name)
+        else {
+            return
+        }
+        overlayCapablePids.insert(pid)
+    }
+
+    func isOverlayCapablePidForTests(_ pid: pid_t) -> Bool {
+        overlayCapablePids.contains(pid)
+    }
+
+    private static func isOverlayCapableRuleName(_ name: String) -> Bool {
+        name == "ghosttyQuickTerminalOverlay"
+            || name == "cleanShotRecordingOverlay"
+            || name == "systemTextInputPanel"
     }
 
     private func recordCloseRecoveryActivationGate(

--- a/Sources/Nehir/Core/Controller/WMController.swift
+++ b/Sources/Nehir/Core/Controller/WMController.swift
@@ -2673,6 +2673,7 @@ final class WMController {
         let decision = applyingManualOverride
             ? decisionApplyingManualOverride(baseDecision, manualOverride: manualOverride)
             : baseDecision
+        axEventHandler.armOverlayCapabilityIfNeeded(source: baseDecision.source, pid: token.pid)
         let evaluation = WindowDecisionEvaluation(
             token: token,
             facts: facts,

--- a/Tests/NehirTests/AXEventHandlerTests.swift
+++ b/Tests/NehirTests/AXEventHandlerTests.swift
@@ -9402,6 +9402,48 @@ private func waitUntilAXEventTest(
         #expect(events == [.order(825), .activate(getpid()), .focus(getpid(), 825), .raise])
     }
 
+    @Test @MainActor func overlayDecisionArmsPidBeforeManualOverrideWithoutTraceContext() {
+        let controller = makeAXEventTestController()
+        guard let workspaceId = controller.interactionWorkspace()?.id else {
+            Issue.record("Missing active workspace")
+            return
+        }
+
+        let pid: pid_t = 5_821
+        let windowId = 824
+        let axRef = AXWindowRef(element: AXUIElementCreateSystemWide(), windowId: windowId)
+        let token = controller.workspaceManager.addWindow(
+            axRef,
+            pid: pid,
+            windowId: windowId,
+            to: workspaceId
+        )
+        controller.workspaceManager.setManualLayoutOverride(.forceTile, for: token)
+        controller.axEventHandler.windowFactsProvider = { _, _ in
+            makeAXEventWindowRuleFacts(
+                bundleId: "com.mitchellh.ghostty",
+                windowServer: WindowServerInfo(
+                    id: UInt32(windowId),
+                    pid: pid,
+                    level: 1,
+                    frame: .zero
+                )
+            )
+        }
+        defer { controller.axEventHandler.windowFactsProvider = nil }
+
+        #expect(!controller.axEventHandler.isOverlayCapablePidForTests(pid))
+        let evaluation = controller.evaluateWindowDisposition(
+            axRef: axRef,
+            pid: pid,
+            appFullscreen: false
+        )
+
+        #expect(evaluation.decision.source == .manualOverride)
+        #expect(evaluation.manualOverride == .forceTile)
+        #expect(controller.axEventHandler.isOverlayCapablePidForTests(pid))
+    }
+
     @Test @MainActor func cleanShotCaptureOverlayCreateIsTrackedAsFloating() async {
         let controller = makeAXEventTestController()
         let pid: pid_t = 5821


### PR DESCRIPTION

## Summary

Every window disposition evaluation now arms overlay-capable pids directly when an overlay built-in rule classifies a window, independent of trace context or diagnostics filtering. The existing live WindowServer scan remains as a fallback and shares the same overlay-rule name check.

## Release notes

Choose one:

- [x] Added a `.changeset/*.md` for user-visible changes (`mise run changeset -- patch "..."`).
- [ ] No user-visible change; apply the `no release note` label to make CI skip intentional.

## Validation

<!-- Commands run, screenshots, or manual checks. -->

- [ ] Ran relevant tests/checks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved quick-terminal window handling after restarting the app.
  * Prevented the first close action from unexpectedly revealing a previously parked column.
  * Improved classification of overlay windows for more consistent window-rule behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->