### PR TITLE
Gate Dock reservation stickiness on the persistent auto-hide preference

### DIFF
--- a/.changeset/20260723163118-fix-external-monitor-reconnect-leaving-a-dock-he.md
+++ b/.changeset/20260723163118-fix-external-monitor-reconnect-leaving-a-dock-he.md
@@ -1,0 +1,6 @@
+---
+"nehir": patch
+contributors: [dagrlx]
+---
+
+Fix external-monitor reconnect leaving a Dock-height gap at the bottom when the Dock is set to auto-hide. Fixes #163

--- a/Sources/Nehir/Core/Monitor/Monitor.swift
+++ b/Sources/Nehir/Core/Monitor/Monitor.swift
@@ -131,7 +131,8 @@ extension NSScreen {
     }
 }
 
-/// Keeps the working area stable against transient loss of the Dock's reserved space.
+/// Keeps a fixed Dock's working area stable against transient loss of its reserved
+/// space, and reclaims the band for an auto-hide Dock.
 ///
 /// `NSScreen.visibleFrame` reflects the *current* Dock reservation, which vanishes
 /// globally whenever the active application suppresses the Dock via
@@ -139,9 +140,15 @@ extension NSScreen {
 /// `.autoHideDock`). With a fixed Dock that makes the reported working area flap
 /// between Dock-inset and full width as focus moves, retiling the workspace and
 /// re-parking hidden windows each time. This helper remembers the last non-zero
-/// Dock inset per display + Dock orientation + screen frame and keeps applying it
-/// while the Dock is configured as fixed (`autohide == false`), so Nehir's working
-/// area stays Dock-inset even when the instantaneous reservation is suppressed.
+/// Dock inset per display + Dock orientation + screen frame and keeps applying it,
+/// so Nehir's working area stays Dock-inset even when the instantaneous reservation
+/// is suppressed.
+///
+/// This stabilization is only correct for a fixed Dock. An auto-hide Dock reserves
+/// no permanent band — its AX bar only animates on-screen during a reveal — so when
+/// the persistent `com.apple.dock autohide` preference is authoritatively enabled,
+/// the learned inset is dropped and the Dock-orientation axis reclaimed (#163). A
+/// nil/unreadable preference is treated conservatively as fixed.
 ///
 /// Known limitation: if a fixed Dock is relocated to another display without an
 /// orientation or screen-frame change (bottom Dock dragged across displays with
@@ -162,6 +169,11 @@ enum DockReservation {
     // sticky and skip re-learning for that one pass, so a frame/bar read straddling the
     // transition cannot immediately re-learn the mode-width delta.
     private nonisolated(unsafe) static var lastFrame: [CGDirectDisplayID: CGRect] = [:]
+    // Global (not per-display) memo of the persistent Dock autohide preference:
+    // (monotonic uptime of the last authoritative read, that value). Only successful
+    // reads are stored; a transient-nil read leaves the last authoritative value in
+    // place so reconnect churn cannot momentarily re-arm the fixed-Dock learn (#163).
+    private nonisolated(unsafe) static var lastAutohideProbe: (uptime: TimeInterval, value: Bool)?
 
     /// Drop every learned Dock inset and the cached AX probe so the next
     /// `stableVisibleFrame` re-derives the working area purely from the current live
@@ -172,6 +184,51 @@ enum DockReservation {
         defer { lock.unlock() }
         stickyInset.removeAll()
         lastAXProbe = nil
+        lastAutohideProbe = nil // #163: re-read live autohide on manual re-evaluate.
+    }
+
+    /// The persistent `com.apple.dock autohide` preference, or nil when it has never
+    /// been readable. Returns true only when auto-hide is authoritatively enabled;
+    /// callers treat nil (and false) conservatively as a fixed Dock.
+    ///
+    /// Memoized for `ttl` seconds against a monotonic clock so a burst of
+    /// `Monitor.current()` rebuilds triggers at most one `CFPreferencesAppSynchronize`.
+    /// After a first authoritative read, a transient unreadable read returns the last
+    /// known value rather than nil, so reconnect churn cannot momentarily re-arm the
+    /// fixed-Dock learn. Never holds `DockReservation.lock` across the CFPreferences
+    /// calls (those can block); the lock only guards the tiny memo read and write.
+    private static func dockAutohideEnabled() -> Bool? {
+        let ttl: TimeInterval = 1.0
+        let now = ProcessInfo.processInfo.systemUptime
+
+        // 1. Fast path: return a fresh memoized value without syncing. Read the memo
+        //    under the lock, then release it before any CFPreferences call.
+        lock.lock()
+        let cached = lastAutohideProbe
+        lock.unlock()
+        if let cached, now - cached.uptime < ttl {
+            return cached.value
+        }
+
+        // 2. TTL expired (or nothing cached yet): synchronize + read OUTSIDE the lock.
+        let dockDomain = "com.apple.dock" as CFString
+        CFPreferencesAppSynchronize(dockDomain)
+        let raw = CFPreferencesCopyAppValue("autohide" as CFString, dockDomain)
+        let fresh: Bool? =
+            if let flag = raw as? Bool { flag }
+            else if let number = raw as? NSNumber { number.boolValue }
+            else { nil }
+
+        // 3. Update the memo (or fall back) under the lock, no CFPreferences call held.
+        lock.lock()
+        defer { lock.unlock() }
+        if let fresh {
+            lastAutohideProbe = (now, fresh)
+            return fresh
+        }
+        // Transient unreadable: keep the last authoritative value if we ever had one;
+        // otherwise nil → conservatively fixed. Do not overwrite the memo on nil.
+        return lastAutohideProbe?.value
     }
 
     static func stableVisibleFrame(
@@ -180,11 +237,13 @@ enum DockReservation {
         displayId: CGDirectDisplayID
     ) -> CGRect {
         let dockDomain = "com.apple.dock" as CFString
-        // The Dock inset is treated as a stable property: once learned it is applied
-        // permanently, regardless of the live reservation flapping (a quick-terminal or
-        // an auto-hide Dock hides/reveals it constantly). This keeps the shield and the
-        // working area rock-stable — no re-tile when the Dock hides. We intentionally do
-        // NOT try to detect auto-hide and reclaim the band.
+        // A fixed Dock's inset is treated as a stable property: once learned it is applied
+        // permanently, regardless of the live reservation flapping (a quick-terminal that
+        // suppresses the Dock via presentationOptions hides/reveals it constantly). This
+        // keeps the shield and the working area rock-stable — no re-tile when the Dock
+        // hides. An auto-hide Dock is different: it reserves no permanent band, so it is
+        // detected via the persistent com.apple.dock autohide preference (see the gate
+        // above) and has its band reclaimed rather than learned (#163).
 
         // CFPreferences("orientation") reads nil intermittently; falling back to
         // "bottom" would pick the wrong axis and drop the reservation. Reuse the last
@@ -242,6 +301,23 @@ enum DockReservation {
             }
             return corrected
         }
+        // Reclaim the Dock-orientation axis back to the physical frame edge, preserving
+        // the orthogonal (menu-bar/notch) edge carried by `rect`. Shared by the
+        // dock-on-another-display reclaim and the #163 auto-hide reclaim.
+        func reclaimDockAxis(from rect: CGRect, orientation: String) -> CGRect {
+            var corrected = rect
+            switch orientation {
+            case "left":
+                corrected.size.width = corrected.maxX - frame.minX
+                corrected.origin.x = frame.minX
+            case "right":
+                corrected.size.width = frame.maxX - corrected.origin.x
+            default:
+                corrected.size.height = corrected.maxY - frame.minY
+                corrected.origin.y = frame.minY
+            }
+            return corrected
+        }
 
         // The Dock lives on ONE display. If its bar is genuinely on ANOTHER connected
         // display, macOS can still report a phantom side reservation on this display
@@ -259,21 +335,27 @@ enum DockReservation {
         // quick-terminal can report offscreen AX coords that intersect NO display, and
         // treating that as "Dock on another display" would wrongly clear a single
         // display's learned inset (working area jumps to full width, shield disappears).
+        // #163: An auto-hide Dock reserves no permanent band. Its AXList bar top-edge only
+        // animates on-screen during a reveal, and a display reconfiguration animates it in
+        // exactly as Monitor.current() rebuilds — sampling it mid-reveal otherwise learns a
+        // sticky 64/78-pt inset that outlives the reveal forever. When the persistent Dock
+        // preference is authoritatively auto-hide, drop any learned inset for this display
+        // and reclaim the Dock-orientation axis from the live frame, keeping the orthogonal
+        // menu-bar edge. A nil/unreadable preference is treated conservatively as fixed, so
+        // fixed Docks and quick-terminal suppression keep the existing stabilization.
+        if dockAutohideEnabled() == true {
+            lock.lock()
+            stickyInset[displayId] = nil
+            lock.unlock()
+            let corrected = reclaimDockAxis(from: visibleFrame, orientation: effectiveOrientation)
+            return reclaimUnconfirmedSideReservation(from: corrected)
+        }
+
         if dockIsOnAnotherDisplay(than: frame) {
             lock.lock()
             stickyInset[displayId] = nil
             lock.unlock()
-            var corrected = visibleFrame
-            switch orientation {
-            case "left":
-                corrected.size.width = corrected.maxX - frame.minX
-                corrected.origin.x = frame.minX
-            case "right":
-                corrected.size.width = frame.maxX - corrected.origin.x
-            default:
-                corrected.size.height = corrected.maxY - frame.minY
-                corrected.origin.y = frame.minY
-            }
+            let corrected = reclaimDockAxis(from: visibleFrame, orientation: orientation)
             return reclaimUnconfirmedSideReservation(from: corrected)
         }
 

--- a/Sources/Nehir/Core/Monitor/Monitor.swift
+++ b/Sources/Nehir/Core/Monitor/Monitor.swift
@@ -187,6 +187,29 @@ enum DockReservation {
         lastAutohideProbe = nil // #163: re-read live autohide on manual re-evaluate.
     }
 
+    /// Pure memo policy for `dockAutohideEnabled`, extracted so the TTL/fallback rules
+    /// are unit-testable without touching CFPreferences or the clock. Given the current
+    /// uptime, the TTL, the cached probe, and a freshly-read value (`nil` when the read
+    /// was unreadable), returns the value to report and the memo to store next:
+    /// - within TTL: report the cached value with the memo unchanged (no re-probe);
+    /// - TTL expired with a readable `fresh`: report it and re-time the memo;
+    /// - TTL expired but unreadable: fall back to the cached value and leave the memo
+    ///   untouched, so a transient-nil read cannot overwrite the last authoritative one.
+    static func resolveAutohideMemo(
+        now: TimeInterval,
+        ttl: TimeInterval,
+        cached: (uptime: TimeInterval, value: Bool)?,
+        fresh: Bool?
+    ) -> (value: Bool?, memo: (uptime: TimeInterval, value: Bool)?) {
+        if let cached, now - cached.uptime < ttl {
+            return (cached.value, cached)
+        }
+        if let fresh {
+            return (fresh, (now, fresh))
+        }
+        return (cached?.value, cached)
+    }
+
     /// The persistent `com.apple.dock autohide` preference, or nil when it has never
     /// been readable. Returns true only when auto-hide is authoritatively enabled;
     /// callers treat nil (and false) conservatively as a fixed Dock.
@@ -219,16 +242,13 @@ enum DockReservation {
             else if let number = raw as? NSNumber { number.boolValue }
             else { nil }
 
-        // 3. Update the memo (or fall back) under the lock, no CFPreferences call held.
+        // 3. Apply the fresh read (or fall back) under the lock via the pure policy, no
+        //    CFPreferences call held. Re-read the memo so a concurrent refresh is honored.
         lock.lock()
         defer { lock.unlock() }
-        if let fresh {
-            lastAutohideProbe = (now, fresh)
-            return fresh
-        }
-        // Transient unreadable: keep the last authoritative value if we ever had one;
-        // otherwise nil → conservatively fixed. Do not overwrite the memo on nil.
-        return lastAutohideProbe?.value
+        let (value, memo) = resolveAutohideMemo(now: now, ttl: ttl, cached: lastAutohideProbe, fresh: fresh)
+        lastAutohideProbe = memo
+        return value
     }
 
     static func stableVisibleFrame(
@@ -303,20 +323,10 @@ enum DockReservation {
         }
         // Reclaim the Dock-orientation axis back to the physical frame edge, preserving
         // the orthogonal (menu-bar/notch) edge carried by `rect`. Shared by the
-        // dock-on-another-display reclaim and the #163 auto-hide reclaim.
+        // dock-on-another-display reclaim and the #163 auto-hide reclaim. Delegates to
+        // the pure, unit-testable `reclaimedDockAxis`.
         func reclaimDockAxis(from rect: CGRect, orientation: String) -> CGRect {
-            var corrected = rect
-            switch orientation {
-            case "left":
-                corrected.size.width = corrected.maxX - frame.minX
-                corrected.origin.x = frame.minX
-            case "right":
-                corrected.size.width = frame.maxX - corrected.origin.x
-            default:
-                corrected.size.height = corrected.maxY - frame.minY
-                corrected.origin.y = frame.minY
-            }
-            return corrected
+            reclaimedDockAxis(from: rect, frame: frame, orientation: orientation)
         }
 
         // The Dock lives on ONE display. If its bar is genuinely on ANOTHER connected
@@ -465,6 +475,26 @@ enum DockReservation {
             corrected.origin.y = newMinY
         }
         return isSideOrientation ? corrected : reclaimUnconfirmedSideReservation(from: corrected)
+    }
+
+    /// Pure geometry for the Dock-axis reclaim: returns `rect` with the Dock-orientation
+    /// axis pushed back to the physical `frame` edge, preserving the orthogonal
+    /// (menu-bar/notch) edge carried by `rect`. For a bottom Dock this restores
+    /// `origin.y = frame.minY` and extends the height to the previous top edge. Extracted
+    /// as a pure seam so the #163 auto-hide reclaim geometry is unit-testable.
+    static func reclaimedDockAxis(from rect: CGRect, frame: CGRect, orientation: String) -> CGRect {
+        var corrected = rect
+        switch orientation {
+        case "left":
+            corrected.size.width = corrected.maxX - frame.minX
+            corrected.origin.x = frame.minX
+        case "right":
+            corrected.size.width = frame.maxX - corrected.origin.x
+        default:
+            corrected.size.height = corrected.maxY - frame.minY
+            corrected.origin.y = frame.minY
+        }
+        return corrected
     }
 
     /// Reads the Dock's bar rect (its `AXList` child) and converts it to an edge

--- a/Tests/NehirTests/DockAutohideReservationTests.swift
+++ b/Tests/NehirTests/DockAutohideReservationTests.swift
@@ -1,0 +1,108 @@
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=nehir-original; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
+import CoreGraphics
+import Foundation
+@testable import Nehir
+import Testing
+
+/// Regression coverage for the #163 auto-hide Dock gate. The gate itself reads the
+/// persistent `com.apple.dock autohide` preference and the Dock AX bar — unmocked OS
+/// boundaries validated at runtime — so these tests exercise the two pure seams that
+/// carry the policy: the memo TTL/fallback rules and the Dock-axis reclaim geometry.
+@Suite struct DockAutohideReservationTests {
+    // MARK: resolveAutohideMemo — TTL and last-value fallback
+
+    @Test func freshMemoWithinTTLIsReusedAndFreshReadIgnored() {
+        // A burst of Monitor.current() rebuilds within the TTL must reuse the cached
+        // value and NOT adopt a differing fresh read (it would not have been synced).
+        let cached = (uptime: 100.0, value: true)
+        let result = DockReservation.resolveAutohideMemo(
+            now: 100.5, ttl: 1.0, cached: cached, fresh: false
+        )
+        #expect(result.value == true)
+        #expect(result.memo?.uptime == 100.0)
+        #expect(result.memo?.value == true)
+    }
+
+    @Test func expiredMemoReprobesAndAdoptsFreshRead() {
+        // Past the TTL, a readable fresh value is adopted and the memo re-timed.
+        let cached = (uptime: 100.0, value: true)
+        let result = DockReservation.resolveAutohideMemo(
+            now: 102.0, ttl: 1.0, cached: cached, fresh: false
+        )
+        #expect(result.value == false)
+        #expect(result.memo?.uptime == 102.0)
+        #expect(result.memo?.value == false)
+    }
+
+    @Test func unreadableReadPreservesLastAuthoritativeValueWithoutOverwritingMemo() {
+        // The #163 reconnect-churn case: a transient-nil read after the TTL expired must
+        // fall back to the last authoritative value and leave the memo untouched, so the
+        // fixed-Dock learn cannot momentarily re-arm.
+        let cached = (uptime: 100.0, value: true)
+        let result = DockReservation.resolveAutohideMemo(
+            now: 103.0, ttl: 1.0, cached: cached, fresh: nil
+        )
+        #expect(result.value == true)
+        #expect(result.memo?.uptime == 100.0)
+        #expect(result.memo?.value == true)
+    }
+
+    @Test func unreadableReadWithNoPriorValueReportsNil() {
+        // Cold start with an unreadable preference → nil, treated conservatively as fixed.
+        let result = DockReservation.resolveAutohideMemo(
+            now: 10.0, ttl: 1.0, cached: nil, fresh: nil
+        )
+        #expect(result.value == nil)
+        #expect(result.memo == nil)
+    }
+
+    @Test func firstReadableValueSeedsTheMemo() {
+        let result = DockReservation.resolveAutohideMemo(
+            now: 10.0, ttl: 1.0, cached: nil, fresh: true
+        )
+        #expect(result.value == true)
+        #expect(result.memo?.uptime == 10.0)
+        #expect(result.memo?.value == true)
+    }
+
+    // MARK: reclaimedDockAxis — the auto-hide reclaim geometry
+
+    @Test func bottomAutohideReclaimRestoresFullDockAxisAndKeepsMenuBarEdge() {
+        // A mid-reveal AX sample would leave a positive bottom band (e.g. 78 pt). When the
+        // auto-hide gate fires it reclaims the Dock (y) axis: origin.y back to frame.minY
+        // and height extended to the previous top edge, while the 39-pt menu-bar band at
+        // the top (maxY) is preserved.
+        let frame = CGRect(x: 0, y: 0, width: 2056, height: 1329)
+        let banded = CGRect(x: 0, y: 78, width: 2056, height: 1212) // top edge = 1290
+        let reclaimed = DockReservation.reclaimedDockAxis(from: banded, frame: frame, orientation: "bottom")
+        #expect(reclaimed.origin.y == 0)
+        #expect(reclaimed.maxY == 1290) // menu-bar edge untouched
+        #expect(reclaimed.height == 1290)
+        #expect(reclaimed.origin.x == banded.origin.x) // orthogonal axis untouched
+        #expect(reclaimed.width == banded.width)
+    }
+
+    @Test func bottomReclaimIsIdempotentWhenNoBandPresent() {
+        // An already-full working area (no reserved band) is unchanged on the Dock axis.
+        let frame = CGRect(x: 0, y: 0, width: 2056, height: 1329)
+        let full = CGRect(x: 0, y: 0, width: 2056, height: 1290)
+        let reclaimed = DockReservation.reclaimedDockAxis(from: full, frame: frame, orientation: "bottom")
+        #expect(reclaimed == full)
+    }
+
+    @Test func sideAutohideReclaimRestoresTheHorizontalAxis() {
+        // A left auto-hide Dock reclaims the x axis to the physical left edge; the vertical
+        // (menu-bar) extent is preserved.
+        let frame = CGRect(x: 0, y: 0, width: 2560, height: 1440)
+        let banded = CGRect(x: 64, y: 0, width: 2496, height: 1415)
+        let reclaimed = DockReservation.reclaimedDockAxis(from: banded, frame: frame, orientation: "left")
+        #expect(reclaimed.origin.x == 0)
+        #expect(reclaimed.maxX == 2560)
+        #expect(reclaimed.origin.y == banded.origin.y)
+        #expect(reclaimed.height == banded.height)
+    }
+}


### PR DESCRIPTION
## Summary

DockReservation kept applying a learned Dock inset even when the Dock is set to
auto-hide. During an external-display disconnect/reconnect the Dock's AX bar
animates into view just as monitors are rebuilt, so a mid-reveal top-edge sample
was learned as a permanent 64/78-point bottom reservation and Niri laid windows
out inside the reduced working area, leaving a gap only a restart cleared.

Read the persistent com.apple.dock autohide preference (synchronized first, and
memoized for 1s against a monotonic clock so a burst of Monitor.current()
rebuilds triggers at most one CFPreferencesAppSynchronize). After a first
authoritative read, a transient unreadable read falls back to the last known
value so reconnect churn cannot momentarily re-arm the fixed-Dock learn. When
auto-hide is authoritatively enabled, drop any learned inset for the display and
reclaim the Dock-orientation axis from the live frame, keeping the menu-bar edge.
A nil/unreadable preference is treated conservatively as fixed, so fixed Docks
and quick-terminal suppression keep the existing stabilization.

Fixes #163
## Release notes

Choose one:

- [x] Added a `.changeset/*.md` for user-visible changes (`mise run changeset -- patch "..."`).
- [ ] No user-visible change; apply the `no release note` label to make CI skip intentional.

## Validation

<!-- Commands run, screenshots, or manual checks. -->

- [ ] Ran relevant tests/checks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where reconnecting an external monitor could leave an unwanted gap along the Dock when Dock auto-hide is enabled.
  * Improved Dock visible-area calculation to more reliably distinguish fixed-Dock vs auto-hide behavior, preventing layout inconsistencies during preference changes.
* **Tests**
  * Added regression coverage for Dock auto-hide memo caching and Dock-axis reclaim geometry (including orientation and edge preservation).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->