### PR TITLE
Restore focus after explicit viewport navigation

### DIFF
--- a/.changeset/20260713170109-restore-managed-focus-after-explicit-viewport-na.md
+++ b/.changeset/20260713170109-restore-managed-focus-after-explicit-viewport-na.md
@@ -1,0 +1,6 @@
+---
+"nehir": patch
+
+---
+
+Restore managed focus after explicit viewport navigation

--- a/Sources/Nehir/Core/Controller/MouseEventHandler.swift
+++ b/Sources/Nehir/Core/Controller/MouseEventHandler.swift
@@ -2180,10 +2180,10 @@ final class MouseEventHandler {
             }
         }
         var didRequestFocus = false
+        let nonManagedFocusAtSelection = controller.workspaceManager.isNonManagedFocusActive
         if let selectedWindow {
             rememberViewportFocusAnchor(selectedWindow, engine: engine, wsId: wsId)
             if !controller.focusFollowsMouseEnabled,
-               !controller.workspaceManager.isNonManagedFocusActive,
                let target = controller.managedKeyboardFocusTarget(for: selectedWindow.token)
             {
                 _ = controller.renderKeyboardFocusBorder(
@@ -2201,8 +2201,6 @@ final class MouseEventHandler {
             focusSelectionDisposition = "none"
         } else if controller.focusFollowsMouseEnabled {
             focusSelectionDisposition = "suppressed"
-        } else if controller.workspaceManager.isNonManagedFocusActive {
-            focusSelectionDisposition = "suppressedNonManagedFocus"
         } else if didRequestFocus {
             focusSelectionDisposition = "requested"
         } else {
@@ -2215,6 +2213,7 @@ final class MouseEventHandler {
                 "input=trackpadTouches",
                 "snap=\(!lockedContext.bypassSnap)",
                 "focusSelection=\(focusSelectionDisposition)",
+                "nonManagedFocusAtSelection=\(nonManagedFocusAtSelection)",
                 "focusFollowsMouse=\(controller.focusFollowsMouseEnabled)",
                 "endedGestureIsAnimating=\(endedGestureIsAnimating)",
                 "previousActiveColumnIndex=\(previousActiveColumnIndex.map(String.init) ?? "nil")",


### PR DESCRIPTION
## Summary

Restore managed focus after explicit viewport navigation

## Release notes

Choose one:

- [x] Added a `.changeset/*.md` for user-visible changes (`mise run changeset -- patch "..."`).
- [ ] No user-visible change; apply the `no release note` label to make CI skip intentional.

## Validation

<!-- Commands run, screenshots, or manual checks. -->

- [ ] Ran relevant tests/checks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restored managed focus after explicit viewport navigation.
  * Improved gesture-end focus handling and diagnostics for more accurate behavior and reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->