### PR TITLE
Reveal a window re-focused after moving to another workspace

### DIFF
--- a/.changeset/20260820140000-reveal-a-window-moved-to-another-workspace-when-it.md
+++ b/.changeset/20260820140000-reveal-a-window-moved-to-another-workspace-when-it.md
@@ -1,0 +1,6 @@
+---
+"nehir": patch
+
+---
+
+Fix a window moved to another workspace staying off screen. When the moved window already had focus, Nehir treated the follow-up focus notification as the same window being re-focused in place and kept the destination workspace's viewport where it was, leaving the moved window parked off the edge of the screen while still receiving keyboard input. A window re-focused after changing workspace is now scrolled into view.

--- a/.provenance.json
+++ b/.provenance.json
@@ -88,6 +88,7 @@
         "Sources/Nehir/UI/SettingInfo.swift",
         "Sources/NehirCtl/CLILegalNotice.swift",
         "Tests/NehirTests/ConfigMismatchDetectorTests.swift",
+        "Tests/NehirTests/ConfirmedFocusWorkspaceTrackingTests.swift",
         "Tests/NehirTests/DisplayEnvironmentDiagnosticsTests.swift",
         "Tests/NehirTests/DisplaySpacesModeTests.swift",
         "Tests/NehirTests/FocusPreviousCrossWorkspaceTests.swift",

--- a/Sources/Nehir/Core/Controller/AXEventHandler.swift
+++ b/Sources/Nehir/Core/Controller/AXEventHandler.swift
@@ -5466,7 +5466,17 @@ final class AXEventHandler: CGSEventDelegate {
         // window; without this guard the viewport scrolls back to a column the
         // user deliberately scrolled away from.
         let previousConfirmedFocusToken = controller.workspaceManager.confirmedManagedFocusToken
+        // A re-confirmation only counts as "in place" when the window is still in the
+        // workspace focus was last confirmed in. The same window re-focused after
+        // moving to a different workspace has to be revealed there: its column is
+        // wherever the transfer appended it, which is usually outside the destination
+        // viewport, and preserving that viewport leaves the window parked offscreen
+        // while holding focus.
+        let previousConfirmedFocusWorkspaceId = controller.workspaceManager.confirmedManagedFocusWorkspaceId
+        let confirmedFocusWorkspaceUnchanged = previousConfirmedFocusWorkspaceId == nil
+            || previousConfirmedFocusWorkspaceId == wsId
         let wasAlreadyConfirmedFocus = previousConfirmedFocusToken == entry.token
+            && confirmedFocusWorkspaceUnchanged
         let selectedSameAppFocusDisappearedBeforeConfirm = selectedSameAppFocusDisappearedSignal(
             for: entry,
             workspaceId: wsId
@@ -5742,6 +5752,10 @@ final class AXEventHandler: CGSEventDelegate {
                         "preserveActiveViewport=\(preserveActiveViewport)",
                         "preserveActiveViewportReason=\(preserveActiveViewportReason.rawValue)",
                         "skipReason=\(isFFM ? "ffm" : "preserve_active_viewport")",
+                        "confirmedFocusWorkspaceUnchanged=\(confirmedFocusWorkspaceUnchanged)",
+                        "previousConfirmedFocusWorkspace="
+                            + (previousConfirmedFocusWorkspaceId
+                                .flatMap { controller.workspaceManager.descriptor(for: $0)?.name } ?? "nil"),
                         "isWorkspaceActive=\(isWorkspaceActive)"
                     ]
                 )

--- a/Sources/Nehir/Core/Reconcile/ReconcileSnapshot.swift
+++ b/Sources/Nehir/Core/Reconcile/ReconcileSnapshot.swift
@@ -145,6 +145,10 @@ struct PendingManagedFocusSnapshot: Equatable {
 
 struct FocusSessionSnapshot: Equatable {
     var focusedToken: WindowToken?
+    /// Workspace the confirmed focus was established in. Distinguishes a same-window
+    /// re-focus *in place* from the same window being re-focused after moving to a
+    /// different workspace, which must still reveal.
+    var focusedWorkspaceId: WorkspaceDescriptor.ID?
     var pendingManagedFocus: PendingManagedFocusSnapshot
     var focusLease: FocusPolicyLease?
     var isNonManagedFocusActive: Bool

--- a/Sources/Nehir/Core/Reconcile/StateReducer.swift
+++ b/Sources/Nehir/Core/Reconcile/StateReducer.swift
@@ -317,12 +317,13 @@ enum StateReducer {
     private static func managedFocusConfirmed(
         from focusSession: FocusSessionSnapshot,
         token: WindowToken,
-        workspaceId _: WorkspaceDescriptor.ID,
+        workspaceId: WorkspaceDescriptor.ID,
         monitorId _: Monitor.ID?,
         appFullscreen: Bool
     ) -> FocusSessionSnapshot {
         var focusSession = focusSession
         focusSession.focusedToken = token
+        focusSession.focusedWorkspaceId = workspaceId
         focusSession.pendingManagedFocus = .empty
         focusSession.isNonManagedFocusActive = false
         focusSession.isAppFullscreenActive = appFullscreen
@@ -353,6 +354,7 @@ enum StateReducer {
         var focusSession = focusSession
         if active, !preserveFocusedToken {
             focusSession.focusedToken = nil
+            focusSession.focusedWorkspaceId = nil
         }
         if !preservePendingManagedFocus {
             focusSession.pendingManagedFocus = .empty
@@ -384,6 +386,7 @@ enum StateReducer {
         var focusSession = focusSession
         if focusSession.focusedToken == token {
             focusSession.focusedToken = nil
+            focusSession.focusedWorkspaceId = nil
             focusSession.isAppFullscreenActive = false
         }
         if focusSession.pendingManagedFocus.token == token {

--- a/Sources/Nehir/Core/Workspace/WorkspaceManager.swift
+++ b/Sources/Nehir/Core/Workspace/WorkspaceManager.swift
@@ -168,6 +168,10 @@ final class WorkspaceManager {
             }
 
             var focusedToken: WindowToken?
+            /// Workspace the confirmed focus was last established in. Distinguishes a
+            /// same-window re-focus *in place* from the same window being re-focused
+            /// after moving to a different workspace, which must still reveal.
+            var focusedWorkspaceId: WorkspaceDescriptor.ID?
             var pendingManagedFocus = PendingManagedFocusRequest()
             var lastTiledFocusedByWorkspace: [WorkspaceDescriptor.ID: WindowToken] = [:]
             var lastFloatingFocusedByWorkspace: [WorkspaceDescriptor.ID: WindowToken] = [:]
@@ -312,6 +316,7 @@ final class WorkspaceManager {
     private func focusSessionSnapshot() -> FocusSessionSnapshot {
         FocusSessionSnapshot(
             focusedToken: sessionState.focus.focusedToken,
+            focusedWorkspaceId: sessionState.focus.focusedWorkspaceId,
             pendingManagedFocus: PendingManagedFocusSnapshot(
                 token: sessionState.focus.pendingManagedFocus.token,
                 workspaceId: sessionState.focus.pendingManagedFocus.workspaceId,
@@ -725,6 +730,7 @@ final class WorkspaceManager {
         }
 
         sessionState.focus.focusedToken = focusSession.focusedToken
+        sessionState.focus.focusedWorkspaceId = focusSession.focusedWorkspaceId
         sessionState.focus.pendingManagedFocus = .init(
             token: focusSession.pendingManagedFocus.token,
             workspaceId: focusSession.pendingManagedFocus.workspaceId,
@@ -1138,6 +1144,11 @@ final class WorkspaceManager {
         sessionState.focus.focusedToken
     }
 
+    /// Workspace the confirmed managed focus was last established in.
+    var confirmedManagedFocusWorkspaceId: WorkspaceDescriptor.ID? {
+        sessionState.focus.focusedWorkspaceId
+    }
+
     var focusedHandle: WindowHandle? {
         confirmedManagedFocusToken.flatMap { windows.handle(for: $0) }
     }
@@ -1276,6 +1287,10 @@ final class WorkspaceManager {
             var focusChanged = false
             if focus.focusedToken != token {
                 focus.focusedToken = token
+                focusChanged = true
+            }
+            if focus.focusedWorkspaceId != workspaceId {
+                focus.focusedWorkspaceId = workspaceId
                 focusChanged = true
             }
             if !focus.isNonManagedFocusActive {
@@ -1909,6 +1924,7 @@ final class WorkspaceManager {
                self.entry(for: confirmed)?.workspaceId == workspaceId
             {
                 focus.focusedToken = nil
+                focus.focusedWorkspaceId = nil
                 focus.isAppFullscreenActive = false
                 focusChanged = true
             }
@@ -1997,6 +2013,10 @@ final class WorkspaceManager {
 
         if focus.focusedToken != token {
             focus.focusedToken = token
+            changed = true
+        }
+        if focus.focusedWorkspaceId != workspaceId {
+            focus.focusedWorkspaceId = workspaceId
             changed = true
         }
         changed = setRememberedFocus(token, in: workspaceId, mode: mode, focus: &focus) || changed

--- a/Tests/NehirTests/ConfirmedFocusWorkspaceTrackingTests.swift
+++ b/Tests/NehirTests/ConfirmedFocusWorkspaceTrackingTests.swift
@@ -1,0 +1,196 @@
+// SPDX-FileCopyrightText: 2026 Aleksei Gurianov and Nehir contributors
+// SPDX-FileComment: Provenance=nehir-original; See=NOTICE.md
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
+import AppKit
+@testable import Nehir
+import Testing
+
+private func makeConfirmedFocusTestDefaults() -> UserDefaults {
+    let suiteName = "dev.guria.nehir.confirmed-focus-workspace.test.\(UUID().uuidString)"
+    return UserDefaults(suiteName: suiteName)!
+}
+
+private func makeConfirmedFocusTestMonitor(
+    displayId: CGDirectDisplayID,
+    name: String,
+    x: CGFloat
+) -> Monitor {
+    let frame = CGRect(x: x, y: 0, width: 1920, height: 1080)
+    return Monitor(
+        id: Monitor.ID(displayId: displayId),
+        displayId: displayId,
+        frame: frame,
+        visibleFrame: frame,
+        hasNotch: false,
+        name: name
+    )
+}
+
+@MainActor
+private func addConfirmedFocusTestHandle(
+    manager: WorkspaceManager,
+    windowId: Int,
+    workspaceId: WorkspaceDescriptor.ID
+) -> WindowHandle {
+    let token = manager.addWindow(
+        AXWindowRef(element: AXUIElementCreateSystemWide(), windowId: windowId),
+        pid: getpid(),
+        windowId: windowId,
+        to: workspaceId
+    )
+    guard let handle = manager.handle(for: token) else {
+        fatalError("Expected bridge handle for confirmed-focus workspace test")
+    }
+    return handle
+}
+
+/// The confirmed managed focus records *where* it was confirmed, not just which
+/// window.
+///
+/// The AX focus-confirmation path preserves the destination viewport when it sees a
+/// re-confirmation of the already-confirmed focus token, so that a quick-terminal
+/// hide re-focusing the existing window does not scroll the viewport back to a
+/// column the user deliberately scrolled away from. Deciding that on the token
+/// alone cannot tell such a re-focus apart from the same window being re-focused
+/// after moving to a different workspace — where the window's column is wherever
+/// the transfer appended it, so preserving the viewport leaves it parked offscreen
+/// while holding focus.
+///
+/// The workspace therefore has to survive the reconcile cycle: confirmations arrive
+/// through `confirmManagedFocus`, whose focus-session write is replaced wholesale
+/// from a `FocusSessionSnapshot`. A value recorded only on the live session state is
+/// overwritten on the next reconcile.
+@Suite @MainActor struct ConfirmedFocusWorkspaceTrackingTests {
+    private struct Fixture {
+        let manager: WorkspaceManager
+        let workspaceOne: WorkspaceDescriptor.ID
+        let workspaceTwo: WorkspaceDescriptor.ID
+        let monitor: Monitor
+    }
+
+    /// Two workspaces on one monitor, matching the topology the bug was reported on.
+    private func makeFixture() -> Fixture {
+        let settings = SettingsStore(defaults: makeConfirmedFocusTestDefaults())
+        settings.workspaceConfigurations = [
+            WorkspaceConfiguration(name: "1", monitorAssignment: .main),
+            WorkspaceConfiguration(name: "2", monitorAssignment: .main)
+        ]
+
+        let manager = WorkspaceManager(settings: settings)
+        let monitor = makeConfirmedFocusTestMonitor(displayId: 10, name: "Main", x: 0)
+        manager.applyMonitorConfigurationChange([monitor])
+
+        guard let workspaceOne = manager.workspaceId(for: "1", createIfMissing: true),
+              let workspaceTwo = manager.workspaceId(for: "2", createIfMissing: true)
+        else {
+            fatalError("Expected both test workspaces")
+        }
+
+        return Fixture(
+            manager: manager,
+            workspaceOne: workspaceOne,
+            workspaceTwo: workspaceTwo,
+            monitor: monitor
+        )
+    }
+
+    @discardableResult
+    private func confirm(
+        _ handle: WindowHandle,
+        in workspaceId: WorkspaceDescriptor.ID,
+        fixture: Fixture
+    ) -> Bool {
+        fixture.manager.confirmManagedFocus(
+            handle,
+            in: workspaceId,
+            onMonitor: fixture.monitor.id,
+            appFullscreen: false,
+            activateWorkspaceOnMonitor: true
+        )
+    }
+
+    @Test func confirmingFocusRecordsTheWorkspaceItWasConfirmedIn() {
+        let fixture = makeFixture()
+        let handle = addConfirmedFocusTestHandle(
+            manager: fixture.manager,
+            windowId: 3101,
+            workspaceId: fixture.workspaceOne
+        )
+
+        confirm(handle, in: fixture.workspaceOne, fixture: fixture)
+
+        #expect(fixture.manager.confirmedManagedFocusToken == handle.id)
+        #expect(fixture.manager.confirmedManagedFocusWorkspaceId == fixture.workspaceOne)
+    }
+
+    /// The case the reported bug turned on: the same window is re-confirmed after
+    /// being reassigned to another workspace, so the recorded workspace must move
+    /// with it. A stale value would make the re-confirmation look like a re-focus in
+    /// place and suppress the reveal.
+    @Test func reconfirmingTheSameWindowInAnotherWorkspaceUpdatesTheRecordedWorkspace() {
+        let fixture = makeFixture()
+        let handle = addConfirmedFocusTestHandle(
+            manager: fixture.manager,
+            windowId: 3102,
+            workspaceId: fixture.workspaceOne
+        )
+
+        confirm(handle, in: fixture.workspaceOne, fixture: fixture)
+        #expect(fixture.manager.confirmedManagedFocusWorkspaceId == fixture.workspaceOne)
+
+        fixture.manager.setWorkspace(for: handle.id, to: fixture.workspaceTwo)
+        confirm(handle, in: fixture.workspaceTwo, fixture: fixture)
+
+        #expect(fixture.manager.confirmedManagedFocusToken == handle.id)
+        #expect(fixture.manager.confirmedManagedFocusWorkspaceId == fixture.workspaceTwo)
+    }
+
+    /// Re-confirming in the same workspace leaves the record alone, which is what
+    /// keeps the quick-terminal viewport-preservation behaviour intact.
+    @Test func reconfirmingInTheSameWorkspaceKeepsTheRecordedWorkspace() {
+        let fixture = makeFixture()
+        let handle = addConfirmedFocusTestHandle(
+            manager: fixture.manager,
+            windowId: 3103,
+            workspaceId: fixture.workspaceOne
+        )
+
+        confirm(handle, in: fixture.workspaceOne, fixture: fixture)
+        confirm(handle, in: fixture.workspaceOne, fixture: fixture)
+
+        #expect(fixture.manager.confirmedManagedFocusWorkspaceId == fixture.workspaceOne)
+    }
+
+    /// The recorded workspace must survive a reconcile pass. `confirmManagedFocus`
+    /// routes through the reducer and `applyReconciledFocusSession` replaces the
+    /// focus session from a snapshot, so a field the snapshot does not carry is
+    /// silently reset — which is exactly what made an earlier attempt at this fix
+    /// inert.
+    @Test func recordedWorkspaceSurvivesFurtherFocusSessionWrites() {
+        let fixture = makeFixture()
+        let first = addConfirmedFocusTestHandle(
+            manager: fixture.manager,
+            windowId: 3104,
+            workspaceId: fixture.workspaceOne
+        )
+        let second = addConfirmedFocusTestHandle(
+            manager: fixture.manager,
+            windowId: 3105,
+            workspaceId: fixture.workspaceTwo
+        )
+
+        confirm(first, in: fixture.workspaceOne, fixture: fixture)
+        confirm(second, in: fixture.workspaceTwo, fixture: fixture)
+
+        #expect(fixture.manager.confirmedManagedFocusToken == second.id)
+        #expect(fixture.manager.confirmedManagedFocusWorkspaceId == fixture.workspaceTwo)
+
+        // And back again, so the field is not merely sticky in one direction.
+        confirm(first, in: fixture.workspaceOne, fixture: fixture)
+
+        #expect(fixture.manager.confirmedManagedFocusToken == first.id)
+        #expect(fixture.manager.confirmedManagedFocusWorkspaceId == fixture.workspaceOne)
+    }
+}


### PR DESCRIPTION
## Symptom

A window moved to another workspace could stay parked off the destination viewport while still holding keyboard focus — the user saw a different window than the one they moved, and keystrokes went somewhere invisible.

## Root cause

The AX focus-confirmation path preserves the active viewport when it sees a re-confirmation of the already-confirmed focus token. That guard exists for a good reason, stated in its own comment: a quick-terminal hide can make macOS re-focus the existing managed window, and scrolling then would yank the viewport back to a column the user deliberately scrolled away from.

But the test compared **only tokens**:

```swift
let previousConfirmedFocusToken = controller.workspaceManager.confirmedManagedFocusToken
let wasAlreadyConfirmedFocus = previousConfirmedFocusToken == entry.token
```

Moving a window that already holds focus produces exactly that signature — the destination workspace emits a `focusedWindowChanged` notification for a token which is already the confirmed focus. So `preserveActiveViewportReason` became `.alreadyConfirmedFocusedWindowChanged` and the reveal was skipped. The moved window's column, however, is wherever the transfer appended it — usually outside the destination viewport — so preserving that viewport left the window parked offscreen.

Captured from a runtime trace of the failing move:

```
reason=ax_focus_confirm_reveal_skipped
preserveActiveViewport=true
preserveActiveViewportReason=already_confirmed_focused_window_changed
skipReason=preserve_active_viewport
isWorkspaceActive=true
activeColumnIndex=3  currentOffset=-3530.0  targetOffset=-3530.0
currentViewStart=-20.0  targetViewStart=-20.0
```

With the destination's columns at x = 0, 1170, 2340, 3510 and a 2560pt viewport resting at −20, column 3 starts roughly 970pt beyond the right edge. `currentViewStart == targetViewStart` confirms no scroll was ever scheduled — the reveal did not run at all.

## Change

Record the workspace the confirmed focus was established in (`focusedWorkspaceId` on the focus session, set wherever `focusedToken` is set and cleared with it), and require it to match before treating a re-confirmation as "in place":

```swift
let confirmedFocusWorkspaceUnchanged = previousConfirmedFocusWorkspaceId == nil
    || previousConfirmedFocusWorkspaceId == wsId
let wasAlreadyConfirmedFocus = previousConfirmedFocusToken == entry.token
    && confirmedFocusWorkspaceUnchanged
```

The invariant: **a same-window re-focus within one workspace preserves the viewport; the same window re-focused after changing workspace reveals.** The quick-terminal case the guard was built for is unaffected — that re-focus happens within one workspace. An absent recorded workspace preserves the previous behavior, so nothing changes before the first confirmation.

The existing skip trace now also carries `confirmedFocusWorkspaceUnchanged` and the previous confirmed-focus workspace name, so this decision is visible in future traces without new instrumentation.

## Status

**Candidate fix, not confirmed.** The mechanism is identified from a runtime trace of the failing move — unlike earlier attempts, the trace names the skip and its reason directly. But the runtime behaviour has **not** yet been confirmed fixed in a real reproduction. Draft until it has been.

Tests are deferred per `docs/TESTING.md` until the behaviour is confirmed.

## Supersedes

This replaces #203 and #207 as the candidate fix for this symptom:

- **#203** (raise the focused window above restored windows) — instrumentation showed its raise never executes here, because a hidden window produces no `diff.focusedFrame`. Closes a real but separate gap.
- **#207** (observe an animated reveal in the recalc gate) — the gating mismatch it fixes is real and measured by tests, but it is downstream of this: the reveal never runs, so there is no scheduled scroll for that gate to miss.

Six further candidate mechanisms were investigated and eliminated; they are recorded in the discovery document in #206, which should be updated once this is confirmed.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR records the workspace associated with confirmed managed focus so that re-focusing a moved window reveals it without disrupting same-workspace viewport preservation.
- Adds workspace identity to focus-session state and propagates it through reconciliation.
- Uses that identity in the AX reveal decision and diagnostic trace.
- Adds manager-level tracking tests, but leaves an existing test initializer incompatible with the new snapshot shape.

<h3>Confidence Score: 4/5</h3>

The PR should not merge until the existing RestorePlannerTests snapshot initializer is updated to compile with the new required field.

The focus-workspace tracking is consistently propagated through the changed runtime paths, but adding the required snapshot property breaks an existing test-target initializer.

**Files Needing Attention:** Sources/Nehir/Core/Reconcile/ReconcileSnapshot.swift and Tests/NehirTests/RestorePlannerTests.swift

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Sources/Nehir/Core/Controller/AXEventHandler.swift | Uses the previous confirmed-focus workspace to distinguish an in-place refocus from one following a workspace move. |
| Sources/Nehir/Core/Reconcile/ReconcileSnapshot.swift | Adds the required focusedWorkspaceId snapshot field, but the new memberwise-initializer contract is not applied to every caller. |
| Sources/Nehir/Core/Reconcile/StateReducer.swift | Sets and clears the workspace alongside confirmed focus through reducer lifecycle events. |
| Sources/Nehir/Core/Workspace/WorkspaceManager.swift | Stores, exposes, snapshots, restores, and clears the confirmed-focus workspace. |
| Tests/NehirTests/ConfirmedFocusWorkspaceTrackingTests.swift | Covers workspace tracking across confirmation and reconciliation, though not the complete AX reveal behavior. |
| Tests/NehirTests/RestorePlannerTests.swift | Its existing FocusSessionSnapshot initializer omits the newly required focusedWorkspaceId argument and will not compile. |

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    A[Managed focus confirmed] --> B[Store token and workspace]
    B --> C[Window reassigned]
    C --> D[AX focus confirmation]
    D --> E{Workspace unchanged?}
    E -- Yes --> F[Preserve viewport]
    E -- No --> G[Reveal focused window]
```

<a href="https://app.greptile.com/ide/claude-code?prompt=Greploop%20apphane-dev%2Fnehir%20PR%20%23209%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%E2%95%AD%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AE%0A%E2%94%82%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%E2%94%82%0A%E2%94%82%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%E2%94%82%0A%E2%95%B0%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AF%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&repo=apphane-dev%2Fnehir&pr=209&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0ASources%2FNehir%2FCore%2FReconcile%2FReconcileSnapshot.swift%3A151%0A**Snapshot%20initializer%20contract%20broken**%0A%0AWhen%20the%20test%20target%20builds%2C%20%60RestorePlannerTests%60%20calls%20the%20synthesized%20%60FocusSessionSnapshot%60%20initializer%20without%20the%20new%20required%20%60focusedWorkspaceId%60%20argument%2C%20causing%20the%20test%20target%20to%20fail%20compilation.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=apphane-dev%2Fnehir&pr=209&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22apphane-dev%2Fnehir%22%20on%20the%20existing%20branch%20%22la%2Freveal-window-refocused-after-workspace-move%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22la%2Freveal-window-refocused-after-workspace-move%22.%0A%0A%23%23%23%20Issue%201%0ASources%2FNehir%2FCore%2FReconcile%2FReconcileSnapshot.swift%3A151%0A**Snapshot%20initializer%20contract%20broken**%0A%0AWhen%20the%20test%20target%20builds%2C%20%60RestorePlannerTests%60%20calls%20the%20synthesized%20%60FocusSessionSnapshot%60%20initializer%20without%20the%20new%20required%20%60focusedWorkspaceId%60%20argument%2C%20causing%20the%20test%20target%20to%20fail%20compilation.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=apphane-dev%2Fnehir&pr=209&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
Sources/Nehir/Core/Reconcile/ReconcileSnapshot.swift:151
**Snapshot initializer contract broken**

When the test target builds, `RestorePlannerTests` calls the synthesized `FocusSessionSnapshot` initializer without the new required `focusedWorkspaceId` argument, causing the test target to fail compilation.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Add tests for the workspace recorded wit..."](https://github.com/apphane-dev/nehir/commit/0271f3754691e8d7fef0cfa7f5e76b9d288f31ad) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55223520)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->