### PR TITLE
Keep the active workspace on the bar when hiding empty ones

### DIFF
--- a/.changeset/20260728033929-hide-empty-workspaces-no-longer-removes-the-work.md
+++ b/.changeset/20260728033929-hide-empty-workspaces-no-longer-removes-the-work.md
@@ -1,0 +1,6 @@
+---
+"nehir": patch
+contributors: [holmns]
+---
+
+Hide Empty Workspaces no longer removes the workspace you are on. Moving to a workspace with no windows kept the bar's focus highlight off every pill and reflowed the bar; the active workspace now stays on the bar as a bare label and stays highlighted. Each other display's active workspace is kept the same way, so a secondary display parked on an empty workspace still shows its pill.

--- a/.provenance.json
+++ b/.provenance.json
@@ -196,6 +196,12 @@
         "repo": "https://github.com/BarutSRB/OmniWM",
         "hash": "ee554c7"
       }
+    ],
+    "Sources/Nehir/UI/WorkspaceBar/WorkspaceBarDataSource.swift": [
+      {
+        "repo": "https://github.com/BarutSRB/OmniWM",
+        "hash": "ac0a0287"
+      }
     ]
   }
 }

--- a/Sources/Nehir/UI/WorkspaceBar/WorkspaceBarDataSource.swift
+++ b/Sources/Nehir/UI/WorkspaceBar/WorkspaceBarDataSource.swift
@@ -148,11 +148,14 @@ enum WorkspaceBarDataSource {
             )
         }
 
-        if options.hideEmptyWorkspaces {
-            workspaces = workspaces.filter(\.hasBarOccupancy)
-        }
-
         let activeWorkspaceId = workspaceManager.activeWorkspace(on: monitor.id)?.id
+
+        if options.hideEmptyWorkspaces {
+            // The active workspace stays on the bar even when empty: it is the only
+            // item that reports focus, so hiding it leaves the bar with no "you are
+            // here" indicator and reflows the remaining pills.
+            workspaces = workspaces.filter { $0.hasBarOccupancy || $0.workspace.id == activeWorkspaceId }
+        }
 
         return workspaces.map { snapshot in
             let orderedTiledEntries = WorkspaceEntryOrdering.orderedEntries(
@@ -199,7 +202,10 @@ enum WorkspaceBarDataSource {
     /// (matching `moveTargetItems`), so disconnected workspaces never appear.
     /// Foreign pills carry no window icons (a navigation aid, not a duplicate of
     /// the home bar); `hideEmptyWorkspaces` is still respected based on real
-    /// workspace occupancy.
+    /// workspace occupancy, except for each other display's own active
+    /// workspace, which is kept even when empty so every display keeps the
+    /// pill marking where it is parked — the same carve-out the local bar
+    /// makes for the focused workspace.
     private static func foreignWorkspaceItems(
         for monitor: Monitor,
         options: WorkspaceBarProjectionOptions,
@@ -218,7 +224,7 @@ enum WorkspaceBarDataSource {
                     in: workspace.id,
                     showFloatingWindows: options.showFloatingWindows
                 ).filter { !workspaceManager.isStickyWindow($0.token) }
-                if options.hideEmptyWorkspaces, projectedEntries.isEmpty { continue }
+                if options.hideEmptyWorkspaces, projectedEntries.isEmpty, workspace.id != activeOnOther { continue }
                 items.append(
                     WorkspaceBarItem(
                         id: workspace.id,

--- a/Tests/NehirTests/WorkspaceBarDataSourceTests.swift
+++ b/Tests/NehirTests/WorkspaceBarDataSourceTests.swift
@@ -386,29 +386,87 @@ private func makeWorkspaceBarTestMetadata(
     }
 
     @Test @MainActor func foreignEmptyWorkspacesRespectHideEmptyWorkspaces() throws {
-        let fixture = makeTwoMonitorLayoutPlanTestController()
-        let controller = fixture.controller
-        let primaryMonitor = fixture.primaryMonitor
-        let secondaryWorkspaceId = fixture.secondaryWorkspaceId
-        // The secondary display's workspace has no windows.
+        let fixture = try makeForeignHideEmptyFixture()
 
-        let projection = WorkspaceBarDataSource.workspaceBarProjection(
-            for: primaryMonitor,
-            options: WorkspaceBarProjectionOptions(
-                deduplicateAppIcons: false,
-                hideEmptyWorkspaces: true,
-                showFloatingWindows: false,
-                showWorkspacesFromOtherDisplays: true
-            ),
-            workspaceManager: controller.workspaceManager,
-            appInfoCache: controller.appInfoCache,
-            niriEngine: nil,
-            focusedToken: controller.workspaceManager.confirmedManagedFocusToken,
-            settings: controller.settings
-        )
+        let projection = foreignHideEmptyProjection(fixture)
 
-        // An empty foreign workspace is hidden, consistent with local items.
-        #expect(projection.items.contains(where: { $0.id == secondaryWorkspaceId }) == false)
-        #expect(projection.items.contains(where: \.isForeign) == false)
+        // The secondary's idle workspace is empty and is not where that display
+        // is parked, so the empty policy hides it as it does for local items.
+        #expect(projection.items.contains(where: { $0.id == fixture.idleSecondaryWorkspaceId }) == false)
     }
+
+    @Test @MainActor func foreignActiveWorkspaceSurvivesHideEmptyWorkspaces() throws {
+        let fixture = try makeForeignHideEmptyFixture()
+
+        let projection = foreignHideEmptyProjection(fixture)
+
+        // The workspace the secondary display is parked on stays as a bare pill
+        // even while empty, so every display keeps its "parked here" marker.
+        let foreign = try #require(
+            projection.items.first(where: { $0.id == fixture.activeSecondaryWorkspaceId })
+        )
+        #expect(foreign.isForeign)
+        #expect(foreign.isActiveOnHomeDisplay)
+        #expect(foreign.isFocused == false)
+        #expect(foreign.windows.isEmpty)
+    }
+}
+
+@MainActor
+private struct ForeignHideEmptyFixture {
+    let controller: WMController
+    let primaryMonitor: Monitor
+    let activeSecondaryWorkspaceId: WorkspaceDescriptor.ID
+    let idleSecondaryWorkspaceId: WorkspaceDescriptor.ID
+}
+
+/// Two displays where the secondary owns two workspaces, both empty: one it is
+/// parked on and one it is not. That is the only topology that separates the
+/// empty policy from the active carve-out on the foreign path.
+@MainActor
+private func makeForeignHideEmptyFixture() throws -> ForeignHideEmptyFixture {
+    let primaryMonitor = makeLayoutPlanPrimaryTestMonitor(name: "Primary")
+    let secondaryMonitor = makeLayoutPlanSecondaryTestMonitor(name: "Secondary", x: 1920)
+    let controller = makeLayoutPlanTestController(
+        monitors: [primaryMonitor, secondaryMonitor],
+        workspaceConfigurations: [
+            WorkspaceConfiguration(name: "1", monitorAssignment: .main),
+            WorkspaceConfiguration(name: "2", monitorAssignment: .secondary),
+            WorkspaceConfiguration(name: "3", monitorAssignment: .secondary)
+        ]
+    )
+
+    let workspaceManager = controller.workspaceManager
+    let primaryWorkspaceId = try #require(workspaceManager.workspaceId(for: "1", createIfMissing: false))
+    let activeSecondaryWorkspaceId = try #require(workspaceManager.workspaceId(for: "2", createIfMissing: false))
+    let idleSecondaryWorkspaceId = try #require(workspaceManager.workspaceId(for: "3", createIfMissing: false))
+
+    #expect(workspaceManager.setActiveWorkspace(primaryWorkspaceId, on: primaryMonitor.id))
+    #expect(workspaceManager.setActiveWorkspace(activeSecondaryWorkspaceId, on: secondaryMonitor.id))
+    _ = workspaceManager.setInteractionMonitor(primaryMonitor.id)
+
+    return ForeignHideEmptyFixture(
+        controller: controller,
+        primaryMonitor: primaryMonitor,
+        activeSecondaryWorkspaceId: activeSecondaryWorkspaceId,
+        idleSecondaryWorkspaceId: idleSecondaryWorkspaceId
+    )
+}
+
+@MainActor
+private func foreignHideEmptyProjection(_ fixture: ForeignHideEmptyFixture) -> WorkspaceBarProjection {
+    WorkspaceBarDataSource.workspaceBarProjection(
+        for: fixture.primaryMonitor,
+        options: WorkspaceBarProjectionOptions(
+            deduplicateAppIcons: false,
+            hideEmptyWorkspaces: true,
+            showFloatingWindows: false,
+            showWorkspacesFromOtherDisplays: true
+        ),
+        workspaceManager: fixture.controller.workspaceManager,
+        appInfoCache: fixture.controller.appInfoCache,
+        niriEngine: nil,
+        focusedToken: fixture.controller.workspaceManager.confirmedManagedFocusToken,
+        settings: fixture.controller.settings
+    )
 }


### PR DESCRIPTION
## Summary

Hide Empty Workspaces filtered the workspace list before the active workspace was resolved, so navigating to a workspace with no bar occupancy left the projection with no item reporting focus: the bar lost its "you are here" pill and reflowed around whichever workspaces still held windows.

Resolve the active workspace id first and filter on occupancy or being active, so the empty policy only hides workspaces you are not standing on.

Apply the same carve-out to the foreign-display pills, keyed on each other display's own active workspace, so a secondary display parked on an empty workspace still shows the pill marking where it is. Retarget the existing foreign empty-policy test at a workspace that display is not parked on, so it still covers exclusion, and cover the carve-out itself.

Credit @holmns for the upstream fix this is adapted from.
## Release notes

Choose one:

- [x] Added a `.changeset/*.md` for user-visible changes (`mise run changeset -- patch "..."`).
- [ ] No user-visible change; apply the `no release note` label to make CI skip intentional.

## Validation

<!-- Commands run, screenshots, or manual checks. -->

- [ ] Ran relevant tests/checks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - “Hide Empty Workspaces” now keeps the currently active workspace visible, even when it contains no windows.
  - Active empty workspaces remain highlighted on the workspace bar.
  - Active empty workspaces on secondary displays continue to appear correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->