### PR TITLE
Open new windows on the display you're using and keep focus on them

### DIFF
--- a/.changeset/20260713215354-open-windows-on-the-display-you-re-using-instead.md
+++ b/.changeset/20260713215354-open-windows-on-the-display-you-re-using-instead.md
@@ -1,0 +1,6 @@
+---
+"nehir": patch
+
+---
+
+Open windows on the display you're using instead of the built-in display when macOS reports an off-screen initial position

--- a/.changeset/20260713233644-keep-focus-on-a-newly-opened-window-instead-of-b.md
+++ b/.changeset/20260713233644-keep-focus-on-a-newly-opened-window-instead-of-b.md
@@ -1,0 +1,6 @@
+---
+"nehir": patch
+
+---
+
+Keep focus on a newly opened window instead of bouncing it to another window in the same workspace

--- a/Sources/Nehir/Core/Controller/AXEventHandler.swift
+++ b/Sources/Nehir/Core/Controller/AXEventHandler.swift
@@ -126,6 +126,7 @@ struct NiriCreateFocusTraceEvent: Equatable {
             nativeSpaceMonitorId: Monitor.ID?,
             frameMonitorId: Monitor.ID?,
             interactionMonitorId: Monitor.ID?,
+            cursorMonitorId: Monitor.ID?,
             contextSource: String?,
             focusedWorkspaceSource: String?,
             recentPidWorkspaceId: WorkspaceDescriptor.ID?
@@ -320,6 +321,12 @@ struct WindowCreatePlacementContext: Equatable {
     let focusedWorkspaceId: WorkspaceDescriptor.ID?
     let focusedMonitorId: Monitor.ID?
     let interactionMonitorId: Monitor.ID?
+    /// The monitor the pointer is physically over at admission time, derived by
+    /// strict containment from `NSEvent.mouseLocation`. Unlike `interactionMonitorId`
+    /// (written only by Nehir-managed actions and therefore stale after a plain
+    /// non-managed desktop click on a display without managed windows), this reflects
+    /// where the user actually is. `nil` when the pointer is over no monitor.
+    let cursorMonitorId: Monitor.ID?
     let source: String
     let focusedWorkspaceSource: String?
     let recentPidWorkspaceId: WorkspaceDescriptor.ID?
@@ -334,6 +341,7 @@ extension WindowCreatePlacementContext: CustomStringConvertible {
             + "focused_workspace=\(focusedWorkspaceId?.uuidString ?? "nil") "
             + "focused_monitor=\(String(describing: focusedMonitorId)) "
             + "interaction_monitor=\(String(describing: interactionMonitorId)) "
+            + "cursor_monitor=\(String(describing: cursorMonitorId)) "
             + "source=\(source) "
             + "focused_workspace_source=\(focusedWorkspaceSource ?? "nil") "
             + "recent_pid_workspace=\(recentPidWorkspaceId?.uuidString ?? "nil") "
@@ -358,11 +366,12 @@ extension NiriCreateFocusTraceEvent: CustomStringConvertible {
             nativeSpaceMonitorId,
             frameMonitorId,
             interactionMonitorId,
+            cursorMonitorId,
             contextSource,
             focusedWorkspaceSource,
             recentPidWorkspaceId
         ):
-            "create_placement_resolved token=\(token) workspace=\(workspaceId.uuidString) pending_workspace=\(pendingWorkspaceId?.uuidString ?? "nil") pending_monitor=\(String(describing: pendingMonitorId)) focused_workspace=\(focusedWorkspaceId?.uuidString ?? "nil") focused_monitor=\(String(describing: focusedMonitorId)) native_monitor=\(String(describing: nativeSpaceMonitorId)) frame_monitor=\(String(describing: frameMonitorId)) interaction_monitor=\(String(describing: interactionMonitorId)) context_source=\(contextSource ?? "nil") focused_workspace_source=\(focusedWorkspaceSource ?? "nil") recent_pid_workspace=\(recentPidWorkspaceId?.uuidString ?? "nil")"
+            "create_placement_resolved token=\(token) workspace=\(workspaceId.uuidString) pending_workspace=\(pendingWorkspaceId?.uuidString ?? "nil") pending_monitor=\(String(describing: pendingMonitorId)) focused_workspace=\(focusedWorkspaceId?.uuidString ?? "nil") focused_monitor=\(String(describing: focusedMonitorId)) native_monitor=\(String(describing: nativeSpaceMonitorId)) frame_monitor=\(String(describing: frameMonitorId)) interaction_monitor=\(String(describing: interactionMonitorId)) cursor_monitor=\(String(describing: cursorMonitorId)) context_source=\(contextSource ?? "nil") focused_workspace_source=\(focusedWorkspaceSource ?? "nil") recent_pid_workspace=\(recentPidWorkspaceId?.uuidString ?? "nil")"
         case let .candidateTracked(token, workspaceId):
             "candidate_tracked token=\(token) workspace=\(workspaceId.uuidString)"
         case let .relayoutActivatedWindow(token, workspaceId):
@@ -981,6 +990,12 @@ final class AXEventHandler: CGSEventDelegate {
     var fastFrameProvider: ((AXWindowRef) -> CGRect?)?
     var isFullscreenProvider: ((AXWindowRef) -> Bool)?
     var spaceDisplayResolver: ((UInt64, [Monitor]) -> CGDirectDisplayID?)?
+    /// OS-boundary seam for the display the pointer is currently over. `nil` uses the
+    /// live AppKit pointer; tests set it (e.g. to `{ nil }`) so the real cursor position
+    /// never leaks into placement decisions. Faking this boundary — not the placement
+    /// algorithm — keeps production and tests on the same resolveCursorPlacementMonitorId
+    /// path.
+    var cursorDisplayIdProvider: (() -> CGDirectDisplayID?)?
     var managedReplacementTimeSourceForTests: (() -> TimeInterval)?
     var axContextWarmupHandlerForTests: ((pid_t) -> Void)?
     private(set) var debugCounters = DebugCounters()
@@ -2853,6 +2868,21 @@ final class AXEventHandler: CGSEventDelegate {
         phase: StableRecoveryRedirectPhase
     ) -> Bool {
         guard activeWindowCloseFocusRecoveryWorkspaceId() == nil else { return false }
+        // A window the user just created lands here with the same `recentNonManaged`
+        // pid signal an overlay steal would produce: opening it (e.g. Finder ⌘N) is a
+        // non-managed app activation, which records recentNonManagedFocus for the new
+        // window's OWN pid. That alone satisfies the overlay-recovery evidence
+        // (hasSameAppOverlayRecoverySignal is evaluated on the observed window), so the
+        // heuristic redirects focus off it. The redirect target is not required to be an
+        // overlay app — stableViewportFocusTarget just picks the nearest on-screen tile
+        // in the workspace excluding the new window, so focus bounces to whatever else
+        // happens to share the workspace. A freshly *managed*-admitted window is an
+        // intentional, stable focus target, not an overlay steal; genuine focus-stealing
+        // overlays are non-managed and never appear in recentManagedAdmissionByToken, so
+        // this exempts only real new windows.
+        if recentManagedAdmissionWorkspaceId(for: observedEntry.token) == workspaceId {
+            return false
+        }
         let signal = hasSameAppOverlayRecoverySignal(for: observedEntry)
         let recentSameAppClose = hasRecentSameAppWindowClose(for: observedEntry.pid)
         let previousSameAppFocusDisappeared = previousSameAppFocusDisappearedSignal(
@@ -5499,6 +5529,7 @@ final class AXEventHandler: CGSEventDelegate {
                     nativeSpaceMonitorId: createPlacementContext?.nativeSpaceMonitorId,
                     frameMonitorId: placementTraceMonitorId(for: windowFrame, controller: controller),
                     interactionMonitorId: createPlacementContext?.interactionMonitorId,
+                    cursorMonitorId: createPlacementContext?.cursorMonitorId,
                     contextSource: createPlacementContext?.source,
                     focusedWorkspaceSource: createPlacementContext?.focusedWorkspaceSource,
                     recentPidWorkspaceId: createPlacementContext?.recentPidWorkspaceId
@@ -7031,11 +7062,36 @@ final class AXEventHandler: CGSEventDelegate {
                 controller.workspaceManager.monitorId(for: $0)
             },
             interactionMonitorId: controller.workspaceManager.interactionMonitorId,
+            cursorMonitorId: resolveCursorPlacementMonitorId(controller: controller),
             source: source,
             focusedWorkspaceSource: focusedWorkspaceSource,
             recentPidWorkspaceId: recentPidWorkspaceId,
             createdAt: Date()
         )
+    }
+
+    /// The monitor the pointer is physically over, by strict containment.
+    /// `NSEvent.mouseLocation` is an AppKit bottom-left point; `Monitor.frame` is
+    /// top-left CG space, so matching the pointer against it directly picks the wrong
+    /// display on vertically stacked monitors. Resolve the containing `NSScreen` in
+    /// AppKit space and map it back through `displayId` — the same decision the command
+    /// palette uses (`CommandPaletteController.paletteScreen`). Returns `nil` when the
+    /// pointer is over no screen (no nearest-snap).
+    private func resolveCursorPlacementMonitorId(
+        controller: WMController
+    ) -> Monitor.ID? {
+        // An installed provider is authoritative: when it returns nil the pointer is
+        // over no screen, and we must not fall back to the live cursor (that would leak
+        // the real pointer through a test's `{ nil }` seam). Only consult AppKit when no
+        // provider is installed at all.
+        let displayId: CGDirectDisplayID?
+        if let cursorDisplayIdProvider {
+            displayId = cursorDisplayIdProvider()
+        } else {
+            displayId = NSScreen.screen(containing: NSEvent.mouseLocation)?.displayId
+        }
+        guard let displayId else { return nil }
+        return controller.workspaceManager.monitors.first { $0.displayId == displayId }?.id
     }
 
     private func resolveActiveFocusRequestPlacementMonitorId(

--- a/Sources/Nehir/Core/Controller/WMController.swift
+++ b/Sources/Nehir/Core/Controller/WMController.swift
@@ -1544,9 +1544,49 @@ final class WMController {
             }
         }
 
+        // Reported repro: the user clicks a display's desktop and hits ⌘N in an app
+        // (e.g. Finder) with no managed window on that display. That non-managed
+        // activation updates none of the signals above — the interaction monitor is
+        // stale (last managed display), the focused/native fields are nil, and the new
+        // window's WindowServer frame is an off-screen park-zone rect that
+        // monitorApproximation snaps to the wrong display. The only signal pointing at
+        // the display the user is actually on is the pointer location. When it is known
+        // (cursor over a real monitor), no native space is claimed, and the authoritative
+        // WindowServer frame is off-screen (contained by no monitor), prefer the cursor
+        // monitor. We deliberately do NOT also require the live AX frame to be off-screen:
+        // a freshly created window's AX frame is macOS's default placement (typically the
+        // built-in display), which is noise here, not user intent. This runs after the
+        // authoritative pending/native/confirmed-focus branches above, so it only fills
+        // the gap where they are all absent. An on-screen WindowServer frame (a window the
+        // user positioned before admission) still falls through to the frame fallback.
+        if let cursorMonitorId = createPlacementContext?.cursorMonitorId,
+           createPlacementContext?.nativeSpaceMonitorId == nil,
+           monitorContainingPlacementFrame(windowFrame) == nil,
+           let workspace = workspaceManager.activeWorkspaceOrFirst(on: cursorMonitorId)
+        {
+            return WorkspacePlacementTarget(
+                workspaceId: workspace.id,
+                monitorId: cursorMonitorId,
+                isAuthoritative: true
+            )
+        }
+
+        // The live AX frame is an IPC round-trip; fetch it at most once per admission and
+        // reuse it across the fast-frame monitor fallback and the interaction-monitor
+        // branch below. The outer optional records whether we have queried yet, so the
+        // query stays lazy — skipped entirely when monitors.count == 1 and the later
+        // off-screen interaction branch is never reached.
+        var cachedFastFrame: CGRect??
+        func liveFastFrame() -> CGRect? {
+            if let cachedFastFrame { return cachedFastFrame }
+            let frame = AXWindowService.framePreferFast(axRef)
+            cachedFastFrame = frame
+            return frame
+        }
+
         let fallbackFrameMonitor = monitorForPlacementFrame(windowFrame)
         let fallbackFastFrameMonitor = workspaceManager.monitors.count > 1
-            ? monitorForPlacementFrame(AXWindowService.framePreferFast(axRef))
+            ? monitorForPlacementFrame(liveFastFrame())
             : nil
         let fallbackResolvedFrameMonitor = fallbackFrameMonitor ?? fallbackFastFrameMonitor
 
@@ -1569,6 +1609,26 @@ final class WMController {
             return WorkspacePlacementTarget(
                 workspaceId: workspace.id,
                 monitorId: monitorId,
+                isAuthoritative: true
+            )
+        }
+
+        // A synthesized focused-admission with no focused/native context still knows the
+        // interaction monitor. If both the WindowServer frame and the live AX frame are
+        // off-screen (contained by no monitor — e.g. a parked negative-y frame that
+        // monitorApproximation would snap to the wrong display), trust the interaction
+        // monitor over the approximated frame monitor. An on-screen frame (contained by
+        // a real monitor) still falls through to the frame-monitor fallback below: a
+        // stale interaction monitor must not override a frame that genuinely places the
+        // window on a display.
+        if let interactionMonitorId = createPlacementContext?.interactionMonitorId,
+           monitorContainingPlacementFrame(windowFrame) == nil,
+           monitorContainingPlacementFrame(liveFastFrame()) == nil,
+           let workspace = workspaceManager.activeWorkspaceOrFirst(on: interactionMonitorId)
+        {
+            return WorkspacePlacementTarget(
+                workspaceId: workspace.id,
+                monitorId: interactionMonitorId,
                 isAuthoritative: true
             )
         }
@@ -1721,6 +1781,11 @@ final class WMController {
     private func monitorForPlacementFrame(_ frame: CGRect?) -> Monitor? {
         guard let frame, !frame.isNull, !frame.isEmpty else { return nil }
         return frame.center.monitorApproximation(in: workspaceManager.monitors)
+    }
+
+    private func monitorContainingPlacementFrame(_ frame: CGRect?) -> Monitor? {
+        guard let frame, !frame.isNull, !frame.isEmpty else { return nil }
+        return frame.center.monitorContaining(in: workspaceManager.monitors)
     }
 
     private func resolvedAppInfo(for pid: pid_t) -> AppInfoCache.AppInfo? {

--- a/Sources/Nehir/Core/Monitor/Monitor.swift
+++ b/Sources/Nehir/Core/Monitor/Monitor.swift
@@ -489,4 +489,8 @@ extension CGPoint {
         }
         return monitors.min(by: { $0.frame.distanceSquared(to: self) < $1.frame.distanceSquared(to: self) })
     }
+
+    func monitorContaining(in monitors: [Monitor]) -> Monitor? {
+        monitors.first(where: { $0.frame.contains(self) })
+    }
 }

--- a/Tests/NehirTests/AXEventHandlerTests.swift
+++ b/Tests/NehirTests/AXEventHandlerTests.swift
@@ -74,6 +74,9 @@ private func makeAXEventTestController(
         settings: settings,
         windowFocusOperations: operations
     )
+    // Fake the pointer-location OS boundary so the real cursor never leaks into
+    // create-placement decisions (test monitors reuse the real main display id).
+    controller.axEventHandler.cursorDisplayIdProvider = { nil }
     if let trackedBundleId {
         controller.appInfoCache.storeInfoForTests(pid: getpid(), bundleId: trackedBundleId)
         controller.axEventHandler.bundleIdProvider = { _ in trackedBundleId }
@@ -271,6 +274,7 @@ private func makeSynthesizedFocusedAdmissionContext() -> WindowCreatePlacementCo
         focusedWorkspaceId: nil,
         focusedMonitorId: nil,
         interactionMonitorId: nil,
+        cursorMonitorId: nil,
         source: "ax_focused_admission_synthesized",
         focusedWorkspaceSource: nil,
         recentPidWorkspaceId: nil,
@@ -10886,6 +10890,7 @@ private func waitUntilAXEventTest(
                 _,
                 _,
                 _,
+                _,
                 _
             ) = event.kind {
                 return token == admittedToken &&
@@ -10982,6 +10987,7 @@ private func waitUntilAXEventTest(
                 contextInteractionMonitorId,
                 _,
                 _,
+                _,
                 _
             ) = event.kind {
                 return token == admittedToken &&
@@ -11074,6 +11080,7 @@ private func waitUntilAXEventTest(
                 _,
                 contextFocusedWorkspaceId,
                 contextFocusedMonitorId,
+                _,
                 _,
                 _,
                 _,

--- a/Tests/NehirTests/LayoutPlanTestSupport.swift
+++ b/Tests/NehirTests/LayoutPlanTestSupport.swift
@@ -136,6 +136,9 @@ func makeLayoutPlanTestController(
         windowFocusOperations: operations
     )
     controller.lockScreenObserver.frontmostApplicationProvider = { nil }
+    // Fake the pointer-location OS boundary so the real cursor never leaks into
+    // create-placement decisions (test monitors reuse the real main display id).
+    controller.axEventHandler.cursorDisplayIdProvider = { nil }
     installSynchronousFrameApplySuccessOverride(on: controller)
     controller.workspaceManager.applyMonitorConfigurationChange(monitors)
     return controller

--- a/Tests/NehirTests/PlacementCursorInteractionMonitorFallbackTests.swift
+++ b/Tests/NehirTests/PlacementCursorInteractionMonitorFallbackTests.swift
@@ -1,0 +1,147 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
+import CoreGraphics
+import Foundation
+@testable import Nehir
+import Testing
+
+/// Placement regression coverage for the reported bug: activating an app on the
+/// external display (e.g. clicking its desktop and hitting ⌘N in Finder) admitted
+/// the new window on the built-in display. macOS reports the new window's
+/// WindowServer frame in an off-screen park zone, which `monitorApproximation`
+/// snaps to the nearest (often built-in) display; placement then trusted that
+/// snapped frame monitor over the signals that actually point at the display the
+/// user is on — the cursor monitor and the interaction monitor.
+@MainActor
+struct PlacementCursorInteractionMonitorFallbackTests {
+    /// Frame contained by neither monitor. Center `(800, -900)` sits above both
+    /// displays (both start at y = 0); nearest-snap resolves it to the primary,
+    /// which is the trap the cursor/interaction signals must override.
+    private static let offScreenFrame = CGRect(x: 400, y: -1200, width: 800, height: 600)
+
+    private func makeContext(
+        cursorMonitorId: Monitor.ID?,
+        interactionMonitorId: Monitor.ID?,
+        nativeSpaceMonitorId: Monitor.ID? = nil
+    ) -> WindowCreatePlacementContext {
+        WindowCreatePlacementContext(
+            nativeSpaceMonitorId: nativeSpaceMonitorId,
+            activeFocusRequestWorkspaceId: nil,
+            activeFocusRequestMonitorId: nil,
+            focusedWorkspaceId: nil,
+            focusedMonitorId: nil,
+            interactionMonitorId: interactionMonitorId,
+            cursorMonitorId: cursorMonitorId,
+            source: "ax_focused_admission_synthesized",
+            focusedWorkspaceSource: nil,
+            recentPidWorkspaceId: nil,
+            createdAt: Date()
+        )
+    }
+
+    /// The cursor monitor wins over the mis-snapped off-screen frame monitor.
+    @Test func offScreenFramePrefersCursorMonitor() async {
+        await withAXFrameProviderIsolationForTests {
+            let fixture = makeTwoMonitorLayoutPlanTestController()
+            AXWindowService.fastFrameProviderForTests = { _ in nil }
+            defer { AXWindowService.fastFrameProviderForTests = nil }
+
+            let resolved = fixture.controller.resolveWorkspaceForNewWindow(
+                axRef: makeLayoutPlanTestWindow(windowId: 9001),
+                pid: getpid(),
+                createPlacementContext: makeContext(
+                    cursorMonitorId: fixture.secondaryMonitor.id,
+                    interactionMonitorId: nil
+                ),
+                windowFrame: Self.offScreenFrame,
+                fallbackWorkspaceId: fixture.primaryWorkspaceId
+            )
+
+            #expect(resolved == fixture.secondaryWorkspaceId)
+        }
+    }
+
+    /// The reported bug's core: the interaction monitor can be stale (it is written
+    /// only by Nehir-managed actions, so a plain desktop click on another display
+    /// leaves it pointing at the previous display). The cursor monitor reflects where
+    /// the user actually is, so for an off-screen frame it must win over a stale
+    /// interaction monitor pointing elsewhere.
+    @Test func offScreenFramePrefersCursorOverStaleInteractionMonitor() async {
+        await withAXFrameProviderIsolationForTests {
+            let fixture = makeTwoMonitorLayoutPlanTestController()
+            AXWindowService.fastFrameProviderForTests = { _ in nil }
+            defer { AXWindowService.fastFrameProviderForTests = nil }
+
+            let resolved = fixture.controller.resolveWorkspaceForNewWindow(
+                axRef: makeLayoutPlanTestWindow(windowId: 9002),
+                pid: getpid(),
+                createPlacementContext: makeContext(
+                    cursorMonitorId: fixture.secondaryMonitor.id,
+                    interactionMonitorId: fixture.primaryMonitor.id
+                ),
+                windowFrame: Self.offScreenFrame,
+                fallbackWorkspaceId: fixture.primaryWorkspaceId
+            )
+
+            #expect(resolved == fixture.secondaryWorkspaceId)
+        }
+    }
+
+    /// A claimed native space is authoritative and outranks the cursor branch: the
+    /// cursor fallback is gated on `nativeSpaceMonitorId == nil`, so when the new
+    /// window's space resolves to the primary display the placement must land there
+    /// even for an off-screen frame with the cursor over the secondary display.
+    @Test func nativeSpaceMonitorWinsOverCursorMonitor() async {
+        await withAXFrameProviderIsolationForTests {
+            let fixture = makeTwoMonitorLayoutPlanTestController()
+            AXWindowService.fastFrameProviderForTests = { _ in nil }
+            defer { AXWindowService.fastFrameProviderForTests = nil }
+
+            let resolved = fixture.controller.resolveWorkspaceForNewWindow(
+                axRef: makeLayoutPlanTestWindow(windowId: 9004),
+                pid: getpid(),
+                createPlacementContext: makeContext(
+                    cursorMonitorId: fixture.secondaryMonitor.id,
+                    interactionMonitorId: nil,
+                    nativeSpaceMonitorId: fixture.primaryMonitor.id
+                ),
+                windowFrame: Self.offScreenFrame,
+                fallbackWorkspaceId: fixture.primaryWorkspaceId
+            )
+
+            #expect(resolved == fixture.primaryWorkspaceId)
+        }
+    }
+
+    /// A window the user positioned on a specific display before admission — an
+    /// on-screen WindowServer frame contained by exactly one monitor — is still
+    /// honored by the frame monitor, not stolen by a cursor/interaction monitor
+    /// that points elsewhere.
+    @Test func onScreenFrameStillHonorsFrameMonitor() async {
+        await withAXFrameProviderIsolationForTests {
+            let fixture = makeTwoMonitorLayoutPlanTestController()
+            AXWindowService.fastFrameProviderForTests = { _ in nil }
+            defer { AXWindowService.fastFrameProviderForTests = nil }
+
+            // Center (2200, 250): inside the secondary monitor (1920…3840 × 0…1080).
+            let onScreenSecondaryFrame = CGRect(x: 2000, y: 100, width: 400, height: 300)
+
+            let resolved = fixture.controller.resolveWorkspaceForNewWindow(
+                axRef: makeLayoutPlanTestWindow(windowId: 9003),
+                pid: getpid(),
+                createPlacementContext: makeContext(
+                    cursorMonitorId: fixture.primaryMonitor.id,
+                    interactionMonitorId: fixture.primaryMonitor.id
+                ),
+                windowFrame: onScreenSecondaryFrame,
+                fallbackWorkspaceId: fixture.primaryWorkspaceId
+            )
+
+            #expect(resolved == fixture.secondaryWorkspaceId)
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Activating an app on an external display (e.g. clicking its desktop and hitting
⌘N in Finder) admitted the new window on the built-in display, and even after
it landed correctly, focus bounced to another window.

Placement: macOS reports a new window's initial WindowServer frame in an off-screen park zone, which monitorApproximation snaps to the nearest (often
built-in) display; placement then trusted that snapped frame monitor over the
signals that actually point at the display the user is on. Derive the pointer's
monitor from NSEvent.mouseLocation via strict NSScreen containment, carry it as
a new cursor-monitor field on the create-placement context (separate from the
interaction monitor, which is only written by Nehir-managed actions and so can
be stale), and prefer it in the focused-admission tail when the WindowServer
frame is off-screen. Ordered after pending/native/confirmed-focus so those
still win; an on-screen frame still honors the frame monitor. The cursor monitor
also appears in the create_placement_resolved trace line.

Focus: a freshly created window triggers the same-app overlay-recovery redirect,
because opening it is a non-managed app activation that records recentNonManagedFocus for its own pid — enough to satisfy the overlay-recovery
evidence, after which the redirect bounces focus to the nearest other tile in
the workspace. Exempt a window that was itself just admitted as a managed window
into the workspace: it is an intentional, stable focus target, and genuine
focus-stealing overlays are non-managed so they never appear in the recent
managed-admission map.

The pointer lookup is faked at the OS boundary in tests (cursorDisplayIdProvider)
so the real cursor never leaks into placement decisions.
## Release notes

Choose one:

- [x] Added a `.changeset/*.md` for user-visible changes (`mise run changeset -- patch "..."`).
- [ ] No user-visible change; apply the `no release note` label to make CI skip intentional.

## Validation

<!-- Commands run, screenshots, or manual checks. -->

- [ ] Ran relevant tests/checks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved macOS window placement when the initial position is reported off-screen.
  * When placement data is unreliable, newly created windows now open on the display where the cursor is located.
  * Preserved focus on newly opened windows instead of redirecting focus within the same workspace.
  * Better handling for cases where monitor/interaction placement data is stale or inconsistent.
* **Tests**
  * Added and updated multi-monitor placement coverage, including cursor-based override scenarios and focus/trace event expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->