### PR TITLE
Keep active workspace when an app re-homes focus after fullscreen exit

### DIFF
--- a/.changeset/20260713223559-fix-swipe-after-exiting-a-fullscreen-video-landi.md
+++ b/.changeset/20260713223559-fix-swipe-after-exiting-a-fullscreen-video-landi.md
@@ -1,0 +1,6 @@
+---
+"nehir": patch
+
+---
+
+Fix swipe after exiting a fullscreen video landing on the wrong workspace: an external focus re-home to a same-app window on an inactive workspace no longer switches the active workspace

--- a/.provenance.json
+++ b/.provenance.json
@@ -113,7 +113,8 @@
         "Sources/Nehir/Core/Diagnostics/ProcessMemoryDiagnostics.swift",
         "Tests/NehirTests/ProcessMemoryDiagnosticsTests.swift",
         "Tests/NehirTests/RuntimeMemoryDumpSectionTests.swift",
-        "Tests/NehirTests/TerminatedAppStatePruningTests.swift"
+        "Tests/NehirTests/TerminatedAppStatePruningTests.swift",
+        "Tests/NehirTests/SwipeAfterFullscreenExitWorkspaceTests.swift"
       ],
       "copyright": [
         "2026 Aleksei Gurianov and Nehir contributors"

--- a/Sources/Nehir/Core/Controller/AXEventHandler.swift
+++ b/Sources/Nehir/Core/Controller/AXEventHandler.swift
@@ -917,8 +917,20 @@ final class AXEventHandler: CGSEventDelegate {
     private static let recentNonManagedFocusTTL: TimeInterval = 2
     private static let focusedWindowLossClosePrecursorTTL: TimeInterval = 0.6
     private static let sameAppRecoveryRedirectLatchTTL: TimeInterval = 2
+    // When one of an app's windows tears down — a native-fullscreen Space
+    // destroyed, an (HTML5/app-level) fullscreen video window closed, or any
+    // same-app window removed — macOS can take several seconds to re-home
+    // keyboard focus to another of the app's windows, which may live on an
+    // inactive workspace. Track that teardown per pid over a grace window wide
+    // enough to span the re-home latency, so a stray same-app
+    // `focusedWindowChanged` to an inactive workspace during that window can be
+    // recognized as automatic re-homing rather than genuine user re-focus. This
+    // is deliberately longer than `recentSameAppWindowCloseTTL` (which gates
+    // tighter same-frame close recovery); observed re-homes here land 5–9 s late.
+    private static let recentSameAppTeardownTTL: TimeInterval = 10
     private var recentSameAppWindowCloseByPid: [pid_t: TimeInterval] = [:]
     private var recentNonManagedFocusByPid: [pid_t: TimeInterval] = [:]
+    private var recentSameAppTeardownByPid: [pid_t: TimeInterval] = [:]
     // Pids that own a recognized app overlay window (e.g. the Ghostty quick
     // terminal). Once observed, the pid stays marked for the process lifetime so
     // the QT open/close focus churn it emits can be suppressed/deferred without
@@ -1026,6 +1038,7 @@ final class AXEventHandler: CGSEventDelegate {
         resetUntrackedActivationRetryState()
         recentSameAppWindowCloseByPid.removeAll()
         recentNonManagedFocusByPid.removeAll()
+        recentSameAppTeardownByPid.removeAll()
         overlayCapablePids.removeAll()
         focusedWindowLossClosePrecursorByPid.removeAll()
         sameAppRecoveryRedirectLatches.removeAll()
@@ -1247,6 +1260,7 @@ final class AXEventHandler: CGSEventDelegate {
         resetUntrackedActivationRetryState()
         recentSameAppWindowCloseByPid.removeAll()
         recentNonManagedFocusByPid.removeAll()
+        recentSameAppTeardownByPid.removeAll()
         overlayCapablePids.removeAll()
         focusedWindowLossClosePrecursorByPid.removeAll()
         sameAppRecoveryRedirectLatches.removeAll()
@@ -2265,6 +2279,7 @@ final class AXEventHandler: CGSEventDelegate {
     func handleRemoved(token: WindowToken) {
         guard let controller else { return }
         recordRecentSameAppWindowClose(pid: token.pid)
+        recordRecentSameAppTeardown(pid: token.pid)
         let entry = controller.workspaceManager.entry(for: token)
         let affectedWorkspaceId = entry?.workspaceId
         let confirmedTokenBeforeRemoval = controller.workspaceManager.confirmedManagedFocusToken
@@ -3755,6 +3770,24 @@ final class AXEventHandler: CGSEventDelegate {
                 return
             }
 
+            if shouldSuppressInactiveSameAppFocusAfterTeardownRehoming(
+                entry: entry,
+                isWorkspaceActive: isWorkspaceActive,
+                requestDisposition: requestDisposition,
+                source: source,
+                origin: origin
+            ) {
+                if case let .conflictsWithPendingRequest(request) = requestDisposition {
+                    continueManagedFocusRequest(
+                        request,
+                        source: source,
+                        origin: origin,
+                        reason: .pendingFocusMismatch
+                    )
+                }
+                return
+            }
+
             if shouldSuppressSameAppInactiveWorkspaceActivationBeforeCloseRecovery(
                 entry: entry,
                 isWorkspaceActive: isWorkspaceActive,
@@ -4675,6 +4708,7 @@ final class AXEventHandler: CGSEventDelegate {
     @discardableResult
     private func suspendManagedWindowForNativeFullscreen(_ entry: WindowModel.Entry) -> Bool {
         guard let controller else { return false }
+        recordRecentSameAppTeardown(pid: entry.token.pid)
         cancelNativeFullscreenLifecycleTasks(containing: entry.token)
         let changed = controller.workspaceManager.markNativeFullscreenSuspended(entry.token)
         _ = controller.focusBorderController.focusChanged(
@@ -4697,6 +4731,7 @@ final class AXEventHandler: CGSEventDelegate {
         guard hadRecord || controller.workspaceManager.layoutReason(for: entry.token) == .nativeFullscreen else {
             return false
         }
+        recordRecentSameAppTeardown(pid: entry.token.pid)
         cancelNativeFullscreenLifecycleTasks(containing: entry.token)
         let restored = controller.workspaceManager.restoreNativeFullscreenRecord(for: entry.token) != nil || hadRecord
         if restored {
@@ -4978,6 +5013,7 @@ final class AXEventHandler: CGSEventDelegate {
         }
 
         guard let unavailableRecord else { return false }
+        recordRecentSameAppTeardown(pid: token.pid)
         controller.focusBorderController.hide()
         controller.nativeFullscreenPlaceholderManager.remove(token)
         clearManagedFocusState(matching: token, workspaceId: unavailableRecord.workspaceId)
@@ -5558,6 +5594,7 @@ final class AXEventHandler: CGSEventDelegate {
                     // let the deferred activation retry reveal the target.
                 } else {
                     recordRecentSameAppWindowClose(pid: destroyedPid)
+                    recordRecentSameAppTeardown(pid: destroyedPid)
                     // Quick-terminal hide/close can destroy an auxiliary AX element
                     // instead of the tracked managed window. Preserve the current
                     // workspace before macOS activates a successor app/window.
@@ -5667,6 +5704,7 @@ final class AXEventHandler: CGSEventDelegate {
         }
 
         recordRecentSameAppWindowClose(pid: candidate.token.pid)
+        recordRecentSameAppTeardown(pid: candidate.token.pid)
         cancelDestroyLivenessVerification(for: candidate.token)
 
         let shouldDelayDestroy = shouldDelayManagedReplacementDestroy(candidate)
@@ -6337,6 +6375,23 @@ final class AXEventHandler: CGSEventDelegate {
             return false
         }
         return true
+    }
+
+    private func recordRecentSameAppTeardown(pid: pid_t) {
+        pruneRecentSameAppTeardowns()
+        recentSameAppTeardownByPid[pid] = managedReplacementCurrentUptime()
+    }
+
+    private func hasRecentSameAppTeardown(for pid: pid_t) -> Bool {
+        pruneRecentSameAppTeardowns()
+        return recentSameAppTeardownByPid[pid] != nil
+    }
+
+    private func pruneRecentSameAppTeardowns(now: TimeInterval? = nil) {
+        let now = now ?? managedReplacementCurrentUptime()
+        recentSameAppTeardownByPid = recentSameAppTeardownByPid.filter { _, at in
+            now - at <= Self.recentSameAppTeardownTTL
+        }
     }
 
     private func isWithinSameAppCloseRecoveryWindow(pid: pid_t) -> Bool {
@@ -7229,6 +7284,87 @@ final class AXEventHandler: CGSEventDelegate {
         source.isAuthoritative && origin == .external
     }
 
+    /// Suppress an external `focusedWindowChanged` that macOS emits when it
+    /// re-homes keyboard focus to another of an app's windows after one of that
+    /// app's windows tears down (a fullscreen video exiting, a window closing).
+    ///
+    /// When a fullscreen video — native-Space *or* app/HTML5 fullscreen — exits,
+    /// or any of the app's windows closes, macOS hands keyboard focus to another
+    /// window of the *same app*, which can live on an inactive workspace. It
+    /// arrives seconds later as an authoritative external `focusedWindowChanged`.
+    /// Left unguarded it switches the active workspace to the inactive one —
+    /// either because `shouldHonorObservedFocusOverPendingRequest` discards
+    /// Nehir's pending restore request (`conflictsWithPendingRequest`), or because
+    /// `shouldHandleObservedManagedActivationWithoutPendingRequest` admits the
+    /// focus outright once that request/confirmed focus has already been cleared
+    /// (`unrelatedNoRequest`). A follow-up 3-finger swipe then scrolls the wrong
+    /// workspace.
+    ///
+    /// The older deferrals key off `confirmedManagedFocusToken`, which the
+    /// teardown clears, so they miss the gap. Anchor instead on the app's live
+    /// managed border target: if it is a *different* window of the *same app* on
+    /// the currently-active workspace, the app's real focus is already where the
+    /// user is, and a same-app `focusedWindowChanged` to an *inactive* (off-screen,
+    /// unclickable) workspace is macOS re-homing, not a user click. Require recent
+    /// same-app teardown evidence so an ordinary deliberate re-focus with no
+    /// teardown is untouched, and never suppress focus on the very window Nehir
+    /// just requested (`matchesActiveRequest`).
+    private func shouldSuppressInactiveSameAppFocusAfterTeardownRehoming(
+        entry observedEntry: WindowModel.Entry,
+        isWorkspaceActive: Bool,
+        requestDisposition: ActivationRequestDisposition,
+        source: ActivationEventSource,
+        origin: ActivationCallOrigin
+    ) -> Bool {
+        guard origin == .external,
+              source == .focusedWindowChanged,
+              !isWorkspaceActive,
+              hasRecentSameAppTeardown(for: observedEntry.pid),
+              let controller
+        else {
+            return false
+        }
+
+        switch requestDisposition {
+        case .matchesActiveRequest:
+            return false
+        case let .conflictsWithPendingRequest(request):
+            // Only the app's own re-homing; a pending request for a different app
+            // is a genuine cross-app conflict that must resolve normally.
+            guard request.token.pid == observedEntry.pid else { return false }
+        case .unrelatedNoRequest:
+            break
+        }
+
+        // The app's live managed focus must already be on the active workspace,
+        // on a different window of the same app. That is the durable "the user is
+        // already here" anchor that survives the teardown clearing confirmed focus.
+        guard let borderTarget = controller.currentBorderTarget(),
+              borderTarget.isManaged,
+              borderTarget.token.pid == observedEntry.pid,
+              borderTarget.token != observedEntry.token,
+              let anchorWorkspaceId = controller.workspaceManager.entry(for: borderTarget.token)?.workspaceId,
+              let anchorMonitorId = controller.workspaceManager.monitorId(for: anchorWorkspaceId),
+              controller.workspaceManager.activeWorkspace(on: anchorMonitorId)?.id == anchorWorkspaceId
+        else {
+            return false
+        }
+
+        controller.diagnostics.recordRuntimeViewportTrace(
+            workspaceId: observedEntry.workspaceId,
+            reason: "same_app_teardown_rehome_suppressed",
+            details: [
+                "token=\(observedEntry.token)",
+                "source=\(source.rawValue)",
+                "origin=\(origin.rawValue)",
+                "requestDisposition=\(requestDisposition)",
+                "anchorTarget=\(borderTarget.token)",
+                "anchorWorkspace=\(anchorWorkspaceId.uuidString)"
+            ]
+        )
+        return true
+    }
+
     private func cleanupPendingStateForTerminatedApp(pid: pid_t) {
         let managedReplacementKeys = Set(pendingManagedReplacementBursts.keys)
             .union(pendingManagedReplacementTasks.keys)
@@ -7287,6 +7423,7 @@ final class AXEventHandler: CGSEventDelegate {
         resetUntrackedActivationRetry(for: pid)
         recentSameAppWindowCloseByPid.removeValue(forKey: pid)
         recentNonManagedFocusByPid.removeValue(forKey: pid)
+        recentSameAppTeardownByPid.removeValue(forKey: pid)
         focusedWindowLossClosePrecursorByPid.removeValue(forKey: pid)
         sameAppRecoveryRedirectLatches = sameAppRecoveryRedirectLatches.filter { $0.key.pid != pid }
         recentParkedFocusFollowByToken = recentParkedFocusFollowByToken.filter { $0.key.pid != pid }

--- a/Tests/NehirTests/SwipeAfterFullscreenExitWorkspaceTests.swift
+++ b/Tests/NehirTests/SwipeAfterFullscreenExitWorkspaceTests.swift
@@ -1,0 +1,92 @@
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=nehir-original; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
+import ApplicationServices
+@testable import Nehir
+import Testing
+
+/// Regression coverage for "swipe after fullscreen video exit lands on the wrong
+/// workspace".
+///
+/// Two workspaces of one display each host a window of the *same* app. A video
+/// plays fullscreen on the active workspace. When it exits, macOS re-homes
+/// keyboard focus to the app's *other* window on the inactive workspace and
+/// delivers it as an external `focusedWindowChanged`. Honoring it switches the
+/// active workspace to the inactive one, so a following swipe scrolls the wrong
+/// workspace. The fix suppresses that re-home while the app's managed border
+/// target still sits on the active workspace, within the same-app teardown grace.
+@MainActor
+struct SwipeAfterFullscreenExitWorkspaceTests {
+    @Test @MainActor
+    func externalSameAppRehomeAfterFullscreenTeardownKeepsActiveWorkspace() {
+        let controller = makeLayoutPlanTestController()
+        controller.hasStartedServices = true
+        controller.setBordersEnabled(true)
+        defer { controller.axEventHandler.resetDebugStateForTests() }
+
+        guard let videoWorkspaceId = controller.workspaceManager.workspaceId(for: "1", createIfMissing: false),
+              let otherWorkspaceId = controller.workspaceManager.workspaceId(for: "2", createIfMissing: false),
+              let monitorId = controller.workspaceManager.monitorId(for: videoWorkspaceId)
+        else {
+            Issue.record("Missing workspace fixture")
+            return
+        }
+
+        let appPid: pid_t = 16_913
+        let videoToken = addLayoutPlanTestWindow(
+            on: controller,
+            workspaceId: videoWorkspaceId,
+            windowId: 47_748,
+            pid: appPid
+        )
+        let otherToken = addLayoutPlanTestWindow(
+            on: controller,
+            workspaceId: otherWorkspaceId,
+            windowId: 47_139,
+            pid: appPid
+        )
+
+        // The video's workspace is active; the video window is the app's managed
+        // border target. Confirmed managed focus is intentionally left unset — the
+        // teardown clears it in the real bug, which is why the guard must anchor on
+        // the durable border target instead.
+        #expect(controller.workspaceManager.setActiveWorkspace(videoWorkspaceId, on: monitorId))
+        confirmFocusedBorderForLayoutPlanTests(on: controller, token: videoToken)
+        #expect(controller.currentBorderTarget()?.token == videoToken)
+
+        // Drive the real native-fullscreen suspend path for the video so the
+        // same-app teardown signal is recorded by production code (not seeded by
+        // the test). This keeps the video entry and its border target intact.
+        controller.axEventHandler.focusedWindowRefProvider = { pid in
+            pid == appPid ? AXWindowRef(element: AXUIElementCreateSystemWide(), windowId: videoToken.windowId) : nil
+        }
+        controller.axEventHandler.isFullscreenProvider = { _ in true }
+        controller.axEventHandler.handleAppActivation(
+            pid: appPid,
+            source: .workspaceDidActivateApplication,
+            origin: .external
+        )
+        #expect(controller.currentBorderTarget()?.token == videoToken)
+        #expect(controller.workspaceManager.activeWorkspace(on: monitorId)?.id == videoWorkspaceId)
+
+        // macOS re-homes keyboard focus to the app's other window on the inactive
+        // workspace and delivers it as an external focusedWindowChanged.
+        controller.axEventHandler.focusedWindowRefProvider = { pid in
+            pid == appPid ? AXWindowRef(element: AXUIElementCreateSystemWide(), windowId: otherToken.windowId) : nil
+        }
+        controller.axEventHandler.isFullscreenProvider = { _ in false }
+        controller.axEventHandler.handleAppActivation(
+            pid: appPid,
+            source: .focusedWindowChanged,
+            origin: .external
+        )
+
+        // The active workspace must stay on the video's workspace — not jump to the
+        // inactive one the re-home pointed at.
+        #expect(controller.workspaceManager.activeWorkspace(on: monitorId)?.id == videoWorkspaceId)
+        #expect(controller.workspaceManager.activeWorkspace(on: monitorId)?.id != otherWorkspaceId)
+        #expect(controller.currentBorderTarget()?.token == videoToken)
+    }
+}


### PR DESCRIPTION
Exiting a fullscreen video (native-Space or app/HTML5) makes macOS re-home
keyboard focus to another window of the same app, which can live on an inactive workspace. That external focusedWindowChanged was honored over the
app's managed focus and switched the active workspace to the inactive one, so
a follow-up 3-finger swipe scrolled the wrong workspace.

Suppress that re-home when the app's live managed border target still sits on
the active workspace, within a short same-app teardown grace (recorded at
fullscreen suspend/restore/destroy and same-app window-close sites). The border
target is durable where confirmed focus and pending requests are not, so this
also covers the case where the teardown already cleared them. Genuine re-focus (Cmd-Tab arrives as an app activation; inactive-workspace windows are
off-screen and unclickable) is unaffected.

## Summary

<!-- What changed and why? -->

## Release notes

Choose one:

- [x] Added a `.changeset/*.md` for user-visible changes (`mise run changeset -- patch "..."`).
- [ ] No user-visible change; apply the `no release note` label to make CI skip intentional.

## Validation

<!-- Commands run, screenshots, or manual checks. -->

- [ ] Ran relevant tests/checks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed workspace switching after exiting a fullscreen video.
  * Prevented external focus changes from moving users to an inactive workspace when the correct same-app window remains on the active workspace.

* **Tests**
  * Added regression coverage for fullscreen exit and swipe behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->