### PR TITLE
Reveal a focus target that sits outside a scroll-locked viewport

### DIFF
--- a/.changeset/20260728052804-viewport-scroll-lock-now-reveals-a-focused-windo.md
+++ b/.changeset/20260728052804-viewport-scroll-lock-now-reveals-a-focused-windo.md
@@ -1,0 +1,6 @@
+---
+"nehir": patch
+
+---
+
+Viewport Scroll Lock now reveals a focused window that sits entirely outside the viewport, whatever moved the focus there — a hotkey, a workspace-bar click, or an app's own Window menu. A partially visible column is left where it is, however little of it shows.

--- a/.provenance.json
+++ b/.provenance.json
@@ -118,7 +118,9 @@
         "Tests/NehirTests/DockAutohideReservationTests.swift",
         "Tests/NehirTests/ColumnWidthCycleViewportAnchorTests.swift",
         "Tests/NehirTests/QuantizationRefusalStreakTests.swift",
-        "Tests/NehirTests/QuickTerminalCloseAnchorTests.swift"
+        "Tests/NehirTests/QuickTerminalCloseAnchorTests.swift",
+        "Tests/NehirTests/ScrollLockRevealPolicyTests.swift",
+        "Tests/NehirTests/ScrollLockFocusCommandRevealTests.swift"
       ],
       "copyright": [
         "2026 Aleksei Gurianov and Nehir contributors"

--- a/Sources/Nehir/Core/Controller/AXEventHandler.swift
+++ b/Sources/Nehir/Core/Controller/AXEventHandler.swift
@@ -4860,7 +4860,7 @@ final class AXEventHandler: CGSEventDelegate {
                     motion: controller.motionPolicy.snapshot(),
                     scale: engine.displayScale(in: wsId),
                     allowFullyVisibleAutomaticRecenter: false,
-                trigger: .automatic
+                    trigger: .automatic
                 )
                 controller.diagnostics.recordRuntimeViewportTrace(
                     workspaceId: wsId,

--- a/Sources/Nehir/Core/Controller/AXEventHandler.swift
+++ b/Sources/Nehir/Core/Controller/AXEventHandler.swift
@@ -4859,7 +4859,8 @@ final class AXEventHandler: CGSEventDelegate {
                     context: context,
                     motion: controller.motionPolicy.snapshot(),
                     scale: engine.displayScale(in: wsId),
-                    allowFullyVisibleAutomaticRecenter: false
+                    allowFullyVisibleAutomaticRecenter: false,
+                trigger: .automatic
                 )
                 controller.diagnostics.recordRuntimeViewportTrace(
                     workspaceId: wsId,

--- a/Sources/Nehir/Core/Controller/NiriLayoutHandler.swift
+++ b/Sources/Nehir/Core/Controller/NiriLayoutHandler.swift
@@ -867,7 +867,7 @@ enum NiriWindowMoveResult {
                 workingFrame: pass.insetFrame,
                 gaps: pass.gap,
                 fromContainerIndex: removal.removalResult.fromIndexForVisibility,
-            revealTrigger: .automatic
+                revealTrigger: .automatic
             )
             if abs(state.viewOffsetPixels.current() - offsetBefore) > 1 {
                 viewportNeedsRecalc = true
@@ -1013,7 +1013,7 @@ enum NiriWindowMoveResult {
                     workingFrame: pass.insetFrame,
                     gaps: pass.gap,
                     fromContainerIndex: state.activeColumnIndex,
-                revealTrigger: .automatic
+                    revealTrigger: .automatic
                 )
 
                 if shouldRestorePrevOffset {
@@ -1436,7 +1436,7 @@ enum NiriWindowMoveResult {
                 state: &state,
                 workingFrame: controller.insetWorkingFrame(for: monitor),
                 gaps: gap,
-            revealTrigger: .automatic
+                revealTrigger: .automatic
             )
         }
         activateNode(
@@ -1489,7 +1489,7 @@ enum NiriWindowMoveResult {
                         state: &state,
                         workingFrame: controller.insetWorkingFrame(for: monitor),
                         gaps: controller.gapSize(for: monitor),
-                    revealTrigger: .automatic
+                        revealTrigger: .automatic
                     )
                 }
                 activateNode(
@@ -2224,7 +2224,7 @@ enum NiriWindowMoveResult {
                 state: &state,
                 workingFrame: workingFrame,
                 gaps: gap,
-            revealTrigger: .automatic
+                revealTrigger: .automatic
             )
         }
 

--- a/Sources/Nehir/Core/Controller/NiriLayoutHandler.swift
+++ b/Sources/Nehir/Core/Controller/NiriLayoutHandler.swift
@@ -866,7 +866,8 @@ enum NiriWindowMoveResult {
                 state: &state,
                 workingFrame: pass.insetFrame,
                 gaps: pass.gap,
-                fromContainerIndex: removal.removalResult.fromIndexForVisibility
+                fromContainerIndex: removal.removalResult.fromIndexForVisibility,
+            revealTrigger: .automatic
             )
             if abs(state.viewOffsetPixels.current() - offsetBefore) > 1 {
                 viewportNeedsRecalc = true
@@ -1011,7 +1012,8 @@ enum NiriWindowMoveResult {
                     state: &state,
                     workingFrame: pass.insetFrame,
                     gaps: pass.gap,
-                    fromContainerIndex: state.activeColumnIndex
+                    fromContainerIndex: state.activeColumnIndex,
+                revealTrigger: .automatic
                 )
 
                 if shouldRestorePrevOffset {
@@ -1433,7 +1435,8 @@ enum NiriWindowMoveResult {
                 motion: controller.motionPolicy.snapshot(),
                 state: &state,
                 workingFrame: controller.insetWorkingFrame(for: monitor),
-                gaps: gap
+                gaps: gap,
+            revealTrigger: .automatic
             )
         }
         activateNode(
@@ -1485,7 +1488,8 @@ enum NiriWindowMoveResult {
                         motion: controller.motionPolicy.snapshot(),
                         state: &state,
                         workingFrame: controller.insetWorkingFrame(for: monitor),
-                        gaps: controller.gapSize(for: monitor)
+                        gaps: controller.gapSize(for: monitor),
+                    revealTrigger: .automatic
                     )
                 }
                 activateNode(
@@ -2219,7 +2223,8 @@ enum NiriWindowMoveResult {
                 motion: controller.motionPolicy.snapshot(),
                 state: &state,
                 workingFrame: workingFrame,
-                gaps: gap
+                gaps: gap,
+            revealTrigger: .automatic
             )
         }
 

--- a/Sources/Nehir/Core/Controller/WorkspaceNavigationHandler.swift
+++ b/Sources/Nehir/Core/Controller/WorkspaceNavigationHandler.swift
@@ -121,7 +121,8 @@ final class WorkspaceNavigationHandler {
                     motion: controller.motionPolicy.snapshot(),
                     state: &targetState,
                     workingFrame: workingFrame,
-                    gaps: gap
+                    gaps: gap,
+                revealTrigger: .automatic
                 )
             }
         }

--- a/Sources/Nehir/Core/Controller/WorkspaceNavigationHandler.swift
+++ b/Sources/Nehir/Core/Controller/WorkspaceNavigationHandler.swift
@@ -122,7 +122,7 @@ final class WorkspaceNavigationHandler {
                     state: &targetState,
                     workingFrame: workingFrame,
                     gaps: gap,
-                revealTrigger: .automatic
+                    revealTrigger: .automatic
                 )
             }
         }

--- a/Sources/Nehir/Core/Layout/Niri/NiriLayoutEngine+ColumnOps.swift
+++ b/Sources/Nehir/Core/Layout/Niri/NiriLayoutEngine+ColumnOps.swift
@@ -207,7 +207,8 @@ extension NiriLayoutEngine {
             motion: motion,
             state: &state,
             workingFrame: workingFrame,
-            gaps: gaps
+            gaps: gaps,
+        revealTrigger: .automatic
         )
 
         return true
@@ -640,7 +641,8 @@ extension NiriLayoutEngine {
             gaps: gaps,
             orientation: orientation,
             fromContainerIndex: previousActiveColumnIndex,
-            previousActiveContainerPosition: previousActiveColumnPosition
+            previousActiveContainerPosition: previousActiveColumnPosition,
+        revealTrigger: .automatic
         )
 
         if case .horizontalConsume = purePlan {
@@ -887,7 +889,8 @@ extension NiriLayoutEngine {
             state: &state,
             workingFrame: workingFrame,
             gaps: gaps,
-            orientation: orientation
+            orientation: orientation,
+        revealTrigger: .automatic
         )
 
         return true
@@ -902,7 +905,7 @@ extension NiriLayoutEngine {
         gaps: CGFloat,
         animationConfig: SpringConfig? = nil,
         fromContainerIndex: Int? = nil,
-        revealTrigger: RevealTrigger = .automatic
+        revealTrigger: RevealTrigger
     ) {
         if let firstWindow = column.windowNodes.first {
             ensureSelectionVisible(

--- a/Sources/Nehir/Core/Layout/Niri/NiriLayoutEngine+ColumnOps.swift
+++ b/Sources/Nehir/Core/Layout/Niri/NiriLayoutEngine+ColumnOps.swift
@@ -208,7 +208,7 @@ extension NiriLayoutEngine {
             state: &state,
             workingFrame: workingFrame,
             gaps: gaps,
-        revealTrigger: .automatic
+            revealTrigger: .automatic
         )
 
         return true
@@ -642,7 +642,7 @@ extension NiriLayoutEngine {
             orientation: orientation,
             fromContainerIndex: previousActiveColumnIndex,
             previousActiveContainerPosition: previousActiveColumnPosition,
-        revealTrigger: .automatic
+            revealTrigger: .automatic
         )
 
         if case .horizontalConsume = purePlan {
@@ -890,7 +890,7 @@ extension NiriLayoutEngine {
             workingFrame: workingFrame,
             gaps: gaps,
             orientation: orientation,
-        revealTrigger: .automatic
+            revealTrigger: .automatic
         )
 
         return true

--- a/Sources/Nehir/Core/Layout/Niri/NiriLayoutEngine+InteractiveMove.swift
+++ b/Sources/Nehir/Core/Layout/Niri/NiriLayoutEngine+InteractiveMove.swift
@@ -233,7 +233,8 @@ extension NiriLayoutEngine {
             motion: motion,
             state: &state,
             workingFrame: workingFrame,
-            gaps: gaps
+            gaps: gaps,
+        revealTrigger: .automatic
         )
 
         return true
@@ -300,7 +301,8 @@ extension NiriLayoutEngine {
             motion: motion,
             state: &state,
             workingFrame: workingFrame,
-            gaps: gaps
+            gaps: gaps,
+        revealTrigger: .automatic
         )
 
         return true

--- a/Sources/Nehir/Core/Layout/Niri/NiriLayoutEngine+InteractiveMove.swift
+++ b/Sources/Nehir/Core/Layout/Niri/NiriLayoutEngine+InteractiveMove.swift
@@ -234,7 +234,7 @@ extension NiriLayoutEngine {
             state: &state,
             workingFrame: workingFrame,
             gaps: gaps,
-        revealTrigger: .automatic
+            revealTrigger: .automatic
         )
 
         return true
@@ -302,7 +302,7 @@ extension NiriLayoutEngine {
             state: &state,
             workingFrame: workingFrame,
             gaps: gaps,
-        revealTrigger: .automatic
+            revealTrigger: .automatic
         )
 
         return true

--- a/Sources/Nehir/Core/Layout/Niri/NiriLayoutEngine+InteractiveResize.swift
+++ b/Sources/Nehir/Core/Layout/Niri/NiriLayoutEngine+InteractiveResize.swift
@@ -266,7 +266,8 @@ extension NiriLayoutEngine {
                 motion: motion,
                 state: &state,
                 workingFrame: workingFrame,
-                gaps: gaps
+                gaps: gaps,
+            revealTrigger: .automatic
             )
         }
 

--- a/Sources/Nehir/Core/Layout/Niri/NiriLayoutEngine+InteractiveResize.swift
+++ b/Sources/Nehir/Core/Layout/Niri/NiriLayoutEngine+InteractiveResize.swift
@@ -267,7 +267,7 @@ extension NiriLayoutEngine {
                 state: &state,
                 workingFrame: workingFrame,
                 gaps: gaps,
-            revealTrigger: .automatic
+                revealTrigger: .automatic
             )
         }
 

--- a/Sources/Nehir/Core/Layout/Niri/NiriLayoutEngine+PureLayoutBridge.swift
+++ b/Sources/Nehir/Core/Layout/Niri/NiriLayoutEngine+PureLayoutBridge.swift
@@ -73,7 +73,8 @@ extension NiriLayoutEngine {
             state: &state,
             workingFrame: workingFrame,
             gaps: gaps,
-            orientation: orientation
+            orientation: orientation,
+            revealTrigger: .explicitNavigation
         )
 
         return .handled(target)

--- a/Sources/Nehir/Core/Layout/Niri/NiriLayoutEngine+ViewportCommands.swift
+++ b/Sources/Nehir/Core/Layout/Niri/NiriLayoutEngine+ViewportCommands.swift
@@ -109,7 +109,7 @@ extension NiriLayoutEngine {
         scale: CGFloat = 2.0,
         animationConfig: SpringConfig? = nil,
         allowFullyVisibleAutomaticRecenter: Bool = false,
-        trigger: RevealTrigger = .automatic
+        trigger: RevealTrigger
     ) -> Bool {
         guard !isFFM else { return false }
         guard context.columns.indices.contains(columnIndex), !context.snapPoints.isEmpty else { return false }

--- a/Sources/Nehir/Core/Layout/Niri/NiriLayoutEngine+ViewportCommands.swift
+++ b/Sources/Nehir/Core/Layout/Niri/NiriLayoutEngine+ViewportCommands.swift
@@ -66,6 +66,39 @@ extension NiriLayoutEngine {
         return syncViewportSelectionToActiveColumn(columns: columns, state: &state)
     }
 
+    /// Scrolls the viewport so `columnIndex` is usable, and returns whether it moved.
+    ///
+    /// Whether a reveal happens depends on three inputs: who asked
+    /// (`trigger`), how visible the target already is, and whether the
+    /// workspace is scroll-locked.
+    ///
+    /// On an **unlocked** workspace:
+    ///
+    /// | Target visibility | `.automatic` | `.explicitNavigation` |
+    /// |---|---|---|
+    /// | `.parked` / `.clipped` | reveal per `revealStyle` | reveal per `revealStyle` |
+    /// | `.fullyVisible`, filling group off-centre | re-centre | re-centre |
+    /// | `.fullyVisible`, otherwise | only with `allowFullyVisibleAutomaticRecenter` and `revealStyle == .auto` | re-centre when `revealStyle == .auto` |
+    ///
+    /// On a **locked** workspace only the `.parked` row survives, and it survives for
+    /// every trigger: a target outside the viewport is revealed per `revealStyle` no
+    /// matter what moved the focus there. `.clipped` and `.fullyVisible` targets leave
+    /// the viewport alone.
+    ///
+    /// So `trigger` does not decide the lock question — visibility does. `.parked` is
+    /// the only "the user cannot see this at all" state, reached when at most
+    /// `niriViewportPreParkMargin` of the column would remain inside the viewport. A
+    /// column showing more than that is something the user can see, so pulling it to a
+    /// snap would be the churn the lock exists to stop; a column showing less is
+    /// focused invisibly, which no lock should be allowed to cause.
+    ///
+    /// Two rules sit outside all of the above:
+    ///
+    /// - Focus-follows-mouse never scrolls. `isFFM` short-circuits before
+    ///   anything else, so an FFM focus change cannot move the viewport no
+    ///   matter what the other inputs say.
+    /// - Nothing moves when the target is already at the chosen offset within
+    ///   one device pixel.
     @discardableResult
     func scrollToReveal(
         columnIndex: Int,
@@ -85,6 +118,23 @@ extension NiriLayoutEngine {
         let visibility = context.visibility(of: columnIndex, viewportOffset: viewStart, in: state)
         let pixel = 1.0 / max(scale, 1.0)
 
+        // Viewport scroll lock. A locked viewport moves for exactly one reason: the
+        // target is fully parked, i.e. outside the viewport entirely. Focus landing on
+        // something the user cannot see at all has to be revealed, or the window is
+        // focused invisibly and input disappears into it.
+        //
+        // Where that focus came from deliberately does not enter into it. A hotkey, a
+        // click, an app's own Window menu and background layout work all leave the user
+        // staring at a viewport that does not contain the focused window, so they all
+        // get the same answer.
+        //
+        // Everything else stays put: a partially visible target is left alone no matter
+        // how little of it shows, because pulling a column the user can already see over
+        // to a snap is precisely the churn the lock exists to stop.
+        if state.isScrollLocked {
+            guard case .parked = visibility else { return false }
+        }
+
         let targetSnaps = context.snapCandidates(for: columnIndex, in: state)
         let closest = targetSnaps.closest(to: viewStart)
         let center = targetSnaps.first { $0.kind == .center }
@@ -99,11 +149,10 @@ extension NiriLayoutEngine {
         let targetSnap: SnapPoint?
         switch visibility {
         case .fullyVisible:
-            guard !trigger.respectsScrollLock || !state.isScrollLocked else { return false }
             // Re-centering a fully visible filling group is viewport-position maintenance,
             // not a reveal. Keep the proportional slack / lone-column centering contract
-            // even when no hidden content needs to be revealed, while still honoring
-            // scroll lock for automatic triggers.
+            // even when no hidden content needs to be revealed. Scroll lock has already
+            // been settled above.
             if context.fillsViewport(at: viewStart, in: state) {
                 guard let centeredStart = context.centeredFillingViewportStart(
                     at: viewStart,
@@ -128,7 +177,6 @@ extension NiriLayoutEngine {
             targetSnap = autoSnap()
         case .parked,
              .clipped:
-            guard !trigger.respectsScrollLock || !state.isScrollLocked else { return false }
             targetSnap = switch revealStyle {
             case .auto:
                 autoSnap()

--- a/Sources/Nehir/Core/Layout/Niri/NiriLayoutEngine+Windows.swift
+++ b/Sources/Nehir/Core/Layout/Niri/NiriLayoutEngine+Windows.swift
@@ -324,7 +324,7 @@ extension NiriLayoutEngine {
                 workingFrame: workingFrame,
                 gaps: gaps,
                 fromContainerIndex: fromIndexForVisibility,
-            revealTrigger: .automatic
+                revealTrigger: .automatic
             )
             visibilityWasCorrected = true
         }
@@ -512,7 +512,7 @@ extension NiriLayoutEngine {
                     workingFrame: workingFrame,
                     gaps: gaps,
                     fromContainerIndex: state.activeColumnIndex,
-                revealTrigger: .automatic
+                    revealTrigger: .automatic
                 )
                 visibilityWasCorrected = true
             }

--- a/Sources/Nehir/Core/Layout/Niri/NiriLayoutEngine+Windows.swift
+++ b/Sources/Nehir/Core/Layout/Niri/NiriLayoutEngine+Windows.swift
@@ -323,7 +323,8 @@ extension NiriLayoutEngine {
                 state: &state,
                 workingFrame: workingFrame,
                 gaps: gaps,
-                fromContainerIndex: fromIndexForVisibility
+                fromContainerIndex: fromIndexForVisibility,
+            revealTrigger: .automatic
             )
             visibilityWasCorrected = true
         }
@@ -510,7 +511,8 @@ extension NiriLayoutEngine {
                     state: &state,
                     workingFrame: workingFrame,
                     gaps: gaps,
-                    fromContainerIndex: state.activeColumnIndex
+                    fromContainerIndex: state.activeColumnIndex,
+                revealTrigger: .automatic
                 )
                 visibilityWasCorrected = true
             }

--- a/Sources/Nehir/Core/Layout/Niri/NiriLayoutEngine.swift
+++ b/Sources/Nehir/Core/Layout/Niri/NiriLayoutEngine.swift
@@ -9,13 +9,19 @@ import Foundation
 
 /// Declares where a viewport reveal came from.
 ///
-/// This does **not** decide viewport scroll lock: a target outside the viewport is
-/// revealed regardless of trigger, and a partially visible one is left alone
-/// regardless of trigger. Lock is answered by visibility alone — see
-/// `scrollToReveal`.
+/// This does **not** decide viewport scroll lock. On a locked workspace a target
+/// outside the viewport is revealed and a partially visible one is left alone, both
+/// regardless of trigger; on an unlocked workspace a `.clipped` target is revealed per
+/// `revealStyle`, again regardless of trigger. Lock is answered by visibility alone.
 ///
-/// What the trigger still decides is re-centring an already fully visible column,
-/// which is a placement preference rather than a reveal.
+/// What the trigger does decide is re-centring an **already fully visible**
+/// non-filling column, which is a placement preference rather than a reveal: allowed
+/// for `.explicitNavigation`, and for `.automatic` only when the call site passes
+/// `allowFullyVisibleAutomaticRecenter`, in both cases only when
+/// `revealStyle == .auto`. Re-centring a fully visible column that fills the viewport
+/// is viewport maintenance and runs for either trigger.
+///
+/// See `scrollToReveal` for the full matrix.
 enum RevealTrigger {
     /// Reveals that the user did not directly ask for: window close recovery,
     /// new-window arrival, selection re-resolution, AX focus confirmation, and the

--- a/Sources/Nehir/Core/Layout/Niri/NiriLayoutEngine.swift
+++ b/Sources/Nehir/Core/Layout/Niri/NiriLayoutEngine.swift
@@ -7,15 +7,29 @@
 import AppKit
 import Foundation
 
+/// Declares where a viewport reveal came from.
+///
+/// This does **not** decide viewport scroll lock: a target outside the viewport is
+/// revealed regardless of trigger, and a partially visible one is left alone
+/// regardless of trigger. Lock is answered by visibility alone — see
+/// `scrollToReveal`.
+///
+/// What the trigger still decides is re-centring an already fully visible column,
+/// which is a placement preference rather than a reveal.
 enum RevealTrigger {
-    /// Background maintenance/layout reveals should be suppressed by viewport scroll lock.
+    /// Reveals that the user did not directly ask for: window close recovery,
+    /// new-window arrival, selection re-resolution, AX focus confirmation, and the
+    /// move/resize/consume/expel layout commands.
+    ///
+    /// Never re-centres an already fully visible non-filling column unless the call
+    /// site opts in via `allowFullyVisibleAutomaticRecenter`.
     case automatic
-    /// Direct user navigation (focus commands, workspace-bar window clicks) may reveal while locked.
+    /// Direct user navigation: the directional focus commands (`focusNeighbor`,
+    /// `focusWindowOrWorkspace`, `focusPrevious`, the column/tile focus commands),
+    /// workspace-bar window activation, and `moveColumn`.
+    ///
+    /// May re-centre an already fully visible column when `revealStyle == .auto`.
     case explicitNavigation
-
-    var respectsScrollLock: Bool {
-        self == .automatic
-    }
 }
 
 enum RevealStyle: String, CaseIterable, Codable, Identifiable {

--- a/Sources/Nehir/Core/Layout/Niri/NiriNavigation.swift
+++ b/Sources/Nehir/Core/Layout/Niri/NiriNavigation.swift
@@ -182,7 +182,7 @@ extension NiriLayoutEngine {
         animationConfig: SpringConfig? = nil,
         fromContainerIndex: Int? = nil,
         previousActiveContainerPosition: CGFloat? = nil,
-        revealTrigger: RevealTrigger = .automatic
+        revealTrigger: RevealTrigger
     ) {
         let containers = columns(in: workspaceId)
         guard !containers.isEmpty else { return }

--- a/Tests/NehirTests/IPCCommandRouterTests.swift
+++ b/Tests/NehirTests/IPCCommandRouterTests.swift
@@ -9,7 +9,7 @@ import Foundation
 import NehirIPC
 import Testing
 
-private let ipcCommandRouterSessionToken = "ipc-command-router-tests"
+let ipcCommandRouterSessionToken = "ipc-command-router-tests"
 
 private enum IPCFloatingRaiseEvent: Equatable {
     case order(Int)
@@ -44,12 +44,12 @@ private func makeIPCFloatingRaiseOperations(
 }
 
 @MainActor
-private func makeIPCCommandRouter(for controller: WMController) -> IPCCommandRouter {
+func makeIPCCommandRouter(for controller: WMController) -> IPCCommandRouter {
     IPCCommandRouter(controller: controller, sessionToken: ipcCommandRouterSessionToken)
 }
 
 @MainActor
-private func prepareIPCNiriState(
+func prepareIPCNiriState(
     on controller: WMController,
     assignments: [(workspaceId: WorkspaceDescriptor.ID, windowId: Int)],
     focusedWindowId: Int
@@ -846,121 +846,6 @@ private func prepareIPCNiriState(
         )
 
         #expect(result == .executed)
-    }
-
-    /// Window 9113 lands in column 1, which is clipped at this geometry (800pt working
-    /// frame, three 400pt columns at x = 0, 416, 832). Scroll lock leaves a target the
-    /// user can already partly see alone, so focus moves but the viewport does not.
-    @Test func windowFocusLeavesClippedTargetAloneWhileScrollLocked() throws {
-        let monitor = makeLayoutPlanTestMonitor(width: 800, height: 600)
-        let controller = makeLayoutPlanTestController(monitors: [monitor])
-        let workspaceId = try #require(controller.workspaceManager.workspaceId(for: "1", createIfMissing: false))
-        let handles = prepareIPCNiriState(
-            on: controller,
-            assignments: [
-                (workspaceId, 9111),
-                (workspaceId, 9112),
-                (workspaceId, 9113)
-            ],
-            focusedWindowId: 9111
-        )
-        let engine = try #require(controller.niriEngine)
-        engine.revealStyle = .center
-        for column in engine.columns(in: workspaceId) {
-            column.width = .fixed(400)
-            column.cachedWidth = 400
-        }
-        let targetHandle = try #require(handles[9113])
-        let targetNode = try #require(engine.findNode(for: targetHandle))
-        var state = controller.workspaceManager.niriViewportState(for: workspaceId)
-        state.selectedNodeId = engine.findNode(for: try #require(handles[9111]))?.id
-        state.activeColumnIndex = 0
-        state.viewOffsetPixels = .static(0)
-        state.isScrollLocked = true
-        controller.workspaceManager.updateNiriViewportState(state, for: workspaceId)
-        let router = makeIPCCommandRouter(for: controller)
-
-        let result = router.handle(
-            IPCWindowRequest(
-                name: .focus,
-                windowId: IPCWindowOpaqueID.encode(
-                    pid: targetHandle.id.pid,
-                    windowId: targetHandle.id.windowId,
-                    sessionToken: ipcCommandRouterSessionToken
-                )
-            )
-        )
-
-        let updated = controller.workspaceManager.niriViewportState(for: workspaceId)
-        let context = engine.makeViewportSnapContext(
-            columns: engine.columns(in: workspaceId),
-            state: updated,
-            workingFrame: controller.insetWorkingFrame(for: monitor),
-            gaps: controller.gapSize(for: monitor)
-        )
-        let viewStart = context.currentViewStart(in: updated)
-        #expect(result == .executed)
-        #expect(updated.isScrollLocked)
-        #expect(updated.selectedNodeId == targetNode.id)
-        #expect(context.visibility(of: 1, viewportOffset: viewStart, in: updated) == .clipped(.maximum))
-        #expect(viewStart == 0)
-    }
-
-    /// Window 9112 lands in column 2, which is parked past the right edge at this
-    /// geometry. A parked target is revealed even while locked, or the window would take
-    /// focus while staying invisible.
-    @Test func windowFocusRevealsParkedTargetWhileScrollLocked() throws {
-        let monitor = makeLayoutPlanTestMonitor(width: 800, height: 600)
-        let controller = makeLayoutPlanTestController(monitors: [monitor])
-        let workspaceId = try #require(controller.workspaceManager.workspaceId(for: "1", createIfMissing: false))
-        let handles = prepareIPCNiriState(
-            on: controller,
-            assignments: [
-                (workspaceId, 9111),
-                (workspaceId, 9112),
-                (workspaceId, 9113)
-            ],
-            focusedWindowId: 9111
-        )
-        let engine = try #require(controller.niriEngine)
-        engine.revealStyle = .center
-        for column in engine.columns(in: workspaceId) {
-            column.width = .fixed(400)
-            column.cachedWidth = 400
-        }
-        let targetHandle = try #require(handles[9112])
-        let targetNode = try #require(engine.findNode(for: targetHandle))
-        var state = controller.workspaceManager.niriViewportState(for: workspaceId)
-        state.selectedNodeId = engine.findNode(for: try #require(handles[9111]))?.id
-        state.activeColumnIndex = 0
-        state.viewOffsetPixels = .static(0)
-        state.isScrollLocked = true
-        controller.workspaceManager.updateNiriViewportState(state, for: workspaceId)
-        let router = makeIPCCommandRouter(for: controller)
-
-        let result = router.handle(
-            IPCWindowRequest(
-                name: .focus,
-                windowId: IPCWindowOpaqueID.encode(
-                    pid: targetHandle.id.pid,
-                    windowId: targetHandle.id.windowId,
-                    sessionToken: ipcCommandRouterSessionToken
-                )
-            )
-        )
-
-        let updated = controller.workspaceManager.niriViewportState(for: workspaceId)
-        let context = engine.makeViewportSnapContext(
-            columns: engine.columns(in: workspaceId),
-            state: updated,
-            workingFrame: controller.insetWorkingFrame(for: monitor),
-            gaps: controller.gapSize(for: monitor)
-        )
-        let viewStart = context.currentViewStart(in: updated)
-        #expect(result == .executed)
-        #expect(updated.isScrollLocked)
-        #expect(updated.selectedNodeId == targetNode.id)
-        #expect(context.visibility(of: 2, viewportOffset: viewStart, in: updated) == .fullyVisible)
     }
 
     @Test func windowNavigateUsesWindowActionHandlerRoute() throws {

--- a/Tests/NehirTests/IPCCommandRouterTests.swift
+++ b/Tests/NehirTests/IPCCommandRouterTests.swift
@@ -848,7 +848,10 @@ private func prepareIPCNiriState(
         #expect(result == .executed)
     }
 
-    @Test func windowFocusBypassesViewportScrollLockForExplicitNavigation() throws {
+    /// Window 9113 lands in column 1, which is clipped at this geometry (800pt working
+    /// frame, three 400pt columns at x = 0, 416, 832). Scroll lock leaves a target the
+    /// user can already partly see alone, so focus moves but the viewport does not.
+    @Test func windowFocusLeavesClippedTargetAloneWhileScrollLocked() throws {
         let monitor = makeLayoutPlanTestMonitor(width: 800, height: 600)
         let controller = makeLayoutPlanTestController(monitors: [monitor])
         let workspaceId = try #require(controller.workspaceManager.workspaceId(for: "1", createIfMissing: false))
@@ -899,7 +902,65 @@ private func prepareIPCNiriState(
         #expect(result == .executed)
         #expect(updated.isScrollLocked)
         #expect(updated.selectedNodeId == targetNode.id)
-        #expect(viewStart > 100)
+        #expect(context.visibility(of: 1, viewportOffset: viewStart, in: updated) == .clipped(.maximum))
+        #expect(viewStart == 0)
+    }
+
+    /// Window 9112 lands in column 2, which is parked past the right edge at this
+    /// geometry. A parked target is revealed even while locked, or the window would take
+    /// focus while staying invisible.
+    @Test func windowFocusRevealsParkedTargetWhileScrollLocked() throws {
+        let monitor = makeLayoutPlanTestMonitor(width: 800, height: 600)
+        let controller = makeLayoutPlanTestController(monitors: [monitor])
+        let workspaceId = try #require(controller.workspaceManager.workspaceId(for: "1", createIfMissing: false))
+        let handles = prepareIPCNiriState(
+            on: controller,
+            assignments: [
+                (workspaceId, 9111),
+                (workspaceId, 9112),
+                (workspaceId, 9113)
+            ],
+            focusedWindowId: 9111
+        )
+        let engine = try #require(controller.niriEngine)
+        engine.revealStyle = .center
+        for column in engine.columns(in: workspaceId) {
+            column.width = .fixed(400)
+            column.cachedWidth = 400
+        }
+        let targetHandle = try #require(handles[9112])
+        let targetNode = try #require(engine.findNode(for: targetHandle))
+        var state = controller.workspaceManager.niriViewportState(for: workspaceId)
+        state.selectedNodeId = engine.findNode(for: try #require(handles[9111]))?.id
+        state.activeColumnIndex = 0
+        state.viewOffsetPixels = .static(0)
+        state.isScrollLocked = true
+        controller.workspaceManager.updateNiriViewportState(state, for: workspaceId)
+        let router = makeIPCCommandRouter(for: controller)
+
+        let result = router.handle(
+            IPCWindowRequest(
+                name: .focus,
+                windowId: IPCWindowOpaqueID.encode(
+                    pid: targetHandle.id.pid,
+                    windowId: targetHandle.id.windowId,
+                    sessionToken: ipcCommandRouterSessionToken
+                )
+            )
+        )
+
+        let updated = controller.workspaceManager.niriViewportState(for: workspaceId)
+        let context = engine.makeViewportSnapContext(
+            columns: engine.columns(in: workspaceId),
+            state: updated,
+            workingFrame: controller.insetWorkingFrame(for: monitor),
+            gaps: controller.gapSize(for: monitor)
+        )
+        let viewStart = context.currentViewStart(in: updated)
+        #expect(result == .executed)
+        #expect(updated.isScrollLocked)
+        #expect(updated.selectedNodeId == targetNode.id)
+        #expect(context.visibility(of: 2, viewportOffset: viewStart, in: updated) == .fullyVisible)
     }
 
     @Test func windowNavigateUsesWindowActionHandlerRoute() throws {

--- a/Tests/NehirTests/ScrollLockFocusCommandRevealTests.swift
+++ b/Tests/NehirTests/ScrollLockFocusCommandRevealTests.swift
@@ -5,15 +5,19 @@
 
 import AppKit
 @testable import Nehir
+import NehirIPC
 import Testing
 
-/// End-to-end reveal behaviour of a directional focus command on a scroll-locked
-/// workspace, exercised through `focusTarget` so the pure-layout bridge's own
-/// `ensureSelectionVisible` call is on the path.
+/// End-to-end reveal behaviour of a focus command on a scroll-locked workspace, covered
+/// at both entry points: the directional hotkey through `focusTarget`, and the IPC
+/// window-focus command.
 ///
 /// The reported repro: with scroll lock on, focusing a window whose column sat entirely
 /// outside the viewport left the viewport pinned, so the window took focus while staying
 /// invisible.
+///
+/// This suite goes through `focusTarget`, so the pure-layout bridge's own
+/// `ensureSelectionVisible` call is on the path.
 @Suite struct ScrollLockFocusCommandRevealTests {
     @Test func focusCommandRevealsParkedColumnWhileLocked() {
         var fixture = makeFixture()
@@ -145,5 +149,125 @@ import Testing
             gap: 8,
             state: state
         )
+    }
+}
+
+/// The same policy reached through the IPC window-focus command rather than a
+/// directional focus hotkey, which is the path a workspace-bar click and `nehirctl`
+/// both take.
+@Suite @MainActor struct ScrollLockIPCWindowFocusRevealTests {
+    /// Window 9113 lands in column 1, which is clipped at this geometry (800pt working
+    /// frame, three 400pt columns at x = 0, 416, 832). Scroll lock leaves a target the
+    /// user can already partly see alone, so focus moves but the viewport does not.
+    @Test func windowFocusLeavesClippedTargetAloneWhileScrollLocked() throws {
+        let monitor = makeLayoutPlanTestMonitor(width: 800, height: 600)
+        let controller = makeLayoutPlanTestController(monitors: [monitor])
+        let workspaceId = try #require(controller.workspaceManager.workspaceId(for: "1", createIfMissing: false))
+        let handles = prepareIPCNiriState(
+            on: controller,
+            assignments: [
+                (workspaceId, 9111),
+                (workspaceId, 9112),
+                (workspaceId, 9113)
+            ],
+            focusedWindowId: 9111
+        )
+        let engine = try #require(controller.niriEngine)
+        engine.revealStyle = .center
+        for column in engine.columns(in: workspaceId) {
+            column.width = .fixed(400)
+            column.cachedWidth = 400
+        }
+        let targetHandle = try #require(handles[9113])
+        let targetNode = try #require(engine.findNode(for: targetHandle))
+        var state = controller.workspaceManager.niriViewportState(for: workspaceId)
+        state.selectedNodeId = engine.findNode(for: try #require(handles[9111]))?.id
+        state.activeColumnIndex = 0
+        state.viewOffsetPixels = .static(0)
+        state.isScrollLocked = true
+        controller.workspaceManager.updateNiriViewportState(state, for: workspaceId)
+        let router = makeIPCCommandRouter(for: controller)
+
+        let result = router.handle(
+            IPCWindowRequest(
+                name: .focus,
+                windowId: IPCWindowOpaqueID.encode(
+                    pid: targetHandle.id.pid,
+                    windowId: targetHandle.id.windowId,
+                    sessionToken: ipcCommandRouterSessionToken
+                )
+            )
+        )
+
+        let updated = controller.workspaceManager.niriViewportState(for: workspaceId)
+        let context = engine.makeViewportSnapContext(
+            columns: engine.columns(in: workspaceId),
+            state: updated,
+            workingFrame: controller.insetWorkingFrame(for: monitor),
+            gaps: controller.gapSize(for: monitor)
+        )
+        let viewStart = context.currentViewStart(in: updated)
+        #expect(result == .executed)
+        #expect(updated.isScrollLocked)
+        #expect(updated.selectedNodeId == targetNode.id)
+        #expect(context.visibility(of: 1, viewportOffset: viewStart, in: updated) == .clipped(.maximum))
+        #expect(viewStart == 0)
+    }
+
+    /// Window 9112 lands in column 2, which is parked past the right edge at this
+    /// geometry. A parked target is revealed even while locked, or the window would take
+    /// focus while staying invisible.
+    @Test func windowFocusRevealsParkedTargetWhileScrollLocked() throws {
+        let monitor = makeLayoutPlanTestMonitor(width: 800, height: 600)
+        let controller = makeLayoutPlanTestController(monitors: [monitor])
+        let workspaceId = try #require(controller.workspaceManager.workspaceId(for: "1", createIfMissing: false))
+        let handles = prepareIPCNiriState(
+            on: controller,
+            assignments: [
+                (workspaceId, 9111),
+                (workspaceId, 9112),
+                (workspaceId, 9113)
+            ],
+            focusedWindowId: 9111
+        )
+        let engine = try #require(controller.niriEngine)
+        engine.revealStyle = .center
+        for column in engine.columns(in: workspaceId) {
+            column.width = .fixed(400)
+            column.cachedWidth = 400
+        }
+        let targetHandle = try #require(handles[9112])
+        let targetNode = try #require(engine.findNode(for: targetHandle))
+        var state = controller.workspaceManager.niriViewportState(for: workspaceId)
+        state.selectedNodeId = engine.findNode(for: try #require(handles[9111]))?.id
+        state.activeColumnIndex = 0
+        state.viewOffsetPixels = .static(0)
+        state.isScrollLocked = true
+        controller.workspaceManager.updateNiriViewportState(state, for: workspaceId)
+        let router = makeIPCCommandRouter(for: controller)
+
+        let result = router.handle(
+            IPCWindowRequest(
+                name: .focus,
+                windowId: IPCWindowOpaqueID.encode(
+                    pid: targetHandle.id.pid,
+                    windowId: targetHandle.id.windowId,
+                    sessionToken: ipcCommandRouterSessionToken
+                )
+            )
+        )
+
+        let updated = controller.workspaceManager.niriViewportState(for: workspaceId)
+        let context = engine.makeViewportSnapContext(
+            columns: engine.columns(in: workspaceId),
+            state: updated,
+            workingFrame: controller.insetWorkingFrame(for: monitor),
+            gaps: controller.gapSize(for: monitor)
+        )
+        let viewStart = context.currentViewStart(in: updated)
+        #expect(result == .executed)
+        #expect(updated.isScrollLocked)
+        #expect(updated.selectedNodeId == targetNode.id)
+        #expect(context.visibility(of: 2, viewportOffset: viewStart, in: updated) == .fullyVisible)
     }
 }

--- a/Tests/NehirTests/ScrollLockFocusCommandRevealTests.swift
+++ b/Tests/NehirTests/ScrollLockFocusCommandRevealTests.swift
@@ -1,0 +1,149 @@
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=nehir-original; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
+import AppKit
+@testable import Nehir
+import Testing
+
+/// End-to-end reveal behaviour of a directional focus command on a scroll-locked
+/// workspace, exercised through `focusTarget` so the pure-layout bridge's own
+/// `ensureSelectionVisible` call is on the path.
+///
+/// The reported repro: with scroll lock on, focusing a window whose column sat entirely
+/// outside the viewport left the viewport pinned, so the window took focus while staying
+/// invisible.
+@Suite struct ScrollLockFocusCommandRevealTests {
+    @Test func focusCommandRevealsParkedColumnWhileLocked() {
+        var fixture = makeFixture()
+        fixture.state.isScrollLocked = true
+
+        // Step onto the clipped middle column first, then onto the parked one.
+        fixture.focusRight()
+        fixture.focusRight()
+
+        #expect(fixture.selectedColumnIndex == 2)
+        #expect(fixture.visibility(of: 2) == .fullyVisible)
+    }
+
+    @Test func focusCommandLeavesClippedColumnAloneWhileLocked() {
+        var fixture = makeFixture()
+        fixture.state.isScrollLocked = true
+        let originalViewStart = fixture.viewStart
+
+        fixture.focusRight()
+
+        #expect(fixture.selectedColumnIndex == 1)
+        #expect(fixture.visibility(of: 1) == .clipped(.maximum))
+        #expect(fixture.viewStart == originalViewStart)
+    }
+
+    @Test func focusCommandRevealsClippedColumnWhenUnlocked() {
+        var fixture = makeFixture()
+
+        fixture.focusRight()
+
+        #expect(fixture.selectedColumnIndex == 1)
+        #expect(fixture.visibility(of: 1) == .fullyVisible)
+    }
+
+    // MARK: - Fixture
+
+    /// Three 400pt columns at x = 0, 408, 816 behind a 600pt working frame resting at 0:
+    /// column 0 fully visible, column 1 clipped, column 2 parked past the right edge.
+    private struct Fixture {
+        let engine: NiriLayoutEngine
+        let workspaceId: WorkspaceDescriptor.ID
+        let workingFrame: CGRect
+        let gap: CGFloat
+        var state: ViewportState
+
+        private var context: ViewportSnapContext {
+            state.snapContext(
+                columns: engine.columns(in: workspaceId),
+                gap: gap,
+                viewportWidth: workingFrame.width
+            )
+        }
+
+        var viewStart: CGFloat {
+            context.currentViewStart(in: state)
+        }
+
+        var selectedColumnIndex: Int? {
+            guard let selectedNodeId = state.selectedNodeId,
+                  let node = engine.findNode(by: selectedNodeId),
+                  let column = engine.column(of: node)
+            else {
+                return nil
+            }
+            return engine.columnIndex(of: column, in: workspaceId)
+        }
+
+        func visibility(of columnIndex: Int) -> ColumnVisibility {
+            let context = context
+            return context.visibility(
+                of: columnIndex,
+                viewportOffset: context.currentViewStart(in: state),
+                in: state
+            )
+        }
+
+        mutating func focusRight() {
+            guard let selectedNodeId = state.selectedNodeId,
+                  let selected = engine.findNode(by: selectedNodeId)
+            else {
+                Issue.record("Fixture lost its selection")
+                return
+            }
+            let target = engine.focusTarget(
+                direction: .right,
+                currentSelection: selected,
+                in: workspaceId,
+                motion: .disabled,
+                state: &state,
+                workingFrame: workingFrame,
+                gaps: gap
+            )
+            if let target {
+                state.selectedNodeId = target.id
+            }
+        }
+    }
+
+    private func makeFixture() -> Fixture {
+        let engine = NiriLayoutEngine()
+        engine.revealStyle = .auto
+        engine.animationClock = AnimationClock()
+        let workspaceId = UUID()
+        let root = engine.ensureRoot(for: workspaceId)
+
+        for windowId in 1 ... 3 {
+            let column = NiriContainer()
+            column.width = .fixed(400)
+            column.cachedWidth = 400
+            root.appendChild(column)
+
+            let token = WindowToken(pid: 704, windowId: windowId)
+            let window = NiriWindow(token: token)
+            column.appendChild(window)
+            engine.tokenToNode[token] = window
+            column.setActiveTileIdx(0)
+        }
+
+        var state = ViewportState()
+        state.animationClock = engine.animationClock
+        state.activeColumnIndex = 0
+        state.viewOffsetPixels = .static(0)
+        state.selectedNodeId = engine.columns(in: workspaceId).first?.windowNodes.first?.id
+
+        return Fixture(
+            engine: engine,
+            workspaceId: workspaceId,
+            workingFrame: CGRect(x: 0, y: 0, width: 600, height: 800),
+            gap: 8,
+            state: state
+        )
+    }
+}

--- a/Tests/NehirTests/ScrollLockRevealPolicyTests.swift
+++ b/Tests/NehirTests/ScrollLockRevealPolicyTests.swift
@@ -1,0 +1,182 @@
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=nehir-original; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
+import AppKit
+@testable import Nehir
+import Testing
+
+/// Viewport scroll lock answers to target visibility, not to who asked for the reveal.
+///
+/// A target outside the viewport is revealed for every trigger, because focus landing
+/// somewhere invisible means input disappears into a window the user cannot see. A
+/// partially visible target is left alone for every trigger, however little of it shows.
+@Suite struct ScrollLockRevealPolicyTests {
+    // MARK: - Parked targets are revealed while locked
+
+    @Test func revealsParkedTargetWhileLockedForAutomaticTrigger() {
+        var fixture = makeFixture()
+        fixture.state.isScrollLocked = true
+        #expect(fixture.visibility(of: parkedColumn) == .parked(.maximum))
+
+        let revealed = fixture.reveal(parkedColumn, trigger: .automatic)
+
+        #expect(revealed)
+        #expect(fixture.visibility(of: parkedColumn) == .fullyVisible)
+    }
+
+    @Test func revealsParkedTargetWhileLockedForExplicitNavigation() {
+        var fixture = makeFixture()
+        fixture.state.isScrollLocked = true
+        #expect(fixture.visibility(of: parkedColumn) == .parked(.maximum))
+
+        let revealed = fixture.reveal(parkedColumn, trigger: .explicitNavigation)
+
+        #expect(revealed)
+        #expect(fixture.visibility(of: parkedColumn) == .fullyVisible)
+    }
+
+    // MARK: - Partially visible targets are left alone while locked
+
+    @Test func leavesClippedTargetAloneWhileLockedForAutomaticTrigger() {
+        var fixture = makeFixture()
+        fixture.state.isScrollLocked = true
+        let originalTarget = fixture.state.viewOffsetPixels.target()
+        #expect(fixture.visibility(of: clippedColumn) == .clipped(.maximum))
+
+        let revealed = fixture.reveal(clippedColumn, trigger: .automatic)
+
+        #expect(!revealed)
+        #expect(fixture.state.viewOffsetPixels.target() == originalTarget)
+    }
+
+    /// The case the reveal policy changed: an explicit focus command no longer drags a
+    /// column the user can already see over to a snap just because it is clipped.
+    @Test func leavesClippedTargetAloneWhileLockedForExplicitNavigation() {
+        var fixture = makeFixture()
+        fixture.state.isScrollLocked = true
+        let originalTarget = fixture.state.viewOffsetPixels.target()
+        #expect(fixture.visibility(of: clippedColumn) == .clipped(.maximum))
+
+        let revealed = fixture.reveal(clippedColumn, trigger: .explicitNavigation)
+
+        #expect(!revealed)
+        #expect(fixture.state.viewOffsetPixels.target() == originalTarget)
+    }
+
+    @Test func leavesFullyVisibleTargetAloneWhileLockedForExplicitNavigation() {
+        var fixture = makeFixture()
+        fixture.state.isScrollLocked = true
+        let originalTarget = fixture.state.viewOffsetPixels.target()
+        #expect(fixture.visibility(of: fullyVisibleColumn) == .fullyVisible)
+
+        let revealed = fixture.reveal(fullyVisibleColumn, trigger: .explicitNavigation)
+
+        #expect(!revealed)
+        #expect(fixture.state.viewOffsetPixels.target() == originalTarget)
+    }
+
+    // MARK: - Unlocked behaviour is untouched
+
+    @Test func revealsClippedTargetWhenUnlocked() {
+        var fixture = makeFixture()
+        #expect(fixture.visibility(of: clippedColumn) == .clipped(.maximum))
+
+        let revealed = fixture.reveal(clippedColumn, trigger: .automatic)
+
+        #expect(revealed)
+        #expect(fixture.visibility(of: clippedColumn) == .fullyVisible)
+    }
+
+    @Test func neverRevealsForFocusFollowsMouseEvenWhenParkedAndUnlocked() {
+        var fixture = makeFixture()
+        let originalTarget = fixture.state.viewOffsetPixels.target()
+        #expect(fixture.visibility(of: parkedColumn) == .parked(.maximum))
+
+        let revealed = fixture.reveal(parkedColumn, isFFM: true, trigger: .automatic)
+
+        #expect(!revealed)
+        #expect(fixture.state.viewOffsetPixels.target() == originalTarget)
+    }
+
+    // MARK: - Fixture
+
+    /// Three 400pt columns with an 8pt gap laid out at x = 0, 408, 816, seen through a
+    /// 600pt viewport resting at 0. That makes column 0 fully visible, column 1 clipped
+    /// with 192pt of 400 showing, and column 2 parked past the right edge.
+    private let fullyVisibleColumn = 0
+    private let clippedColumn = 1
+    private let parkedColumn = 2
+
+    private struct Fixture {
+        let engine: NiriLayoutEngine
+        let columns: [NiriContainer]
+        let gap: CGFloat
+        let viewportWidth: CGFloat
+        var state: ViewportState
+
+        var context: ViewportSnapContext {
+            state.snapContext(columns: columns, gap: gap, viewportWidth: viewportWidth)
+        }
+
+        func visibility(of columnIndex: Int) -> ColumnVisibility {
+            let context = context
+            return context.visibility(
+                of: columnIndex,
+                viewportOffset: context.currentViewStart(in: state),
+                in: state
+            )
+        }
+
+        mutating func reveal(
+            _ columnIndex: Int,
+            isFFM: Bool = false,
+            trigger: RevealTrigger
+        ) -> Bool {
+            engine.scrollToReveal(
+                columnIndex: columnIndex,
+                isFFM: isFFM,
+                state: &state,
+                context: context,
+                motion: .disabled,
+                trigger: trigger
+            )
+        }
+    }
+
+    private func makeFixture() -> Fixture {
+        let engine = NiriLayoutEngine()
+        engine.revealStyle = .auto
+        engine.animationClock = AnimationClock()
+        let workspaceId = UUID()
+
+        var previous: NiriNode?
+        for pid in pid_t(701) ... pid_t(703) {
+            previous = engine.addWindow(
+                handle: makeTestHandle(pid: pid),
+                to: workspaceId,
+                afterSelection: previous?.id
+            )
+        }
+
+        let columns = engine.columns(in: workspaceId)
+        for column in columns {
+            column.width = .fixed(400)
+            column.cachedWidth = 400
+        }
+
+        var state = ViewportState()
+        state.animationClock = engine.animationClock
+        state.activeColumnIndex = 0
+        state.viewOffsetPixels = .static(0)
+
+        return Fixture(
+            engine: engine,
+            columns: columns,
+            gap: 8,
+            viewportWidth: 600,
+            state: state
+        )
+    }
+}

--- a/Tests/NehirTests/ViewportSnapContextTests.swift
+++ b/Tests/NehirTests/ViewportSnapContextTests.swift
@@ -549,24 +549,8 @@ private func makeContext(
             isFFM: true,
             state: &fixture.state,
             context: fixture.context,
-            motion: .disabled
-        )
-
-        #expect(!revealed)
-        #expect(fixture.state.viewOffsetPixels.target() == originalTarget)
-    }
-
-    @Test func scrollToRevealSkipsWhenLocked() {
-        var fixture = makeRevealFixture(viewportWidth: 800)
-        fixture.state.isScrollLocked = true
-        let originalTarget = fixture.state.viewOffsetPixels.target()
-
-        let revealed = fixture.engine.scrollToReveal(
-            columnIndex: 2,
-            isFFM: false,
-            state: &fixture.state,
-            context: fixture.context,
-            motion: .disabled
+            motion: .disabled,
+            trigger: .automatic
         )
 
         #expect(!revealed)
@@ -582,7 +566,8 @@ private func makeContext(
             isFFM: false,
             state: &fixture.state,
             context: fixture.context,
-            motion: .disabled
+            motion: .disabled,
+            trigger: .automatic
         )
 
         #expect(!revealed)
@@ -657,7 +642,8 @@ private func makeContext(
             isFFM: false,
             state: &fixture.state,
             context: fixture.context,
-            motion: .disabled
+            motion: .disabled,
+            trigger: .automatic
         )
 
         #expect(revealed)
@@ -673,7 +659,8 @@ private func makeContext(
             isFFM: false,
             state: &fixture.state,
             context: fixture.context,
-            motion: .disabled
+            motion: .disabled,
+            trigger: .automatic
         )
 
         #expect(revealed)
@@ -689,7 +676,8 @@ private func makeContext(
             isFFM: false,
             state: &fixture.state,
             context: fixture.context,
-            motion: .disabled
+            motion: .disabled,
+            trigger: .automatic
         )
 
         #expect(revealed)
@@ -706,7 +694,8 @@ private func makeContext(
                 isFFM: false,
                 state: &fixture.state,
                 context: fixture.context,
-                motion: .disabled
+                motion: .disabled,
+                trigger: .automatic
             )
 
             #expect(revealed)


### PR DESCRIPTION
## Summary

Focusing a window whose column was entirely outside the viewport left the viewport pinned whenever the workspace was scroll-locked, so the window took focus while staying invisible and input disappeared into it. Reproduced with a hotkey focus command and with an app's own Window menu: a column parked at x=4068 under a viewport starting at 1011 reported
visibility=parked(maximum) with usable snap candidates, and still returned didReveal=false.

Scroll lock now answers to visibility instead of provenance. A parked target is revealed for every trigger, because whatever moved the focus there, the result is a viewport that does not contain the focused window. A clipped or fully visible target is left alone for every trigger, however little of it shows, since dragging a column the user can already see over to a snap is the churn the lock exists to stop.

Two suppressions are gone as a result: the per-branch `trigger.respectsScrollLock` guards in scrollToReveal, and the property itself, which no longer decided anything. RevealTrigger now governs only whether an already fully visible column may be re-centred, which is a placement preference rather than a reveal.

Also passes revealTrigger explicitly from pureLayoutFocusTarget, which was silently defaulting to .automatic, and documents the resulting contract next to scrollToReveal and RevealTrigger.
## Release notes

Choose one:

- [x] Added a `.changeset/*.md` for user-visible changes (`mise run changeset -- patch "..."`).
- [ ] No user-visible change; apply the `no release note` label to make CI skip intentional.

## Validation

<!-- Commands run, screenshots, or manual checks. -->

- [ ] Ran relevant tests/checks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved focus-reveal behavior under “Viewport Scroll Lock”: fully outside (parked) focused content is now revealed even when locked, while partially visible (clipped) content remains in place.
  * Refined how explicit navigation vs automatic navigation affect whether a fully visible column may be re-centered.
* **Documentation**
  * Expanded and clarified the reveal/scroll rules for visibility states and scroll-lock behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->