### PR TITLE
Raise the focused window above windows restored during a workspace transition

### DIFF
--- a/.changeset/20260819123000-raise-a-window-moved-to-another-workspace-above-th.md
+++ b/.changeset/20260819123000-raise-a-window-moved-to-another-workspace-above-th.md
@@ -1,0 +1,6 @@
+---
+"nehir": patch
+
+---
+
+Fix a moved window being hidden behind other windows on its destination workspace. When you moved a window to another workspace and Nehir followed it there, the windows already on that workspace were raised to the front while the moved window was not, so it held keyboard focus but was covered by whatever else was there. The focused window is now raised along with them.

--- a/Sources/Nehir/Core/Controller/LayoutRefreshController.swift
+++ b/Sources/Nehir/Core/Controller/LayoutRefreshController.swift
@@ -4722,6 +4722,32 @@ final class LayoutDiffExecutor {
             }
         }
 
+        // A window transferred in from a *visible* workspace has no visibility
+        // change to hook onto: it was never hidden, so it produces neither a
+        // `.show` nor a `restoreChange` and is therefore absent from
+        // `visibleJobs` above. The windows already resident on this workspace
+        // were parked while it was inactive, so they *do* restore and get
+        // force-ordered above — burying the transferred window even though it
+        // holds focus. Raise the focused window last, through the same
+        // SkyLight ordering the restore pass uses, so it ends up on top of the
+        // windows this pass just raised. The post-layout focus handoff's
+        // AXRaise cannot be relied on for this: it is app-cooperative and runs
+        // after these forced private-API orderings.
+        //
+        // This runs unconditionally for the focused window rather than only for
+        // tokens missing from `visibleJobs`: a focused window that *did* restore
+        // is ordered somewhere in the middle of the loop above and can still be
+        // buried by a sibling raised after it. Re-raising it here is idempotent
+        // and makes "the focused window ends up on top" hold either way.
+        if isPlanWorkspaceActive,
+           let focusedToken = diff.focusedFrame?.token,
+           !blockedRevealTokens.contains(focusedToken),
+           !hiddenTokens.contains(focusedToken),
+           let skyLightWindowId = UInt32(exactly: focusedToken.windowId)
+        {
+            SkyLight.shared.orderWindow(skyLightWindowId, relativeTo: 0, order: .above)
+        }
+
         var frameUpdates: [(pid: pid_t, windowId: Int, frame: CGRect)] = []
         frameUpdates.reserveCapacity(diff.frameChanges.count)
         var resizeMinimumProbeFrameUpdates: [(pid: pid_t, windowId: Int, frame: CGRect)] = []


### PR DESCRIPTION
## Problem

A window moved to another workspace holds keyboard focus on its destination but is drawn *underneath* the windows already there. Reproduced with a single TextEdit window moved from workspace 1 to workspace 2: the workspace switch happens, focus lands on the moved window, but the window visible on screen is a different one.

## Root cause

The layout pass raises windows only when their *visibility* changed. `visibleJobs` (`LayoutRefreshController.swift`) is built from `restoreEntries` and `shownEntries`, which come from `diff.restoreChanges` and `.show` visibility changes. Both are gated on prior hidden state in the diff builder (`NiriLayoutHandler.swift`): `.show` requires `previousOffscreenSide != nil`, and `restoreChanges` requires `hiddenState.workspaceInactive`.

A window transferred in from a **visible** workspace was never hidden, so its `hiddenState` is `nil`, both branches are skipped, and it falls through as a plain `frameChange`. It is framed correctly and made writable, but never raised.

The windows already resident on the destination workspace *were* parked while that workspace was inactive, so they do produce `restoreChanges`, land in `restoreEntries`, and get force-ordered above via `SkyLight.orderWindow`. Whichever is raised last ends up on top of the transferred window.

The only thing raising the moved window was the post-layout focus handoff's `raiseWindow` → `AXUIElementPerformAction(kAXRaiseAction)`, which is app-cooperative and runs *after* those forced private-API orderings. The `diff.focusedFrame` raise that would otherwise have covered this is gated on `column.isEffectivelyTabbed`, so it does not apply to an untabbed single-window column.

## Change

Raise the focused window through the same SkyLight ordering the restore pass uses, immediately after that pass, so it ends up above the windows just raised. `diff.focusedFrame` already identifies the right window: its token comes from `visualFocusToken`, which starts from the engine's `selectedNodeId` — set to the moved window during transfer.

Guards mirror the existing ordering loop (`blockedRevealTokens`, `hiddenTokens`, `isPlanWorkspaceActive`), so this cannot raise a window on an inactive workspace or one deliberately withheld from reveal.

The raise runs unconditionally for the focused window rather than only for tokens missing from `visibleJobs`: a focused window that *did* restore is ordered somewhere in the middle of that loop and can still be buried by a sibling raised after it. The call is idempotent, so "the focused window ends up on top" holds either way.

## Notes

- The existing tabbed-column raise still runs afterward for tabbed columns; that path is unchanged.
- This is distinct from #69, which is the Nehir-fullscreen `sizingMode` / `effectiveViewportWidth` issue. This PR is only about z-ordering on transfer.

## Status

`swift build` passes. The fix is **implemented but unconfirmed**: the diagnosis of *which* ordering mechanism wins is a hypothesis about runtime behavior, and only the real reproduction can settle it. Tests are deferred per `docs/TESTING.md` until the behavior is confirmed.

Stacked on #202 (that commit is this branch's parent).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a “Move Past Last Workspace” setting with options to create a new workspace or wrap to the first workspace.
  - Saved and imported the new setting with other preferences.
  - Improved workspace navigation behavior when moving beyond the final workspace.

- **Bug Fixes**
  - Focused windows moved to another workspace now remain above other windows and visible after the transition.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR raises the focused window after workspace restoration ordering so that a transferred window remains above restored destination windows.
- Adds a guarded SkyLight ordering call for the focused, visible window on the active workspace.
- Adds a patch changeset describing the corrected workspace-transition z-order behavior.

<h3>Confidence Score: 4/5</h3>

The PR is not yet safe to merge because the previously reported create policy still fails to create and move to an absent adjacent workspace.

The focused-window ordering change introduces no eligible blocking finding, but the existing adjacent-workspace resolver still checks that the target is absent and then disables creation, so moving a window or column past the final workspace returns without completing the requested move.

**Files Needing Attention:** Sources/Nehir/Core/Controller/WorkspaceNavigationHandler.swift; Sources/Nehir/Core/Controller/WorkspaceManager.swift

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Sources/Nehir/Core/Controller/LayoutRefreshController.swift | Raises the eligible focused window after restored windows have been ordered, preserving its intended frontmost position. |
| .changeset/20260819123000-raise-a-window-moved-to-another-workspace-above-th.md | Documents the focused-window z-order correction as a patch release. |

<sub>Reviews (2): Last reviewed commit: ["Raise the focused window above windows r..."](https://github.com/apphane-dev/nehir/commit/e7bba3cbe8bb7ed16e9cd0a545ba13ff5f2feda9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55221834)</sub>

<!-- /greptile_comment -->