### PR TITLE
Add a setting for what happens when moving a window past the last workspace

### DIFF
--- a/.changeset/20260819120000-add-a-setting-for-what-happens-when-moving-a-wind.md
+++ b/.changeset/20260819120000-add-a-setting-for-what-happens-when-moving-a-wind.md
@@ -1,0 +1,6 @@
+---
+"nehir": minor
+
+---
+
+Add a "Move Past Last Workspace" setting that controls what happens when you move a window down past the last workspace on a monitor. The default, "Create New Workspace", keeps the existing behavior of creating the next numbered workspace. Choosing "Wrap to First Workspace" instead moves the window to the first workspace, matching how workspace switching already wraps. Moving a window up past the first workspace now wraps to the last workspace instead of doing nothing.

--- a/Sources/Nehir/Core/Config/CanonicalTOMLConfig.swift
+++ b/Sources/Nehir/Core/Config/CanonicalTOMLConfig.swift
@@ -24,6 +24,7 @@ struct CanonicalTOMLConfig: Codable, Equatable {
     var mouseWarp: MouseWarp
     var gaps: Gaps
     var niri: Niri
+    var workspace: Workspace
     var borders: Borders
     var workspaceBar: WorkspaceBar
     var gestures: Gestures
@@ -31,7 +32,8 @@ struct CanonicalTOMLConfig: Codable, Equatable {
     var appearance: Appearance
 
     enum CodingKeys: String, CodingKey, CaseIterable {
-        case general, focus, mouseWarp, gaps, niri, borders, workspaceBar, gestures, statusBar, appearance
+        case general, focus, mouseWarp, gaps, niri, workspace, borders, workspaceBar, gestures,
+             statusBar, appearance
     }
 
     struct General: Codable, Equatable {
@@ -118,6 +120,15 @@ struct CanonicalTOMLConfig: Codable, Equatable {
         enum CodingKeys: String, CodingKey, CaseIterable {
             case balancedColumnCount, infiniteLoop, revealStyle, loneWindowMaxWidth, columnWidthPresets,
                  defaultColumnWidth
+        }
+    }
+
+    struct Workspace: Codable, Equatable {
+        var movePastLastWorkspace: String
+        var unknownFields: [String: SettingsTOMLUnknownValue] = [:]
+
+        enum CodingKeys: String, CodingKey, CaseIterable {
+            case movePastLastWorkspace
         }
     }
 
@@ -305,6 +316,10 @@ extension CanonicalTOMLConfig {
             defaultColumnWidth: export.niriDefaultColumnWidth,
             unknownFields: unknown["niri"] ?? [:]
         )
+        workspace = Workspace(
+            movePastLastWorkspace: export.movePastLastWorkspace,
+            unknownFields: unknown["workspace"] ?? [:]
+        )
         borders = Borders(
             enabled: export.bordersEnabled,
             width: export.borderWidth,
@@ -405,6 +420,7 @@ extension CanonicalTOMLConfig {
             niriLoneWindowMaxWidth: niri.loneWindowMaxWidth,
             niriColumnWidthPresets: niri.columnWidthPresets,
             niriDefaultColumnWidth: niri.defaultColumnWidth,
+            movePastLastWorkspace: workspace.movePastLastWorkspace,
             workspaceConfigurations: BuiltInSettingsDefaults.workspaceConfigurations,
             bordersEnabled: borders.enabled,
             borderWidth: borders.width,
@@ -476,6 +492,7 @@ extension CanonicalTOMLConfig {
         mouseWarp = try container.decodeWithDefault(MouseWarp.self, forKey: .mouseWarp, default: d.mouseWarp)
         gaps = try container.decodeWithDefault(Gaps.self, forKey: .gaps, default: d.gaps)
         niri = try container.decodeWithDefault(Niri.self, forKey: .niri, default: d.niri)
+        workspace = try container.decodeWithDefault(Workspace.self, forKey: .workspace, default: d.workspace)
         borders = try container.decodeWithDefault(Borders.self, forKey: .borders, default: d.borders)
         workspaceBar = try container.decodeWithDefault(
             WorkspaceBar.self,
@@ -494,6 +511,7 @@ extension CanonicalTOMLConfig {
         try container.encode(mouseWarp, forKey: .mouseWarp)
         try container.encode(gaps, forKey: .gaps)
         try container.encode(niri, forKey: .niri)
+        try container.encode(workspace, forKey: .workspace)
         try container.encode(borders, forKey: .borders)
         try container.encode(workspaceBar, forKey: .workspaceBar)
         try container.encode(gestures, forKey: .gestures)
@@ -702,6 +720,25 @@ extension CanonicalTOMLConfig.Niri {
         try container.encodeIfPresent(loneWindowMaxWidth, forKey: "loneWindowMaxWidth")
         try container.encodeIfPresent(columnWidthPresets, forKey: "columnWidthPresets")
         try container.encodeIfPresent(defaultColumnWidth, forKey: "defaultColumnWidth")
+        try container.encodeUnknownFields(unknownFields)
+    }
+}
+
+extension CanonicalTOMLConfig.Workspace {
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let d = CanonicalTOMLConfig.defaults().workspace
+        movePastLastWorkspace = try container.decodeWithDefault(
+            String.self,
+            forKey: .movePastLastWorkspace,
+            default: d.movePastLastWorkspace
+        )
+        unknownFields = try SettingsTOMLUnknownValue.decodeUnknownFields(from: decoder, excluding: CodingKeys.self)
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: SettingsTOMLDynamicKey.self)
+        try container.encode(movePastLastWorkspace, forKey: "movePastLastWorkspace")
         try container.encodeUnknownFields(unknownFields)
     }
 }

--- a/Sources/Nehir/Core/Config/SettingsExport.swift
+++ b/Sources/Nehir/Core/Config/SettingsExport.swift
@@ -38,6 +38,8 @@ struct SettingsExport: Equatable, Sendable {
     var niriColumnWidthPresets: [Double]?
     var niriDefaultColumnWidth: Double?
 
+    var movePastLastWorkspace: String
+
     var workspaceConfigurations: [WorkspaceConfiguration]
 
     var bordersEnabled: Bool
@@ -147,6 +149,7 @@ extension SettingsExport {
             niriLoneWindowMaxWidth: nil,
             niriColumnWidthPresets: BuiltInSettingsDefaults.niriColumnWidthPresets,
             niriDefaultColumnWidth: nil,
+            movePastLastWorkspace: MovePastLastWorkspacePolicy.create.rawValue,
             workspaceConfigurations: BuiltInSettingsDefaults.workspaceConfigurations,
             bordersEnabled: false,
             borderWidth: 5.0,

--- a/Sources/Nehir/Core/Config/SettingsStore.swift
+++ b/Sources/Nehir/Core/Config/SettingsStore.swift
@@ -107,6 +107,12 @@ final class SettingsStore {
         didSet { scheduleSave() }
     }
 
+    var movePastLastWorkspace = MovePastLastWorkspacePolicy(
+        rawValue: SettingsStore.defaultExport.movePastLastWorkspace
+    ) ?? .create {
+        didSet { scheduleSave() }
+    }
+
     var niriLoneWindowMaxWidth = SettingsStore.validatedLoneWindowMaxWidth(
         SettingsStore.defaultExport.niriLoneWindowMaxWidth
     ) {
@@ -476,6 +482,7 @@ final class SettingsStore {
             niriLoneWindowMaxWidth: niriLoneWindowMaxWidth,
             niriColumnWidthPresets: niriColumnWidthPresets,
             niriDefaultColumnWidth: niriDefaultColumnWidth,
+            movePastLastWorkspace: movePastLastWorkspace.rawValue,
             workspaceConfigurations: workspaceConfigurations,
             bordersEnabled: bordersEnabled,
             borderWidth: borderWidth,
@@ -563,6 +570,9 @@ final class SettingsStore {
             export.niriColumnWidthPresets ?? baseline.niriColumnWidthPresets ?? SettingsStore.defaultColumnWidthPresets
         )
         niriDefaultColumnWidth = SettingsStore.validatedDefaultColumnWidth(export.niriDefaultColumnWidth)
+        movePastLastWorkspace = MovePastLastWorkspacePolicy(
+            rawValue: export.movePastLastWorkspace
+        ) ?? .create
 
         workspaceConfigurations = SettingsStore.normalizedWorkspaceConfigurations(
             export.workspaceConfigurations,

--- a/Sources/Nehir/Core/Controller/WorkspaceNavigationHandler.swift
+++ b/Sources/Nehir/Core/Controller/WorkspaceNavigationHandler.swift
@@ -571,6 +571,8 @@ final class WorkspaceNavigationHandler {
         guard let controller else { return nil }
         let wm = controller.workspaceManager
 
+        // Interior moves resolve without wrapping, so the edge cases below are
+        // reached only when there is no further workspace in `direction`.
         let existing: WorkspaceDescriptor? = if direction == .down {
             wm.nextWorkspaceInOrder(on: monitorId, from: workspaceId, wrapAround: false)
         } else {
@@ -578,14 +580,41 @@ final class WorkspaceNavigationHandler {
         }
         if let existing { return existing }
 
+        // Past the end of the list, `movePastLastWorkspace` decides between
+        // creating the next numbered workspace and wrapping to the first.
+        // Moving up past the first workspace always wraps: workspaces are
+        // numbered from 1, so there is no lower-numbered workspace to create.
+        if direction == .down,
+           controller.settings.movePastLastWorkspace == .create,
+           let created = createNextNumberedWorkspace(after: workspaceId, on: monitorId)
+        {
+            return created
+        }
+
+        return if direction == .down {
+            wm.nextWorkspaceInOrder(on: monitorId, from: workspaceId, wrapAround: true)
+        } else {
+            wm.previousWorkspaceInOrder(on: monitorId, from: workspaceId, wrapAround: true)
+        }
+    }
+
+    /// Creates the workspace numbered one higher than `workspaceId` and assigns
+    /// it to `monitorId`. Returns `nil` when the current workspace is not
+    /// numerically named, or when the successor name is already taken (in which
+    /// case the caller wraps instead of silently reusing another monitor's
+    /// workspace).
+    private func createNextNumberedWorkspace(
+        after workspaceId: WorkspaceDescriptor.ID,
+        on monitorId: Monitor.ID
+    ) -> WorkspaceDescriptor? {
+        guard let controller else { return nil }
+        let wm = controller.workspaceManager
+
         guard let currentName = wm.descriptor(for: workspaceId)?.name,
               let currentNumber = Int(currentName)
         else { return nil }
 
-        let candidateNumber = direction == .down ? currentNumber + 1 : currentNumber - 1
-        guard candidateNumber > 0 else { return nil }
-
-        let candidateName = String(candidateNumber)
+        let candidateName = String(currentNumber + 1)
         guard wm.workspaceId(named: candidateName) == nil else { return nil }
 
         guard let targetId = wm.workspaceId(for: candidateName, createIfMissing: false) else { return nil }

--- a/Sources/Nehir/Core/Workspace/MovePastLastWorkspacePolicy.swift
+++ b/Sources/Nehir/Core/Workspace/MovePastLastWorkspacePolicy.swift
@@ -1,0 +1,36 @@
+// SPDX-FileCopyrightText: 2026 BarutSRB
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=upstream-derived; Upstream-Project=OmniWM; Upstream-Author=BarutSRB; Nehir-Changes-Since=2026; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
+import Foundation
+
+/// What "move the focused window one workspace further" does when there is no
+/// further workspace in that direction on the monitor.
+///
+/// This governs only the end-of-list edge reached by moving *down* (toward
+/// higher-numbered workspaces). Moving *up* past the first workspace always
+/// wraps: workspaces are numbered from 1, so there is no lower-numbered
+/// workspace to create, and refusing to move would leave the keystroke with no
+/// effect at all.
+///
+/// Workspace *switching* is deliberately not governed by this policy — it has
+/// always wrapped in both directions and never created workspaces.
+enum MovePastLastWorkspacePolicy: String, CaseIterable, Codable, Identifiable, Sendable {
+    /// Create the next numbered workspace and move the window into it.
+    case create
+    /// Wrap around to the first workspace on the monitor.
+    case wrap
+
+    var id: String {
+        rawValue
+    }
+
+    var displayName: String {
+        switch self {
+        case .create: "Create New Workspace"
+        case .wrap: "Wrap to First Workspace"
+        }
+    }
+}

--- a/Sources/Nehir/UI/BehaviorSettingsTab.swift
+++ b/Sources/Nehir/UI/BehaviorSettingsTab.swift
@@ -49,6 +49,16 @@ struct BehaviorSettingsTab: View {
                     "When moving a window to another workspace, switches your active workspace to follow it."
                 )
 
+                Picker("Move Past Last Workspace", selection: $settings.movePastLastWorkspace) {
+                    ForEach(MovePastLastWorkspacePolicy.allCases) { policy in
+                        Text(policy.displayName).tag(policy)
+                    }
+                }
+                SettingsCaption(
+                    "When moving a window down past the last workspace, either create a new workspace "
+                        + "or wrap around to the first. Moving up past the first workspace always wraps."
+                )
+
                 Picker("Reveal Style", selection: $settings.revealStyle) {
                     ForEach(RevealStyle.allCases, id: \.self) { policy in
                         Text(policy.displayName).tag(policy)


### PR DESCRIPTION
## Problem

Moving a window down past the last workspace on a monitor created the next numbered workspace, while moving a window up past the first workspace did nothing at all — the keystroke was silently dropped.

Workspace switching, which is commonly bound to the same keys without Shift, has always wrapped in both directions (`switchWorkspaceRelative` defaults to `wrapAround: true`). Moving a window hardcoded `wrapAround: false`, so the two paths disagreed at both edges of the workspace list.

## Change

Adds a `MovePastLastWorkspacePolicy` setting, exposed as `[workspace] movePastLastWorkspace` in `settings.toml` and as a "Move Past Last Workspace" picker in the Behavior settings tab.

- `create` (default) preserves the existing behavior of creating the next numbered workspace at the end of the list.
- `wrap` instead wraps to the first workspace on the monitor, matching how switching already behaves.

Moving up past the first workspace now always wraps regardless of the setting. Workspaces are numbered from 1, so there is no lower-numbered workspace to create, and the previous behavior left the keystroke with no effect — the setting governs only the end-of-list edge reached by moving down.

Workspace switching deliberately keeps its own always-wrap behavior and does not read the new setting, so this changes nothing about switching.

## Notes

- Absent or unknown config keys take the default, so existing configs are unaffected. No migration shim, since the key has never shipped.
- A single-workspace monitor still creates the next workspace under `create`: `adjacentWorkspaceInOrder` returns `nil` for `ordered.count <= 1` even when wrapping, so the creation branch is still reached.

## Status

`swift build` passes. Runtime behavior is **implemented but unconfirmed** — not yet verified in a real reproduction. Tests are deferred per `docs/TESTING.md` until the behavior is confirmed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a “Move Past Last Workspace” navigation setting.
  - Choose whether moving beyond the last workspace creates a new workspace or wraps to the first.
  - Moving upward past the first workspace now wraps to the last workspace.
  - The setting is preserved when exporting and importing preferences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a persisted workspace-edge movement policy and exposes it in Behavior settings, while changing upward edge moves to wrap.
- Adds create and wrap policy choices with TOML serialization and live SettingsStore binding.
- Refactors adjacent-workspace resolution to handle creation and wrapping at list boundaries.
- The create path currently cannot create its target, workspace unknown fields are not preserved, and the canonical fixture is stale.

<h3>Confidence Score: 2/5</h3>

The PR is not safe to merge until create mode can create its successor workspace, workspace unknown keys are preserved, and the canonical fixture is updated.

The default movement policy always falls through to wrapping because creation is disabled for an absent target; the new TOML table also drops unknown workspace keys during round trips and breaks the exact canonical serialization test.

**Files Needing Attention:** Sources/Nehir/Core/Controller/WorkspaceNavigationHandler.swift, Sources/Nehir/Core/Config/CanonicalTOMLConfig.swift, Tests/NehirTests/Fixtures/canonical-settings.toml

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| Sources/Nehir/Core/Controller/WorkspaceNavigationHandler.swift | Refactors edge resolution, but disables creation when looking up the confirmed-absent successor, causing create mode to wrap. |
| Sources/Nehir/Core/Config/CanonicalTOMLConfig.swift | Adds workspace TOML serialization but omits workspace unknown-field propagation and invalidates the existing canonical fixture. |
| Sources/Nehir/Core/Config/SettingsStore.swift | Correctly stores, exports, imports, and autosaves the typed policy. |
| Sources/Nehir/UI/BehaviorSettingsTab.swift | Adds a picker bound to the shared live SettingsStore policy. |
| Sources/Nehir/Core/Workspace/MovePastLastWorkspacePolicy.swift | Defines the create and wrap policy values and display labels. |


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Move window or column vertically] --> B{Interior adjacent workspace exists?}
    B -- Yes --> C[Move to adjacent workspace]
    B -- No --> D{Direction is down and policy is create?}
    D -- Yes --> E[Create next numbered workspace]
    E -- Creation succeeds --> F[Move to new workspace]
    E -- Creation returns nil --> G[Wrap lookup]
    D -- No --> G
    G --> H[Move to opposite edge workspace]
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `Sources/Nehir/Core/Config/CanonicalTOMLConfig.swift`, line 393-394 ([link](https://github.com/apphane-dev/nehir/blob/82c3e79434be843f391e598ee0020cb9e80da111/Sources/Nehir/Core/Config/CanonicalTOMLConfig.swift#L393-L394)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Workspace Unknown Fields Are Dropped**

   When a hand-edited or newer configuration contains an unrecognized key under `[workspace]`, decoding captures it in `workspace.unknownFields` but this conversion omits it from `SettingsExport`, causing the key to be silently deleted on the next save.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: Sources/Nehir/Core/Config/CanonicalTOMLConfig.swift
   Line: 393-394

   Comment:
   **Workspace Unknown Fields Are Dropped**

   When a hand-edited or newer configuration contains an unrecognized key under `[workspace]`, decoding captures it in `workspace.unknownFields` but this conversion omits it from `SettingsExport`, causing the key to be silently deleted on the next save.

   

   ---

   For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20Sources%2FNehir%2FCore%2FConfig%2FCanonicalTOMLConfig.swift%0ALine%3A%20393-394%0A%0AComment%3A%0A**Workspace%20Unknown%20Fields%20Are%20Dropped**%0A%0AWhen%20a%20hand-edited%20or%20newer%20configuration%20contains%20an%20unrecognized%20key%20under%20%60%5Bworkspace%5D%60%2C%20decoding%20captures%20it%20in%20%60workspace.unknownFields%60%20but%20this%20conversion%20omits%20it%20from%20%60SettingsExport%60%2C%20causing%20the%20key%20to%20be%20silently%20deleted%20on%20the%20next%20save.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20add%28%22niri%22%2C%20niri.unknownFields%29%0A%20%20%20%20%20%20%20%20add%28%22workspace%22%2C%20workspace.unknownFields%29%0A%20%20%20%20%20%20%20%20add%28%22borders%22%2C%20borders.unknownFields%29%0A%60%60%60%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=apphane-dev%2Fnehir&pr=202&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22apphane-dev%2Fnehir%22%20on%20the%20existing%20branch%20%22la%2Fmove-past-last-workspace%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22la%2Fmove-past-last-workspace%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20Sources%2FNehir%2FCore%2FConfig%2FCanonicalTOMLConfig.swift%0ALine%3A%20393-394%0A%0AComment%3A%0A**Workspace%20Unknown%20Fields%20Are%20Dropped**%0A%0AWhen%20a%20hand-edited%20or%20newer%20configuration%20contains%20an%20unrecognized%20key%20under%20%60%5Bworkspace%5D%60%2C%20decoding%20captures%20it%20in%20%60workspace.unknownFields%60%20but%20this%20conversion%20omits%20it%20from%20%60SettingsExport%60%2C%20causing%20the%20key%20to%20be%20silently%20deleted%20on%20the%20next%20save.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20add%28%22niri%22%2C%20niri.unknownFields%29%0A%20%20%20%20%20%20%20%20add%28%22workspace%22%2C%20workspace.unknownFields%29%0A%20%20%20%20%20%20%20%20add%28%22borders%22%2C%20borders.unknownFields%29%0A%60%60%60%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=apphane-dev%2Fnehir&pr=202&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Greploop%20apphane-dev%2Fnehir%20PR%20%23202%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%E2%95%AD%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AE%0A%E2%94%82%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%E2%94%82%0A%E2%94%82%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%E2%94%82%0A%E2%95%B0%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AF%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&repo=apphane-dev%2Fnehir&pr=202&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0ASources%2FNehir%2FCore%2FController%2FWorkspaceNavigationHandler.swift%3A620%0A**Creation%20Lookup%20Disables%20Creation**%0A%0AWhen%20a%20window%20or%20column%20moves%20down%20from%20the%20last%20numbered%20workspace%20under%20the%20default%20%60create%60%20policy%2C%20the%20helper%20first%20confirms%20the%20successor%20is%20absent%20and%20then%20requests%20it%20with%20%60createIfMissing%3A%20false%60%2C%20so%20creation%20always%20returns%20%60nil%60%20and%20the%20move%20wraps%20to%20the%20first%20workspace%20instead.%0A%0A%23%23%23%20Issue%202%0ASources%2FNehir%2FCore%2FConfig%2FCanonicalTOMLConfig.swift%3A393-394%0A**Workspace%20Unknown%20Fields%20Are%20Dropped**%0A%0AWhen%20a%20hand-edited%20or%20newer%20configuration%20contains%20an%20unrecognized%20key%20under%20%60%5Bworkspace%5D%60%2C%20decoding%20captures%20it%20in%20%60workspace.unknownFields%60%20but%20this%20conversion%20omits%20it%20from%20%60SettingsExport%60%2C%20causing%20the%20key%20to%20be%20silently%20deleted%20on%20the%20next%20save.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20add%28%22niri%22%2C%20niri.unknownFields%29%0A%20%20%20%20%20%20%20%20add%28%22workspace%22%2C%20workspace.unknownFields%29%0A%20%20%20%20%20%20%20%20add%28%22borders%22%2C%20borders.unknownFields%29%0A%60%60%60%0A%0A%23%23%23%20Issue%203%0ASources%2FNehir%2FCore%2FConfig%2FCanonicalTOMLConfig.swift%3A513%0A**Canonical%20Fixture%20No%20Longer%20Matches**%0A%0ACanonical%20encoding%20now%20always%20emits%20%60%5Bworkspace%5D%60%20and%20%60movePastLastWorkspace%60%2C%20while%20the%20existing%20golden%20fixture%20contains%20neither%2C%20causing%20%60canonicalDefaultsMatchGoldenFixture%60%20to%20record%20a%20test%20failure.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=apphane-dev%2Fnehir&pr=202&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22apphane-dev%2Fnehir%22%20on%20the%20existing%20branch%20%22la%2Fmove-past-last-workspace%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22la%2Fmove-past-last-workspace%22.%0A%0A%23%23%23%20Issue%201%0ASources%2FNehir%2FCore%2FController%2FWorkspaceNavigationHandler.swift%3A620%0A**Creation%20Lookup%20Disables%20Creation**%0A%0AWhen%20a%20window%20or%20column%20moves%20down%20from%20the%20last%20numbered%20workspace%20under%20the%20default%20%60create%60%20policy%2C%20the%20helper%20first%20confirms%20the%20successor%20is%20absent%20and%20then%20requests%20it%20with%20%60createIfMissing%3A%20false%60%2C%20so%20creation%20always%20returns%20%60nil%60%20and%20the%20move%20wraps%20to%20the%20first%20workspace%20instead.%0A%0A%23%23%23%20Issue%202%0ASources%2FNehir%2FCore%2FConfig%2FCanonicalTOMLConfig.swift%3A393-394%0A**Workspace%20Unknown%20Fields%20Are%20Dropped**%0A%0AWhen%20a%20hand-edited%20or%20newer%20configuration%20contains%20an%20unrecognized%20key%20under%20%60%5Bworkspace%5D%60%2C%20decoding%20captures%20it%20in%20%60workspace.unknownFields%60%20but%20this%20conversion%20omits%20it%20from%20%60SettingsExport%60%2C%20causing%20the%20key%20to%20be%20silently%20deleted%20on%20the%20next%20save.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20add%28%22niri%22%2C%20niri.unknownFields%29%0A%20%20%20%20%20%20%20%20add%28%22workspace%22%2C%20workspace.unknownFields%29%0A%20%20%20%20%20%20%20%20add%28%22borders%22%2C%20borders.unknownFields%29%0A%60%60%60%0A%0A%23%23%23%20Issue%203%0ASources%2FNehir%2FCore%2FConfig%2FCanonicalTOMLConfig.swift%3A513%0A**Canonical%20Fixture%20No%20Longer%20Matches**%0A%0ACanonical%20encoding%20now%20always%20emits%20%60%5Bworkspace%5D%60%20and%20%60movePastLastWorkspace%60%2C%20while%20the%20existing%20golden%20fixture%20contains%20neither%2C%20causing%20%60canonicalDefaultsMatchGoldenFixture%60%20to%20record%20a%20test%20failure.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=apphane-dev%2Fnehir&pr=202&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
Sources/Nehir/Core/Controller/WorkspaceNavigationHandler.swift:620
**Creation Lookup Disables Creation**

When a window or column moves down from the last numbered workspace under the default `create` policy, the helper first confirms the successor is absent and then requests it with `createIfMissing: false`, so creation always returns `nil` and the move wraps to the first workspace instead.

### Issue 2
Sources/Nehir/Core/Config/CanonicalTOMLConfig.swift:393-394
**Workspace Unknown Fields Are Dropped**

When a hand-edited or newer configuration contains an unrecognized key under `[workspace]`, decoding captures it in `workspace.unknownFields` but this conversion omits it from `SettingsExport`, causing the key to be silently deleted on the next save.

```suggestion
        add("niri", niri.unknownFields)
        add("workspace", workspace.unknownFields)
        add("borders", borders.unknownFields)
```

### Issue 3
Sources/Nehir/Core/Config/CanonicalTOMLConfig.swift:513
**Canonical Fixture No Longer Matches**

Canonical encoding now always emits `[workspace]` and `movePastLastWorkspace`, while the existing golden fixture contains neither, causing `canonicalDefaultsMatchGoldenFixture` to record a test failure.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Add a setting for what happens when movi..."](https://github.com/apphane-dev/nehir/commit/82c3e79434be843f391e598ee0020cb9e80da111) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55220888)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->