### PR TITLE
Send a finite window location in the SkyLight key-window event

### DIFF
--- a/.changeset/20260728144300-send-a-valid-finite-window-location-in-the-synth.md
+++ b/.changeset/20260728144300-send-a-valid-finite-window-location-in-the-synth.md
@@ -1,0 +1,6 @@
+---
+"nehir": none
+
+---
+
+Send a valid finite window location in the synthesised SkyLight key-window event instead of NaN coordinates (internal hardening; no behaviour change observed)

--- a/.provenance.json
+++ b/.provenance.json
@@ -169,6 +169,12 @@
         "hash": "06eb42d"
       }
     ],
+    "Sources/Nehir/Core/PrivateAPIs.swift": [
+      {
+        "repo": "https://github.com/BarutSRB/OmniWM",
+        "hash": "a4b8611a"
+      }
+    ],
     "Sources/Nehir/Core/SkyLight/DisplaySpacesMode.swift": [
       {
         "repo": "https://github.com/BarutSRB/OmniWM",

--- a/.provenance.json
+++ b/.provenance.json
@@ -208,6 +208,12 @@
         "repo": "https://github.com/BarutSRB/OmniWM",
         "hash": "ac0a0287"
       }
+    ],
+    "Tests/NehirTests/SkyLightKeyWindowEventRecordTests.swift": [
+      {
+        "repo": "https://github.com/BarutSRB/OmniWM",
+        "hash": "a4b8611a"
+      }
     ]
   }
 }

--- a/Sources/Nehir/Core/PrivateAPIs.swift
+++ b/Sources/Nehir/Core/PrivateAPIs.swift
@@ -5,6 +5,7 @@
 // SPDX-License-Identifier: GPL-2.0-only
 
 import ApplicationServices
+import CoreGraphics
 import Foundation
 
 typealias SLPSMode = UInt32
@@ -35,25 +36,52 @@ func getWindowId(from windowRef: AXUIElement) -> CGWindowID? {
     return result == .success ? windowId : nil
 }
 
+enum KeyWindowEventRecord {
+    enum EventType: UInt8 {
+        case mouseDown = 0x01
+        case mouseUp = 0x02
+    }
+
+    private static let bufferSize = 0x100
+    private static let declaredLength: UInt8 = 0xF8
+    private static let declaredLengthOffset = 0x04
+    private static let eventTypeOffset = 0x08
+    private static let windowLocationOffset = 0x20
+    private static let keyWindowFlagOffset = 0x3A
+    private static let keyWindowFlag: UInt8 = 0x10
+    private static let windowIdOffset = 0x3C
+    /// A finite point outside any window's content. All-`0xFF` here decodes as
+    /// NaN, which some apps (Chrome PWAs) mishandle badly enough to close the
+    /// window they were asked to focus.
+    private static let offContentLocation = CGPoint(x: -1, y: -1)
+
+    static func make(windowId: UInt32) -> [UInt8] {
+        var bytes = [UInt8](repeating: 0, count: bufferSize)
+        bytes[declaredLengthOffset] = declaredLength
+        bytes[keyWindowFlagOffset] = keyWindowFlag
+        setEventType(.mouseDown, in: &bytes)
+        encode(offContentLocation, in: &bytes, at: windowLocationOffset)
+        encode(windowId, in: &bytes, at: windowIdOffset)
+        return bytes
+    }
+
+    static func setEventType(_ eventType: EventType, in bytes: inout [UInt8]) {
+        bytes[eventTypeOffset] = eventType.rawValue
+    }
+
+    private static func encode(_ value: some Any, in bytes: inout [UInt8], at offset: Int) {
+        withUnsafeBytes(of: value) { encodedValue in
+            for index in encodedValue.indices {
+                bytes[offset + index] = encodedValue[index]
+            }
+        }
+    }
+}
+
 func makeKeyWindow(psn: inout ProcessSerialNumber, windowId: UInt32) {
-    var eventBytes = [UInt8](repeating: 0, count: 0xF8)
-    eventBytes[0x04] = 0xF8
-    eventBytes[0x08] = 0x01
-    eventBytes[0x3A] = 0x10
-
-    withUnsafeBytes(of: windowId) { ptr in
-        eventBytes[0x3C] = ptr[0]
-        eventBytes[0x3D] = ptr[1]
-        eventBytes[0x3E] = ptr[2]
-        eventBytes[0x3F] = ptr[3]
-    }
-
-    for i in 0x20 ..< 0x30 {
-        eventBytes[i] = 0xFF
-    }
-
+    var eventBytes = KeyWindowEventRecord.make(windowId: windowId)
     _ = SLPSPostEventRecordTo(&psn, &eventBytes)
-    eventBytes[0x08] = 0x02
+    KeyWindowEventRecord.setEventType(.mouseUp, in: &eventBytes)
     _ = SLPSPostEventRecordTo(&psn, &eventBytes)
 }
 

--- a/Sources/Nehir/Core/PrivateAPIs.swift
+++ b/Sources/Nehir/Core/PrivateAPIs.swift
@@ -51,8 +51,8 @@ enum KeyWindowEventRecord {
     private static let keyWindowFlag: UInt8 = 0x10
     private static let windowIdOffset = 0x3C
     /// A finite point outside any window's content. All-`0xFF` here decodes as
-    /// NaN, which some apps (Chrome PWAs) mishandle badly enough to close the
-    /// window they were asked to focus.
+    /// NaN in both coordinates; a synthesised mouse-derived event should carry
+    /// a valid position instead.
     private static let offContentLocation = CGPoint(x: -1, y: -1)
 
     static func make(windowId: UInt32) -> [UInt8] {

--- a/Tests/NehirTests/SkyLightKeyWindowEventRecordTests.swift
+++ b/Tests/NehirTests/SkyLightKeyWindowEventRecordTests.swift
@@ -1,0 +1,127 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
+import CoreGraphics
+import Foundation
+@testable import Nehir
+import Testing
+
+/// Byte-layout coverage for the synthesised SkyLight key-window event record.
+///
+/// The record is handed to an undocumented SkyLight entry point, so its layout
+/// is a wire format with no compiler-checked contract: a wrong offset or width
+/// fails silently at runtime rather than at build time. These tests pin the
+/// offsets as literals on purpose — reusing the production constants would
+/// assert only that the file agrees with itself.
+///
+/// The window-location field is the reason this file exists. It once carried
+/// `0xFF` in all sixteen bytes, which decodes as NaN in both coordinates; a
+/// synthesised mouse-derived event must carry a valid position instead.
+struct SkyLightKeyWindowEventRecordTests {
+    /// Byte offsets, restated independently of `KeyWindowEventRecord`.
+    private enum Offset {
+        static let declaredLength = 0x04
+        static let eventType = 0x08
+        static let windowLocation = 0x20
+        static let keyWindowFlag = 0x3A
+        static let windowId = 0x3C
+    }
+
+    private static let bufferSize = 0x100
+    private static let declaredLength = 0xF8
+
+    @Test
+    func recordDeclaresItsProtocolFields() {
+        let bytes = KeyWindowEventRecord.make(windowId: 1)
+
+        #expect(bytes.count == Self.bufferSize)
+        #expect(bytes[Offset.declaredLength] == UInt8(Self.declaredLength))
+        #expect(bytes[Offset.keyWindowFlag] == 0x10)
+    }
+
+    @Test
+    func recordStartsAsAMouseDownEvent() {
+        let bytes = KeyWindowEventRecord.make(windowId: 1)
+
+        #expect(bytes[Offset.eventType] == 0x01)
+    }
+
+    @Test
+    func settingTheEventTypeRewritesOnlyThatByte() {
+        var bytes = KeyWindowEventRecord.make(windowId: 0xA1B2_C3D4)
+        let beforeMutation = bytes
+
+        KeyWindowEventRecord.setEventType(.mouseUp, in: &bytes)
+
+        #expect(bytes[Offset.eventType] == 0x02)
+        let untouched = bytes.indices.filter { $0 != Offset.eventType }
+        #expect(untouched.allSatisfy { bytes[$0] == beforeMutation[$0] })
+
+        KeyWindowEventRecord.setEventType(.mouseDown, in: &bytes)
+        #expect(bytes == beforeMutation)
+    }
+
+    @Test
+    func recordCarriesTheWindowIdVerbatim() {
+        let windowId: UInt32 = 0xA1B2_C3D4
+        let bytes = KeyWindowEventRecord.make(windowId: windowId)
+
+        var decoded: UInt32 = 0
+        withUnsafeMutableBytes(of: &decoded) { destination in
+            destination.copyBytes(
+                from: bytes[Offset.windowId ..< Offset.windowId + MemoryLayout<UInt32>.size]
+            )
+        }
+
+        #expect(decoded == windowId)
+    }
+
+    /// The regression this file is named for: the location must decode as a
+    /// finite point, never NaN.
+    @Test
+    func windowLocationIsAFiniteOffContentPoint() {
+        let bytes = KeyWindowEventRecord.make(windowId: 1)
+
+        var decoded = CGPoint.zero
+        withUnsafeMutableBytes(of: &decoded) { destination in
+            destination.copyBytes(
+                from: bytes[Offset.windowLocation ..< Offset.windowLocation + MemoryLayout<CGPoint>.size]
+            )
+        }
+
+        #expect(!decoded.x.isNaN)
+        #expect(!decoded.y.isNaN)
+        #expect(decoded.x.isFinite)
+        #expect(decoded.y.isFinite)
+        #expect(decoded == CGPoint(x: -1, y: -1))
+    }
+
+    /// The buffer is padded past the declared payload; the padding must stay
+    /// zero so the extra bytes carry no accidental meaning.
+    @Test
+    func bytesPastTheDeclaredLengthAreZero() {
+        let bytes = KeyWindowEventRecord.make(windowId: 0xFFFF_FFFF)
+
+        #expect(bytes[Self.declaredLength...].allSatisfy { $0 == 0 })
+    }
+
+    /// Every byte outside the four fields the record actually sets must be
+    /// zero — a stray write elsewhere in the payload would be invisible
+    /// otherwise.
+    @Test
+    func noOtherPayloadByteIsSet() {
+        let bytes = KeyWindowEventRecord.make(windowId: 0xA1B2_C3D4)
+
+        let written = Set(
+            [Offset.declaredLength, Offset.eventType, Offset.keyWindowFlag]
+                + Array(Offset.windowLocation ..< Offset.windowLocation + MemoryLayout<CGPoint>.size)
+                + Array(Offset.windowId ..< Offset.windowId + MemoryLayout<UInt32>.size)
+        )
+
+        let strays = bytes.indices.filter { !written.contains($0) && bytes[$0] != 0 }
+        #expect(strays.isEmpty, "unexpected non-zero bytes at offsets \(strays.map { String($0, radix: 16) })")
+    }
+}


### PR DESCRIPTION
## Summary

`makeKeyWindow` synthesises the SkyLight key-window event record that Nehir posts to make a specific window key. Its window-location field — bytes `0x20..<0x30`, read back as a `CGPoint`, i.e. two native-endian `Double`s — was filled with `0xFF` in every byte, which decodes as **NaN** in both coordinates.

This writes a finite off-content point `(-1, -1)` there instead, pads the record buffer to `0x100` bytes while still declaring the `0xF8` payload length, and gives the previously magic offsets names (`windowLocationOffset`, `keyWindowFlagOffset`, `windowIdOffset`, …). Behaviour is otherwise unchanged: same `makeKeyWindow`/`focusWindow` signatures, same two posts (`.mouseDown` then `.mouseUp`).

The source change is in `Sources/Nehir/Core/PrivateAPIs.swift`; byte-layout coverage lives in a new per-behaviour test file, with `.provenance.json` audit entries for both adaptations and a level-`none` changeset.

## Why this is hardening, not a bug fix

A synthesised mouse-derived event should carry a valid position. Sending NaN is wrong on its own terms, and that is the whole justification here.

It is adapted from an upstream change (recorded in `.provenance.json`) motivated by a report of Chromium web-app windows closing on focus. **That symptom does not reproduce.** Checked on macOS 26.5.2 (25F84) — the same build named in the upstream report — with three Chromium web apps open across two browsers (one Chrome PWA, two Helium PWAs):

- **This tree without the change, focus switching.** Hotkey focus (`focus_direction_dispatch direction=right`) onto the Chrome web app, `managed_focus_requested` → `managed_focus_confirmed`, focus away and back repeatedly. No destroy events; the window ends the capture `phase=tiled hidden=nil observedVisible=true`.
- **This tree without the change, WM startup.** A capture beginning at `startedServices=false`, all three web apps admitted via `context=startup_full_rescan`, all three focused during the capture, all three alive at the end. This is the upstream report's headline scenario.
- **Upstream's own affected release**, run on the same machine with the same web apps: also does not reproduce it.

The upstream issue has zero comments — no diagnosis, and no confirmation from the reporter that the change helped. So the causal chain "NaN location → Chromium mishandles it → window closes" is an undemonstrated hypothesis. The one variable left unexcluded is the Chromium build, which auto-updates.

Full write-up with the inlined evidence is on the planning branch: `discovery/20260728-skylight-key-window-nan-location-symptom-not-reproducible.md`.

## Tests

The user explicitly approved byte-layout coverage after reviewing the implementation and the non-reproduction evidence. `Tests/NehirTests/SkyLightKeyWindowEventRecordTests.swift` is a new per-behaviour Swift Testing file adapted from the upstream companion test.

It independently restates the byte offsets rather than reusing production constants, and pins:

- buffer size `0x100` and declared length `0xF8` at `0x04`;
- key-window flag and default mouse-down event type;
- mouse-down → mouse-up mutation, with every other byte unchanged;
- window-id round-trip at `0x3C`;
- a finite `CGPoint(x: -1, y: -1)` at `0x20`;
- zero padding from `0xF8` and no unexpected non-zero byte elsewhere.

A falsification run temporarily restored the pre-change `0xF8` buffer and NaN location. The suite failed on both intended assertions (248 vs 256 bytes; decoded `(nan, nan)` vs finite `(-1, -1)`), then passed again after restoring the implementation.

## Release notes

Choose one:

- [x] Added a `.changeset/*.md` for user-visible changes (`mise run changeset -- patch "..."`). — **level `none`**: the change is real but there is no user-visible behaviour to announce. `mise run changeset:check` passes on it, so no `no release note` label is needed.
- [ ] No user-visible change; apply the `no release note` label to make CI skip intentional.

## Validation

- [x] Ran relevant tests/checks.
  - `mise run check` (format + lint + build + test) — passes after rebasing onto current `main`; 1491 tests in 130 suites.
  - `mise run license:check` — passes; SPDX headers up to date.
  - `mise run changeset:check` — "Changeset present."

**Pre-existing flake, unrelated to this branch.** `IPCServerTests` intermittently dies with SIGTRAP: `HotkeyCenter.deinit` calls `MainActor.assumeIsolated` off the main actor during teardown, reached from `WMController.deinit` ← `IPCApplicationBridge.deinit` ← `IPCConnection.deinit`. Reproduced on the base commit *without* this change (failed on run 10 of 15 of the same filter). Not fixed here; worth its own issue.
