### PR TITLE
Add Summon Right to workspace bar window menus

### DIFF
--- a/.changeset/20260713013707-summon-windows-to-the-right-from-workspace-bar-c.md
+++ b/.changeset/20260713013707-summon-windows-to-the-right-from-workspace-bar-c.md
@@ -1,0 +1,6 @@
+---
+"nehir": minor
+
+---
+
+Summon windows to the right from workspace bar context menus

--- a/.provenance.json
+++ b/.provenance.json
@@ -106,6 +106,7 @@
         "Tests/NehirTests/WindowActionHandlerTests.swift",
         "Tests/NehirTests/WorkspaceBarGeometryTests.swift",
         "Tests/NehirTests/WorkspaceBarRightClickWiringTests.swift",
+        "Tests/NehirTests/WorkspaceBarSummonRightTests.swift",
         "Tests/NehirTests/CreateAppRuleForFocusedWindowTests.swift",
         "Tests/NehirTests/WorkspaceNavigationHandlerTests.swift",
         "Tests/NehirTests/WorkspacesTOMLCodecTests.swift",

--- a/Sources/Nehir/Core/Controller/SummonRightAnchor.swift
+++ b/Sources/Nehir/Core/Controller/SummonRightAnchor.swift
@@ -1,0 +1,50 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
+import Foundation
+
+struct SummonRightAnchor: Equatable {
+    let token: WindowToken?
+    let workspaceId: WorkspaceDescriptor.ID
+}
+
+extension WMController {
+    /// Resolves the destination and insertion anchor shared by every Summon
+    /// Right UI surface. A supplied monitor owns the destination; interaction
+    /// workspace is only a fallback when that monitor has no workspace.
+    func summonRightAnchor(on monitorId: Monitor.ID?) -> SummonRightAnchor? {
+        let activeWorkspace: WorkspaceDescriptor
+        if let monitorId,
+           let workspace = workspaceManager.activeWorkspaceOrFirst(on: monitorId)
+        {
+            activeWorkspace = workspace
+        } else if let workspace = interactionWorkspace() {
+            activeWorkspace = workspace
+        } else {
+            return nil
+        }
+
+        let anchorToken = if let focusedToken = workspaceManager.confirmedManagedFocusToken,
+                             let entry = workspaceManager.entry(for: focusedToken),
+                             entry.workspaceId == activeWorkspace.id
+        {
+            focusedToken
+        } else {
+            workspaceManager.preferredWorkspaceFocusToken(in: activeWorkspace.id)
+        }
+
+        let validatedToken = anchorToken.flatMap { token -> WindowToken? in
+            guard let entry = workspaceManager.entry(for: token),
+                  entry.workspaceId == activeWorkspace.id
+            else {
+                return nil
+            }
+            return token
+        }
+
+        return SummonRightAnchor(token: validatedToken, workspaceId: activeWorkspace.id)
+    }
+}

--- a/Sources/Nehir/Core/Controller/WMController.swift
+++ b/Sources/Nehir/Core/Controller/WMController.swift
@@ -799,6 +799,24 @@ final class WMController {
         windowActionHandler.focusWindowFromBar(token: token, suppressMouseWarp: true)
     }
 
+    /// Token-based Summon Right backing the workspace bar's window menu. The
+    /// source is always the represented token while the owning bar monitor
+    /// determines the destination workspace and shared anchor policy.
+    @discardableResult
+    func summonWindowRightFromBar(token: WindowToken, on monitorId: Monitor.ID) -> ExternalCommandResult {
+        guard let handle = workspaceManager.handle(for: token),
+              let anchor = summonRightAnchor(on: monitorId),
+              windowActionHandler.summonWindowRight(
+                  handle: handle,
+                  anchorToken: anchor.token,
+                  anchorWorkspaceId: anchor.workspaceId
+              )
+        else {
+            return .notFound
+        }
+        return .executed
+    }
+
     /// Token-based close backing the workspace bar's right-click *Close* item.
     /// Resolves the token to its handle (same lookup as
     /// `focusWindowFromBar(token:)`) and delegates to the shared

--- a/Sources/Nehir/Core/Diagnostics/SummonTraceFormatting.swift
+++ b/Sources/Nehir/Core/Diagnostics/SummonTraceFormatting.swift
@@ -18,7 +18,7 @@ enum SummonTraceFormatting {
         token.map { String(describing: $0) } ?? "nil"
     }
 
-    static func describe(_ anchor: CommandPaletteSummonAnchor?) -> String {
+    static func describe(_ anchor: SummonRightAnchor?) -> String {
         guard let anchor else { return "nil" }
         return "token=\(describe(anchor.token)),workspace=\(anchor.workspaceId.uuidString)"
     }

--- a/Sources/Nehir/UI/CommandPalette/CommandPaletteController.swift
+++ b/Sources/Nehir/UI/CommandPalette/CommandPaletteController.swift
@@ -44,11 +44,6 @@ struct CommandPaletteAppSnapshot: Equatable {
     }
 }
 
-struct CommandPaletteSummonAnchor: Equatable {
-    let token: WindowToken?
-    let workspaceId: WorkspaceDescriptor.ID
-}
-
 private struct CommandPaletteFocusTarget {
     let app: CommandPaletteAppSnapshot
     let focusedWindow: AXUIElement?
@@ -202,7 +197,7 @@ final class CommandPaletteController: NSObject, ObservableObject, NSWindowDelega
     private weak var wmController: WMController?
     private var restoreFocusTarget: CommandPaletteFocusTarget?
     private var menuFocusTarget: CommandPaletteFocusTarget?
-    private var summonAnchor: CommandPaletteSummonAnchor?
+    private var summonAnchor: SummonRightAnchor?
     private var cachedMenuTargetApp: CommandPaletteAppSnapshot?
     private var sessionMenuCache: [pid_t: [MenuItemModel]] = [:]
     private var hasLoadedMenuItems = false
@@ -218,7 +213,7 @@ final class CommandPaletteController: NSObject, ObservableObject, NSWindowDelega
 
     private enum SelectionAction {
         case navigateWindow(WMController, WindowHandle)
-        case summonWindowRight(WMController, WindowHandle, CommandPaletteSummonAnchor)
+        case summonWindowRight(WMController, WindowHandle, SummonRightAnchor)
         case pressMenu(CommandPaletteFocusTarget, AXUIElement)
         case executeCommand(WMController, HotkeyCommand)
     }
@@ -342,10 +337,7 @@ final class CommandPaletteController: NSObject, ObservableObject, NSWindowDelega
         let paletteMonitorId = Self.paletteMonitorId(for: wmController, screen: paletteScreen)
         restoreFocusTarget = captureFrontmostFocusTarget()
         menuFocusTarget = resolveMenuFocusTarget()
-        summonAnchor = Self.resolveSummonAnchor(
-            for: wmController,
-            pointerMonitorId: paletteMonitorId
-        )
+        summonAnchor = wmController.summonRightAnchor(on: paletteMonitorId)
         Self.recordSummonTrace(
             wmController,
             "palette.show pointerMonitor=\(SummonTraceFormatting.describe(paletteMonitorId)) "
@@ -441,47 +433,6 @@ final class CommandPaletteController: NSObject, ObservableObject, NSWindowDelega
     static func paletteMonitorId(for wmController: WMController, displayId: CGDirectDisplayID?) -> Monitor.ID? {
         guard let displayId else { return nil }
         return wmController.workspaceManager.monitors.first { $0.displayId == displayId }?.id
-    }
-
-    static func resolveSummonAnchor(
-        for wmController: WMController,
-        pointerMonitorId: Monitor.ID?
-    ) -> CommandPaletteSummonAnchor? {
-        // Target the active workspace on the monitor the palette opened on, not
-        // the interaction monitor — otherwise a no-anchor summon lands on
-        // whichever display last had a managed interaction rather than the one
-        // the user is looking at. Fall back to the interaction workspace only
-        // when the palette screen cannot be mapped to a managed monitor.
-        let activeWorkspace: WorkspaceDescriptor
-        if let pointerMonitorId,
-           let workspace = wmController.workspaceManager.activeWorkspaceOrFirst(on: pointerMonitorId)
-        {
-            activeWorkspace = workspace
-        } else if let workspace = wmController.interactionWorkspace() {
-            activeWorkspace = workspace
-        } else {
-            return nil
-        }
-
-        let anchorToken = if let focusedToken = wmController.workspaceManager.confirmedManagedFocusToken,
-                             let entry = wmController.workspaceManager.entry(for: focusedToken),
-                             entry.workspaceId == activeWorkspace.id
-        {
-            focusedToken
-        } else {
-            wmController.workspaceManager.preferredWorkspaceFocusToken(in: activeWorkspace.id)
-        }
-
-        let validatedToken: WindowToken? = anchorToken.flatMap { token in
-            guard let entry = wmController.workspaceManager.entry(for: token),
-                  entry.workspaceId == activeWorkspace.id
-            else {
-                return nil
-            }
-            return token
-        }
-
-        return .init(token: validatedToken, workspaceId: activeWorkspace.id)
     }
 
     private static func recordSummonTrace(_ wmController: WMController, _ message: String) {
@@ -1199,7 +1150,7 @@ final class CommandPaletteController: NSObject, ObservableObject, NSWindowDelega
         wmController: WMController,
         items: [CommandPaletteWindowItem],
         selectedItemID: CommandPaletteSelectionID?,
-        summonAnchor: CommandPaletteSummonAnchor? = nil
+        summonAnchor: SummonRightAnchor? = nil
     ) {
         self.wmController = wmController
         windows = items

--- a/Sources/Nehir/UI/WorkspaceBar/WorkspaceBarManager.swift
+++ b/Sources/Nehir/UI/WorkspaceBar/WorkspaceBarManager.swift
@@ -273,6 +273,9 @@ final class WorkspaceBarManager {
                 onToggleScratchpadAssignment: { [weak controller] token in
                     _ = controller?.toggleWindowScratchpadAssignment(token: token)
                 },
+                onSummonWindowRight: { [weak controller] token in
+                    _ = controller?.summonWindowRightFromBar(token: token, on: monitor.id)
+                },
                 onCloseWindow: { [weak controller] token in
                     _ = controller?.closeWindowFromBar(token: token)
                 },

--- a/Sources/Nehir/UI/WorkspaceBar/WorkspaceBarView.swift
+++ b/Sources/Nehir/UI/WorkspaceBar/WorkspaceBarView.swift
@@ -169,6 +169,7 @@ struct WorkspaceBarView: View {
     let onToggleWindowFloating: (WindowToken) -> Void
     let onToggleWindowSticky: (WindowToken) -> Void
     let onToggleScratchpadAssignment: (WindowToken) -> Void
+    let onSummonWindowRight: (WindowToken) -> Void
     let onCloseWindow: (WindowToken) -> Void
     let onMoveWindowToWorkspace: (WindowToken, WorkspaceDescriptor.ID) -> Void
     let onToggleScratchpadVisible: () -> Void
@@ -188,6 +189,7 @@ struct WorkspaceBarView: View {
             onToggleWindowFloating: onToggleWindowFloating,
             onToggleWindowSticky: onToggleWindowSticky,
             onToggleScratchpadAssignment: onToggleScratchpadAssignment,
+            onSummonWindowRight: onSummonWindowRight,
             onCloseWindow: onCloseWindow,
             onMoveWindowToWorkspace: onMoveWindowToWorkspace,
             onToggleScratchpadVisible: onToggleScratchpadVisible
@@ -214,6 +216,7 @@ struct WorkspaceBarMeasurementView: View {
             onToggleWindowFloating: { _ in },
             onToggleWindowSticky: { _ in },
             onToggleScratchpadAssignment: { _ in },
+            onSummonWindowRight: { _ in },
             onCloseWindow: { _ in },
             onMoveWindowToWorkspace: { _, _ in },
             onToggleScratchpadVisible: {}
@@ -242,6 +245,7 @@ struct WorkspaceBarWindowActions {
     let onToggleSticky: (WindowToken) -> Void
     let onToggleScratchpadAssignment: (WindowToken) -> Void
     let onCreateAppRule: (WindowToken) -> Void
+    let onSummonRight: (WindowToken) -> Void
     let onClose: (WindowToken) -> Void
     let onMoveToWorkspace: (WindowToken, WorkspaceDescriptor.ID) -> Void
     let moveTargets: [WorkspaceBarWindowMoveTarget]
@@ -270,6 +274,7 @@ private struct WorkspaceBarContentView: View {
     let onToggleWindowFloating: (WindowToken) -> Void
     let onToggleWindowSticky: (WindowToken) -> Void
     let onToggleScratchpadAssignment: (WindowToken) -> Void
+    let onSummonWindowRight: (WindowToken) -> Void
     let onCloseWindow: (WindowToken) -> Void
     let onMoveWindowToWorkspace: (WindowToken, WorkspaceDescriptor.ID) -> Void
     let onToggleScratchpadVisible: () -> Void
@@ -360,6 +365,7 @@ private struct WorkspaceBarContentView: View {
             onToggleSticky: onToggleWindowSticky,
             onToggleScratchpadAssignment: onToggleScratchpadAssignment,
             onCreateAppRule: onCreateAppRuleForWindow,
+            onSummonRight: onSummonWindowRight,
             onClose: onCloseWindow,
             onMoveToWorkspace: onMoveWindowToWorkspace,
             moveTargets: windowMoveTargets,
@@ -510,6 +516,7 @@ private struct WorkspaceItemView: View {
             onToggleSticky: windowActions.onToggleSticky,
             onToggleScratchpadAssignment: windowActions.onToggleScratchpadAssignment,
             onCreateAppRule: windowActions.onCreateAppRule,
+            onSummonRight: windowActions.onSummonRight,
             onClose: windowActions.onClose,
             onMoveToWorkspace: windowActions.onMoveToWorkspace,
             moveTargets: workspaceBarMoveTargetsExcludingCurrentWorkspace(
@@ -1097,7 +1104,7 @@ private struct WindowIconView: View {
             isHovered = hovering
         }
         // Right-click window icon: *Toggle Floating; Assign to Scratchpad;
-        // Create App Rule; Move to Workspace ▸; Close; Windows…*. Acts on
+        // Create App Rule; Move to Workspace ▸; Summon Right; Close; Windows…*. Acts on
         // this window's token, not focus.
         .contextMenu {
             Button {
@@ -1131,6 +1138,11 @@ private struct WindowIconView: View {
                 actions.onCreateAppRule(window.id)
             } label: {
                 Label("Create App Rule for This Window…", systemImage: "slider.horizontal.3")
+            }
+            Button {
+                actions.onSummonRight(window.id)
+            } label: {
+                Label("Summon Right", systemImage: "arrow.right.to.line")
             }
             Divider()
             Button(role: .destructive) {

--- a/Tests/NehirTests/CommandPaletteControllerTests.swift
+++ b/Tests/NehirTests/CommandPaletteControllerTests.swift
@@ -36,7 +36,7 @@ private func makeCommandPaletteWindowItem(windowId: Int) -> CommandPaletteWindow
 private func makeCommandPaletteSummonAnchor(
     wmController: WMController,
     windowId: Int = 11
-) -> CommandPaletteSummonAnchor {
+) -> SummonRightAnchor {
     guard let workspaceId = wmController.interactionWorkspace()?.id else {
         fatalError("Expected active workspace for summon-anchor test fixture")
     }
@@ -561,7 +561,7 @@ private func makeCommandPaletteMenuItem(title: String, parent: String = "View") 
         #expect(controller.selectedMode == .windows)
     }
 
-    @Test func resolveSummonAnchorReturnsWorkspaceOnlyAnchorWhenNoManagedWindow() {
+    @Test func sharedSummonAnchorReturnsWorkspaceOnlyAnchorWhenNoManagedWindow() {
         let wmController = makeCommandPaletteTestWMController()
         guard let workspaceId = wmController.interactionWorkspace()?.id else {
             Issue.record("Missing active workspace for summon-anchor test")
@@ -570,13 +570,13 @@ private func makeCommandPaletteMenuItem(title: String, parent: String = "View") 
 
         _ = wmController.workspaceManager.enterNonManagedFocus(appFullscreen: false)
 
-        let anchor = CommandPaletteController.resolveSummonAnchor(for: wmController, pointerMonitorId: nil)
+        let anchor = wmController.summonRightAnchor(on: nil)
 
         #expect(anchor?.token == nil)
         #expect(anchor?.workspaceId == workspaceId)
     }
 
-    @Test func resolveSummonAnchorReturnsTokenAnchorWhenManagedWindowPresent() {
+    @Test func sharedSummonAnchorReturnsTokenAnchorWhenManagedWindowPresent() {
         let wmController = makeCommandPaletteTestWMController()
         guard let workspaceId = wmController.interactionWorkspace()?.id else {
             Issue.record("Missing active workspace for summon-anchor test")
@@ -601,25 +601,25 @@ private func makeCommandPaletteMenuItem(title: String, parent: String = "View") 
             onMonitor: wmController.workspaceManager.monitorId(for: workspaceId)
         )
 
-        let anchor = CommandPaletteController.resolveSummonAnchor(for: wmController, pointerMonitorId: nil)
+        let anchor = wmController.summonRightAnchor(on: nil)
 
         #expect(anchor?.token == storedHandle.id)
         #expect(anchor?.workspaceId == workspaceId)
     }
 
-    @Test func resolveSummonAnchorReturnsNilWhenNoInteractionWorkspace() {
+    @Test func sharedSummonAnchorReturnsNilWhenNoInteractionWorkspace() {
         let settings = SettingsStore(defaults: makeCommandPaletteTestDefaults())
         settings.workspaceConfigurations = []
         let wmController = WMController(settings: settings)
         wmController.workspaceManager.applyMonitorConfigurationChange([])
         _ = wmController.workspaceManager.setInteractionMonitor(nil)
 
-        let anchor = CommandPaletteController.resolveSummonAnchor(for: wmController, pointerMonitorId: nil)
+        let anchor = wmController.summonRightAnchor(on: nil)
 
         #expect(anchor == nil)
     }
 
-    @Test func resolveSummonAnchorTargetsWorkspaceOnPointerMonitorNotInteractionMonitor() {
+    @Test func sharedSummonAnchorTargetsWorkspaceOnSuppliedMonitorNotInteractionMonitor() {
         let settings = SettingsStore(defaults: makeCommandPaletteTestDefaults())
         settings.workspaceConfigurations = [
             WorkspaceConfiguration(name: "1", monitorAssignment: .main),
@@ -648,10 +648,7 @@ private func makeCommandPaletteMenuItem(title: String, parent: String = "View") 
         // …but the palette opened on the secondary monitor, so a no-anchor
         // summon must target the secondary (visually active) workspace, not the
         // interaction monitor's workspace on the other display.
-        let anchor = CommandPaletteController.resolveSummonAnchor(
-            for: wmController,
-            pointerMonitorId: secondaryMonitor.id
-        )
+        let anchor = wmController.summonRightAnchor(on: secondaryMonitor.id)
 
         #expect(anchor?.workspaceId == secondaryWorkspaceId)
         #expect(anchor?.workspaceId != primaryWorkspaceId)
@@ -685,7 +682,7 @@ private func makeCommandPaletteMenuItem(title: String, parent: String = "View") 
         #expect(CommandPaletteController.paletteMonitorId(for: wmController, displayId: nil) == nil)
     }
 
-    @Test func resolveSummonAnchorFallsBackToLastFocusedMemory() {
+    @Test func sharedSummonAnchorFallsBackToLastFocusedMemory() {
         let wmController = makeCommandPaletteTestWMController()
         guard let workspaceId = wmController.interactionWorkspace()?.id else {
             Issue.record("Missing active workspace for summon-anchor test")
@@ -707,7 +704,7 @@ private func makeCommandPaletteMenuItem(title: String, parent: String = "View") 
         _ = wmController.workspaceManager.rememberFocus(storedHandle, in: workspaceId)
         _ = wmController.workspaceManager.enterNonManagedFocus(appFullscreen: false)
 
-        let anchor = CommandPaletteController.resolveSummonAnchor(for: wmController, pointerMonitorId: nil)
+        let anchor = wmController.summonRightAnchor(on: nil)
 
         #expect(anchor?.token == storedHandle.id)
         #expect(anchor?.workspaceId == workspaceId)

--- a/Tests/NehirTests/WorkspaceBarSummonRightTests.swift
+++ b/Tests/NehirTests/WorkspaceBarSummonRightTests.swift
@@ -16,7 +16,10 @@ private func prepareWorkspaceBarSummonRightLayout(
     await waitForLayoutPlanRefreshWork(on: controller)
     controller.syncMonitorsToNiriEngine()
 
-    guard let engine = controller.niriEngine else { return }
+    guard let engine = controller.niriEngine else {
+        Issue.record("Expected Niri engine after enabling Niri layout")
+        return
+    }
     for workspaceId in workspaceIds {
         let handles = controller.workspaceManager.entries(in: workspaceId).map(\.handle)
         let focusedHandle = controller.workspaceManager.lastFocusedHandle(in: workspaceId)

--- a/Tests/NehirTests/WorkspaceBarSummonRightTests.swift
+++ b/Tests/NehirTests/WorkspaceBarSummonRightTests.swift
@@ -1,0 +1,188 @@
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=nehir-original; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
+import Foundation
+@testable import Nehir
+import Testing
+
+@MainActor
+private func prepareWorkspaceBarSummonRightLayout(
+    on controller: WMController,
+    workspaceIds: Set<WorkspaceDescriptor.ID>
+) async {
+    controller.enableNiriLayout(revealStyle: .auto)
+    await waitForLayoutPlanRefreshWork(on: controller)
+    controller.syncMonitorsToNiriEngine()
+
+    guard let engine = controller.niriEngine else { return }
+    for workspaceId in workspaceIds {
+        let handles = controller.workspaceManager.entries(in: workspaceId).map(\.handle)
+        let focusedHandle = controller.workspaceManager.lastFocusedHandle(in: workspaceId)
+        _ = engine.syncWindows(
+            handles,
+            in: workspaceId,
+            selectedNodeId: controller.workspaceManager.niriViewportState(for: workspaceId).selectedNodeId,
+            focusedHandle: focusedHandle
+        )
+        let selection = focusedHandle.flatMap { engine.findNode(for: $0)?.id }
+            ?? engine.validateSelection(nil, in: workspaceId)
+        controller.workspaceManager.withNiriViewportState(for: workspaceId) { state in
+            state.selectedNodeId = selection
+        }
+    }
+}
+
+@MainActor
+private func workspaceBarSummonColumnOrder(
+    on controller: WMController,
+    workspaceId: WorkspaceDescriptor.ID
+) -> [WindowToken] {
+    controller.niriEngine?.columns(in: workspaceId).compactMap { $0.windowNodes.first?.token } ?? []
+}
+
+@Suite(.serialized) @MainActor struct WorkspaceBarSummonRightTests {
+    @Test func clickedTokenIsSummonedImmediatelyRightOfFocusedAnchor() async throws {
+        let monitor = makeLayoutPlanTestMonitor(displayId: 921)
+        let controller = makeLayoutPlanTestController(monitors: [monitor])
+        let targetWorkspace = try #require(controller.workspaceManager.workspaceId(for: "1", createIfMissing: false))
+        let sourceWorkspace = try #require(controller.workspaceManager.workspaceId(for: "2", createIfMissing: false))
+        let anchor = addLayoutPlanTestWindow(on: controller, workspaceId: targetWorkspace, windowId: 9210)
+        let clicked = addLayoutPlanTestWindow(on: controller, workspaceId: sourceWorkspace, windowId: 9211)
+        let anchorHandle = try #require(controller.workspaceManager.handle(for: anchor))
+        _ = controller.workspaceManager.setManagedFocus(anchorHandle, in: targetWorkspace, onMonitor: monitor.id)
+        await prepareWorkspaceBarSummonRightLayout(
+            on: controller,
+            workspaceIds: [targetWorkspace, sourceWorkspace]
+        )
+
+        #expect(controller.summonWindowRightFromBar(token: clicked, on: monitor.id) == .executed)
+        await waitForLayoutPlanRefreshWork(on: controller)
+
+        #expect(controller.workspaceManager.workspace(for: clicked) == targetWorkspace)
+        #expect(workspaceBarSummonColumnOrder(on: controller, workspaceId: targetWorkspace) == [anchor, clicked])
+    }
+
+    @Test func owningSecondaryBarOverridesPrimaryInteractionMonitor() async throws {
+        let fixture = makeTwoMonitorLayoutPlanTestController()
+        let controller = fixture.controller
+        let primaryWindow = addLayoutPlanTestWindow(
+            on: controller,
+            workspaceId: fixture.primaryWorkspaceId,
+            windowId: 9220
+        )
+        let secondaryAnchor = addLayoutPlanTestWindow(
+            on: controller,
+            workspaceId: fixture.secondaryWorkspaceId,
+            windowId: 9221
+        )
+        let clicked = addLayoutPlanTestWindow(
+            on: controller,
+            workspaceId: fixture.primaryWorkspaceId,
+            windowId: 9222
+        )
+        let primaryHandle = try #require(controller.workspaceManager.handle(for: primaryWindow))
+        let secondaryHandle = try #require(controller.workspaceManager.handle(for: secondaryAnchor))
+        _ = controller.workspaceManager.rememberFocus(secondaryHandle, in: fixture.secondaryWorkspaceId)
+        _ = controller.workspaceManager.setManagedFocus(
+            primaryHandle,
+            in: fixture.primaryWorkspaceId,
+            onMonitor: fixture.primaryMonitor.id
+        )
+        await prepareWorkspaceBarSummonRightLayout(
+            on: controller,
+            workspaceIds: [fixture.primaryWorkspaceId, fixture.secondaryWorkspaceId]
+        )
+
+        #expect(
+            controller.summonWindowRightFromBar(token: clicked, on: fixture.secondaryMonitor.id) == .executed
+        )
+        await waitForLayoutPlanRefreshWork(on: controller)
+
+        #expect(controller.workspaceManager.workspace(for: clicked) == fixture.secondaryWorkspaceId)
+        #expect(
+            workspaceBarSummonColumnOrder(on: controller, workspaceId: fixture.secondaryWorkspaceId)
+                == [secondaryAnchor, clicked]
+        )
+    }
+
+    @Test func emptyDestinationUsesWorkspaceOnlyAnchor() async throws {
+        let fixture = makeTwoMonitorLayoutPlanTestController()
+        let controller = fixture.controller
+        let clicked = addLayoutPlanTestWindow(
+            on: controller,
+            workspaceId: fixture.primaryWorkspaceId,
+            windowId: 9230
+        )
+        await prepareWorkspaceBarSummonRightLayout(
+            on: controller,
+            workspaceIds: [fixture.primaryWorkspaceId, fixture.secondaryWorkspaceId]
+        )
+        let anchor = controller.summonRightAnchor(on: fixture.secondaryMonitor.id)
+        #expect(anchor?.workspaceId == fixture.secondaryWorkspaceId)
+        #expect(anchor?.token == nil)
+
+        #expect(
+            controller.summonWindowRightFromBar(token: clicked, on: fixture.secondaryMonitor.id) == .executed
+        )
+        await waitForLayoutPlanRefreshWork(on: controller)
+
+        #expect(workspaceBarSummonColumnOrder(on: controller, workspaceId: fixture.secondaryWorkspaceId) == [clicked])
+    }
+
+    @Test func unmanagedFocusUsesRememberedWorkspaceAnchor() async throws {
+        let monitor = makeLayoutPlanTestMonitor(displayId: 924)
+        let controller = makeLayoutPlanTestController(monitors: [monitor])
+        let targetWorkspace = try #require(controller.workspaceManager.workspaceId(for: "1", createIfMissing: false))
+        let sourceWorkspace = try #require(controller.workspaceManager.workspaceId(for: "2", createIfMissing: false))
+        let anchor = addLayoutPlanTestWindow(on: controller, workspaceId: targetWorkspace, windowId: 9240)
+        let clicked = addLayoutPlanTestWindow(on: controller, workspaceId: sourceWorkspace, windowId: 9241)
+        let anchorHandle = try #require(controller.workspaceManager.handle(for: anchor))
+        _ = controller.workspaceManager.rememberFocus(anchorHandle, in: targetWorkspace)
+        _ = controller.workspaceManager.enterNonManagedFocus(appFullscreen: false)
+        await prepareWorkspaceBarSummonRightLayout(
+            on: controller,
+            workspaceIds: [targetWorkspace, sourceWorkspace]
+        )
+
+        #expect(controller.summonRightAnchor(on: monitor.id)?.token == anchor)
+        #expect(controller.summonWindowRightFromBar(token: clicked, on: monitor.id) == .executed)
+        await waitForLayoutPlanRefreshWork(on: controller)
+        #expect(workspaceBarSummonColumnOrder(on: controller, workspaceId: targetWorkspace) == [anchor, clicked])
+    }
+
+    @Test func staleTokenAndUnavailableDestinationLeaveStateUnchanged() async throws {
+        let monitor = makeLayoutPlanTestMonitor(displayId: 925)
+        let controller = makeLayoutPlanTestController(monitors: [monitor])
+        let workspace = try #require(controller.workspaceManager.workspaceId(for: "1", createIfMissing: false))
+        let token = addLayoutPlanTestWindow(on: controller, workspaceId: workspace, windowId: 9250)
+        await prepareWorkspaceBarSummonRightLayout(on: controller, workspaceIds: [workspace])
+        let before = workspaceBarSummonColumnOrder(on: controller, workspaceId: workspace)
+        let stale = WindowToken(pid: token.pid, windowId: 9259)
+
+        #expect(controller.summonWindowRightFromBar(token: stale, on: monitor.id) == .notFound)
+        #expect(workspaceBarSummonColumnOrder(on: controller, workspaceId: workspace) == before)
+
+        controller.workspaceManager.applyMonitorConfigurationChange([])
+        _ = controller.workspaceManager.setInteractionMonitor(nil)
+        #expect(controller.summonWindowRightFromBar(token: token, on: monitor.id) == .notFound)
+        #expect(controller.workspaceManager.workspace(for: token) == workspace)
+        #expect(workspaceBarSummonColumnOrder(on: controller, workspaceId: workspace) == before)
+    }
+
+    @Test func selectingCurrentAnchorIsSafeNoOp() async throws {
+        let monitor = makeLayoutPlanTestMonitor(displayId: 926)
+        let controller = makeLayoutPlanTestController(monitors: [monitor])
+        let workspace = try #require(controller.workspaceManager.workspaceId(for: "1", createIfMissing: false))
+        let anchor = addLayoutPlanTestWindow(on: controller, workspaceId: workspace, windowId: 9260)
+        let anchorHandle = try #require(controller.workspaceManager.handle(for: anchor))
+        _ = controller.workspaceManager.setManagedFocus(anchorHandle, in: workspace, onMonitor: monitor.id)
+        await prepareWorkspaceBarSummonRightLayout(on: controller, workspaceIds: [workspace])
+        let before = workspaceBarSummonColumnOrder(on: controller, workspaceId: workspace)
+
+        #expect(controller.summonWindowRightFromBar(token: anchor, on: monitor.id) == .notFound)
+        #expect(controller.workspaceManager.workspace(for: anchor) == workspace)
+        #expect(workspaceBarSummonColumnOrder(on: controller, workspaceId: workspace) == before)
+    }
+}


### PR DESCRIPTION
## Summary

Summon windows to the right from workspace bar context menus

## Release notes

Choose one:

- [x] Added a `.changeset/*.md` for user-visible changes (`mise run changeset -- patch "..."`).
- [ ] No user-visible change; apply the `no release note` label to make CI skip intentional.

## Validation

<!-- Commands run, screenshots, or manual checks. -->

- [ ] Ran relevant tests/checks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a **“Summon Right”** action to workspace bar window context menus.
  * Windows can now be placed immediately to the right of the active or remembered anchor in the appropriate workspace.
  * Added support for secondary monitors, empty workspaces, and safe handling of stale or unchanged selections.

* **Bug Fixes**
  * Improved anchor and workspace resolution for window placement across monitors and interaction contexts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->