### PR TITLE
Quick terminal close selection theft

### DIFF
--- a/.changeset/20260728020129-creating-a-window-from-the-ghostty-quick-termina.md
+++ b/.changeset/20260728020129-creating-a-window-from-the-ghostty-quick-termina.md
@@ -1,0 +1,6 @@
+---
+"nehir": patch
+
+---
+
+Open the Ghostty quick terminal, create a regular window from it, then dismiss the quick terminal: focus, the layout selection and the command target now stay on the window you just created instead of jumping to a neighbouring one, so a column-width command resizes that new window. Closing a focused window no longer switches away from the current workspace when the quick terminal is involved, and focus-activation traces now record whether an activation was Nehir's own doing.

--- a/.provenance.json
+++ b/.provenance.json
@@ -117,7 +117,8 @@
         "Tests/NehirTests/SwipeAfterFullscreenExitWorkspaceTests.swift",
         "Tests/NehirTests/DockAutohideReservationTests.swift",
         "Tests/NehirTests/ColumnWidthCycleViewportAnchorTests.swift",
-        "Tests/NehirTests/QuantizationRefusalStreakTests.swift"
+        "Tests/NehirTests/QuantizationRefusalStreakTests.swift",
+        "Tests/NehirTests/QuickTerminalCloseAnchorTests.swift"
       ],
       "copyright": [
         "2026 Aleksei Gurianov and Nehir contributors"

--- a/Sources/Nehir/Core/Controller/AXEventHandler.swift
+++ b/Sources/Nehir/Core/Controller/AXEventHandler.swift
@@ -965,6 +965,11 @@ final class AXEventHandler: CGSEventDelegate {
     private var recentManagedAdmissionByToken: [WindowToken: RecentManagedAdmission] = [:]
     private var pendingManagedReplacementBursts: [ManagedReplacementKey: PendingManagedReplacementBurst] = [:]
     private var pendingManagedReplacementTasks: [ManagedReplacementKey: Task<Void, Never>] = [:]
+    // Removal-driven focus recoveries deferred because a managed-replacement
+    // burst was still pending, keyed by the very burst they wait on so two
+    // apps replacing windows in the same workspace cannot consume each
+    // other's deferral. A scheduling flag, not a focus memory.
+    private var deferredRemovalFocusRecoveryKeys: Set<ManagedReplacementKey> = []
     // Last time Nehir itself fronted a window of this pid. Purely for trace
     // attribution: an app activation observed shortly after our own
     // NSRunningApplication.activate is an echo of a Nehir request, not an
@@ -1086,7 +1091,7 @@ final class AXEventHandler: CGSEventDelegate {
         recentParkedFocusFollowByToken.removeAll()
         parkedFollowHoldByPid.removeAll()
         recentManagedAdmissionByToken.removeAll()
-        resetManagedReplacementState()
+        resetManagedReplacementState(resolvingDeferredFocusRecovery: false)
         deferredInactiveNativeActivationTokens.removeAll()
         deferredSameAppActiveNativeActivationTokens.removeAll()
         endWindowCloseFocusRecovery()
@@ -1290,7 +1295,7 @@ final class AXEventHandler: CGSEventDelegate {
 
     func resetDebugStateForTests() {
         debugCounters = .init()
-        resetManagedReplacementState()
+        resetManagedReplacementState(resolvingDeferredFocusRecovery: false)
         resetNativeFullscreenReplacementState()
         resetWindowStabilizationState()
         resetLifecycleVerificationState()
@@ -2472,11 +2477,38 @@ final class AXEventHandler: CGSEventDelegate {
         controller.focusBorderController.clear(matching: token)
 
         if let wsId = affectedWorkspaceId {
+            // Removal-driven focus recovery must yield to an in-flight same-pid
+            // replacement. Quick-terminal Cmd+N (and similar app flows) create a
+            // transient window, destroy it, and create the real window under a
+            // new id; the transient is confirmed focus when its destroy
+            // verifies, so immediate focusNextWindow recovery hands focus,
+            // selection, and the command target to a neighboring app — the
+            // "stolen resize target" family of captures. The replacement-burst
+            // correlation for (pid, workspace) is still pending at this moment
+            // (destroy-liveness verifies after 75 ms, bursts flush after
+            // 150 ms), so defer recovery to the burst flush: if the replacement
+            // window confirmed by then, recovery is unnecessary; a genuine
+            // close still recovers, ~100 ms later.
+            var recoverFocusNow = shouldRecoverFocus
+            let replacementKey = ManagedReplacementKey(pid: token.pid, workspaceId: wsId)
+            if shouldRecoverFocus, pendingManagedReplacementBursts[replacementKey] != nil {
+                recoverFocusNow = false
+                deferredRemovalFocusRecoveryKeys.insert(replacementKey)
+                controller.diagnostics.recordRuntimeViewportTrace(
+                    workspaceId: wsId,
+                    reason: "removed_focus_recovery_deferred",
+                    details: [
+                        "uptimeMs=\(traceUptimeMs())",
+                        "removedToken=\(token)",
+                        "reason=pending_managed_replacement"
+                    ]
+                )
+            }
             controller.layoutRefreshController.requestWindowRemoval(
                 workspaceId: wsId,
                 removedNodeId: removedNodeId,
                 niriOldFrames: oldFrames,
-                shouldRecoverFocus: shouldRecoverFocus
+                shouldRecoverFocus: recoverFocusNow
             )
         }
         scheduleWindowRuleReevaluationIfNeeded(targets: [.pid(token.pid)])
@@ -5278,13 +5310,23 @@ final class AXEventHandler: CGSEventDelegate {
         controller.layoutRefreshController.requestRefresh(reason: .appUnhidden)
     }
 
-    func resetManagedReplacementState() {
+    func resetManagedReplacementState(resolvingDeferredFocusRecovery: Bool = true) {
         for (_, task) in pendingManagedReplacementTasks {
             task.cancel()
         }
         pendingManagedReplacementTasks.removeAll()
         pendingManagedReplacementBursts.removeAll()
         nextManagedReplacementEventSequence = 0
+        // The bursts these deferrals were waiting on will never flush now, so
+        // resolve them here or the removed window's focus recovery is lost.
+        // Teardown paths pass false: nothing should be focused on the way out.
+        let deferred = deferredRemovalFocusRecoveryKeys
+        deferredRemovalFocusRecoveryKeys.removeAll()
+        guard resolvingDeferredFocusRecovery else { return }
+        for key in deferred {
+            deferredRemovalFocusRecoveryKeys.insert(key)
+            resumeDeferredRemovalFocusRecovery(for: key, replacementCreated: false)
+        }
     }
 
     func resetWindowStabilizationState() {
@@ -6977,6 +7019,14 @@ final class AXEventHandler: CGSEventDelegate {
     private func flushManagedReplacementBurst(for key: ManagedReplacementKey) {
         pendingManagedReplacementTasks.removeValue(forKey: key)?.cancel()
         guard let burst = pendingManagedReplacementBursts.removeValue(forKey: key) else { return }
+        // Runs after the replay below: a deferred removal focus recovery either
+        // becomes unnecessary (a replacement create arrived) or resumes now.
+        defer {
+            resumeDeferredRemovalFocusRecovery(
+                for: key,
+                replacementCreated: !burst.creates.isEmpty
+            )
+        }
         let elapsedMillis = max(
             0,
             Int(((managedReplacementCurrentUptime() - burst.firstEventUptime) * 1000).rounded())
@@ -7040,6 +7090,37 @@ final class AXEventHandler: CGSEventDelegate {
             )
         )
         replayManagedReplacementEvents(burst.orderedEvents, key: key, reason: "no_match")
+    }
+
+    private func resumeDeferredRemovalFocusRecovery(
+        for key: ManagedReplacementKey,
+        replacementCreated: Bool
+    ) {
+        guard deferredRemovalFocusRecoveryKeys.remove(key) != nil,
+              let controller
+        else {
+            return
+        }
+        let workspaceId = key.workspaceId
+        guard !replacementCreated else {
+            // The same-pid replacement window arrived; its own admission and
+            // focus request take over, so the deferred recovery is dropped.
+            controller.diagnostics.recordRuntimeViewportTrace(
+                workspaceId: workspaceId,
+                reason: "removed_focus_recovery_dropped",
+                details: [
+                    "uptimeMs=\(traceUptimeMs())",
+                    "reason=replacement_created"
+                ]
+            )
+            return
+        }
+        controller.diagnostics.recordRuntimeViewportTrace(
+            workspaceId: workspaceId,
+            reason: "removed_focus_recovery_resumed",
+            details: ["uptimeMs=\(traceUptimeMs())"]
+        )
+        controller.ensureFocusedTokenValid(in: workspaceId)
     }
 
     private func nextManagedReplacementSequence() -> UInt64 {
@@ -7613,6 +7694,10 @@ final class AXEventHandler: CGSEventDelegate {
         for key in managedReplacementKeys where key.pid == pid {
             pendingManagedReplacementTasks.removeValue(forKey: key)?.cancel()
             pendingManagedReplacementBursts.removeValue(forKey: key)
+        }
+        for key in deferredRemovalFocusRecoveryKeys where key.pid == pid {
+            // The app is gone, so no replacement window is coming.
+            resumeDeferredRemovalFocusRecovery(for: key, replacementCreated: false)
         }
 
         deferredInactiveNativeActivationTokens = deferredInactiveNativeActivationTokens.filter {

--- a/Sources/Nehir/Core/Controller/AXEventHandler.swift
+++ b/Sources/Nehir/Core/Controller/AXEventHandler.swift
@@ -139,7 +139,7 @@ struct NiriCreateFocusTraceEvent: Equatable {
             workspaceId: WorkspaceDescriptor.ID,
             reason: FocusWindowReason
         )
-        case activationSourceObserved(pid: pid_t, source: ActivationEventSource)
+        case activationSourceObserved(pid: pid_t, source: ActivationEventSource, selfFrontingAgeMs: Int?)
         case followFocusToParkedWindow(token: WindowToken, workspaceId: WorkspaceDescriptor.ID, decision: String)
         /// The macOS-observed reality for a focus Nehir just confirmed. Emitted
         /// alongside `focus_confirmed` so a reader can tell Nehir's *intent*
@@ -350,7 +350,13 @@ extension WindowCreatePlacementContext: CustomStringConvertible {
 }
 
 extension NiriCreateFocusTraceEvent: CustomStringConvertible {
+    private static let timestampFormat = Date.ISO8601FormatStyle(includingFractionalSeconds: true)
+
     var description: String {
+        "t=\(timestamp.formatted(Self.timestampFormat)) " + kindDescription
+    }
+
+    private var kindDescription: String {
         switch kind {
         case let .createSeen(windowId):
             "create_seen window=\(windowId)"
@@ -378,8 +384,9 @@ extension NiriCreateFocusTraceEvent: CustomStringConvertible {
             "relayout_activated_window token=\(token) workspace=\(workspaceId.uuidString)"
         case let .pendingFocusStarted(requestId, token, workspaceId, reason):
             "pending_focus_started request=\(requestId) token=\(token) workspace=\(workspaceId.uuidString) reason=\(reason.rawValue)"
-        case let .activationSourceObserved(pid, source):
-            "activation_source_observed pid=\(pid) source=\(source.rawValue)"
+        case let .activationSourceObserved(pid, source, selfFrontingAgeMs):
+            "activation_source_observed pid=\(pid) source=\(source.rawValue) "
+                + "self_fronting_age_ms=\(selfFrontingAgeMs.map(String.init) ?? "nil")"
         case let .followFocusToParkedWindow(token, workspaceId, decision):
             "follow_focus_to_parked_window token=\(token) workspace=\(workspaceId.uuidString) decision=\(decision)"
         case let .focusReality(
@@ -958,6 +965,25 @@ final class AXEventHandler: CGSEventDelegate {
     private var recentManagedAdmissionByToken: [WindowToken: RecentManagedAdmission] = [:]
     private var pendingManagedReplacementBursts: [ManagedReplacementKey: PendingManagedReplacementBurst] = [:]
     private var pendingManagedReplacementTasks: [ManagedReplacementKey: Task<Void, Never>] = [:]
+    // Last time Nehir itself fronted a window of this pid. Purely for trace
+    // attribution: an app activation observed shortly after our own
+    // NSRunningApplication.activate is an echo of a Nehir request, not an
+    // independent native event — the ambiguity that repeatedly misled the
+    // focus-theft investigations.
+    private var recentSelfFrontingByPid: [pid_t: TimeInterval] = [:]
+    private static let selfFrontingAttributionTTL: TimeInterval = 1.5
+    func recordSelfInitiatedFronting(pid: pid_t) {
+        recentSelfFrontingByPid[pid] = managedReplacementCurrentUptime()
+    }
+
+    private func selfFrontingAgeMs(for pid: pid_t) -> Int? {
+        let now = managedReplacementCurrentUptime()
+        recentSelfFrontingByPid = recentSelfFrontingByPid.filter {
+            now - $0.value <= Self.selfFrontingAttributionTTL
+        }
+        return recentSelfFrontingByPid[pid].map { Int(((now - $0) * 1000).rounded()) }
+    }
+
     private var windowCloseFocusRecoveryContext: WindowCloseFocusRecoveryContext?
     private var deferredInactiveNativeActivationTokens: Set<DeferredInactiveNativeActivationKey> = []
     private var deferredSameAppActiveNativeActivationTokens: Set<WindowToken> = []
@@ -3730,7 +3756,8 @@ final class AXEventHandler: CGSEventDelegate {
             .init(
                 kind: .activationSourceObserved(
                     pid: pid,
-                    source: source
+                    source: source,
+                    selfFrontingAgeMs: selfFrontingAgeMs(for: pid)
                 )
             )
         )

--- a/Sources/Nehir/Core/Controller/AXEventHandler.swift
+++ b/Sources/Nehir/Core/Controller/AXEventHandler.swift
@@ -953,6 +953,12 @@ final class AXEventHandler: CGSEventDelegate {
     // relying on the overlay being visibly on screen at the churn instant (it
     // races: the churn often leads the overlay show/hide signal).
     private var overlayCapablePids: Set<pid_t> = []
+    // Window ids the rule engine recognized as an app's overlay (e.g. the
+    // Ghostty quick terminal). The destroy of one of these windows IS the
+    // overlay-teardown signal, so guards can key on the event itself instead
+    // of on time-limited evidence recorded when the overlay opened — that
+    // evidence has usually expired by the time the destroy arrives.
+    private var recognizedOverlayWindowIdsByPid: [pid_t: Set<Int>] = [:]
     private var focusedWindowLossClosePrecursorByPid: [pid_t: FocusedWindowLossClosePrecursor] = [:]
     private var sameAppRecoveryRedirectLatches: [SameAppRecoveryRedirectLatchKey: SameAppRecoveryRedirectLatch] = [:]
     private static let parkedFocusFollowDedupTTL: TimeInterval = 1.5
@@ -977,6 +983,18 @@ final class AXEventHandler: CGSEventDelegate {
     // focus-theft investigations.
     private var recentSelfFrontingByPid: [pid_t: TimeInterval] = [:]
     private static let selfFrontingAttributionTTL: TimeInterval = 1.5
+    // Class stamp of the live confirmed token: the last confirmation that was
+    // NOT a cause-less external app-level event (i.e. it had a matching
+    // managed request, arrived as window-level focusedWindowChanged, or was
+    // the echo of Nehir's own fronting). A cause-less external activation for
+    // a DIFFERENT token, arriving while the explicitly confirmed app's overlay
+    // is closing, is that app's own "restore the previous app" call (Ghostty's
+    // QuickTerminalController re-activates the pre-overlay frontmost app on
+    // hide) and must not displace the explicit confirmation. Not a parallel
+    // token store: it annotates the existing confirmation flow and is only
+    // consulted against the live state plus overlay-lifecycle evidence.
+    private var lastExplicitManagedConfirmation: (token: WindowToken, at: TimeInterval)?
+
     func recordSelfInitiatedFronting(pid: pid_t) {
         recentSelfFrontingByPid[pid] = managedReplacementCurrentUptime()
     }
@@ -1086,12 +1104,14 @@ final class AXEventHandler: CGSEventDelegate {
         recentNonManagedFocusByPid.removeAll()
         recentSameAppTeardownByPid.removeAll()
         overlayCapablePids.removeAll()
+        recognizedOverlayWindowIdsByPid.removeAll()
         focusedWindowLossClosePrecursorByPid.removeAll()
         sameAppRecoveryRedirectLatches.removeAll()
         recentParkedFocusFollowByToken.removeAll()
         parkedFollowHoldByPid.removeAll()
         recentManagedAdmissionByToken.removeAll()
         resetManagedReplacementState(resolvingDeferredFocusRecovery: false)
+        lastExplicitManagedConfirmation = nil
         deferredInactiveNativeActivationTokens.removeAll()
         deferredSameAppActiveNativeActivationTokens.removeAll()
         endWindowCloseFocusRecovery()
@@ -1242,6 +1262,7 @@ final class AXEventHandler: CGSEventDelegate {
         recentSameAppWindowCloseByPid[pid] = now
         recentNonManagedFocusByPid[pid] = now
         overlayCapablePids.insert(pid)
+        recognizedOverlayWindowIdsByPid[pid, default: []].insert(windowId)
         focusedWindowLossClosePrecursorByPid[pid] = .init(
             workspaceId: workspaceId,
             preservedToken: token,
@@ -1296,6 +1317,7 @@ final class AXEventHandler: CGSEventDelegate {
     func resetDebugStateForTests() {
         debugCounters = .init()
         resetManagedReplacementState(resolvingDeferredFocusRecovery: false)
+        lastExplicitManagedConfirmation = nil
         resetNativeFullscreenReplacementState()
         resetWindowStabilizationState()
         resetLifecycleVerificationState()
@@ -1308,6 +1330,7 @@ final class AXEventHandler: CGSEventDelegate {
         recentNonManagedFocusByPid.removeAll()
         recentSameAppTeardownByPid.removeAll()
         overlayCapablePids.removeAll()
+        recognizedOverlayWindowIdsByPid.removeAll()
         focusedWindowLossClosePrecursorByPid.removeAll()
         sameAppRecoveryRedirectLatches.removeAll()
         recentParkedFocusFollowByToken.removeAll()
@@ -3198,13 +3221,14 @@ final class AXEventHandler: CGSEventDelegate {
         return false
     }
 
-    func armOverlayCapabilityIfNeeded(source: WindowDecisionSource, pid: pid_t) {
+    func armOverlayCapabilityIfNeeded(source: WindowDecisionSource, token: WindowToken) {
         guard case let .builtInRule(name) = source,
               Self.isOverlayCapableRuleName(name)
         else {
             return
         }
-        overlayCapablePids.insert(pid)
+        overlayCapablePids.insert(token.pid)
+        recognizedOverlayWindowIdsByPid[token.pid, default: []].insert(token.windowId)
     }
 
     func isOverlayCapablePidForTests(_ pid: pid_t) -> Bool {
@@ -4582,6 +4606,21 @@ final class AXEventHandler: CGSEventDelegate {
         )
         let activeRequest = controller.focusBridge.activeManagedRequest(for: entry.pid)
         let shouldConfirmRequest = confirmRequest ?? true
+
+        // Confirmation-class stamp only: a cause-less external app-level
+        // activation (no matching request, app-level source, not an echo of
+        // our own fronting) does not update the explicit stamp. Suppressing
+        // such activations here proved far too dangerous — genuine clicks and
+        // Cmd-Tab switches share the same event shape, and a false positive
+        // traps the user (each re-front refreshes the evidence). The stamp is
+        // consulted only in the narrowly scoped overlay-close anchor assert.
+        let causelessExternalConfirmation = (source == .workspaceDidActivateApplication
+            || source == .cgsFrontAppChanged)
+            && activeRequest?.token != entry.token
+            && selfFrontingAgeMs(for: entry.pid) == nil
+        if !causelessExternalConfirmation, shouldConfirmRequest {
+            lastExplicitManagedConfirmation = (entry.token, managedReplacementCurrentUptime())
+        }
         // Detect re-confirmation of an already-confirmed focus token. A
         // quick-terminal hide can cause macOS to re-focus the existing managed
         // window; without this guard the viewport scrolls back to a column the
@@ -5820,6 +5859,10 @@ final class AXEventHandler: CGSEventDelegate {
                     // instead of the tracked managed window. Preserve the current
                     // workspace before macOS activates a successor app/window.
                     armWindowCloseFocusRecoveryForFocusedAppEvent(pid: destroyedPid)
+                    assertManagedAnchorAfterOverlayClose(
+                        destroyedPid: destroyedPid,
+                        destroyedWindowId: Int(windowId)
+                    )
                 }
             }
             clearFocusedTargetForDestroyedWindow(
@@ -6551,6 +6594,74 @@ final class AXEventHandler: CGSEventDelegate {
     private func activeRecoveryRemainingMs() -> String {
         guard let context = windowCloseFocusRecoveryContext else { return "nil" }
         return String(Int(context.expiresAt.timeIntervalSinceNow * 1000))
+    }
+
+    /// An overlay closing is an unambiguous, Nehir-observable moment — the only
+    /// safe place to correct focus for this shape. The overlay's owner may
+    /// re-activate the app that was frontmost before the overlay opened
+    /// (Ghostty's quick terminal does exactly this on hide, deliberately ahead
+    /// of the system default), displacing the window the user established
+    /// during the overlay session. That activation arrives as a genuinely
+    /// external app-level event, indistinguishable per-event from a real
+    /// click or Cmd-Tab — so it must not be gated on arrival; it is corrected
+    /// here instead.
+    ///
+    /// The anchor is the last *explicitly* confirmed token (matching request,
+    /// window-level source, or an echo of our own fronting). That stamp is
+    /// immune to the cause-less overwrite, so it still names the user's window
+    /// whichever way the destroy and the restore interleave. Both cases are
+    /// covered by one assertion: with no window created during the session the
+    /// stamp is the preserved pre-overlay token and this is a no-op.
+    private func assertManagedAnchorAfterOverlayClose(destroyedPid: pid_t, destroyedWindowId: Int) {
+        // Key on the destroy of a window the rule engine recognized as this
+        // app's overlay. Time-limited evidence recorded when the overlay
+        // opened cannot be used: the owner restores the previous app before
+        // the destroy notification arrives — which can be seconds after the
+        // overlay was shown — by which point that evidence has expired.
+        guard recognizedOverlayWindowIdsByPid[destroyedPid]?.contains(destroyedWindowId) == true,
+              let controller,
+              controller.workspaceManager.activeFocusRequestToken == nil,
+              let confirmedToken = controller.workspaceManager.confirmedManagedFocusToken,
+              let confirmedEntry = controller.workspaceManager.entry(for: confirmedToken),
+              let monitorId = controller.workspaceManager.monitorId(for: confirmedEntry.workspaceId),
+              controller.workspaceManager.activeWorkspace(on: monitorId)?.id == confirmedEntry.workspaceId
+        else {
+            return
+        }
+
+        // Prefer the last explicitly confirmed token: the overlay owner's own
+        // "restore the previous app" call (Ghostty's quick terminal) may have
+        // already been accepted as the live confirmed token by the time the
+        // overlay's destroy is processed. The explicit stamp is immune to that
+        // cause-less overwrite, so it still names the window the user actually
+        // established (e.g. the Cmd+N window). Fall back to the live confirmed
+        // token when the stamped one is gone or elsewhere.
+        let anchorToken: WindowToken
+        if let lastExplicit = lastExplicitManagedConfirmation,
+           let explicitEntry = controller.workspaceManager.entry(for: lastExplicit.token),
+           explicitEntry.workspaceId == confirmedEntry.workspaceId
+        {
+            anchorToken = lastExplicit.token
+        } else {
+            anchorToken = confirmedToken
+        }
+
+        controller.diagnostics.recordRuntimeViewportTrace(
+            workspaceId: confirmedEntry.workspaceId,
+            reason: "overlay_close_anchor_asserted",
+            details: [
+                "uptimeMs=\(traceUptimeMs())",
+                "destroyedPid=\(destroyedPid)",
+                "anchor=\(anchorToken)",
+                "confirmedFocus=\(confirmedToken)",
+                "anchorSource=\(anchorToken == confirmedToken ? "confirmed" : "explicit_stamp")",
+                "nonManagedFocusActive=\(controller.workspaceManager.isNonManagedFocusActive)"
+            ]
+        )
+        guard anchorToken != confirmedToken || controller.currentBorderTarget()?.token != anchorToken else {
+            return
+        }
+        controller.focusWindow(anchorToken, reason: .overlayCloseAnchorAssert)
     }
 
     private func recordRecentSameAppWindowClose(pid: pid_t) {

--- a/Sources/Nehir/Core/Controller/AXEventHandler.swift
+++ b/Sources/Nehir/Core/Controller/AXEventHandler.swift
@@ -2204,7 +2204,24 @@ final class AXEventHandler: CGSEventDelegate {
             }
             let shouldRemove: Bool
             if windowServerAlive {
-                shouldRemove = axEnumerationSucceededAndMissingToken
+                // AX disappearance while the WindowServer still lists the
+                // window normally means the window really is gone (AX is the
+                // authoritative oracle for app-level window lifetime), so it
+                // is removed.
+                //
+                // The exception is an app tearing an overlay down: Ghostty
+                // transiently drops its regular window from the AX tree while
+                // the quick terminal closes, and a probe landing in that blind
+                // moment removed a live, focused window — handing its focus,
+                // the layout selection and the command target to a neighbour.
+                // Keep the window while that overlay teardown is in progress;
+                // it is then removed by the authoritative WindowServer signal
+                // if it really closed, or by the rescan's consecutive-miss
+                // sweep. Evidence-gated, so no timer and no effect on ordinary
+                // window closes.
+                let overlayTeardownInProgress = self.overlayCapablePids.contains(token.pid)
+                    && self.hasOverlayLifecycleEvidence(for: token.pid)
+                shouldRemove = axEnumerationSucceededAndMissingToken && !overlayTeardownInProgress
             } else if confirmAXWhenWindowServerMissing, axEnumerationContainsToken {
                 shouldRemove = false
             } else {
@@ -2214,6 +2231,16 @@ final class AXEventHandler: CGSEventDelegate {
                   controller.workspaceManager.entry(for: token) != nil
             else {
                 return
+            }
+            if windowServerAlive, axEnumerationSucceededAndMissingToken {
+                // The window is at least *probably* closing (AX already dropped
+                // it): arm the same-app close evidence now so the
+                // churn-suppression gates (e.g. same-app re-home to an
+                // inactive workspace) have their evidence when the native
+                // churn arrives moments later. A false alarm merely leaves a
+                // short-lived, harmless evidence record behind.
+                self.recordRecentSameAppWindowClose(pid: token.pid)
+                self.recordRecentSameAppTeardown(pid: token.pid)
             }
             if shouldRemove {
                 self.recordDestroyLivenessVerification(
@@ -6574,6 +6601,18 @@ final class AXEventHandler: CGSEventDelegate {
 
     private func isWithinSameAppCloseRecoveryWindow(pid: pid_t) -> Bool {
         hasRecentNonManagedFocus(for: pid) || hasRecentSameAppWindowClose(for: pid)
+    }
+
+    /// Whether this pid's overlay is in (or just finished) a close lifecycle:
+    /// the quick-terminal hide emits a focused-window loss before the app
+    /// re-activates the pre-overlay app, and the overlay's destroy records
+    /// same-app close/teardown evidence. Any of these marks the cause-less
+    /// external activation that follows as the overlay-close restore rather
+    /// than a genuine user app switch.
+    private func hasOverlayLifecycleEvidence(for pid: pid_t) -> Bool {
+        isWithinSameAppCloseRecoveryWindow(pid: pid)
+            || hasRecentSameAppTeardown(for: pid)
+            || focusedWindowLossClosePrecursor(for: pid) != nil
     }
 
     /// The workspace a recent follow_focus pinned for `pid`, if the hold has not

--- a/Sources/Nehir/Core/Controller/WMController.swift
+++ b/Sources/Nehir/Core/Controller/WMController.swift
@@ -73,6 +73,7 @@ enum FocusWindowReason: String, Equatable {
     case closeRecoveryStableRedirect
     case overlayStableRecoveryRedirect
     case closeRecoveryPreconfirmStableRedirect
+    case overlayCloseAnchorAssert
     case deferredFocus
 }
 
@@ -2756,7 +2757,7 @@ final class WMController {
         let decision = applyingManualOverride
             ? decisionApplyingManualOverride(baseDecision, manualOverride: manualOverride)
             : baseDecision
-        axEventHandler.armOverlayCapabilityIfNeeded(source: baseDecision.source, pid: token.pid)
+        axEventHandler.armOverlayCapabilityIfNeeded(source: baseDecision.source, token: token)
         let evaluation = WindowDecisionEvaluation(
             token: token,
             facts: facts,

--- a/Sources/Nehir/Core/Controller/WMController.swift
+++ b/Sources/Nehir/Core/Controller/WMController.swift
@@ -3909,6 +3909,36 @@ final class WMController {
         guard !shouldSuppressManagedFocusRecovery else { return }
         guard !workspaceManager.hasPendingNativeFullscreenTransition else { return }
 
+        // Branch tracing: focus recovery after a window removal has repeatedly
+        // been the actor that displaced a freshly confirmed window (stale
+        // destroy of an already-closed window arriving after a new window's
+        // confirmation). Record the arbitration inputs so a capture shows WHY
+        // the focusNextWindow branch was reachable.
+        let confirmedToken = workspaceManager.confirmedManagedFocusToken
+        let confirmedEntryWorkspace = confirmedToken.flatMap { workspaceManager.entry(for: $0)?.workspaceId }
+        let branch: String
+        if let requestToken = workspaceManager.activeFocusRequestToken,
+           workspaceManager.activeFocusRequestWorkspaceId == workspaceId
+        {
+            branch = "active_request:\(requestToken)"
+        } else if let confirmedToken, confirmedEntryWorkspace == workspaceId {
+            branch = "confirmed_in_workspace:\(confirmedToken)"
+        } else {
+            branch = "next_window"
+        }
+        diagnostics.recordRuntimeViewportTrace(
+            workspaceId: workspaceId,
+            reason: "ensure_focused_token_valid",
+            details: [
+                "branch=\(branch)",
+                "confirmed=\(confirmedToken.map(String.init(describing:)) ?? "nil")",
+                "confirmedEntryWs=\(confirmedEntryWorkspace?.uuidString ?? "nil")",
+                "activeRequest=\(workspaceManager.activeFocusRequestToken.map(String.init(describing:)) ?? "nil")",
+                "activeRequestWs=\(workspaceManager.activeFocusRequestWorkspaceId?.uuidString ?? "nil")",
+                "nonManaged=\(workspaceManager.isNonManagedFocusActive)"
+            ]
+        )
+
         if let activeFocusRequestToken = workspaceManager.activeFocusRequestToken,
            workspaceManager.activeFocusRequestWorkspaceId == workspaceId
         {
@@ -4112,6 +4142,7 @@ extension WMController {
         windowId: Int,
         axRef: AXWindowRef
     ) {
+        axEventHandler.recordSelfInitiatedFronting(pid: pid)
         windowFocusOperations.activateApp(pid)
         windowFocusOperations.focusSpecificWindow(pid, UInt32(windowId), axRef.element)
         windowFocusOperations.raiseWindow(axRef.element)

--- a/Tests/NehirTests/QuickTerminalCloseAnchorTests.swift
+++ b/Tests/NehirTests/QuickTerminalCloseAnchorTests.swift
@@ -1,0 +1,210 @@
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=nehir-original; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
+import ApplicationServices
+import CoreGraphics
+import Foundation
+@testable import Nehir
+import Testing
+
+/// Regression coverage for the quick-terminal close stealing the focus,
+/// layout selection and command target of the window created during the
+/// overlay session.
+///
+/// Ghostty's quick terminal captures the frontmost application when it opens
+/// and re-activates it when it hides, ahead of the system default — it has no
+/// way to know a regular window was created meanwhile. That activation is
+/// genuinely external and per-event indistinguishable from a real click or
+/// Cmd-Tab, so it is corrected at the overlay window's destroy instead of
+/// being gated on arrival.
+@MainActor
+struct QuickTerminalCloseAnchorTests {
+    private struct Fixture {
+        let controller: WMController
+        let workspaceId: WorkspaceDescriptor.ID
+        let overlayPid: pid_t
+        let overlayWindowId: Int
+        /// The window the user created from the quick terminal.
+        let userToken: WindowToken
+        /// Another window of the same app, so assertions must distinguish
+        /// windows rather than merely processes.
+        let siblingToken: WindowToken
+        let neighborToken: WindowToken
+        let fronted: FrontedWindows
+    }
+
+    /// Records the windows Nehir fronted, in order. Window-level granularity
+    /// matters: the defect is about *which* window of an app ends up focused,
+    /// so a pid alone cannot tell a pass from a failure.
+    private final class FrontedWindows: @unchecked Sendable {
+        private(set) var tokens: [WindowToken] = []
+        private(set) var activatedPids: [pid_t] = []
+
+        func recordActivation(_ pid: pid_t) {
+            activatedPids.append(pid)
+        }
+
+        func recordWindow(pid: pid_t, windowId: UInt32) {
+            tokens.append(WindowToken(pid: pid, windowId: Int(windowId)))
+        }
+
+        func reset() {
+            tokens.removeAll()
+            activatedPids.removeAll()
+        }
+    }
+
+    private func makeFixture() -> Fixture? {
+        let fronted = FrontedWindows()
+        let controller = makeLayoutPlanTestController(
+            windowFocusOperations: WindowFocusOperations(
+                activateApp: { pid in fronted.recordActivation(pid) },
+                focusSpecificWindow: { pid, windowId, _ in
+                    fronted.recordWindow(pid: pid, windowId: windowId)
+                },
+                raiseWindow: { _ in }
+            )
+        )
+        guard let workspaceId = controller.interactionWorkspace()?.id,
+              let monitorId = controller.workspaceManager.monitorId(for: workspaceId)
+        else {
+            Issue.record("Missing active workspace for quick-terminal fixture")
+            return nil
+        }
+
+        let overlayPid: pid_t = 9_101
+        let neighborPid: pid_t = 9_102
+        let overlayWindowId = 9_001
+
+        // Two windows of the overlay's app — the one the user created from
+        // the quick terminal and an older sibling — plus a neighbouring app's
+        // window. The sibling is what makes the assertions meaningful: both
+        // candidates share a pid, so only the window identity distinguishes a
+        // correct recovery from a wrong one.
+        let siblingToken = controller.workspaceManager.addWindow(
+            AXWindowRef(element: AXUIElementCreateSystemWide(), windowId: 9_004),
+            pid: overlayPid,
+            windowId: 9_004,
+            to: workspaceId
+        )
+        let userToken = controller.workspaceManager.addWindow(
+            AXWindowRef(element: AXUIElementCreateSystemWide(), windowId: 9_002),
+            pid: overlayPid,
+            windowId: 9_002,
+            to: workspaceId
+        )
+        let neighborToken = controller.workspaceManager.addWindow(
+            AXWindowRef(element: AXUIElementCreateSystemWide(), windowId: 9_003),
+            pid: neighborPid,
+            windowId: 9_003,
+            to: workspaceId
+        )
+        _ = controller.workspaceManager.setManagedFocus(userToken, in: workspaceId, onMonitor: monitorId)
+
+        // The rule engine recognizing the overlay is what arms both the
+        // overlay-capable pid and the window id whose destroy means teardown.
+        controller.axEventHandler.armOverlayCapabilityIfNeeded(
+            source: .builtInRule("ghosttyQuickTerminalOverlay"),
+            token: WindowToken(pid: overlayPid, windowId: overlayWindowId)
+        )
+
+        return Fixture(
+            controller: controller,
+            workspaceId: workspaceId,
+            overlayPid: overlayPid,
+            overlayWindowId: overlayWindowId,
+            userToken: userToken,
+            siblingToken: siblingToken,
+            neighborToken: neighborToken,
+            fronted: fronted
+        )
+    }
+
+    /// Confirms `token` the way an explicitly requested focus does: through a
+    /// window-level activation, which is authoritative.
+    private func confirmExplicitly(_ fx: Fixture, _ token: WindowToken) {
+        guard let entry = fx.controller.workspaceManager.entry(for: token) else {
+            Issue.record("Missing entry for \(token)")
+            return
+        }
+        fx.controller.axEventHandler.handleManagedAppActivation(
+            entry: entry,
+            isWorkspaceActive: true,
+            appFullscreen: false,
+            source: .focusedWindowChanged
+        )
+    }
+
+    /// The shape of the overlay owner's own "restore the previous app" call:
+    /// an app-level activation with no matching managed request.
+    private func confirmCauselessly(_ fx: Fixture, _ token: WindowToken) {
+        guard let entry = fx.controller.workspaceManager.entry(for: token) else {
+            Issue.record("Missing entry for \(token)")
+            return
+        }
+        fx.controller.axEventHandler.handleManagedAppActivation(
+            entry: entry,
+            isWorkspaceActive: true,
+            appFullscreen: false,
+            source: .workspaceDidActivateApplication
+        )
+    }
+
+    @Test func overlayCloseReAssertsTheWindowCreatedDuringTheSession() {
+        guard let fx = makeFixture() else { return }
+
+        // The user worked in an older window of the app, then created a new
+        // one from the quick terminal: the newer explicit confirmation is the
+        // anchor.
+        confirmExplicitly(fx, fx.siblingToken)
+        confirmExplicitly(fx, fx.userToken)
+        // The overlay owner restores the pre-overlay app before its window's
+        // destroy notification arrives.
+        confirmCauselessly(fx, fx.neighborToken)
+        #expect(fx.controller.workspaceManager.confirmedManagedFocusToken == fx.neighborToken)
+
+        fx.fronted.reset()
+        fx.controller.axEventHandler.handleRemoved(pid: fx.overlayPid, winId: fx.overlayWindowId)
+
+        // Window-level: the app's *other* window must not be the one restored.
+        // The confirmed token only changes once macOS echoes the activation
+        // back, which no fake produces, so Nehir's intent is asserted through
+        // the window it fronted and the request it opened.
+        #expect(fx.fronted.tokens == [fx.userToken])
+        #expect(fx.controller.workspaceManager.activeFocusRequestToken == fx.userToken)
+    }
+
+    /// With nothing created during the session the explicit stamp is the
+    /// preserved pre-overlay token, so closing the overlay changes nothing.
+    @Test func overlayCloseIsANoOpWhenNoWindowWasCreated() {
+        guard let fx = makeFixture() else { return }
+
+        confirmExplicitly(fx, fx.neighborToken)
+        #expect(fx.controller.workspaceManager.confirmedManagedFocusToken == fx.neighborToken)
+
+        fx.fronted.reset()
+        fx.controller.axEventHandler.handleRemoved(pid: fx.overlayPid, winId: fx.overlayWindowId)
+
+        #expect(fx.controller.workspaceManager.confirmedManagedFocusToken == fx.neighborToken)
+        #expect(fx.fronted.tokens.isEmpty)
+        #expect(fx.fronted.activatedPids.isEmpty)
+    }
+
+    /// Destroying some other untracked element of the overlay's app is not an
+    /// overlay teardown and must not move focus — the assertion is keyed on
+    /// the recognized overlay window's identity, not on the pid.
+    @Test func destroyingAnUnrelatedWindowOfTheOverlayAppDoesNotReAssert() {
+        guard let fx = makeFixture() else { return }
+
+        confirmExplicitly(fx, fx.userToken)
+        confirmCauselessly(fx, fx.neighborToken)
+
+        fx.fronted.reset()
+        fx.controller.axEventHandler.handleRemoved(pid: fx.overlayPid, winId: 9_999)
+
+        #expect(fx.fronted.tokens.isEmpty)
+        #expect(fx.controller.workspaceManager.confirmedManagedFocusToken == fx.neighborToken)
+    }
+}


### PR DESCRIPTION
## Summary

<!-- What changed and why? -->

## Release notes

Choose one:

- [ ] Added a `.changeset/*.md` for user-visible changes (`mise run changeset -- patch "..."`).
- [ ] No user-visible change; apply the `no release note` label to make CI skip intentional.

## Validation

<!-- Commands run, screenshots, or manual checks. -->

- [ ] Ran relevant tests/checks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Ghostty quick terminal handling across open/convert/dismiss flows, keeping focus/layout/command targeting on the newly created window.
  * Column-width commands now resize the correct quick-terminal window.
  * Closing a focused quick-terminal window no longer switches away from the current workspace.
  * Enhanced focus recovery for overlay teardown and window removal to prevent unexpected jumps to neighboring windows.
* **Tests**
  * Added regression coverage for quick-terminal close anchor and overlay teardown focus behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->