### PR TITLE
Hide focus borders during macOS screenshots

### DIFF
--- a/.changeset/20260711134140-exclude-the-focus-border-overlay-from-macos-wind.md
+++ b/.changeset/20260711134140-exclude-the-focus-border-overlay-from-macos-wind.md
@@ -1,0 +1,6 @@
+---
+"nehir": patch
+
+---
+
+Temporarily hide focus borders during macOS screenshot shortcuts so Capture Selected Window captures the app window

--- a/Sources/Nehir/Core/Border/FocusBorderController.swift
+++ b/Sources/Nehir/Core/Border/FocusBorderController.swift
@@ -37,6 +37,7 @@ final class FocusBorderController {
     private var visualFocusTarget: KeyboardFocusTarget?
     private var requiresFocusValidationBeforeRender = false
     private var suppressedManagedTargets: Set<WindowToken> = []
+    private var isScreenshotCaptureSuppressed = false
 
     init(
         controller: WMController,
@@ -71,6 +72,11 @@ final class FocusBorderController {
         preferredFrameSource: BorderFrameSource = .layout,
         forceOrdering: Bool = false
     ) -> Bool {
+        if isScreenshotCaptureSuppressed {
+            borderManager.hideBorder()
+            return false
+        }
+
         guard let target = visualFocusTarget else {
             borderManager.hideBorder()
             return false
@@ -184,6 +190,32 @@ final class FocusBorderController {
         )
     }
 
+    func setScreenshotCaptureSuppressed(_ suppressed: Bool) {
+        guard isScreenshotCaptureSuppressed != suppressed else {
+            if suppressed {
+                borderManager.hideBorder()
+            }
+            return
+        }
+
+        isScreenshotCaptureSuppressed = suppressed
+        if suppressed {
+            borderManager.hideBorder()
+            return
+        }
+
+        if visualFocusTarget != nil {
+            _ = refresh(forceOrdering: true)
+            return
+        }
+        guard let controller,
+              !controller.workspaceManager.isNonManagedFocusActive,
+              let token = controller.workspaceManager.confirmedManagedFocusToken,
+              let target = controller.managedKeyboardFocusTarget(for: token)
+        else { return }
+        _ = focusChanged(to: target, forceOrdering: true)
+    }
+
     func setEnabled(_ enabled: Bool) {
         borderManager.setEnabled(enabled)
         if enabled {
@@ -202,6 +234,7 @@ final class FocusBorderController {
         visualFocusTarget = nil
         requiresFocusValidationBeforeRender = false
         suppressedManagedTargets.removeAll()
+        isScreenshotCaptureSuppressed = false
         borderManager.cleanup()
     }
 

--- a/Sources/Nehir/Core/Controller/MouseEventHandler.swift
+++ b/Sources/Nehir/Core/Controller/MouseEventHandler.swift
@@ -260,6 +260,7 @@ final class MouseEventHandler {
     }
 
     nonisolated(unsafe) weak static var _instance: MouseEventHandler?
+    private nonisolated static let escapeKeyCode: Int64 = 53
 
     weak var controller: WMController?
     var state = State()
@@ -285,7 +286,8 @@ final class MouseEventHandler {
             (1 << CGEventType.rightMouseDown.rawValue) |
             (1 << CGEventType.rightMouseDragged.rawValue) |
             (1 << CGEventType.rightMouseUp.rawValue) |
-            (1 << CGEventType.scrollWheel.rawValue)
+            (1 << CGEventType.scrollWheel.rawValue) |
+            (1 << CGEventType.keyDown.rawValue)
 
         let callback: CGEventTapCallBack = { _, type, event, _ in
             if type == .tapDisabledByTimeout || type == .tapDisabledByUserInput {
@@ -2394,6 +2396,22 @@ final class MouseEventHandler {
     ) -> Bool {
         guard isMainThread else { return false }
 
+        if type == .keyDown {
+            let keyCode = event.getIntegerValueField(.keyboardEventKeycode)
+            let modifiers = event.flags
+            let requiredModifiers: CGEventFlags = [.maskCommand, .maskShift]
+            guard modifiers.contains(requiredModifiers) || keyCode == Self.escapeKeyCode else { return false }
+            MainActor.assumeIsolated {
+                guard let handler = MouseEventHandler._instance else { return }
+                if modifiers.contains(requiredModifiers) {
+                    handler.controller?.serviceLifecycleManager.handleSystemScreenshotShortcut(keyCode: keyCode)
+                } else if keyCode == Self.escapeKeyCode {
+                    handler.controller?.serviceLifecycleManager.handlePotentialScreenshotInteractionCompletion()
+                }
+            }
+            return false
+        }
+
         let location = event.location
         let screenLocation = ScreenCoordinateSpace.toAppKit(point: location)
         let modifiers = event.flags
@@ -2442,6 +2460,7 @@ final class MouseEventHandler {
                 handler.receiveTapMouseDragged(at: screenLocation, windowUnderPointer: windowUnderPointer)
             case .leftMouseUp:
                 handler.receiveTapMouseUp(at: screenLocation, windowUnderPointer: windowUnderPointer)
+                handler.controller?.serviceLifecycleManager.handlePotentialScreenshotInteractionCompletion()
             case .rightMouseDown:
                 suppressEvent = handler.receiveTapMouseDown(
                     at: screenLocation,

--- a/Sources/Nehir/Core/Controller/ServiceLifecycleManager.swift
+++ b/Sources/Nehir/Core/Controller/ServiceLifecycleManager.swift
@@ -33,6 +33,9 @@ final class ServiceLifecycleManager {
     private var permissionCheckerTask: Task<Void, Never>?
     private var dockReservationSettleTasks: [Task<Void, Never>] = []
     private var monitorConfigurationCoalesceTask: Task<Void, Never>?
+    private var screenshotCaptureVisibilityTask: Task<Void, Never>?
+    private var screenshotShortcutSuppressionActive = false
+    private var screenshotShortcutSuppressionGeneration: UInt64 = 0
     var accessibilityPermissionStreamProviderForTests: ((Bool) -> AsyncStream<Bool>)?
     var accessibilityPermissionStateProviderForTests: (() -> Bool)?
     var accessibilityPermissionRequestHandlerForTests: (() -> Bool)?
@@ -267,6 +270,122 @@ final class ServiceLifecycleManager {
         controller?.layoutRefreshController.requestRefresh(reason: .appLaunched)
     }
 
+    /// Hide focus borders before macOS handles its standard screenshot shortcuts.
+    /// `screencaptureui` remains resident between captures, so process lifecycle is
+    /// not a reliable signal for the interactive picker's lifetime.
+    func handleSystemScreenshotShortcut(keyCode: Int64) {
+        guard Self.screenshotShortcutKeyCodes.contains(keyCode) else { return }
+        screenshotShortcutSuppressionGeneration &+= 1
+        let generation = screenshotShortcutSuppressionGeneration
+        screenshotShortcutSuppressionActive = true
+        controller?.focusBorderController.setScreenshotCaptureSuppressed(true)
+        recordScreenshotBorderSuppression(state: "entered", trigger: "shortcut-\(keyCode)")
+        screenshotCaptureVisibilityTask?.cancel()
+
+        if keyCode == Self.fullScreenScreenshotKeyCode {
+            screenshotCaptureVisibilityTask = Task { @MainActor [weak self] in
+                try? await Task.sleep(for: .milliseconds(750))
+                guard !Task.isCancelled else { return }
+                self?.endScreenshotShortcutSuppression(
+                    trigger: "full-screen-timeout",
+                    generation: generation
+                )
+            }
+            return
+        }
+
+        screenshotCaptureVisibilityTask = Task { @MainActor [weak self] in
+            var observedPickerWindow = false
+            let deadline = Date().addingTimeInterval(Self.interactiveScreenshotSuppressionTimeout)
+            while !Task.isCancelled {
+                guard let self,
+                      self.screenshotShortcutSuppressionActive,
+                      self.screenshotShortcutSuppressionGeneration == generation
+                else { return }
+
+                let pickerVisible = self.isScreenshotPickerWindowVisible
+                observedPickerWindow = observedPickerWindow || pickerVisible
+                if observedPickerWindow, !pickerVisible {
+                    self.endScreenshotShortcutSuppression(
+                        trigger: "picker-window-hidden",
+                        generation: generation
+                    )
+                    return
+                }
+                if Date() >= deadline {
+                    self.endScreenshotShortcutSuppression(
+                        trigger: "picker-window-timeout",
+                        generation: generation
+                    )
+                    return
+                }
+                try? await Task.sleep(for: .milliseconds(100))
+            }
+        }
+    }
+
+    func handlePotentialScreenshotInteractionCompletion() {
+        guard screenshotShortcutSuppressionActive else { return }
+        let generation = screenshotShortcutSuppressionGeneration
+        Task { @MainActor [weak self] in
+            try? await Task.sleep(for: .milliseconds(300))
+            guard !Task.isCancelled,
+                  let self,
+                  self.screenshotShortcutSuppressionActive,
+                  self.screenshotShortcutSuppressionGeneration == generation,
+                  !self.isScreenshotPickerWindowVisible
+            else { return }
+            self.endScreenshotShortcutSuppression(
+                trigger: "interaction-completed",
+                generation: generation
+            )
+        }
+    }
+
+    private func endScreenshotShortcutSuppression(trigger: String, generation: UInt64) {
+        guard screenshotShortcutSuppressionActive,
+              screenshotShortcutSuppressionGeneration == generation
+        else { return }
+        screenshotShortcutSuppressionActive = false
+        screenshotCaptureVisibilityTask?.cancel()
+        screenshotCaptureVisibilityTask = nil
+        controller?.focusBorderController.setScreenshotCaptureSuppressed(false)
+        recordScreenshotBorderSuppression(state: "exited", trigger: trigger)
+    }
+
+    private func recordScreenshotBorderSuppression(state: String, trigger: String) {
+        controller?.diagnostics.recordRuntimeDecisionEvent(
+            named: "screenshot_border_suppression",
+            cluster: "border-capture"
+        ) {
+            [
+                RuntimeDecisionTraceField("state", state),
+                RuntimeDecisionTraceField("trigger", trigger)
+            ]
+        }
+    }
+
+    private var isScreenshotPickerWindowVisible: Bool {
+        let pids = Set(
+            NSRunningApplication.runningApplications(
+                withBundleIdentifier: Self.screenshotCaptureUIBundleIdentifier
+            ).map(\.processIdentifier)
+        )
+        guard !pids.isEmpty,
+              let windows = CGWindowListCopyWindowInfo([.optionOnScreenOnly], 0) as? [[String: Any]]
+        else { return false }
+
+        return windows.contains { window in
+            guard let ownerPid = (window[kCGWindowOwnerPID as String] as? NSNumber)?.int32Value,
+                  pids.contains(ownerPid),
+                  let layer = (window[kCGWindowLayer as String] as? NSNumber)?.intValue
+            else { return false }
+            // The persistent transparent backing window is at layer 24. The
+            // interactive controls are transient high-level windows (1000+).
+            return layer >= 1_000
+        }
+    }
+
     func handleUnlockDetected() {
         guard let controller else { return }
         controller.layoutRefreshController.requestRefresh(reason: .unlock)
@@ -443,6 +562,10 @@ final class ServiceLifecycleManager {
         controller.axManager.onAppTerminated = nil
         controller.axManager.isRuntimeTraceCaptureActive = { false }
         controller.workspaceManager.onGapsChanged = nil
+        screenshotShortcutSuppressionActive = false
+        screenshotShortcutSuppressionGeneration &+= 1
+        screenshotCaptureVisibilityTask?.cancel()
+        screenshotCaptureVisibilityTask = nil
 
         controller.layoutRefreshController.resetState()
         controller.mouseEventHandler.cleanup()
@@ -500,6 +623,12 @@ final class ServiceLifecycleManager {
         monitorConfigurationCoalesceTask = nil
         controller.reconcileEnabledAndHotkeysState()
     }
+
+    private static let screenshotCaptureUIBundleIdentifier = "com.apple.screencaptureui"
+    private static let interactiveScreenshotSuppressionTimeout: TimeInterval = 30
+    // Hardware key codes for 3, 4, and 5 in macOS's standard screenshot chords.
+    private static let fullScreenScreenshotKeyCode: Int64 = 20
+    private static let screenshotShortcutKeyCodes: Set<Int64> = [20, 21, 23]
 
     private func accessibilityPermissionStream(initial: Bool) -> AsyncStream<Bool> {
         accessibilityPermissionStreamProviderForTests?(initial)


### PR DESCRIPTION
## Summary

Observe the standard macOS screenshot shortcuts before the system picker enumerates windows, hide focus borders for the interaction, and restore them after capture or dismissal.

## Release notes

Choose one:

- [x] Added a `.changeset/*.md` for user-visible changes (`mise run changeset -- patch "..."`).
- [ ] No user-visible change; apply the `no release note` label to make CI skip intentional.

## Validation

<!-- Commands run, screenshots, or manual checks. -->

- [ ] Ran relevant tests/checks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Temporarily hides focus borders during macOS screenshot shortcuts to prevent them from appearing in captured images.
  * Ensures “Capture Selected Window” screenshots exclude the focus-border overlay.
  * Restores focus borders automatically after the screenshot interaction completes.
* **Chores**
  * Added a patch release note documenting the improved screenshot capture behavior on macOS.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->