### PR TITLE
Width cycle anchor #170

### DIFF
--- a/.changeset/20260727210741-cycling-column-width-no-longer-recenters-the-foc.md
+++ b/.changeset/20260727210741-cycling-column-width-no-longer-recenters-the-foc.md
@@ -1,0 +1,6 @@
+---
+"nehir": patch
+contributors: [gerardomtz26]
+---
+
+Cycling column width no longer recenters the focused column: the viewport keeps its current anchor (including edge snaps) and moves only the minimum needed to keep the resized column visible. Stale relayout frames no longer fight the resize animation, and a window that refuses to shrink now teaches the layout its real minimum width so neighboring columns keep their gap. Fixes #170

--- a/.provenance.json
+++ b/.provenance.json
@@ -116,7 +116,8 @@
         "Tests/NehirTests/TerminatedAppStatePruningTests.swift",
         "Tests/NehirTests/SwipeAfterFullscreenExitWorkspaceTests.swift",
         "Tests/NehirTests/DockAutohideReservationTests.swift",
-        "Tests/NehirTests/ColumnWidthCycleViewportAnchorTests.swift"
+        "Tests/NehirTests/ColumnWidthCycleViewportAnchorTests.swift",
+        "Tests/NehirTests/QuantizationRefusalStreakTests.swift"
       ],
       "copyright": [
         "2026 Aleksei Gurianov and Nehir contributors"

--- a/.provenance.json
+++ b/.provenance.json
@@ -115,7 +115,8 @@
         "Tests/NehirTests/RuntimeMemoryDumpSectionTests.swift",
         "Tests/NehirTests/TerminatedAppStatePruningTests.swift",
         "Tests/NehirTests/SwipeAfterFullscreenExitWorkspaceTests.swift",
-        "Tests/NehirTests/DockAutohideReservationTests.swift"
+        "Tests/NehirTests/DockAutohideReservationTests.swift",
+        "Tests/NehirTests/ColumnWidthCycleViewportAnchorTests.swift"
       ],
       "copyright": [
         "2026 Aleksei Gurianov and Nehir contributors"

--- a/.provenance.json
+++ b/.provenance.json
@@ -114,7 +114,8 @@
         "Tests/NehirTests/ProcessMemoryDiagnosticsTests.swift",
         "Tests/NehirTests/RuntimeMemoryDumpSectionTests.swift",
         "Tests/NehirTests/TerminatedAppStatePruningTests.swift",
-        "Tests/NehirTests/SwipeAfterFullscreenExitWorkspaceTests.swift"
+        "Tests/NehirTests/SwipeAfterFullscreenExitWorkspaceTests.swift",
+        "Tests/NehirTests/DockAutohideReservationTests.swift"
       ],
       "copyright": [
         "2026 Aleksei Gurianov and Nehir contributors"

--- a/Sources/Nehir/Core/Controller/LayoutRefreshController.swift
+++ b/Sources/Nehir/Core/Controller/LayoutRefreshController.swift
@@ -213,6 +213,18 @@ import QuartzCore
     private var delayedParkReverifyAttemptsByWindowId: [Int: Int] = [:]
     private var nativeFullscreenRestoredFrameApplyTokens: Set<WindowToken> = []
 
+    /// Consecutive quantization-classified shrink refusals per window where the
+    /// observed frame never moved. A genuine cell-quantizing app snaps to the
+    /// nearest grid line on the first write; an observed size frozen across
+    /// several attempts is a hard app minimum wearing the quantization disguise.
+    struct QuantizationSkipStreak {
+        var observedSize: CGSize
+        var count: Int
+    }
+
+    private var quantizationSkipStreakByToken: [WindowToken: QuantizationSkipStreak] = [:]
+    static let quantizationSkipStreakLearnThreshold = 3
+
     func fastFrame(for token: WindowToken, axRef: AXWindowRef) -> CGRect? {
         activeFrameContext?.fastFrame(for: token, axRef: axRef)
             ?? AXWindowService.framePreferFast(axRef)
@@ -1103,6 +1115,7 @@ import QuartzCore
         layoutState.pendingRefresh = nil
         layoutState.didExecuteRefreshExecutionPlan = false
         nativeFullscreenRestoredFrameApplyTokens.removeAll()
+        quantizationSkipStreakByToken.removeAll()
 
         for (_, link) in layoutState.displayLinksByDisplay {
             link.invalidate()
@@ -1639,6 +1652,7 @@ import QuartzCore
             controller.axManager.removeWindowState(pid: token.pid, windowId: token.windowId)
             _ = controller.workspaceManager.removeWindow(pid: token.pid, windowId: token.windowId)
             controller.clearKeyboardFocusTarget(matching: token)
+            quantizationSkipStreakByToken[token] = nil
         }
 
         let shouldPreserveMissingWindows = shouldPreserveMissingWindowsDuringNativeFullscreen(
@@ -1717,6 +1731,7 @@ import QuartzCore
             controller.nativeFullscreenPlaceholderManager.remove(entry.token)
             controller.axManager.removeWindowState(pid: entry.pid, windowId: entry.windowId)
             controller.clearKeyboardFocusTarget(matching: entry.token)
+            quantizationSkipStreakByToken[entry.token] = nil
         }
         if let scratchpadTokenBeforeRemove,
            controller.workspaceManager.entry(for: scratchpadTokenBeforeRemove) == nil
@@ -4110,11 +4125,13 @@ import QuartzCore
         }
 
         if let confirmedFrame = result.confirmedFrame {
+            quantizationSkipStreakByToken[entry.token] = nil
             controller.axManager.confirmFrameWrite(for: result.windowId, frame: confirmedFrame)
             return
         }
 
         if liveFrameMatchesTarget(for: entry, targetFrame: result.targetFrame) {
+            quantizationSkipStreakByToken[entry.token] = nil
             controller.axManager.confirmFrameWrite(for: result.windowId, frame: result.targetFrame)
             return
         }
@@ -4129,16 +4146,51 @@ import QuartzCore
             // size. Accept the snapped frame and do NOT record an inferred resize minimum — pinning
             // it would over-constrain the solver and permanently break uniform fill heights among
             // sibling windows in the same workspace.
-            controller.axManager.confirmFrameWrite(for: result.windowId, frame: observedFrame)
-            _ = controller.focusBorderController.updateFrameHint(
-                for: entry.token,
-                frame: observedFrame,
-                forceOrdering: true
+            //
+            // Exception: a quantizing app moves to a nearby grid line on the first write. When
+            // the observed size stays frozen across several shrink attempts, the app is refusing
+            // outright — that is a hard minimum, and swallowing it leaves the canonical layout
+            // narrower than the live window, overlapping the neighboring column. Escalate to the
+            // inferred-minimum learn path below.
+            let isShrinkRefusal = targetSizeIsSmallerThanObservedSize(
+                result.targetFrame.size,
+                observedSize: observedFrame.size
             )
+            var streakCount = 0
+            if isShrinkRefusal {
+                if let streak = quantizationSkipStreakByToken[entry.token],
+                   abs(streak.observedSize.width - observedFrame.size.width) <= 0.5,
+                   abs(streak.observedSize.height - observedFrame.size.height) <= 0.5
+                {
+                    streakCount = streak.count + 1
+                } else {
+                    streakCount = 1
+                }
+                quantizationSkipStreakByToken[entry.token] = .init(
+                    observedSize: observedFrame.size,
+                    count: streakCount
+                )
+            } else {
+                quantizationSkipStreakByToken[entry.token] = nil
+            }
+
+            if streakCount < Self.quantizationSkipStreakLearnThreshold {
+                controller.axManager.confirmFrameWrite(for: result.windowId, frame: observedFrame)
+                _ = controller.focusBorderController.updateFrameHint(
+                    for: entry.token,
+                    frame: observedFrame,
+                    forceOrdering: true
+                )
+                controller.axManager.recordFrameApplyTrace(
+                    "resizeMin.skipQuantization id=\(entry.windowId) target=\(LayoutTrace.rect(result.targetFrame)) observed=\(LayoutTrace.rect(observedFrame)) streak=\(streakCount)"
+                )
+                return
+            }
+
+            quantizationSkipStreakByToken[entry.token] = nil
             controller.axManager.recordFrameApplyTrace(
-                "resizeMin.skipQuantization id=\(entry.windowId) target=\(LayoutTrace.rect(result.targetFrame)) observed=\(LayoutTrace.rect(observedFrame))"
+                "resizeMin.quantizationStreakEscalated id=\(entry.windowId) target=\(LayoutTrace.rect(result.targetFrame)) observed=\(LayoutTrace.rect(observedFrame)) streak=\(streakCount)"
             )
-            return
         }
 
         guard let minimumSize = inferredResizeMinimumSize(for: result, entry: entry) else { return }

--- a/Sources/Nehir/Core/Controller/LayoutRefreshController.swift
+++ b/Sources/Nehir/Core/Controller/LayoutRefreshController.swift
@@ -4344,7 +4344,25 @@ final class LayoutDiffExecutor {
             return
         }
 
-        let diff = plan.diff
+        var diff = plan.diff
+
+        // While a scroll animation is registered for this workspace, the display-link
+        // driver applies fresh spring-sampled frames every tick. A scheduled relayout
+        // plan can be built before the animation starts and applied after it is well
+        // underway, pushing stale pre-animation frames that visibly snap windows
+        // backwards mid-animation. Frame changes from non-driver plans are dropped;
+        // the driver re-emits current frames on its next tick and lands the exact
+        // targets at settle, so nothing is lost.
+        if !plan.fromScrollAnimationDriver,
+           !diff.frameChanges.isEmpty,
+           refreshController.niriHandler.hasScrollAnimation(for: plan.workspaceId)
+        {
+            LayoutTrace.log(
+                "diffExecutor.dropStaleFrames ws=\(plan.workspaceId.uuidString.prefix(8)) "
+                    + "dropped=\(diff.frameChanges.count)"
+            )
+            diff.frameChanges = []
+        }
 
         // Whether this plan targets the workspace that is currently active on its own
         // monitor. Frame writes for an inactive workspace are the layout engine

--- a/Sources/Nehir/Core/Controller/NiriLayoutHandler.swift
+++ b/Sources/Nehir/Core/Controller/NiriLayoutHandler.swift
@@ -411,7 +411,8 @@ enum NiriWindowMoveResult {
             workspaceId: snapshot.workspaceId,
             monitor: snapshot.monitor,
             sessionPatch: WorkspaceSessionPatch(workspaceId: snapshot.workspaceId),
-            diff: diff
+            diff: diff,
+            fromScrollAnimationDriver: true
         )
     }
 

--- a/Sources/Nehir/Core/Layout/LayoutBoundary.swift
+++ b/Sources/Nehir/Core/Layout/LayoutBoundary.swift
@@ -140,6 +140,11 @@ struct WorkspaceLayoutPlan {
     var sessionPatch: WorkspaceSessionPatch
     var diff: WorkspaceLayoutDiff
     var animationDirectives: [AnimationDirective] = []
+    /// True for plans emitted by the scroll-animation display-link driver. While a
+    /// scroll animation is registered for a workspace, that driver is the sole
+    /// authority for window frames: a scheduled relayout plan may have been built
+    /// before the animation started and would push stale pre-animation frames.
+    var fromScrollAnimationDriver: Bool = false
 }
 
 typealias RefreshPostLayoutAction = @MainActor () -> Void

--- a/Sources/Nehir/Core/Layout/Niri/NiriLayoutEngine+Sizing.swift
+++ b/Sources/Nehir/Core/Layout/Niri/NiriLayoutEngine+Sizing.swift
@@ -286,58 +286,92 @@ extension NiriLayoutEngine {
         workingFrame: CGRect,
         gaps: CGFloat
     ) {
-        guard let window = column.windowNodes.first else { return }
+        guard !column.windowNodes.isEmpty else { return }
 
-        func revealTargetWidth() {
-            ensureSelectionVisible(
-                node: window,
-                in: workspaceId,
-                motion: motion,
-                state: &state,
+        // A width command is not viewport navigation: the user's current anchor
+        // (including deliberate edge snaps) must survive the resize. Only move
+        // when the new width would leave the resized column clipped, and then by
+        // the minimum distance that restores full visibility.
+        func preserveViewportAnchorForTargetWidth() {
+            // Centered lone window: its anchor IS the center, not the previous
+            // offset, so the anchor-preservation rule below does not apply.
+            // Keep the pre-existing explicit-navigation reveal for this case;
+            // its known stale-override centering defect is addressed separately.
+            if let singleContext = singleWindowLayoutContext(in: workspaceId),
+               singleContext.container === column,
+               let window = column.windowNodes.first
+            {
+                ensureSelectionVisible(
+                    node: window,
+                    in: workspaceId,
+                    motion: motion,
+                    state: &state,
+                    workingFrame: workingFrame,
+                    gaps: gaps,
+                    revealTrigger: .explicitNavigation
+                )
+                return
+            }
+
+            let columns = self.columns(in: workspaceId)
+            guard let columnIndex = columnIndex(of: column, in: workspaceId) else { return }
+
+            if state.activeColumnIndex != columnIndex, !columns.isEmpty {
+                let boundedActiveIndex = state.activeColumnIndex.clamped(to: 0 ... (columns.count - 1))
+                let oldX = state.columnX(at: boundedActiveIndex, columns: columns, gap: gaps)
+                let newX = state.columnX(at: columnIndex, columns: columns, gap: gaps)
+                state.withRecordedViewportMutation(reason: "pendingWidth.rebaseActiveColumn") { state in
+                    state.viewOffsetPixels.offset(delta: Double(oldX - newX))
+                    state.activeColumnIndex = columnIndex
+                }
+                state.activatePrevColumnOnRemoval = nil
+                state.viewOffsetToRestore = nil
+            }
+
+            let context = makeViewportSnapContext(
+                columns: columns,
+                state: state,
                 workingFrame: workingFrame,
                 gaps: gaps,
-                revealTrigger: .explicitNavigation
+                intentionallyDoesNotFillViewport: loneWindowIntentionallyDoesNotFillViewport(in: workspaceId)
             )
-            ensureColumnWidthVisible(
-                column,
-                in: workspaceId,
-                motion: motion,
-                state: &state,
-                workingFrame: workingFrame,
-                gaps: gaps
+            let viewStart = context.currentViewStart(in: state)
+            if case .fullyVisible = context.visibility(of: columnIndex, viewportOffset: viewStart, in: state) {
+                return
+            }
+
+            let columnStart = state.columnX(at: columnIndex, columns: columns, gap: gaps)
+            let columnWidth = max(0, column.effectiveViewportWidth)
+            let viewportWidth = workingFrame.width
+            // Edge snaps keep a gap sliver visible (the niri overscroll idiom);
+            // clamping between them yields the minimal-displacement anchor. An
+            // over-wide column cannot be fully visible — anchor its leading edge.
+            let trailingEdgeStart = columnStart + columnWidth + gaps - viewportWidth
+            let leadingEdgeStart = columnStart - gaps
+            let newStart: CGFloat = if trailingEdgeStart > leadingEdgeStart {
+                leadingEdgeStart
+            } else {
+                viewStart.clamped(to: trailingEdgeStart ... leadingEdgeStart)
+            }
+
+            let scale = displayScale(in: workspaceId)
+            let targetOffset = context.targetOffset(
+                forViewportStart: newStart,
+                activeColumnIndex: columnIndex,
+                in: state
             )
+            let pixel = 1.0 / max(scale, 1.0)
+            guard abs(targetOffset - state.viewOffsetPixels.target()) > pixel else { return }
+            state.animateToOffset(targetOffset, motion: motion, scale: scale)
         }
 
         if restorePreviousWidthAfterFit {
             column.cachedWidth = targetWidth
             defer { column.cachedWidth = previousWidth }
-            revealTargetWidth()
+            preserveViewportAnchorForTargetWidth()
         } else {
             column.cachedWidth = targetWidth
-            revealTargetWidth()
-        }
-    }
-
-    private func ensureColumnWidthVisible(
-        _ column: NiriContainer,
-        in workspaceId: WorkspaceDescriptor.ID,
-        motion: MotionSnapshot,
-        state: inout ViewportState,
-        workingFrame: CGRect,
-        gaps: CGFloat
-    ) {
-        let columns = self.columns(in: workspaceId)
-        guard let columnIndex = columnIndex(of: column, in: workspaceId) else { return }
-        let context = makeViewportSnapContext(columns: columns, state: state, workingFrame: workingFrame, gaps: gaps)
-        let viewStart = context.currentViewStart(in: state)
-        guard case .fullyVisible = context.visibility(of: columnIndex, viewportOffset: viewStart, in: state) else {
-            guard let targetSnap = context.snapPoints(for: columnIndex).closest(to: viewStart) else { return }
-            state.animateToOffset(
-                context.targetOffset(for: targetSnap, in: state),
-                motion: motion,
-                scale: displayScale(in: workspaceId)
-            )
-            return
+            preserveViewportAnchorForTargetWidth()
         }
     }
 

--- a/Tests/NehirTests/ColumnWidthCycleViewportAnchorTests.swift
+++ b/Tests/NehirTests/ColumnWidthCycleViewportAnchorTests.swift
@@ -1,0 +1,222 @@
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=nehir-original; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
+import ApplicationServices
+import CoreGraphics
+import Foundation
+@testable import Nehir
+import Testing
+
+/// Regression coverage for #170: changing a column's width must not move the
+/// viewport while the resized column stays fully visible at the user's current
+/// anchor (including deliberate edge snaps). When the new width does clip the
+/// column, the viewport moves only the minimum distance that restores full
+/// visibility, and an over-wide column anchors its leading edge.
+@MainActor
+struct ColumnWidthCycleViewportAnchorTests {
+    private struct Fixture {
+        let controller: WMController
+        let workspaceId: WorkspaceDescriptor.ID
+        let engine: NiriLayoutEngine
+        let nodes: [NiriWindow]
+        let gap: CGFloat
+        let workingFrame: CGRect
+    }
+
+    private func makeFixture(widthFactors: [CGFloat]) async -> Fixture? {
+        let controller = makeLayoutPlanTestController()
+        guard let monitor = controller.workspaceManager.monitors.first,
+              let workspaceId = controller.workspaceManager.activeWorkspaceOrFirst(on: monitor.id)?.id
+        else {
+            Issue.record("Missing monitor or workspace for width-cycle fixture")
+            return nil
+        }
+
+        controller.enableNiriLayout(revealStyle: .auto)
+        controller.updateNiriConfig(balancedColumnCount: 1)
+        await controller.layoutRefreshController.waitForRefreshWorkForTests()
+        controller.syncMonitorsToNiriEngine()
+        guard let engine = controller.niriEngine else {
+            Issue.record("Missing Niri engine for width-cycle fixture")
+            return nil
+        }
+
+        let workingFrame = controller.insetWorkingFrame(for: monitor)
+        let gap = controller.gapSize(for: monitor)
+
+        let pid: pid_t = 7_800
+        var nodes: [NiriWindow] = []
+        var previousNodeId: NodeId?
+        for index in widthFactors.indices {
+            let windowId = 7_801 + index
+            let token = controller.workspaceManager.addWindow(
+                AXWindowRef(element: AXUIElementCreateSystemWide(), windowId: windowId),
+                pid: pid,
+                windowId: windowId,
+                to: workspaceId
+            )
+            let node = engine.addWindow(
+                token: token,
+                to: workspaceId,
+                afterSelection: previousNodeId,
+                focusedToken: token
+            )
+            nodes.append(node)
+            previousNodeId = node.id
+        }
+
+        let columns = engine.columns(in: workspaceId)
+        guard columns.count == widthFactors.count else {
+            Issue.record("Expected \(widthFactors.count) columns, got \(columns.count)")
+            return nil
+        }
+        for (column, factor) in zip(columns, widthFactors) {
+            let width = (workingFrame.width * factor).rounded()
+            column.width = .fixed(width)
+            column.cachedWidth = width
+            column.cachedHeight = workingFrame.height
+        }
+
+        return Fixture(
+            controller: controller,
+            workspaceId: workspaceId,
+            engine: engine,
+            nodes: nodes,
+            gap: gap,
+            workingFrame: workingFrame
+        )
+    }
+
+    /// Places the viewport so its view start is exactly `viewStart` with
+    /// `activeColumn` selected, returning the resolved start for preconditions.
+    private func park(_ fx: Fixture, activeColumn: Int, viewStart: CGFloat) -> CGFloat {
+        fx.controller.workspaceManager.withNiriViewportState(for: fx.workspaceId) { state in
+            let columns = fx.engine.columns(in: fx.workspaceId)
+            state.selectedNodeId = fx.nodes[activeColumn].id
+            state.activeColumnIndex = activeColumn
+            let activeX = state.columnX(at: activeColumn, columns: columns, gap: fx.gap)
+            state.viewOffsetPixels = .static(viewStart - activeX)
+        }
+        return currentViewStart(fx)
+    }
+
+    private func currentViewStart(_ fx: Fixture) -> CGFloat {
+        let state = fx.controller.workspaceManager.niriViewportState(for: fx.workspaceId)
+        let columns = fx.engine.columns(in: fx.workspaceId)
+        return state.targetViewPosPixels(columns: columns, gap: fx.gap)
+    }
+
+    private func setWidth(_ fx: Fixture, column columnIndex: Int, percent: CGFloat) {
+        fx.controller.workspaceManager.withNiriViewportState(for: fx.workspaceId) { state in
+            let column = fx.engine.columns(in: fx.workspaceId)[columnIndex]
+            fx.engine.setColumnWidth(
+                column,
+                change: .setProportion(percent),
+                in: fx.workspaceId,
+                motion: .disabled,
+                state: &state,
+                workingFrame: fx.workingFrame,
+                gaps: fx.gap
+            )
+        }
+    }
+
+    // MARK: - Fully visible: the anchor survives both grow and shrink
+
+    @Test func fullyVisibleColumnKeepsViewportOnGrow() async {
+        guard let fx = await makeFixture(widthFactors: [0.5, 0.3, 0.5, 0.5]) else { return }
+
+        // Column 1 sits fully visible but deliberately off-center.
+        let columns = fx.engine.columns(in: fx.workspaceId)
+        let columnStart = fx.controller.workspaceManager.niriViewportState(for: fx.workspaceId)
+            .columnX(at: 1, columns: columns, gap: fx.gap)
+        let parkStart = columnStart - fx.workingFrame.width * 0.1
+        let resolvedStart = park(fx, activeColumn: 1, viewStart: parkStart)
+        #expect(abs(resolvedStart - parkStart) < 0.5)
+
+        // Growing to 40% keeps the column fully visible from the current anchor.
+        setWidth(fx, column: 1, percent: 40)
+
+        #expect(abs(currentViewStart(fx) - parkStart) < 0.5)
+    }
+
+    @Test func fullyVisibleColumnKeepsViewportOnShrink() async {
+        guard let fx = await makeFixture(widthFactors: [0.5, 0.65, 0.5, 0.5]) else { return }
+
+        let columns = fx.engine.columns(in: fx.workspaceId)
+        let columnStart = fx.controller.workspaceManager.niriViewportState(for: fx.workspaceId)
+            .columnX(at: 1, columns: columns, gap: fx.gap)
+        let parkStart = columnStart - fx.workingFrame.width * 0.2
+        let resolvedStart = park(fx, activeColumn: 1, viewStart: parkStart)
+        #expect(abs(resolvedStart - parkStart) < 0.5)
+
+        setWidth(fx, column: 1, percent: 35)
+
+        #expect(abs(currentViewStart(fx) - parkStart) < 0.5)
+    }
+
+    /// The exact #170 edge-snap capture shape: a leading-edge-snapped column
+    /// grows but still fits from that snap — the snap must survive instead of
+    /// being replaced by the center snap.
+    @Test func leadingEdgeSnapSurvivesGrowThatStillFits() async {
+        guard let fx = await makeFixture(widthFactors: [0.65, 0.5, 0.5, 0.5]) else { return }
+
+        // Left-edge snap for column 0: columnX - gap.
+        let parkStart = -fx.gap
+        let resolvedStart = park(fx, activeColumn: 0, viewStart: parkStart)
+        #expect(abs(resolvedStart - parkStart) < 0.5)
+
+        // 95% of the working width still fits inside the viewport from -gap.
+        setWidth(fx, column: 0, percent: 95)
+
+        #expect(abs(currentViewStart(fx) - parkStart) < 0.5)
+    }
+
+    // MARK: - Clipped by growth: minimal shift, not recenter
+
+    @Test func growThatClipsTrailingEdgeShiftsMinimally() async {
+        guard let fx = await makeFixture(widthFactors: [0.5, 0.5, 0.5, 0.5]) else { return }
+
+        // Park so column 1 starts 60% into the viewport: growing it to 65%
+        // pushes its trailing edge past the viewport end.
+        let columns = fx.engine.columns(in: fx.workspaceId)
+        let state = fx.controller.workspaceManager.niriViewportState(for: fx.workspaceId)
+        let columnStart = state.columnX(at: 1, columns: columns, gap: fx.gap)
+        let parkStart = columnStart - fx.workingFrame.width * 0.6
+        let resolvedStart = park(fx, activeColumn: 1, viewStart: parkStart)
+        #expect(abs(resolvedStart - parkStart) < 0.5)
+
+        setWidth(fx, column: 1, percent: 65)
+
+        // Minimal restore of full visibility is the trailing-edge snap:
+        // columnEnd + gap - viewportWidth. Anything closer to the old center
+        // would be a recenter regression.
+        let newWidth = fx.engine.columns(in: fx.workspaceId)[1].cachedWidth
+        let expectedStart = columnStart + newWidth + fx.gap - fx.workingFrame.width
+        #expect(abs(currentViewStart(fx) - expectedStart) < 0.5)
+        let centerStart = columnStart + newWidth / 2 - fx.workingFrame.width / 2
+        #expect(abs(currentViewStart(fx) - centerStart) > 1.0)
+    }
+
+    // MARK: - Over-wide column anchors its leading edge
+
+    @Test func overWideColumnAnchorsLeadingEdge() async {
+        guard let fx = await makeFixture(widthFactors: [0.5, 0.5, 0.5, 0.5]) else { return }
+
+        let columns = fx.engine.columns(in: fx.workspaceId)
+        let state = fx.controller.workspaceManager.niriViewportState(for: fx.workspaceId)
+        let columnStart = state.columnX(at: 1, columns: columns, gap: fx.gap)
+        let parkStart = columnStart - fx.workingFrame.width * 0.5
+        let resolvedStart = park(fx, activeColumn: 1, viewStart: parkStart)
+        #expect(abs(resolvedStart - parkStart) < 0.5)
+
+        // 120% of the working width cannot be fully visible; the leading edge
+        // (columnX - gap) is the anchor.
+        setWidth(fx, column: 1, percent: 120)
+
+        let expectedStart = columnStart - fx.gap
+        #expect(abs(currentViewStart(fx) - expectedStart) < 0.5)
+    }
+}

--- a/Tests/NehirTests/QuantizationRefusalStreakTests.swift
+++ b/Tests/NehirTests/QuantizationRefusalStreakTests.swift
@@ -1,0 +1,185 @@
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=nehir-original; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
+import CoreGraphics
+import Foundation
+@testable import Nehir
+import Testing
+
+/// Regression coverage for the quantization-refusal streak: a shrink refusal
+/// whose overshoot stays within the 32 pt cell-quantization threshold is
+/// absorbed as grid-snapping, but when the observed size stays frozen across
+/// three consecutive attempts the window is refusing outright — a hard app
+/// minimum that must be learned so the canonical layout stops overlapping the
+/// neighboring column (the Helium 717 px case).
+@MainActor
+@Suite
+struct QuantizationRefusalStreakTests {
+    private func shrinkRefusalResult(
+        pid: pid_t,
+        windowId: Int,
+        targetWidth: CGFloat,
+        observedWidth: CGFloat
+    ) -> AXFrameApplyResult {
+        let targetFrame = CGRect(x: 0, y: 0, width: targetWidth, height: 500)
+        let observedFrame = CGRect(x: 0, y: 0, width: observedWidth, height: 500)
+        return AXFrameApplyResult(
+            requestId: 0,
+            pid: pid,
+            windowId: windowId,
+            targetFrame: targetFrame,
+            currentFrameHint: nil,
+            writeResult: AXFrameWriteResult(
+                targetFrame: targetFrame,
+                observedFrame: observedFrame,
+                writeOrder: AXWindowService.frameWriteOrder(
+                    currentFrame: nil,
+                    targetFrame: targetFrame
+                ),
+                sizeError: .success,
+                positionError: .success,
+                failureReason: .verificationMismatch
+            )
+        )
+    }
+
+    /// A frozen observed size across three quantization-classified shrink
+    /// refusals escalates to the inferred-minimum learner. The first two
+    /// attempts are still absorbed as quantization.
+    @Test func frozenObservedSizeEscalatesToInferredMinimumOnThirdRefusal() throws {
+        let controller = makeLayoutPlanTestController()
+        guard let monitor = controller.workspaceManager.monitors.first,
+              let workspaceId = controller.workspaceManager.activeWorkspaceOrFirst(on: monitor.id)?.id
+        else {
+            Issue.record("Missing workspace for streak-escalation test")
+            return
+        }
+
+        let windowId = 5401
+        let token = addLayoutPlanTestWindow(on: controller, workspaceId: workspaceId, windowId: windowId)
+        #expect(controller.workspaceManager.inferredResizeMinimumSize(for: token) == nil)
+
+        // Helium shape: target 706, window pinned at 717 — an 11 pt overshoot
+        // inside the quantization threshold, identical on every attempt.
+        for attempt in 1 ... 2 {
+            let result = shrinkRefusalResult(
+                pid: token.pid,
+                windowId: windowId,
+                targetWidth: 706,
+                observedWidth: 717
+            )
+            controller.layoutRefreshController.handleResizeMinimumFrameApplyResult(result, workspaceId: workspaceId)
+            #expect(
+                controller.workspaceManager.inferredResizeMinimumSize(for: token) == nil,
+                "attempt \(attempt) must still be absorbed as quantization"
+            )
+        }
+
+        let third = shrinkRefusalResult(
+            pid: token.pid,
+            windowId: windowId,
+            targetWidth: 706,
+            observedWidth: 717
+        )
+        controller.layoutRefreshController.handleResizeMinimumFrameApplyResult(third, workspaceId: workspaceId)
+
+        let pinned = try #require(controller.workspaceManager.inferredResizeMinimumSize(for: token))
+        #expect(pinned.width >= 717)
+    }
+
+    /// A genuine cell-quantizing app snaps to different grid lines as the
+    /// target changes; a changing observed size resets the streak and never
+    /// escalates, no matter how many attempts are made.
+    @Test func changingObservedSizesNeverEscalate() {
+        let controller = makeLayoutPlanTestController()
+        guard let monitor = controller.workspaceManager.monitors.first,
+              let workspaceId = controller.workspaceManager.activeWorkspaceOrFirst(on: monitor.id)?.id
+        else {
+            Issue.record("Missing workspace for streak-reset test")
+            return
+        }
+
+        let windowId = 5402
+        let token = addLayoutPlanTestWindow(on: controller, workspaceId: workspaceId, windowId: windowId)
+
+        // Grid walk: each attempt snaps to a different nearby cell boundary.
+        let attempts: [(target: CGFloat, observed: CGFloat)] = [
+            (706, 717), (706, 728), (706, 717), (706, 728), (706, 717), (706, 728)
+        ]
+        for (index, attempt) in attempts.enumerated() {
+            let result = shrinkRefusalResult(
+                pid: token.pid,
+                windowId: windowId,
+                targetWidth: attempt.target,
+                observedWidth: attempt.observed
+            )
+            controller.layoutRefreshController.handleResizeMinimumFrameApplyResult(result, workspaceId: workspaceId)
+            #expect(
+                controller.workspaceManager.inferredResizeMinimumSize(for: token) == nil,
+                "attempt \(index + 1) with changing observed size must not escalate"
+            )
+        }
+    }
+
+    /// A successful write between refusals resets the streak: the window did
+    /// resize, so the earlier refusals were transient, not a hard minimum.
+    @Test func confirmedWriteBetweenRefusalsResetsStreak() {
+        let controller = makeLayoutPlanTestController()
+        guard let monitor = controller.workspaceManager.monitors.first,
+              let workspaceId = controller.workspaceManager.activeWorkspaceOrFirst(on: monitor.id)?.id
+        else {
+            Issue.record("Missing workspace for streak-confirm-reset test")
+            return
+        }
+
+        let windowId = 5403
+        let token = addLayoutPlanTestWindow(on: controller, workspaceId: workspaceId, windowId: windowId)
+
+        for _ in 1 ... 2 {
+            let result = shrinkRefusalResult(
+                pid: token.pid,
+                windowId: windowId,
+                targetWidth: 706,
+                observedWidth: 717
+            )
+            controller.layoutRefreshController.handleResizeMinimumFrameApplyResult(result, workspaceId: workspaceId)
+        }
+        #expect(controller.workspaceManager.inferredResizeMinimumSize(for: token) == nil)
+
+        // A confirmed write proves the window can resize; the streak restarts.
+        let confirmedFrame = CGRect(x: 0, y: 0, width: 800, height: 500)
+        let confirmed = AXFrameApplyResult(
+            requestId: 0,
+            pid: token.pid,
+            windowId: windowId,
+            targetFrame: confirmedFrame,
+            currentFrameHint: nil,
+            writeResult: AXFrameWriteResult(
+                targetFrame: confirmedFrame,
+                observedFrame: confirmedFrame,
+                writeOrder: AXWindowService.frameWriteOrder(
+                    currentFrame: nil,
+                    targetFrame: confirmedFrame
+                ),
+                sizeError: .success,
+                positionError: .success,
+                failureReason: nil
+            )
+        )
+        controller.layoutRefreshController.handleResizeMinimumFrameApplyResult(confirmed, workspaceId: workspaceId)
+
+        // Two more refusals stay under the threshold after the reset.
+        for _ in 1 ... 2 {
+            let result = shrinkRefusalResult(
+                pid: token.pid,
+                windowId: windowId,
+                targetWidth: 706,
+                observedWidth: 717
+            )
+            controller.layoutRefreshController.handleResizeMinimumFrameApplyResult(result, workspaceId: workspaceId)
+        }
+        #expect(controller.workspaceManager.inferredResizeMinimumSize(for: token) == nil)
+    }
+}

--- a/Tests/NehirTests/ResizeMinimumLearnerTests.swift
+++ b/Tests/NehirTests/ResizeMinimumLearnerTests.swift
@@ -54,7 +54,7 @@ struct ResizeMinimumLearnerTests {
     /// quantization threshold pins an inferred minimum >= the observed size.
     /// This is the genuine-refusal path (the app clamped a too-small frame back
     /// to its real minimum), not grid-snapping.
-    @Test func oversizedVerificationMismatchPinsInferredMinimum() {
+    @Test func oversizedVerificationMismatchPinsInferredMinimum() throws {
         let controller = makeLayoutPlanTestController()
         guard let monitor = controller.workspaceManager.monitors.first,
               let workspaceId = controller.workspaceManager.activeWorkspaceOrFirst(on: monitor.id)?.id
@@ -84,10 +84,9 @@ struct ResizeMinimumLearnerTests {
         )
         controller.layoutRefreshController.handleResizeMinimumFrameApplyResult(result, workspaceId: workspaceId)
 
-        let pinned = controller.workspaceManager.inferredResizeMinimumSize(for: token)
-        #expect(pinned != nil)
-        #expect(pinned!.height >= observedFrame.height)
-        #expect(pinned!.width >= observedFrame.width)
+        let pinned = try #require(controller.workspaceManager.inferredResizeMinimumSize(for: token))
+        #expect(pinned.height >= observedFrame.height)
+        #expect(pinned.width >= observedFrame.width)
     }
 
     /// Gap B #3 — A verificationMismatch whose overshoot is WITHIN the 32pt cell-


### PR DESCRIPTION
## Summary

Cycling a column width previously ran the explicit-navigation reveal,
whose auto snap resolution recenters any column that does not fill the
viewport. Every width cycle therefore translated the whole layout and
discarded deliberate edge snaps.

A width command is not viewport navigation: keep the current anchor when
the resized column stays fully visible, and otherwise move the minimum
distance that restores full visibility (leading edge for over-wide
columns). The active column is still rebased onto the resized column
without moving the viewport on screen.

Fixes #170

## Release notes

Choose one:

- [x] Added a `.changeset/*.md` for user-visible changes (`mise run changeset -- patch "..."`).
- [ ] No user-visible change; apply the `no release note` label to make CI skip intentional.

## Validation

<!-- Commands run, screenshots, or manual checks. -->

- [ ] Ran relevant tests/checks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Resizing columns no longer unexpectedly recenters the focused column.
  * Preserved the viewport anchor and edge-snapping behavior while cycling or adjusting column widths.
  * Improved handling when windows refuse to shrink, ensuring neighboring columns keep consistent spacing.
  * Prevented stale layout updates from interfering with scroll/resize animations, avoiding visual jumps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->