### PR TITLE
Trace placement affinity, cursor evidence, and explicit workspace activation at admission

### DIFF
--- a/.changeset/20260728215917-internal-add-placement-affinity-runtime-decision.md
+++ b/.changeset/20260728215917-internal-add-placement-affinity-runtime-decision.md
@@ -1,0 +1,6 @@
+---
+"nehir": none
+
+---
+
+Internal: add placement-affinity runtime decision tracing that records the winning placement signal, cursor evidence, and explicit-workspace-activation provenance at window admission. Instrumentation only; no placement behavior change.

--- a/Sources/Nehir/Core/Controller/AXEventHandler.swift
+++ b/Sources/Nehir/Core/Controller/AXEventHandler.swift
@@ -314,6 +314,13 @@ struct NiriCreateFocusTraceEvent: Equatable {
     }
 }
 
+struct CursorPlacementEvidence: Equatable {
+    let appKitPoint: CGPoint?
+    let containingScreenDisplayId: CGDirectDisplayID?
+    let mappedMonitorId: Monitor.ID?
+    let monitorTopology: String
+}
+
 struct WindowCreatePlacementContext: Equatable {
     let nativeSpaceMonitorId: Monitor.ID?
     let activeFocusRequestWorkspaceId: WorkspaceDescriptor.ID?
@@ -327,6 +334,8 @@ struct WindowCreatePlacementContext: Equatable {
     /// non-managed desktop click on a display without managed windows), this reflects
     /// where the user actually is. `nil` when the pointer is over no monitor.
     let cursorMonitorId: Monitor.ID?
+    private(set) var cursorEvidence: CursorPlacementEvidence?
+    private(set) var explicitWorkspaceActivation: ExplicitWorkspacePlacementIntentSnapshot?
     let source: String
     let focusedWorkspaceSource: String?
     let recentPidWorkspaceId: WorkspaceDescriptor.ID?
@@ -342,6 +351,17 @@ extension WindowCreatePlacementContext: CustomStringConvertible {
             + "focused_monitor=\(String(describing: focusedMonitorId)) "
             + "interaction_monitor=\(String(describing: interactionMonitorId)) "
             + "cursor_monitor=\(String(describing: cursorMonitorId)) "
+            + "cursor_point=\(String(describing: cursorEvidence?.appKitPoint)) "
+            + "cursor_screen_display=\(String(describing: cursorEvidence?.containingScreenDisplayId)) "
+            + "cursor_mapped_monitor=\(String(describing: cursorEvidence?.mappedMonitorId ?? cursorMonitorId)) "
+            + "monitor_topology=\(cursorEvidence?.monitorTopology ?? "not_captured") "
+            + "explicit_activation_workspace=\(explicitWorkspaceActivation?.workspaceId.uuidString ?? "nil") "
+            + "explicit_activation_monitor=\(String(describing: explicitWorkspaceActivation?.monitorId)) "
+            + "explicit_activation_source=\(explicitWorkspaceActivation?.source ?? "nil") "
+            + "explicit_activation_age_ms=\(explicitWorkspaceActivation.map { String($0.ageMs) } ?? "nil") "
+            + "explicit_activation_generation=\(explicitWorkspaceActivation.map { String($0.generation) } ?? "nil") "
+            + "explicit_activation_valid=\(explicitWorkspaceActivation.map { String($0.isValid) } ?? "false") "
+            + "explicit_activation_rejection=\(explicitWorkspaceActivation?.rejection ?? "none") "
             + "source=\(source) "
             + "focused_workspace_source=\(focusedWorkspaceSource ?? "nil") "
             + "recent_pid_workspace=\(recentPidWorkspaceId?.uuidString ?? "nil") "
@@ -1042,7 +1062,7 @@ final class AXEventHandler: CGSEventDelegate {
     /// OS-boundary seam for the display the pointer is currently over. `nil` uses the
     /// live AppKit pointer; tests set it (e.g. to `{ nil }`) so the real cursor position
     /// never leaks into placement decisions. Faking this boundary — not the placement
-    /// algorithm — keeps production and tests on the same resolveCursorPlacementMonitorId
+    /// algorithm — keeps production and tests on the same resolveCursorPlacementEvidence
     /// path.
     var cursorDisplayIdProvider: (() -> CGDirectDisplayID?)?
     var managedReplacementTimeSourceForTests: (() -> TimeInterval)?
@@ -7432,6 +7452,7 @@ final class AXEventHandler: CGSEventDelegate {
         } else {
             nil
         }
+        let cursorEvidence = resolveCursorPlacementEvidence(controller: controller)
         return WindowCreatePlacementContext(
             nativeSpaceMonitorId: nativeSpaceMonitorId,
             activeFocusRequestWorkspaceId: controller.workspaceManager.activeFocusRequestWorkspaceId,
@@ -7441,7 +7462,9 @@ final class AXEventHandler: CGSEventDelegate {
                 controller.workspaceManager.monitorId(for: $0)
             },
             interactionMonitorId: controller.workspaceManager.interactionMonitorId,
-            cursorMonitorId: resolveCursorPlacementMonitorId(controller: controller),
+            cursorMonitorId: cursorEvidence.mappedMonitorId,
+            cursorEvidence: cursorEvidence,
+            explicitWorkspaceActivation: controller.explicitWorkspacePlacementIntentSnapshot(),
             source: source,
             focusedWorkspaceSource: focusedWorkspaceSource,
             recentPidWorkspaceId: recentPidWorkspaceId,
@@ -7456,21 +7479,36 @@ final class AXEventHandler: CGSEventDelegate {
     /// AppKit space and map it back through `displayId` — the same decision the command
     /// palette uses (`CommandPaletteController.paletteScreen`). Returns `nil` when the
     /// pointer is over no screen (no nearest-snap).
-    private func resolveCursorPlacementMonitorId(
+    private func resolveCursorPlacementEvidence(
         controller: WMController
-    ) -> Monitor.ID? {
+    ) -> CursorPlacementEvidence {
         // An installed provider is authoritative: when it returns nil the pointer is
         // over no screen, and we must not fall back to the live cursor (that would leak
         // the real pointer through a test's `{ nil }` seam). Only consult AppKit when no
-        // provider is installed at all.
+        // provider is installed at all. Provider-backed captures intentionally omit the
+        // raw point because it did not participate in their screen decision.
+        let point: CGPoint?
         let displayId: CGDirectDisplayID?
         if let cursorDisplayIdProvider {
+            point = nil
             displayId = cursorDisplayIdProvider()
         } else {
-            displayId = NSScreen.screen(containing: NSEvent.mouseLocation)?.displayId
+            let livePoint = NSEvent.mouseLocation
+            point = livePoint
+            displayId = NSScreen.screen(containing: livePoint)?.displayId
         }
-        guard let displayId else { return nil }
-        return controller.workspaceManager.monitors.first { $0.displayId == displayId }?.id
+        let mappedMonitorId = displayId.flatMap { resolvedDisplayId in
+            controller.workspaceManager.monitors.first { $0.displayId == resolvedDisplayId }?.id
+        }
+        let topology = controller.workspaceManager.monitors.map { monitor in
+            "\(monitor.id){display=\(monitor.displayId),frame=\(monitor.frame)}"
+        }.joined(separator: ",")
+        return CursorPlacementEvidence(
+            appKitPoint: point,
+            containingScreenDisplayId: displayId,
+            mappedMonitorId: mappedMonitorId,
+            monitorTopology: topology
+        )
     }
 
     private func resolveActiveFocusRequestPlacementMonitorId(

--- a/Sources/Nehir/Core/Controller/LayoutRefreshController.swift
+++ b/Sources/Nehir/Core/Controller/LayoutRefreshController.swift
@@ -1444,7 +1444,8 @@ import QuartzCore
                 existingEntry: existingEntry,
                 fallbackWorkspaceId: focusedWorkspaceId,
                 restrictWorkspaceRuleToPlacementMonitor: false,
-                createPlacementContext: createPlacementContext
+                createPlacementContext: createPlacementContext,
+                recordPlacementDecision: false
             )
             var restoredNativeFullscreenReplacement = false
             if controller.workspaceAssignment(pid: pid, windowId: winId) == nil,

--- a/Sources/Nehir/Core/Controller/NiriLayoutHandler.swift
+++ b/Sources/Nehir/Core/Controller/NiriLayoutHandler.swift
@@ -1603,7 +1603,8 @@ enum NiriWindowMoveResult {
             {
                 controller.workspaceNavigationHandler.activateWorkspace(
                     targetWsId,
-                    focusing: globalPrevious.token
+                    focusing: globalPrevious.token,
+                    placementIntentSource: "focus_previous_window"
                 )
                 return
             }

--- a/Sources/Nehir/Core/Controller/WMController.swift
+++ b/Sources/Nehir/Core/Controller/WMController.swift
@@ -77,6 +77,17 @@ enum FocusWindowReason: String, Equatable {
     case deferredFocus
 }
 
+struct ExplicitWorkspacePlacementIntentSnapshot: Equatable {
+    let workspaceId: WorkspaceDescriptor.ID
+    let monitorId: Monitor.ID
+    let source: String
+    let generation: UInt64
+    let recordedUptime: TimeInterval
+    let ageMs: Int
+    let isValid: Bool
+    let rejection: String
+}
+
 @MainActor @Observable
 final class WMController {
     private static let runtimeDebugLogger = Logger(subsystem: "com.nehir", category: "runtime-debug")
@@ -183,9 +194,22 @@ final class WMController {
         let createdAt: Date
     }
 
+    private struct ExplicitWorkspacePlacementIntent {
+        let workspaceId: WorkspaceDescriptor.ID
+        let monitorId: Monitor.ID
+        let source: String
+        let generation: UInt64
+        let recordedUptime: TimeInterval
+        var invalidationReason: String?
+    }
+
     @ObservationIgnored
     private var explicitWorkspaceMoveIntentsByToken: [WindowToken: ExplicitWorkspaceMoveIntent] = [:]
     private let explicitWorkspaceMoveIntentTTL: TimeInterval = 15
+    @ObservationIgnored
+    private var explicitWorkspacePlacementIntent: ExplicitWorkspacePlacementIntent?
+    @ObservationIgnored
+    private var explicitWorkspacePlacementIntentGeneration: UInt64 = 0
 
     @ObservationIgnored
     private(set) lazy var mouseEventHandler = MouseEventHandler(controller: self)
@@ -1174,6 +1198,81 @@ final class WMController {
         return workspaceManager.activeWorkspaceOrFirst(on: monitor.id)
     }
 
+    /// Captures provenance only. Step 1 deliberately does not consult this record
+    /// while selecting a workspace, consume it, or assign it a timeout.
+    func recordExplicitWorkspacePlacementIntent(
+        workspaceId: WorkspaceDescriptor.ID,
+        monitorId: Monitor.ID,
+        source: String
+    ) {
+        let replacedGeneration = explicitWorkspacePlacementIntent?.generation
+        explicitWorkspacePlacementIntentGeneration &+= 1
+        let generation = explicitWorkspacePlacementIntentGeneration
+        let recordedUptime = ProcessInfo.processInfo.systemUptime
+        explicitWorkspacePlacementIntent = ExplicitWorkspacePlacementIntent(
+            workspaceId: workspaceId,
+            monitorId: monitorId,
+            source: source,
+            generation: generation,
+            recordedUptime: recordedUptime,
+            invalidationReason: nil
+        )
+        diagnostics.recordRuntimeDecisionEvent(
+            named: "explicit_workspace_placement_intent",
+            cluster: "window_placement"
+        ) {
+            [
+                RuntimeDecisionTraceField("workspace", workspaceId.uuidString),
+                RuntimeDecisionTraceField("monitor", monitorId),
+                RuntimeDecisionTraceField("source", source),
+                RuntimeDecisionTraceField("generation", generation),
+                RuntimeDecisionTraceField("replaced_generation", replacedGeneration),
+                RuntimeDecisionTraceField(
+                    "replaced_invalidation",
+                    replacedGeneration == nil ? nil : "superseded"
+                ),
+                RuntimeDecisionTraceField("recorded_uptime", recordedUptime),
+                RuntimeDecisionTraceField("consumption_policy", "none_instrumentation_only"),
+                RuntimeDecisionTraceField("expiry_policy", "none_instrumentation_only")
+            ]
+        }
+    }
+
+    /// Returns an immutable admission-time view and lazily marks topology/activity
+    /// invalidations. No expiry or consumption policy exists in the instrumentation
+    /// iteration; those decisions require the next runtime capture.
+    func explicitWorkspacePlacementIntentSnapshot() -> ExplicitWorkspacePlacementIntentSnapshot? {
+        guard var intent = explicitWorkspacePlacementIntent else { return nil }
+        if intent.invalidationReason == nil {
+            if workspaceManager.descriptor(for: intent.workspaceId) == nil
+                || workspaceManager.monitor(byId: intent.monitorId) == nil
+            {
+                intent.invalidationReason = "monitor_mismatch"
+            } else if workspaceManager.monitorId(for: intent.workspaceId) != intent.monitorId {
+                intent.invalidationReason = "monitor_mismatch"
+            } else if workspaceManager.activeWorkspace(on: intent.monitorId)?.id != intent.workspaceId {
+                intent.invalidationReason = "workspace_inactive"
+            }
+            if intent.invalidationReason != nil {
+                explicitWorkspacePlacementIntent = intent
+            }
+        }
+        let ageMs = max(
+            0,
+            Int(((ProcessInfo.processInfo.systemUptime - intent.recordedUptime) * 1000).rounded())
+        )
+        return ExplicitWorkspacePlacementIntentSnapshot(
+            workspaceId: intent.workspaceId,
+            monitorId: intent.monitorId,
+            source: intent.source,
+            generation: intent.generation,
+            recordedUptime: intent.recordedUptime,
+            ageMs: ageMs,
+            isValid: intent.invalidationReason == nil,
+            rejection: intent.invalidationReason ?? "none"
+        )
+    }
+
     func resolveWorkspaceForNewWindow(
         workspaceName: String? = nil,
         axRef: AXWindowRef,
@@ -1202,7 +1301,8 @@ final class WMController {
             windowFrame: windowFrame,
             existingEntry: nil,
             fallbackWorkspaceId: fallbackWorkspaceId,
-            context: .automatic
+            context: .automatic,
+            recordPlacementDecision: true
         )
     }
 
@@ -1210,6 +1310,7 @@ final class WMController {
         let workspaceId: WorkspaceDescriptor.ID?
         let monitorId: Monitor.ID?
         let isAuthoritative: Bool
+        let winner: String
     }
 
     private func resolveWorkspacePlacement(
@@ -1226,8 +1327,85 @@ final class WMController {
         windowFrame: CGRect?,
         existingEntry: WindowModel.Entry?,
         fallbackWorkspaceId: WorkspaceDescriptor.ID?,
-        context: WindowRuleReevaluationContext
+        context: WindowRuleReevaluationContext,
+        recordPlacementDecision: Bool
     ) -> WorkspaceDescriptor.ID {
+        func finish(_ workspaceId: WorkspaceDescriptor.ID, winner: String) -> WorkspaceDescriptor.ID {
+            guard recordPlacementDecision,
+                  context == .automatic,
+                  existingEntry == nil,
+                  let pid
+            else {
+                return workspaceId
+            }
+            diagnostics.recordRuntimeDecisionEvent(
+                named: "placement_affinity_decision",
+                cluster: "window_placement"
+            ) { [self] in
+                let activation = createPlacementContext?.explicitWorkspaceActivation
+                let strongerWinners: Set<String> = [
+                    "explicit_move", "workspace_rule", "tracked_parent", "structural_replacement",
+                    "active_focus_request", "native_space"
+                ]
+                let activationRejection: String = if let activation, activation.rejection != "none" {
+                    activation.rejection
+                } else if activation != nil, strongerWinners.contains(winner) {
+                    "stronger_affinity"
+                } else {
+                    "none"
+                }
+                let containedFrameMonitor = monitorContainingPlacementFrame(windowFrame)?.id
+                let approximatedFrameMonitor = monitorForPlacementFrame(windowFrame)?.id
+                let cursorPoint = createPlacementContext?.cursorEvidence?.appKitPoint.map {
+                    "\($0.x),\($0.y)"
+                }
+                return [
+                    RuntimeDecisionTraceField("token", WindowToken(pid: pid, windowId: axRef.windowId)),
+                    RuntimeDecisionTraceField("winner", winner),
+                    RuntimeDecisionTraceField("workspace", workspaceId.uuidString),
+                    RuntimeDecisionTraceField("monitor", self.workspaceManager.monitorId(for: workspaceId)),
+                    RuntimeDecisionTraceField("explicit_activation_workspace", activation?.workspaceId.uuidString),
+                    RuntimeDecisionTraceField("explicit_activation_monitor", activation?.monitorId),
+                    RuntimeDecisionTraceField("explicit_activation_source", activation?.source),
+                    RuntimeDecisionTraceField("explicit_activation_age_ms", activation?.ageMs),
+                    RuntimeDecisionTraceField("explicit_activation_generation", activation?.generation),
+                    RuntimeDecisionTraceField(
+                        "explicit_activation_valid",
+                        activation.map { String($0.isValid) } ?? "false"
+                    ),
+                    RuntimeDecisionTraceField("explicit_activation_rejection", activationRejection),
+                    RuntimeDecisionTraceField("explicit_activation_consumed", "false"),
+                    RuntimeDecisionTraceField("explicit_activation_expired", "false"),
+                    RuntimeDecisionTraceField(
+                        "explicit_activation_observation",
+                        activation != nil && activationRejection == "none"
+                            ? "eligible_not_applied_instrumentation_only"
+                            : nil
+                    ),
+                    RuntimeDecisionTraceField("context_source", createPlacementContext?.source),
+                    RuntimeDecisionTraceField("cursor_point_appkit", cursorPoint),
+                    RuntimeDecisionTraceField(
+                        "cursor_screen_display",
+                        createPlacementContext?.cursorEvidence?.containingScreenDisplayId
+                    ),
+                    RuntimeDecisionTraceField(
+                        "cursor_mapped_monitor",
+                        createPlacementContext?.cursorEvidence?.mappedMonitorId
+                            ?? createPlacementContext?.cursorMonitorId
+                    ),
+                    RuntimeDecisionTraceField(
+                        "monitor_topology",
+                        createPlacementContext?.cursorEvidence?.monitorTopology
+                    ),
+                    RuntimeDecisionTraceField("placement_frame", windowFrame.map(String.init(describing:))),
+                    RuntimeDecisionTraceField("placement_frame_strict_monitor", containedFrameMonitor),
+                    RuntimeDecisionTraceField("placement_frame_strict_contained", String(containedFrameMonitor != nil)),
+                    RuntimeDecisionTraceField("placement_frame_approximated_monitor", approximatedFrameMonitor)
+                ]
+            }
+            return workspaceId
+        }
+
         if context == .automatic, let existingEntry {
             return existingEntry.workspaceId
         }
@@ -1236,21 +1414,21 @@ final class WMController {
            let explicitMoveTarget = explicitWorkspaceMovePlacementTarget(pid: pid, windowId: axRef.windowId),
            let workspaceId = explicitMoveTarget.workspaceId
         {
-            return workspaceId
+            return finish(workspaceId, winner: "explicit_move")
         }
 
         if existingEntry == nil,
            let structuralReplacementWorkspaceId,
            workspaceManager.descriptor(for: structuralReplacementWorkspaceId) != nil
         {
-            return structuralReplacementWorkspaceId
+            return finish(structuralReplacementWorkspaceId, winner: "structural_replacement")
         }
 
         if existingEntry == nil,
            inheritTrackedParentWorkspace,
            let parentWorkspaceId = workspaceForTrackedParentWindow(parentWindowId: parentWindowId, pid: pid)
         {
-            return parentWorkspaceId
+            return finish(parentWorkspaceId, winner: "tracked_parent")
         }
 
         let placementTarget = createPlacementTarget(
@@ -1272,7 +1450,7 @@ final class WMController {
                targetMonitorId: placementTarget.isAuthoritative ? placementTarget.monitorId : nil
            )
         {
-            return siblingWorkspaceId
+            return finish(siblingWorkspaceId, winner: "same_app_sibling")
         }
 
         if let workspaceName,
@@ -1281,7 +1459,7 @@ final class WMController {
            !restrictWorkspaceRuleToPlacementMonitor ||
            shouldApplyWorkspaceRule(workspaceId, placementTarget: placementTarget)
         {
-            return workspaceId
+            return finish(workspaceId, winner: "workspace_rule")
         }
 
         // A newly-created non-user-addressable transient floating surface with no
@@ -1298,14 +1476,15 @@ final class WMController {
            let pid,
            let siblingWorkspaceId = workspaceForPrimarySiblingWindow(pid: pid)
         {
-            return siblingWorkspaceId
+            return finish(siblingWorkspaceId, winner: "primary_sibling")
         }
 
         if let existingEntry {
             return existingEntry.workspaceId
         }
 
-        return defaultWorkspaceId(placementTarget: placementTarget)
+        let workspaceId = defaultWorkspaceId(placementTarget: placementTarget)
+        return finish(workspaceId, winner: placementTarget.winner)
     }
 
     private func workspaceForTrackedParentWindow(
@@ -1478,7 +1657,8 @@ final class WMController {
         if preferManagedFocusPlacement {
             if let target = managedFocusPlacementTarget(
                 createPlacementContext?.activeFocusRequestWorkspaceId,
-                createPlacementContext?.activeFocusRequestMonitorId
+                createPlacementContext?.activeFocusRequestMonitorId,
+                winner: "active_focus_request"
             ) {
                 return target
             }
@@ -1489,7 +1669,8 @@ final class WMController {
                 return WorkspacePlacementTarget(
                     workspaceId: workspace.id,
                     monitorId: nativeMonitorId,
-                    isAuthoritative: true
+                    isAuthoritative: true,
+                    winner: "native_space"
                 )
             }
 
@@ -1507,7 +1688,8 @@ final class WMController {
                     return WorkspacePlacementTarget(
                         workspaceId: workspace.id,
                         monitorId: frameMonitor.id,
-                        isAuthoritative: true
+                        isAuthoritative: true,
+                        winner: "frame"
                     )
                 }
 
@@ -1518,7 +1700,8 @@ final class WMController {
                     return WorkspacePlacementTarget(
                         workspaceId: workspace.id,
                         monitorId: interactionMonitorId,
-                        isAuthoritative: true
+                        isAuthoritative: true,
+                        winner: "interaction"
                     )
                 }
             }
@@ -1533,13 +1716,15 @@ final class WMController {
                 return WorkspacePlacementTarget(
                     workspaceId: activeWorkspace.id,
                     monitorId: interactionMonitorId,
-                    isAuthoritative: true
+                    isAuthoritative: true,
+                    winner: "interaction"
                 )
             }
 
             if let target = managedFocusPlacementTarget(
                 createPlacementContext?.focusedWorkspaceId,
-                createPlacementContext?.focusedMonitorId
+                createPlacementContext?.focusedMonitorId,
+                winner: createPlacementContext?.focusedWorkspaceSource ?? "confirmed_focus"
             ) {
                 return target
             }
@@ -1568,7 +1753,8 @@ final class WMController {
             return WorkspacePlacementTarget(
                 workspaceId: workspace.id,
                 monitorId: cursorMonitorId,
-                isAuthoritative: true
+                isAuthoritative: true,
+                winner: "cursor"
             )
         }
 
@@ -1600,7 +1786,8 @@ final class WMController {
             return WorkspacePlacementTarget(
                 workspaceId: workspace.id,
                 monitorId: interactionMonitorId,
-                isAuthoritative: true
+                isAuthoritative: true,
+                winner: "interaction"
             )
         }
 
@@ -1610,7 +1797,8 @@ final class WMController {
             return WorkspacePlacementTarget(
                 workspaceId: workspace.id,
                 monitorId: monitorId,
-                isAuthoritative: true
+                isAuthoritative: true,
+                winner: "native_space"
             )
         }
 
@@ -1630,7 +1818,8 @@ final class WMController {
             return WorkspacePlacementTarget(
                 workspaceId: workspace.id,
                 monitorId: interactionMonitorId,
-                isAuthoritative: true
+                isAuthoritative: true,
+                winner: "interaction"
             )
         }
 
@@ -1640,7 +1829,8 @@ final class WMController {
             return WorkspacePlacementTarget(
                 workspaceId: workspace.id,
                 monitorId: monitor.id,
-                isAuthoritative: true
+                isAuthoritative: true,
+                winner: "frame"
             )
         }
 
@@ -1650,21 +1840,24 @@ final class WMController {
             return WorkspacePlacementTarget(
                 workspaceId: workspace.id,
                 monitorId: monitor.id,
-                isAuthoritative: true
+                isAuthoritative: true,
+                winner: "frame"
             )
         }
 
         if !preferManagedFocusPlacement {
             if let target = managedFocusPlacementTarget(
                 createPlacementContext?.activeFocusRequestWorkspaceId,
-                createPlacementContext?.activeFocusRequestMonitorId
+                createPlacementContext?.activeFocusRequestMonitorId,
+                winner: "active_focus_request"
             ) {
                 return target
             }
 
             if let target = managedFocusPlacementTarget(
                 createPlacementContext?.focusedWorkspaceId,
-                createPlacementContext?.focusedMonitorId
+                createPlacementContext?.focusedMonitorId,
+                winner: createPlacementContext?.focusedWorkspaceSource ?? "confirmed_focus"
             ) {
                 return target
             }
@@ -1676,7 +1869,8 @@ final class WMController {
             return WorkspacePlacementTarget(
                 workspaceId: workspace.id,
                 monitorId: monitorId,
-                isAuthoritative: true
+                isAuthoritative: true,
+                winner: "interaction"
             )
         }
 
@@ -1686,14 +1880,16 @@ final class WMController {
             return WorkspacePlacementTarget(
                 workspaceId: fallbackWorkspaceId,
                 monitorId: workspaceManager.monitorId(for: fallbackWorkspaceId),
-                isAuthoritative: false
+                isAuthoritative: false,
+                winner: "fallback"
             )
         }
 
         return WorkspacePlacementTarget(
             workspaceId: nil,
             monitorId: nil,
-            isAuthoritative: false
+            isAuthoritative: false,
+            winner: "fallback"
         )
     }
 
@@ -1723,7 +1919,8 @@ final class WMController {
         return WorkspacePlacementTarget(
             workspaceId: intent.workspaceId,
             monitorId: workspaceManager.monitorId(for: intent.workspaceId),
-            isAuthoritative: true
+            isAuthoritative: true,
+            winner: "explicit_move"
         )
     }
 
@@ -1753,7 +1950,8 @@ final class WMController {
 
     private func managedFocusPlacementTarget(
         _ workspaceId: WorkspaceDescriptor.ID?,
-        _ monitorId: Monitor.ID?
+        _ monitorId: Monitor.ID?,
+        winner: String
     ) -> WorkspacePlacementTarget? {
         if let workspaceId,
            workspaceManager.descriptor(for: workspaceId) != nil
@@ -1762,7 +1960,8 @@ final class WMController {
             return WorkspacePlacementTarget(
                 workspaceId: workspaceId,
                 monitorId: resolvedMonitorId,
-                isAuthoritative: true
+                isAuthoritative: true,
+                winner: winner
             )
         }
 
@@ -1772,7 +1971,8 @@ final class WMController {
             return WorkspacePlacementTarget(
                 workspaceId: workspace.id,
                 monitorId: monitorId,
-                isAuthoritative: true
+                isAuthoritative: true,
+                winner: winner
             )
         }
 
@@ -2684,7 +2884,8 @@ final class WMController {
         structuralReplacementWorkspaceId: WorkspaceDescriptor.ID? = nil,
         restrictWorkspaceRuleToPlacementMonitor: Bool = true,
         createPlacementContext: WindowCreatePlacementContext? = nil,
-        context: WindowRuleReevaluationContext = .automatic
+        context: WindowRuleReevaluationContext = .automatic,
+        recordPlacementDecision: Bool = true
     ) -> WorkspaceDescriptor.ID {
         let inheritTrackedParentWorkspace = shouldInheritTrackedParentWorkspace(for: evaluation)
         let bindTransientFloatingToAppWorkspace =
@@ -2708,7 +2909,8 @@ final class WMController {
             windowFrame: evaluation.facts.windowServer?.frame,
             existingEntry: existingEntry,
             fallbackWorkspaceId: fallbackWorkspaceId,
-            context: context
+            context: context,
+            recordPlacementDecision: recordPlacementDecision
         )
     }
 

--- a/Sources/Nehir/Core/Controller/WindowActionHandler.swift
+++ b/Sources/Nehir/Core/Controller/WindowActionHandler.swift
@@ -479,6 +479,11 @@ final class WindowActionHandler {
         if workspaceId != currentWsId {
             let wsName = controller.workspaceManager.descriptor(for: workspaceId)?.name ?? ""
             if let result = controller.workspaceManager.focusWorkspace(named: wsName) {
+                controller.recordExplicitWorkspacePlacementIntent(
+                    workspaceId: result.workspace.id,
+                    monitorId: result.monitor.id,
+                    source: "window_navigation_\(source.rawValue)"
+                )
                 _ = controller.workspaceManager.setInteractionMonitor(result.monitor.id)
                 controller.syncMonitorsToNiriEngine()
             }
@@ -722,6 +727,11 @@ final class WindowActionHandler {
     ) -> Bool {
         guard let controller else { return false }
 
+        controller.recordExplicitWorkspacePlacementIntent(
+            workspaceId: result.workspace.id,
+            monitorId: result.monitor.id,
+            source: "workspace_bar"
+        )
         let focusedToken = controller.resolveAndSetWorkspaceFocusToken(for: result.workspace.id)
         recordNavigationDiagnostic(
             reason: "navigate.workspace",

--- a/Sources/Nehir/Core/Controller/WorkspaceNavigationHandler.swift
+++ b/Sources/Nehir/Core/Controller/WorkspaceNavigationHandler.swift
@@ -241,6 +241,11 @@ final class WorkspaceNavigationHandler {
         }
 
         _ = controller.workspaceManager.setInteractionMonitor(targetMonitorId)
+        controller.recordExplicitWorkspacePlacementIntent(
+            workspaceId: targetWorkspace.id,
+            monitorId: target.id,
+            source: "monitor_navigation"
+        )
         let handoff = resolveWorkspaceTransitionFocusHandoff(for: targetWorkspace.id)
 
         controller.layoutRefreshController.commitWorkspaceTransition(
@@ -288,6 +293,11 @@ final class WorkspaceNavigationHandler {
             with: targetWsId, on: targetMonitor.id
         ) else { return }
 
+        controller.recordExplicitWorkspacePlacementIntent(
+            workspaceId: targetWsId,
+            monitorId: currentMonitorId,
+            source: "workspace_monitor_swap"
+        )
         controller.syncMonitorsToNiriEngine()
 
         let focusToken = controller.resolveAndSetWorkspaceFocusToken(for: targetWsId)
@@ -332,6 +342,11 @@ final class WorkspaceNavigationHandler {
         }
 
         guard let result = controller.workspaceManager.focusWorkspace(named: rawWorkspaceID) else { return }
+        controller.recordExplicitWorkspacePlacementIntent(
+            workspaceId: result.workspace.id,
+            monitorId: result.monitor.id,
+            source: "numbered_workspace"
+        )
 
         commitWorkspaceTransitionFocusHandoff(
             targetWorkspaceId: result.workspace.id,
@@ -368,6 +383,11 @@ final class WorkspaceNavigationHandler {
         guard controller.workspaceManager.setActiveWorkspace(targetWorkspace.id, on: currentMonitorId) else {
             return
         }
+        controller.recordExplicitWorkspacePlacementIntent(
+            workspaceId: targetWorkspace.id,
+            monitorId: currentMonitorId,
+            source: "adjacent_navigation"
+        )
 
         let monitor = controller.workspaceManager.monitor(for: targetWorkspace.id)
             ?? controller.workspaceManager.monitor(byId: currentMonitorId)
@@ -421,6 +441,11 @@ final class WorkspaceNavigationHandler {
         }
 
         guard controller.workspaceManager.setActiveWorkspace(targetWsId, on: targetMonitor.id) else { return }
+        controller.recordExplicitWorkspacePlacementIntent(
+            workspaceId: targetWsId,
+            monitorId: targetMonitor.id,
+            source: "numbered_workspace_anywhere"
+        )
 
         controller.syncMonitorsToNiriEngine()
 
@@ -450,6 +475,11 @@ final class WorkspaceNavigationHandler {
         guard controller.workspaceManager.setActiveWorkspace(prevWorkspace.id, on: currentMonitorId) else {
             return
         }
+        controller.recordExplicitWorkspacePlacementIntent(
+            workspaceId: prevWorkspace.id,
+            monitorId: currentMonitorId,
+            source: "back_and_forth"
+        )
 
         let monitor = controller.workspaceManager.monitor(for: prevWorkspace.id)
             ?? controller.workspaceManager.monitor(byId: currentMonitorId)
@@ -473,7 +503,8 @@ final class WorkspaceNavigationHandler {
     /// `swapCurrentWorkspaceWithMonitor`).
     func activateWorkspace(
         _ targetWorkspaceId: WorkspaceDescriptor.ID,
-        focusing targetToken: WindowToken
+        focusing targetToken: WindowToken,
+        placementIntentSource: String? = nil
     ) {
         guard let controller else { return }
         guard let engine = controller.niriEngine,
@@ -503,6 +534,13 @@ final class WorkspaceNavigationHandler {
 
         guard controller.workspaceManager.setActiveWorkspace(targetWorkspaceId, on: targetMonitor.id) else {
             return
+        }
+        if let placementIntentSource {
+            controller.recordExplicitWorkspacePlacementIntent(
+                workspaceId: targetWorkspaceId,
+                monitorId: targetMonitor.id,
+                source: placementIntentSource
+            )
         }
         controller.syncMonitorsToNiriEngine()
 


### PR DESCRIPTION
## Summary

Adds runtime decision tracing for window placement so a capture can show **why** a new window landed on a given workspace/monitor — instrumentation only, no placement behavior change.

Records a `placement_affinity_decision` event at every newly admitted window naming the **winning placement signal** (frame, cursor, interaction, native space, explicit move, workspace rule, tracked parent, structural replacement, sibling/fallback), alongside:

- **Cursor evidence**: AppKit point, containing display, mapped monitor, monitor topology.
- **Explicit-workspace-activation provenance**: source, age (ms), generation, validity, rejection reason.

A new **explicit workspace placement intent** is captured on user-driven transitions so the admission event can report whether placement followed explicit intent (`eligible_not_applied_instrumentation_only`) or was overridden by a stronger affinity (`stronger_affinity`) / topology mismatch. Sources covered: workspace bar, numbered/adjacent/back-and-forth navigation, window navigation (bar/overview/command), focus-previous-window, monitor focus, workspace swap.

## Why these specific fixes

- **Affinity event was emitted twice per admission.** `LayoutRefreshController` resolves the workspace twice for a new window (a native-fullscreen preflight, then the real assignment). Only the real assignment now emits the event — the preflight passes `recordPlacementDecision: false`.
- **Explicit activation was missed on the most common user path.** Selecting a window from another workspace via bar/overview/command and Focus-Previous-Window cross-workspace didn't record intent, producing false negatives. Now recorded.

## Validation

- `mise run build` — passed
- `mise run test` — 1491 tests in 130 suites passed
- `mise run format:check` — passed
- `mise run lint` — passed (no new warnings adjacent to the change)
- No test files modified (runtime-confirmation gate respected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Diagnostics**
  * Enhanced runtime tracing for window placement decisions with cursor evidence, monitor topology, and explicit workspace activation provenance.
  * Improved placement-context details during window creation and expanded debug output for cursor/monitor mapping.
  * Added explicit workspace placement intent capture across window navigation and workspace switching flows, including source tracking.
* **Bug Fixes**
  * Preserved existing placement behavior while improving decision/context visibility during workspace transitions and full rescan evaluations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->