### PR TITLE
Add a diagnostic test for revealing a window moved into a four-column workspace

### DIFF
--- a/.provenance.json
+++ b/.provenance.json
@@ -93,6 +93,7 @@
         "Tests/NehirTests/FocusPreviousCrossWorkspaceTests.swift",
         "Tests/NehirTests/InteractiveMoveDemoModelTests.swift",
         "Tests/NehirTests/MonitorIdentityMatchingTests.swift",
+        "Tests/NehirTests/MovedWindowRevealAfterWorkspaceTransferTests.swift",
         "Tests/NehirTests/NiriMonitorTests.swift",
         "Tests/NehirTests/ParkedViewportRelayoutTests.swift",
         "Tests/NehirTests/PureLayoutAgreementTests.swift",

--- a/Tests/NehirTests/MovedWindowRevealAfterWorkspaceTransferTests.swift
+++ b/Tests/NehirTests/MovedWindowRevealAfterWorkspaceTransferTests.swift
@@ -1,0 +1,234 @@
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=nehir-original; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
+import AppKit
+@testable import Nehir
+import Testing
+
+/// Moving a window to another workspace must leave its column inside the
+/// destination viewport, not parked outside it.
+///
+/// `ensureSelectionVisible` does two things in sequence: it rebases
+/// `viewOffsetPixels` so that retargeting `activeColumnIndex` does not shift what
+/// is on screen, and it then calls `scrollToReveal` to bring the newly selected
+/// column into view. The rebase is deliberately view-neutral, so the reveal is
+/// the only step that can actually move the viewport.
+///
+/// The state under test is the one observed in a real reproduction: a window moved
+/// into a four-column destination workspace ends up selected in the last column
+/// while the viewport still rests at the far left, so the focused window is parked
+/// offscreen and never receives a frame write.
+@Suite struct MovedWindowRevealAfterWorkspaceTransferTests {
+    /// The rebase preserves the on-screen view exactly, which is what makes the
+    /// follow-up reveal load-bearing. Retargeting from column 2 to column 3 turns
+    /// `viewOffsetPixels` -2360 into -3530 while `viewStart` stays at -20.
+    @Test func rebasingActiveColumnPreservesViewStart() {
+        let fixture = makeFixture()
+
+        let beforeViewStart = fixture.state.viewPosPixels(columns: fixture.columns, gap: fixture.gap)
+        #expect(beforeViewStart == -20)
+
+        var state = fixture.state
+        let oldActivePos = state.containerPosition(
+            at: state.activeColumnIndex,
+            containers: fixture.columns,
+            gap: fixture.gap,
+            sizeKeyPath: \.cachedWidth
+        )
+        let newActivePos = state.containerPosition(
+            at: movedColumn,
+            containers: fixture.columns,
+            gap: fixture.gap,
+            sizeKeyPath: \.cachedWidth
+        )
+        state.viewOffsetPixels.offset(delta: Double(oldActivePos - newActivePos))
+        state.activeColumnIndex = movedColumn
+
+        #expect(state.viewOffsetPixels.current() == -3530)
+        #expect(state.viewPosPixels(columns: fixture.columns, gap: fixture.gap) == -20)
+    }
+
+    /// With the viewport resting at -20 and the moved window's column starting at
+    /// 3510, the column is entirely outside the viewport.
+    @Test func movedColumnIsParkedBeforeReveal() {
+        let fixture = rebasedFixture()
+
+        #expect(fixture.visibility(of: movedColumn) == .parked(.maximum))
+    }
+
+    /// The behaviour the real reproduction contradicts: a parked destination column
+    /// must be revealed, leaving the moved window inside the viewport.
+    @Test func revealsMovedColumnParkedOutsideDestinationViewport() {
+        var fixture = rebasedFixture()
+        #expect(fixture.visibility(of: movedColumn) == .parked(.maximum))
+
+        let revealed = fixture.reveal(movedColumn, trigger: .automatic)
+
+        #expect(revealed)
+        #expect(fixture.visibility(of: movedColumn) != .parked(.maximum))
+    }
+
+    /// A scroll must actually be scheduled. In the reproduction the committed state
+    /// had `currentViewStart == targetViewStart == -20`, meaning nothing was queued.
+    @Test func schedulesScrollTowardMovedColumn() {
+        var fixture = rebasedFixture()
+        let originalTarget = fixture.state.viewOffsetPixels.target()
+
+        _ = fixture.reveal(movedColumn, trigger: .automatic)
+
+        #expect(fixture.state.viewOffsetPixels.target() != originalTarget)
+    }
+
+    /// Scroll lock does not exempt this: its own contract is that a fully parked
+    /// target is still revealed, because focus otherwise lands somewhere invisible.
+    @Test func revealsMovedColumnEvenWhenViewportIsScrollLocked() {
+        var fixture = rebasedFixture()
+        fixture.state.isScrollLocked = true
+        #expect(fixture.visibility(of: movedColumn) == .parked(.maximum))
+
+        let revealed = fixture.reveal(movedColumn, trigger: .automatic)
+
+        #expect(revealed)
+        #expect(fixture.visibility(of: movedColumn) != .parked(.maximum))
+    }
+
+    /// With motion disabled the reveal is instantaneous: `animateToOffset` takes its
+    /// static fallback, so both the current and target offsets land on the snap and
+    /// nothing is left animating. The five tests above exercise this path.
+    @Test func revealWithMotionDisabledLandsStaticallyOnTheSnap() {
+        var fixture = rebasedFixture()
+
+        _ = fixture.reveal(movedColumn, trigger: .automatic, motion: .disabled)
+
+        #expect(!fixture.state.viewOffsetPixels.isAnimating)
+        #expect(fixture.state.viewOffsetPixels.current() == fixture.state.viewOffsetPixels.target())
+    }
+
+    /// `MotionPolicy.snapshot()` returns `.enabled`, so this is the configuration the
+    /// runtime move path actually uses. Here `animateToOffset` installs a spring:
+    /// the target moves to the snap while the current offset stays put for the
+    /// display-link driver to interpolate.
+    @Test func revealWithMotionEnabledSchedulesAnimationWithoutMovingCurrentOffset() {
+        var fixture = rebasedFixture()
+        let currentBefore = fixture.state.viewOffsetPixels.current()
+        let targetBefore = fixture.state.viewOffsetPixels.target()
+
+        _ = fixture.reveal(movedColumn, trigger: .automatic, motion: .enabled)
+
+        #expect(fixture.state.viewOffsetPixels.isAnimating)
+        #expect(fixture.state.viewOffsetPixels.target() != targetBefore)
+        #expect(abs(fixture.state.viewOffsetPixels.current() - currentBefore) <= 1)
+    }
+
+    /// The plan-build step in `NiriLayoutHandler` decides whether to emit a
+    /// `.startNiriScroll` directive by testing
+    /// `abs(viewOffsetPixels.current() - offsetBefore) > 1`. Under the production
+    /// motion value the reveal moves only the target, so that comparison does not
+    /// observe the scheduled scroll — while `isAnimating` and the target delta do.
+    ///
+    /// This records the asymmetry between the three signals rather than asserting a
+    /// desired directive outcome.
+    @Test func currentOffsetDeltaDoesNotObserveAnAnimatedScroll() {
+        var fixture = rebasedFixture()
+        let offsetBefore = fixture.state.viewOffsetPixels.current()
+
+        _ = fixture.reveal(movedColumn, trigger: .automatic, motion: .enabled)
+
+        let currentDelta = abs(fixture.state.viewOffsetPixels.current() - offsetBefore)
+        let targetDelta = abs(fixture.state.viewOffsetPixels.target() - offsetBefore)
+
+        #expect(currentDelta <= 1)
+        #expect(targetDelta > 1)
+        #expect(fixture.state.viewOffsetPixels.isAnimating)
+    }
+
+    // MARK: - Fixture
+
+    /// Four 1150pt columns with a 20pt gap at x = 0, 1170, 2340, 3510, seen through a
+    /// 2560pt viewport — the destination workspace geometry from the reproduction.
+    /// The moved window lands in the last column.
+    private let movedColumn = 3
+
+    private struct Fixture {
+        let engine: NiriLayoutEngine
+        let columns: [NiriContainer]
+        let gap: CGFloat
+        let viewportWidth: CGFloat
+        var state: ViewportState
+
+        var context: ViewportSnapContext {
+            state.snapContext(columns: columns, gap: gap, viewportWidth: viewportWidth)
+        }
+
+        func visibility(of columnIndex: Int) -> ColumnVisibility {
+            let context = context
+            return context.visibility(
+                of: columnIndex,
+                viewportOffset: context.currentViewStart(in: state),
+                in: state
+            )
+        }
+
+        mutating func reveal(
+            _ columnIndex: Int,
+            trigger: RevealTrigger,
+            motion: MotionSnapshot = .disabled
+        ) -> Bool {
+            engine.scrollToReveal(
+                columnIndex: columnIndex,
+                isFFM: false,
+                state: &state,
+                context: context,
+                motion: motion,
+                trigger: trigger
+            )
+        }
+    }
+
+    /// The pre-transfer destination state: selection on column 2, viewport at -20.
+    private func makeFixture() -> Fixture {
+        let engine = NiriLayoutEngine()
+        engine.revealStyle = .auto
+        engine.animationClock = AnimationClock()
+        let workspaceId = UUID()
+
+        var previous: NiriNode?
+        for pid in pid_t(801) ... pid_t(804) {
+            previous = engine.addWindow(
+                handle: makeTestHandle(pid: pid),
+                to: workspaceId,
+                afterSelection: previous?.id
+            )
+        }
+
+        let columns = engine.columns(in: workspaceId)
+        for column in columns {
+            column.width = .fixed(1150)
+            column.cachedWidth = 1150
+        }
+
+        var state = ViewportState()
+        state.animationClock = engine.animationClock
+        state.activeColumnIndex = 2
+        state.viewOffsetPixels = .static(-2360)
+
+        return Fixture(
+            engine: engine,
+            columns: columns,
+            gap: 20,
+            viewportWidth: 2560,
+            state: state
+        )
+    }
+
+    /// `makeFixture()` after the view-neutral rebase onto the moved window's column:
+    /// `activeColumnIndex` 3 with `viewOffsetPixels` -3530, i.e. `viewStart` -20.
+    private func rebasedFixture() -> Fixture {
+        var fixture = makeFixture()
+        fixture.state.activeColumnIndex = movedColumn
+        fixture.state.viewOffsetPixels = .static(-3530)
+        return fixture
+    }
+}


### PR DESCRIPTION
## Why

A window moved to another workspace can end up selected in a column outside the destination viewport: parked offscreen, given no frame write, yet holding keyboard focus. The user sees a different window than the one they moved, while keystrokes go to the moved window.

The runtime defect is **timing-dependent** — it does not reproduce while trace capture is active, and reproduces most of the time when it is off. That makes runtime instrumentation unreliable for locating it, so this records the observed state as a deterministic test instead.

## What this records

The fixture is the destination geometry from a real reproduction: four 1150pt columns with a 20pt gap at `x = 0, 1170, 2340, 3510`, seen through a 2560pt viewport, with the moved window landing in the last column.

In that state the rebase step of `ensureSelectionVisible` leaves `viewOffsetPixels` at `-3530` with `viewStart` at `-20` — verified by reproducing the arithmetic from the captured values. Column 3 therefore starts roughly 970pt beyond the right viewport edge, and `columnVisibility` classifies it `.parked(.maximum)`.

The tests assert what should then happen:

- `rebasingActiveColumnPreservesViewStart` — the rebase is view-neutral (this is by design, and is what makes the follow-up reveal load-bearing)
- `movedColumnIsParkedBeforeReveal` — the moved column is fully outside the viewport
- `revealsMovedColumnParkedOutsideDestinationViewport` — a parked destination column is revealed
- `schedulesScrollTowardMovedColumn` — a scroll is actually queued (the reproduction showed `currentViewStart == targetViewStart == -20`, i.e. nothing queued)
- `revealsMovedColumnEvenWhenViewportIsScrollLocked` — scroll lock does not exempt a fully parked target, per its own documented contract

## Status

**Diagnostic, not a regression guard for a landed fix.** No fix accompanies it. The point is to determine deterministically whether `scrollToReveal` mishandles this state, or whether the reveal result is computed correctly and then lost before the layout pass consumes it.

Source analysis of `scrollToReveal` against these exact numbers suggests every snap candidate for column 3 yields a target offset far from `-3530` (`leftEdge` → `-20`, `rightEdge` → `-1390`, `center` → `-705`, against a 0.5pt tolerance), so the reveal *should* schedule a scroll. If these tests pass, that points at the commit/ordering path rather than the reveal logic.

Note this cannot be run locally without Xcode (Swift Testing ships with it); opening as a draft so CI runs the suite.

Based on `main` rather than on #202/#203 so the result is not affected by those changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a deterministic Swift Testing fixture for the viewport state observed after moving a window into a four-column workspace and records the file in provenance metadata.
- Verifies view-neutral active-column rebasing and initial parked visibility.
- Exercises reveal behavior with scroll lock and both disabled and enabled motion.
- Records the offset-signal asymmetry involved in scheduling animated scrolling, but does not cover the subsequent layout directive boundary.

<h3>Confidence Score: 4/5</h3>

The PR appears safe to merge, with the non-blocking limitation that its diagnostic stops before the production layout directive path it is intended to help distinguish.

The fixture correctly exercises viewport rebasing, visibility, and reveal state transitions, but it can pass without demonstrating that the scheduled animated scroll survives layout-plan construction and reaches the display-link driver.

**Files Needing Attention:** Tests/NehirTests/MovedWindowRevealAfterWorkspaceTransferTests.swift

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Tests/NehirTests/MovedWindowRevealAfterWorkspaceTransferTests.swift | Adds coherent unit-level coverage of the reproduced viewport arithmetic and reveal behavior, but does not assert the production layout/directive boundary implicated by the defect. |
| .provenance.json | Correctly records the newly added Nehir-original test file in the existing provenance override. |

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Transfer as Workspace transfer
    participant Reveal as ensureSelectionVisible / scrollToReveal
    participant State as ViewportState
    participant Plan as Layout plan
    participant Driver as Display-link driver
    Transfer->>Reveal: Move selection into destination column
    Reveal->>State: Install spring target
    State-->>Reveal: current unchanged, target changed
    Reveal-->>Plan: Return scheduled reveal state
    Plan->>Driver: Emit startNiriScroll directive
    Note over Reveal,State: New tests stop here
    Driver->>State: Interpolate current toward target
```

<a href="https://app.greptile.com/ide/claude-code?prompt=Greploop%20apphane-dev%2Fnehir%20PR%20%23204%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%E2%95%AD%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AE%0A%E2%94%82%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%E2%94%82%0A%E2%94%82%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%E2%94%82%0A%E2%95%B0%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AF%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&repo=apphane-dev%2Fnehir&pr=204&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0ATests%2FNehirTests%2FMovedWindowRevealAfterWorkspaceTransferTests.swift%3A134-146%0A**Diagnostic%20stops%20before%20directive%20emission**%0A%0AThis%20test%20records%20that%20an%20enabled-motion%20reveal%20changes%20the%20target%20while%20leaving%20the%20current%20offset%20unchanged%2C%20but%20it%20bypasses%20layout-plan%20construction%20and%20never%20checks%20whether%20%60.startNiriScroll%60%20reaches%20the%20display-link%20driver.%20The%20suite%20therefore%20passes%20even%20when%20the%20subsequent%20production%20boundary%20drops%20the%20scheduled%20scroll%2C%20limiting%20its%20ability%20to%20localize%20the%20reported%20defect.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=apphane-dev%2Fnehir&pr=204&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22apphane-dev%2Fnehir%22%20on%20the%20existing%20branch%20%22la%2Fmoved-window-reveal-diagnostic%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22la%2Fmoved-window-reveal-diagnostic%22.%0A%0A%23%23%23%20Issue%201%0ATests%2FNehirTests%2FMovedWindowRevealAfterWorkspaceTransferTests.swift%3A134-146%0A**Diagnostic%20stops%20before%20directive%20emission**%0A%0AThis%20test%20records%20that%20an%20enabled-motion%20reveal%20changes%20the%20target%20while%20leaving%20the%20current%20offset%20unchanged%2C%20but%20it%20bypasses%20layout-plan%20construction%20and%20never%20checks%20whether%20%60.startNiriScroll%60%20reaches%20the%20display-link%20driver.%20The%20suite%20therefore%20passes%20even%20when%20the%20subsequent%20production%20boundary%20drops%20the%20scheduled%20scroll%2C%20limiting%20its%20ability%20to%20localize%20the%20reported%20defect.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=apphane-dev%2Fnehir&pr=204&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
Tests/NehirTests/MovedWindowRevealAfterWorkspaceTransferTests.swift:134-146
**Diagnostic stops before directive emission**

This test records that an enabled-motion reveal changes the target while leaving the current offset unchanged, but it bypasses layout-plan construction and never checks whether `.startNiriScroll` reaches the display-link driver. The suite therefore passes even when the subsequent production boundary drops the scheduled scroll, limiting its ability to localize the reported defect.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Add diagnostic tests for revealing a win..."](https://github.com/apphane-dev/nehir/commit/db1ecef949953fa6cea9f7a32a5fa30e7e1a87a4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55229392)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->