### PR TITLE
Fix fantom dock shield and heave recomputations on monitor configuration change

### DIFF
--- a/.changeset/20260721115910-fix-a-cluster-of-wake-glitches-on-scaled-resolut.md
+++ b/.changeset/20260721115910-fix-a-cluster-of-wake-glitches-on-scaled-resolut.md
@@ -1,0 +1,5 @@
+---
+"nehir": patch
+---
+
+Fix two wake glitches on scaled-resolution displays: a phantom right-edge Dock shield that appeared after opening the lid from sleep (a Dock inset learned from a stale display-mode reading), and a runaway internal relayout loop that could execute millions of times during the wake settle.

--- a/Sources/Nehir/Core/Controller/LayoutRefreshController.swift
+++ b/Sources/Nehir/Core/Controller/LayoutRefreshController.swift
@@ -188,7 +188,18 @@ import QuartzCore
         var screenChangeObserver: NSObjectProtocol?
         var hasCompletedInitialRefresh: Bool = false
         var didExecuteRefreshExecutionPlan: Bool = false
+        /// Consecutive times a refresh finished with `didComplete == false` and was
+        /// re-armed (via `preserveCancelledRefreshState`) without a new request being
+        /// recorded. Bounds the self-perpetuating re-execution loop (see `finishRefresh`).
+        var consecutiveNoProgressReexecutions: Int = 0
     }
+
+    /// Upper bound on consecutive no-progress re-executions of a preserved,
+    /// cancelled refresh before the synchronous restart is suppressed and the
+    /// pending refresh is left for the next genuine event to drive. Small enough to
+    /// turn a runaway (millions of executions) into a handful, large enough to
+    /// tolerate a brief transient (a re-entrancy overlap that clears in a beat).
+    private static let maxConsecutiveNoProgressReexecutions = 8
 
     var layoutState = LayoutState()
     var debugCounters = RefreshDebugCounters()
@@ -1887,6 +1898,18 @@ import QuartzCore
         startNextRefreshIfNeeded()
     }
 
+    /// Cancels the in-flight refresh so a higher-priority incoming one can take over.
+    /// The cancelled refresh returns didComplete=false and is re-armed
+    /// (`preserveCancelledRefreshState`), so during a wake topology bounce this is the
+    /// driver of the repeated full re-parks (the "dancing"): trace active vs incoming to
+    /// see exactly which reasons keep pre-empting the rescan.
+    private func cancelActiveRefreshForIncoming(active: ScheduledRefresh, incoming: ScheduledRefresh) {
+        LayoutTrace.log(
+            "refresh.cancel active=\(active.kind)/\(active.reason) incoming=\(incoming.kind)/\(incoming.reason)"
+        )
+        layoutState.activeRefreshTask?.cancel()
+    }
+
     private func handleRefresh(_ refresh: ScheduledRefresh, whileActive activeRefresh: ScheduledRefresh) {
         switch (activeRefresh.kind, refresh.kind) {
         case (.fullRescan, .fullRescan):
@@ -1904,14 +1927,14 @@ import QuartzCore
              (.visibilityRefresh, .immediateRelayout),
              (.visibilityRefresh, .relayout):
             mergePendingRefresh(refresh)
-            layoutState.activeRefreshTask?.cancel()
+            cancelActiveRefreshForIncoming(active: activeRefresh, incoming: refresh)
         case (.windowRemoval, .fullRescan):
             mergePendingRefresh(refresh)
         case (.windowRemoval, _):
             mergePendingRefresh(refresh)
         case (.immediateRelayout, .fullRescan):
             mergePendingRefresh(refresh)
-            layoutState.activeRefreshTask?.cancel()
+            cancelActiveRefreshForIncoming(active: activeRefresh, incoming: refresh)
         case (.immediateRelayout, .immediateRelayout):
             mergePendingRefresh(refresh)
         case (.immediateRelayout, .relayout):
@@ -1920,14 +1943,14 @@ import QuartzCore
             mergePendingRefresh(refresh)
         case (.immediateRelayout, .windowRemoval):
             mergePendingRefresh(refresh)
-            layoutState.activeRefreshTask?.cancel()
+            cancelActiveRefreshForIncoming(active: activeRefresh, incoming: refresh)
         case (.relayout, .relayout):
             mergePendingRefresh(refresh)
         case (.relayout, .fullRescan),
              (.relayout, .immediateRelayout),
              (.relayout, .windowRemoval):
             mergePendingRefresh(refresh)
-            layoutState.activeRefreshTask?.cancel()
+            cancelActiveRefreshForIncoming(active: activeRefresh, incoming: refresh)
         case (.relayout, .visibilityRefresh):
             mergePendingRefresh(refresh)
         }
@@ -2122,6 +2145,16 @@ import QuartzCore
     private func finishRefresh(_ refresh: ScheduledRefresh, didComplete: Bool) {
         let completedRefresh = layoutState.activeRefresh ?? refresh
         let didExecuteRefreshExecutionPlan = layoutState.didExecuteRefreshExecutionPlan
+        // Diagnostic for the wake "dancing": a re-park storm shows up here as many
+        // finishes for the same reason with didComplete=false (cancelled mid-flux and
+        // re-armed). noProgressReexec climbs across a spin; pendingKind reveals whether a
+        // follow-on rescan is already queued to re-park again.
+        LayoutTrace.log(
+            "refresh.finish kind=\(completedRefresh.kind) reason=\(completedRefresh.reason) "
+                + "didComplete=\(didComplete) "
+                + "noProgressReexec=\(layoutState.consecutiveNoProgressReexecutions) "
+                + "pendingKind=\(layoutState.pendingRefresh.map { "\($0.kind)" } ?? "nil")"
+        )
 
         if !didComplete {
             preserveCancelledRefreshState(completedRefresh)
@@ -2132,6 +2165,7 @@ import QuartzCore
         layoutState.didExecuteRefreshExecutionPlan = false
 
         if didComplete {
+            layoutState.consecutiveNoProgressReexecutions = 0
             if !didExecuteRefreshExecutionPlan, let controller {
                 let shouldRequestWorkspaceProjectionRefresh =
                     completedRefresh.kind != .visibilityRefresh && completedRefresh.needsVisibilityReconciliation
@@ -2154,6 +2188,30 @@ import QuartzCore
                         affectedWorkspaceIds: followUpRefresh.affectedWorkspaceIds
                     )
                 )
+            }
+        }
+
+        // Bound the self-perpetuating re-execution loop. When a refresh keeps
+        // returning didComplete=false for a persistent transient reason (e.g. the
+        // login/lock-screen window is still up during a wake settle),
+        // preserveCancelledRefreshState re-arms pendingRefresh WITHOUT recording a
+        // request, and the restart below re-runs the identical refresh immediately —
+        // spinning executedByReason into the millions while requestedByReason stays
+        // flat. Only a successful completion resets the counter — NOT an unrelated new
+        // request, because a busy wake enqueues hundreds of other refreshes that would
+        // otherwise keep clearing the guard so it never trips. So this bounds the
+        // pathological no-progress spin while normal work (which completes, resetting to
+        // 0) never approaches the cap. The preserved refresh stays pending and is
+        // re-driven by the next genuine event (unlock, display change, AX event).
+        if !didComplete, layoutState.pendingRefresh != nil {
+            layoutState.consecutiveNoProgressReexecutions += 1
+            if layoutState.consecutiveNoProgressReexecutions >= Self.maxConsecutiveNoProgressReexecutions {
+                LayoutTrace.log(
+                    "refresh re-execution bounded after "
+                        + "\(layoutState.consecutiveNoProgressReexecutions) no-progress executions; "
+                        + "pending refresh retained for the next genuine event"
+                )
+                return
             }
         }
 

--- a/Sources/Nehir/Core/Monitor/Monitor.swift
+++ b/Sources/Nehir/Core/Monitor/Monitor.swift
@@ -155,6 +155,13 @@ enum DockReservation {
     private nonisolated(unsafe) static var stickyInset: [CGDirectDisplayID: CGFloat] = [:]
     private nonisolated(unsafe) static var lastOrientation: [CGDirectDisplayID: String] = [:]
     private nonisolated(unsafe) static var lastAXProbe: (uptime: TimeInterval, barRect: CGRect?)?
+    // Last physical frame seen per display. A sticky inset is a fixed pixel count keyed
+    // to a specific physical edge, so a value learned under one resolution/mode is
+    // meaningless under another (e.g. a 328px right inset learned at 2056-wide produces
+    // a giant phantom shield at 1728-wide). When a display's frame changes we drop its
+    // sticky and skip re-learning for that one pass, so a frame/bar read straddling the
+    // transition cannot immediately re-learn the mode-width delta.
+    private nonisolated(unsafe) static var lastFrame: [CGDirectDisplayID: CGRect] = [:]
 
     /// Drop every learned Dock inset and the cached AX probe so the next
     /// `stableVisibleFrame` re-derives the working area purely from the current live
@@ -190,6 +197,17 @@ enum DockReservation {
             stickyInset[displayId] = nil
         }
         if let rawOrientation { lastOrientation[displayId] = rawOrientation }
+        // A display mode/resolution change invalidates any inset learned under the old
+        // frame. Drop the stale sticky and skip re-learning this pass (see the learn
+        // block below), so a frame/bar read straddling the transition cannot re-learn
+        // the mode-width delta as a phantom side inset. First sighting (nil → value) is
+        // not a change; a Dock hide/show does not alter the physical frame, so the
+        // sticky still survives transient suppression.
+        let frameChanged = (lastFrame[displayId].map { $0 != frame }) ?? false
+        lastFrame[displayId] = frame
+        if frameChanged {
+            stickyInset[displayId] = nil
+        }
         let sticky = stickyInset[displayId] ?? 0
         lock.unlock()
 
@@ -301,7 +319,7 @@ enum DockReservation {
         // TODO: consider a tighter side-inset ceiling than the loose cross-orientation
         // 0.33 cap once we have a safe upper bound for legitimately large side Docks.
 
-        if let derivedInset, derivedInset > 0.5, derivedInset <= maxPlausibleInset {
+        if !frameChanged, let derivedInset, derivedInset > 0.5, derivedInset <= maxPlausibleInset {
             // Hysteresis: the AX Dock-bar measurement jitters a few px as it settles, so
             // adopting every reading makes the working area and shield flap (e.g. 71↔76px)
             // and desyncs the park target from the shield. Keep the learned inset unless
@@ -311,8 +329,14 @@ enum DockReservation {
                 // within jitter — keep the stable value
             } else {
                 stickyInset[displayId] = derivedInset
+                LayoutTrace.log(
+                    "dockInset.learn displayId=\(displayId) orientation=\(effectiveOrientation) "
+                        + "derived=\(String(format: "%.1f", derivedInset)) "
+                        + "frame=\(LayoutTrace.rect(frame)) rawVisible=\(LayoutTrace.rect(visibleFrame))"
+                )
             }
-        } else if !isSideOrientation,
+        } else if !frameChanged,
+                  !isSideOrientation,
                   stickyInset[displayId] == nil,
                   currentInset > 0.5,
                   currentInset <= maxPlausibleInset
@@ -385,14 +409,24 @@ enum DockReservation {
     private static func axDerivedInset(frame: CGRect, orientation: String) -> CGFloat? {
         guard let rawBar = cachedDockBarRect(), let appKitBar = appKitDockBarRect(from: rawBar) else { return nil }
 
+        // A genuine side Dock bar sits flush against the screen edge it insets. A bar
+        // rect cached under a different (smaller) display mode — the ~5s memo surviving a
+        // scaled-resolution switch — has its OUTER edge short of the current frame edge by
+        // exactly the mode-width delta. Reject that stale/straddled read: otherwise the
+        // delta is learned as a phantom side inset (e.g. 2056 - 1728 = 328) that clears
+        // the 0.33x ratio ceiling and sticks as a giant shield. (A bar from a *larger*
+        // mode is already rejected by the maxX<=frame.maxX / minX>=frame.minX guards.)
+        let edgeFlushTolerance: CGFloat = 24
         switch orientation {
         case "left":
             guard appKitBar.minY < frame.maxY, appKitBar.maxY > frame.minY else { return nil }
             guard appKitBar.minX >= frame.minX, appKitBar.maxX <= frame.midX else { return nil }
+            guard appKitBar.minX - frame.minX <= edgeFlushTolerance else { return nil }
             return appKitBar.maxX - frame.minX
         case "right":
             guard appKitBar.minY < frame.maxY, appKitBar.maxY > frame.minY else { return nil }
             guard appKitBar.maxX <= frame.maxX, appKitBar.minX >= frame.midX else { return nil }
+            guard frame.maxX - appKitBar.maxX <= edgeFlushTolerance else { return nil }
             return frame.maxX - appKitBar.minX
         default:
             return appKitBar.maxY - frame.minY


### PR DESCRIPTION
## Summary

Fix two wake glitches on scaled-resolution displays: a phantom right-edge Dock shield that appeared after opening the lid from sleep (a Dock inset learned from a stale display-mode reading), and a runaway internal relayout loop that could execute millions of times during the wake settle.

## Release notes

Choose one:

- [x] Added a `.changeset/*.md` for user-visible changes (`mise run changeset -- patch "..."`).
- [ ] No user-visible change; apply the `no release note` label to make CI skip intentional.

## Validation

<!-- Commands run, screenshots, or manual checks. -->

- [ ] Ran relevant tests/checks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a phantom right-edge Dock shield that could appear after waking from sleep or changing display modes.
  * Improved Dock layout handling during display resolution and topology changes.
  * Prevented repeated refresh cycles from continuing indefinitely while the layout settles.
  * Improved prioritization of newer layout refreshes during transitions.

* **Diagnostics**
  * Added enhanced tracing for wake-related layout refreshes and Dock inset calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->