### PR TITLE
Keep a centered lone window centered while its width changes

### DIFF
--- a/.changeset/20260727210741-cycling-column-width-no-longer-recenters-the-foc.md
+++ b/.changeset/20260727210741-cycling-column-width-no-longer-recenters-the-foc.md
@@ -3,4 +3,4 @@
 contributors: [gerardomtz26]
 ---
 
-Cycling column width no longer recenters the focused column: the viewport keeps its current anchor (including edge snaps) and moves only the minimum needed to keep the resized column visible. Stale relayout frames no longer fight the resize animation, and a window that refuses to shrink now teaches the layout its real minimum width so neighboring columns keep their gap. Fixes #170
+Cycling column width no longer recenters the focused column: the viewport keeps its current anchor (including edge snaps) and moves only the minimum needed to keep the resized column visible. A centered lone window is the intentional exception — it now stays centered as its width changes instead of staying pinned at its old x-position and clamping against the display edge. Stale relayout frames no longer fight the resize animation, and a window that refuses to shrink now teaches the layout its real minimum width so neighboring columns keep their gap. Fixes #170

--- a/Sources/Nehir/Core/Layout/Niri/NiriLayoutEngine+Sizing.swift
+++ b/Sources/Nehir/Core/Layout/Niri/NiriLayoutEngine+Sizing.swift
@@ -293,23 +293,25 @@ extension NiriLayoutEngine {
         // when the new width would leave the resized column clipped, and then by
         // the minimum distance that restores full visibility.
         func preserveViewportAnchorForTargetWidth() {
-            // Centered lone window: its anchor IS the center, not the previous
-            // offset, so the anchor-preservation rule below does not apply.
-            // Keep the pre-existing explicit-navigation reveal for this case;
-            // its known stale-override centering defect is addressed separately.
+            // Centered lone window: its anchor IS the center, so it tracks the
+            // changing width instead of preserving the previous offset.
+            // Resolving the single-window geometry here also clears the stale
+            // policy width override that otherwise masks the target width from
+            // viewport geometry, freezing the old center offset and pinning the
+            // window to its old x-position while it grows.
             if let singleContext = singleWindowLayoutContext(in: workspaceId),
-               singleContext.container === column,
-               let window = column.windowNodes.first
+               singleContext.container === column
             {
-                ensureSelectionVisible(
-                    node: window,
+                let scale = displayScale(in: workspaceId)
+                guard let geometry = prepareSingleWindowViewport(
                     in: workspaceId,
-                    motion: motion,
-                    state: &state,
                     workingFrame: workingFrame,
-                    gaps: gaps,
-                    revealTrigger: .explicitNavigation
-                )
+                    scale: scale,
+                    gaps: gaps
+                ) else { return }
+                let pixel = 1.0 / max(scale, 1.0)
+                guard abs(geometry.centerOffset - state.viewOffsetPixels.target()) > pixel else { return }
+                state.animateToOffset(geometry.centerOffset, motion: motion, scale: scale)
                 return
             }
 


### PR DESCRIPTION
## Summary

The width command previously ran the explicit-navigation reveal while the stale lone-window policy width override still masked the target width from viewport geometry. The reveal concluded the old center was still correct, freezing the viewport offset: the window grew from its old x-position until the display edge clamped it, leaving it visibly off-center (and a cascade of AX verification mismatches at the edge).

The centered lone window's anchor is the center itself, so it must track the new width: resolve the single-window geometry at command time (which clears the stale override) and animate the viewport to the new center offset. Deliberate side snaps continue to recenter on an explicit width command, matching the behavior the existing single-window tests pin.
## Release notes

Choose one:

- [x] Added a `.changeset/*.md` for user-visible changes (`mise run changeset -- patch "..."`).
- [ ] No user-visible change; apply the `no release note` label to make CI skip intentional.

## Validation

<!-- Commands run, screenshots, or manual checks. -->

- [ ] Ran relevant tests/checks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Resizing or cycling a column now preserves the viewport’s current position instead of recentering the focused column.
  - Edge-snapped views remain anchored, with adjustments made only when needed to keep the resized column visible.
  - Single-window views remain centered while their width changes.
  - Resize animations are no longer disrupted by outdated layout updates.
  - Windows that cannot shrink now preserve accurate spacing between neighboring columns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->